### PR TITLE
Test VisitCounter on Single Tetrahedron

### DIFF
--- a/GEMS2/Testing/testatlasmeshvisitcounter.cpp
+++ b/GEMS2/Testing/testatlasmeshvisitcounter.cpp
@@ -92,11 +92,12 @@ BOOST_AUTO_TEST_CASE( OriginOnly )
   MeshSource::Pointer meshSource = MeshSource::New();
 
   // Define tetrahedron enclosing origin and (0,0,1), (0,1,0) and (1,0,0)
-  const float delta = 0.5f;
+  const float delta = 0.1f;
+  BOOST_REQUIRE( delta < 0.5f );
   const float  p0[] = { -delta, -delta, -delta };
-  const float  p1[] = { 1+delta,- delta, -delta };
-  const float  p2[] = { -delta, 1+delta, -delta };
-  const float  p3[] = { -delta, -delta, 1+delta };
+  const float  p1[] = { 1+(2*delta),- delta, -delta };
+  const float  p2[] = { -delta, 1+(2*delta), -delta };
+  const float  p3[] = { -delta, -delta, 1+(2*delta) };
   const IdentifierType  id0 = meshSource->AddPoint( p0 );
   const IdentifierType  id1 = meshSource->AddPoint( p1 );
   const IdentifierType  id2 = meshSource->AddPoint( p2 );
@@ -107,15 +108,15 @@ BOOST_AUTO_TEST_CASE( OriginOnly )
 
   BOOST_TEST_CHECKPOINT("Mesh created");
 
-  kvl::AtlasMeshVisitCounterCPUWrapper visitCounter;
+  kvl::AtlasMeshVisitCounterCPU::Pointer visitCounter = kvl::AtlasMeshVisitCounterCPU::New();
 
-  visitCounter.SetRegions( image->GetLargestPossibleRegion() );
-  visitCounter.VisitCount( mesh );
+  visitCounter->SetRegions( image->GetLargestPossibleRegion() );
+  visitCounter->Rasterize( mesh );
 
   BOOST_TEST_CHECKPOINT("VisitCounter Complete");
 
   // Check points in tetrahedron
-  const ImageType* result = visitCounter.GetImage();
+  const ImageType* result = visitCounter->GetImage();
   for( int k=0; k<nz; k++ ) {
     for( int j=0; j<ny; j++ ) {
       for( int i=0; i<nx; i++ ) {

--- a/GEMS2/Testing/testatlasmeshvisitcounter.cpp
+++ b/GEMS2/Testing/testatlasmeshvisitcounter.cpp
@@ -53,6 +53,7 @@ BOOST_AUTO_TEST_CASE( OriginOnly )
 
   typedef kvl::interfaces::AtlasMeshVisitCounter::ImageType ImageType;
   typedef itk::AutomaticTopologyMeshSource<kvl::AtlasMesh> MeshSource;
+  typedef MeshSource::IdentifierType  IdentifierType;
   typedef kvl::AtlasMesh Mesh;
 
   ImageType::RegionType region;
@@ -87,10 +88,54 @@ BOOST_AUTO_TEST_CASE( OriginOnly )
 
   BOOST_TEST_CHECKPOINT("Cube set");
 
-  // Create mesh
+  // Create mesh with single tetrahedron
   MeshSource::Pointer meshSource = MeshSource::New();
 
-  Mesh::Pointer mesh = Mesh::New();
+  // Define tetrahedron enclosing origin and (0,0,1), (0,1,0) and (1,0,0)
+  const float delta = 0.5f;
+  const float  p0[] = { -delta, -delta, -delta };
+  const float  p1[] = { 1+delta,- delta, -delta };
+  const float  p2[] = { -delta, 1+delta, -delta };
+  const float  p3[] = { -delta, -delta, 1+delta };
+  const IdentifierType  id0 = meshSource->AddPoint( p0 );
+  const IdentifierType  id1 = meshSource->AddPoint( p1 );
+  const IdentifierType  id2 = meshSource->AddPoint( p2 );
+  const IdentifierType  id3 = meshSource->AddPoint( p3 );
+  meshSource->AddTetrahedron( id0, id1, id2, id3 );
+
+  Mesh::Pointer mesh = meshSource->GetOutput();
+
+  BOOST_TEST_CHECKPOINT("Mesh created");
+
+  kvl::AtlasMeshVisitCounterCPUWrapper visitCounter;
+
+  visitCounter.SetRegions( image->GetLargestPossibleRegion() );
+  visitCounter.VisitCount( mesh );
+
+  BOOST_TEST_CHECKPOINT("VisitCounter Complete");
+
+  // Check points in tetrahedron
+  const ImageType* result = visitCounter.GetImage();
+  for( int k=0; k<nz; k++ ) {
+    for( int j=0; j<ny; j++ ) {
+      for( int i=0; i<nx; i++ ) {
+	ImageType::IndexType idx;
+	idx[0] = i;
+	idx[1] = j;
+	idx[2] = k;
+
+	// Recall that the tetrahedron is constructed to be the lower one
+	// enclosing points with at most one index equal to 1
+	int expected = 0;
+	if( i+j+k <= 1 ) {
+	  expected = 1;
+	}
+
+	BOOST_TEST_INFO( "(" << i << "," << j << "," << k << ")" );
+	BOOST_CHECK_EQUAL( result->GetPixel(idx), expected );
+      }
+    }
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/GEMS2/Testing/testatlasmeshvisitcounter.cpp
+++ b/GEMS2/Testing/testatlasmeshvisitcounter.cpp
@@ -2,6 +2,7 @@
 
 #include "itkImageRegionConstIteratorWithIndex.h"
 
+#include "kvlAtlasMesh.h"
 #include "atlasmeshvisitcounter.hpp"
 #include "atlasmeshvisitcountercpuwrapper.hpp"
 #ifdef CUDA_FOUND
@@ -73,6 +74,7 @@ BOOST_AUTO_TEST_CASE( OriginOnly )
   }
 
   // Create mesh with single triangle
+  kvl::AtlasMesh::Pointer mesh = kvl::AtlasMesh::New();
 }
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/GEMS2/Testing/testatlasmeshvisitcounter.cpp
+++ b/GEMS2/Testing/testatlasmeshvisitcounter.cpp
@@ -39,7 +39,47 @@ void CheckVisitCounter( kvl::interfaces::AtlasMeshVisitCounter* visitCounter,
 
 // -------------------
 
-BOOST_FIXTURE_TEST_SUITE( AtlasMeshVisitCounter, TestFileLoader )
+BOOST_AUTO_TEST_SUITE( AtlasMeshVisitCounter )
+
+BOOST_AUTO_TEST_SUITE( UnitCubeSingleTetrahedron )
+
+BOOST_AUTO_TEST_CASE( OriginOnly )
+{
+  // Create unit cube
+  kvl::interfaces::AtlasMeshVisitCounter::ImageType::RegionType region;
+  kvl::interfaces::AtlasMeshVisitCounter::ImageType::IndexType start;
+  kvl::interfaces::AtlasMeshVisitCounter::ImageType::SizeType size;
+  start[0] = start[1] = start[2] = 0;
+  size[0] = size[1] = size[2] = 1;
+
+  region.SetSize(size);
+  region.SetIndex(start);
+
+  kvl::interfaces::AtlasMeshVisitCounter::ImageType::Pointer image;
+  image->SetRegions(region);
+  image->Allocate();
+
+  for( int k=0; k<2; k++ ) {
+    for( int j=0; j<2; j++ ) {
+      for( int i=0; i<2; i++ ) {
+	kvl::interfaces::AtlasMeshVisitCounter::ImageType::IndexType idx;
+	idx[0] = k;
+	idx[1] = j;
+	idx[2] = i;
+
+	image->SetPixel(idx, 0);
+      }
+    }
+  }
+
+  // Create mesh with single triangle
+}
+
+BOOST_AUTO_TEST_SUITE_END();
+
+// --
+
+BOOST_FIXTURE_TEST_SUITE( ActualImage, TestFileLoader )
 
 BOOST_AUTO_TEST_CASE( ReferenceImpl )
 {
@@ -59,5 +99,6 @@ BOOST_AUTO_TEST_CASE( CUDAImpl )
 }
 #endif
 
+BOOST_AUTO_TEST_SUITE_END();
 
 BOOST_AUTO_TEST_SUITE_END();

--- a/GEMS2/Testing/testatlasmeshvisitcounter.cpp
+++ b/GEMS2/Testing/testatlasmeshvisitcounter.cpp
@@ -46,35 +46,51 @@ BOOST_AUTO_TEST_SUITE( UnitCubeSingleTetrahedron )
 
 BOOST_AUTO_TEST_CASE( OriginOnly )
 {
+  const int nx = 2;
+  const int ny = 2;
+  const int nz = 2;
   // Create unit cube
-  kvl::interfaces::AtlasMeshVisitCounter::ImageType::RegionType region;
-  kvl::interfaces::AtlasMeshVisitCounter::ImageType::IndexType start;
-  kvl::interfaces::AtlasMeshVisitCounter::ImageType::SizeType size;
+
+  typedef kvl::interfaces::AtlasMeshVisitCounter::ImageType ImageType;
+  typedef itk::AutomaticTopologyMeshSource<kvl::AtlasMesh> MeshSource;
+  typedef kvl::AtlasMesh Mesh;
+
+  ImageType::RegionType region;
+  ImageType::IndexType start;
+  ImageType::SizeType size;
   start[0] = start[1] = start[2] = 0;
-  size[0] = size[1] = size[2] = 1;
+  size[0] = nx-1;
+  size[1] = ny-1;
+  size[2] = nz-1;
 
   region.SetSize(size);
   region.SetIndex(start);
 
-  kvl::interfaces::AtlasMeshVisitCounter::ImageType::Pointer image;
+  ImageType::Pointer image = ImageType::New();
   image->SetRegions(region);
   image->Allocate();
 
-  for( int k=0; k<2; k++ ) {
-    for( int j=0; j<2; j++ ) {
-      for( int i=0; i<2; i++ ) {
-	kvl::interfaces::AtlasMeshVisitCounter::ImageType::IndexType idx;
-	idx[0] = k;
+  BOOST_TEST_CHECKPOINT("Cube allocated");
+
+  for( int k=0; k<nz; k++ ) {
+    for( int j=0; j<ny; j++ ) {
+      for( int i=0; i<nx; i++ ) {
+	ImageType::IndexType idx;
+	idx[0] = i;
 	idx[1] = j;
-	idx[2] = i;
+	idx[2] = k;
 
 	image->SetPixel(idx, 0);
       }
     }
   }
 
-  // Create mesh with single triangle
-  kvl::AtlasMesh::Pointer mesh = kvl::AtlasMesh::New();
+  BOOST_TEST_CHECKPOINT("Cube set");
+
+  // Create mesh
+  MeshSource::Pointer meshSource = MeshSource::New();
+
+  Mesh::Pointer mesh = Mesh::New();
 }
 
 BOOST_AUTO_TEST_SUITE_END();


### PR DESCRIPTION
**This is not yet ready to merge** - the test is failing and I don't understand why.

I'm attempting to create a simple unit test of the VisitCounter, using a single tetrahedron and a unit cube. In this particular test case, the tetrahedron is supposed to enclose the points (0,0,0), (0,0,1), (0,1,0) and (1,0,0).

In the final image (from the VisitCount), I'm expecting the above four vertices of the cube to have a value of 1, and the remaining four to have a value of 0.

However, when I run, the test fails with the following assertions:

`"AtlasMeshVisitCounter/UnitCubeSingleTetrahedron/OriginOnly": check result->GetPixel(idx) == expected has failed [0 != 1]
Failure occurred in a following context:
    (0,0,0)`

`"AtlasMeshVisitCounter/UnitCubeSingleTetrahedron/OriginOnly": check result->GetPixel(idx) == expected has failed [0 != 1]
Failure occurred in a following context:
    (1,0,0)`

`"AtlasMeshVisitCounter/UnitCubeSingleTetrahedron/OriginOnly": check result->GetPixel(idx) == expected has failed [0 != 1]
Failure occurred in a following context:
    (0,1,0)`

`"AtlasMeshVisitCounter/UnitCubeSingleTetrahedron/OriginOnly": check result->GetPixel(idx) == expected has failed [2 != 0]
Failure occurred in a following context:
    (1,1,0)`

`"AtlasMeshVisitCounter/UnitCubeSingleTetrahedron/OriginOnly": check result->GetPixel(idx) == expected has failed [0 != 1]
Failure occurred in a following context:
    (0,0,1)`

`"AtlasMeshVisitCounter/UnitCubeSingleTetrahedron/OriginOnly": check result->GetPixel(idx) == expected has failed [2 != 0]
Failure occurred in a following context:
    (1,0,1)`

`"AtlasMeshVisitCounter/UnitCubeSingleTetrahedron/OriginOnly": check result->GetPixel(idx) == expected has failed [2 != 0]
Failure occurred in a following context:
    (0,1,1)`

Except for the point (1,1,1), everything has a different value to that which I expect. Furthermore, I don't see how any points can have wound up with a value of 2, when I only created a single tetrahedron.
