### PR TITLE
Unset initialization options on --init-best

### DIFF
--- a/scripts/bbregister
+++ b/scripts/bbregister
@@ -947,6 +947,12 @@ while( $#argv != 0 )
 
     case "--init-best":
       set DoInitBest = 1;
+      set InitFSL = 0;
+      set InitSPM = 0;
+      set InitCoreg = 0;
+      set InitRR = 0;
+      set InitHeader = 0;
+      set InitReg = ();
       breaksw
     case "--no-init-best":
       set DoInitBest = 0;


### PR DESCRIPTION
See [report](https://mail.nmr.mgh.harvard.edu/pipermail/freesurfer/2017-March/050803.html):

> `bbregister --init-best` always produces "ERROR: cannot spec an init method
with --init-best", because `InitCoreg` is defined as 1 by default, and never
set to 0 by `--init-best`. (Setting something else that unsets `InitCoreg` will
trigger the same error.)
> 
> Example, given SUBJ and EPI:

```Shell
$ bbregister --init-best --s $SUBJ --mov $EPI --o ${EPI%.nii.gz}_bbr.nii.gz
--reg ${EPI%.nii.gz}_bbr.dat
ERROR: cannot spec an init method with --init-best
```

Using FreeSurfer 6.0 release installed on an Ubuntu 16.04 machine.