### PR TITLE
OpenMP Comparisons for mri_em_register

### DIFF
--- a/mri_em_register/run_compare.tcsh
+++ b/mri_em_register/run_compare.tcsh
@@ -4,7 +4,9 @@
 
 gunzip -c testdata.tar.gz | tar xvf -
 
-set threads=( 8 )
+echo "============================"
+
+set threads=( 1 2 4 8 )
 
 foreach num ($threads)
     
@@ -13,7 +15,11 @@ foreach num ($threads)
 
     time ./run_one.tcsh
 
+    echo "-- -- -- --"
+
     time ./run_two.tcsh
+
+    echo "============================"
 end
 
 

--- a/mri_em_register/run_compare.tcsh
+++ b/mri_em_register/run_compare.tcsh
@@ -1,0 +1,25 @@
+#!/bin/tcsh -f
+
+# Extract test data
+
+gunzip -c testdata.tar.gz | tar xvf -
+
+set threads=( 8 )
+
+foreach num ($threads)
+    
+    setenv OMP_NUM_THREADS $num
+    echo "OMP_NUM_THREADS: " $OMP_NUM_THREADS
+
+    time ./run_one.tcsh
+
+    time ./run_two.tcsh
+end
+
+
+
+#
+# cleanup
+#
+cd ..
+rm -Rf testdata

--- a/mri_em_register/run_compare.tcsh
+++ b/mri_em_register/run_compare.tcsh
@@ -4,6 +4,9 @@
 
 gunzip -c testdata.tar.gz | tar xvf -
 
+# Set up performance monitors (comment out to turn off)
+setenv PERF "perf stat -B -e cache-references,cache-misses,faults,migrations,dTLB-loads,dTLB-load-misses"
+
 echo "============================"
 
 set threads=( 1 2 4 8 )

--- a/mri_em_register/run_one.tcsh
+++ b/mri_em_register/run_one.tcsh
@@ -1,0 +1,15 @@
+#!/bin/tcsh -f
+
+cd testdata
+
+echo "Running single mri_em_register"
+
+../mri_em_register \
+        -uns 3 \
+        -mask brainmask.mgz \
+        nu.mgz \
+        ../../distribution/average/RB_all_2016-05-10.vc700.gca \
+        talairach.run_one.lta >& ../run_one.log &
+
+wait
+

--- a/mri_em_register/run_one.tcsh
+++ b/mri_em_register/run_one.tcsh
@@ -9,7 +9,7 @@ echo "Running single mri_em_register"
         -mask brainmask.mgz \
         nu.mgz \
         ../../distribution/average/RB_all_2016-05-10.vc700.gca \
-        talairach.run_one.lta >& ../run_one.log &
+        talairach.run_one.lta >& ../run_one_$OMP_NUM_THREADS.log &
 
 wait
 

--- a/mri_em_register/run_one.tcsh
+++ b/mri_em_register/run_one.tcsh
@@ -4,7 +4,7 @@ cd testdata
 
 echo "Running single mri_em_register"
 
-../mri_em_register \
+$PERF ../mri_em_register \
         -uns 3 \
         -mask brainmask.mgz \
         nu.mgz \

--- a/mri_em_register/run_one.tcsh
+++ b/mri_em_register/run_one.tcsh
@@ -9,7 +9,7 @@ echo "Running single mri_em_register"
         -mask brainmask.mgz \
         nu.mgz \
         ../../distribution/average/RB_all_2016-05-10.vc700.gca \
-        talairach.run_one.lta >& ../run_one_$OMP_NUM_THREADS.log &
+        talairach.run_one.lta >& ../run_one_${OMP_NUM_THREADS}.log &
 
 wait
 

--- a/mri_em_register/run_two.tcsh
+++ b/mri_em_register/run_two.tcsh
@@ -9,13 +9,13 @@ echo "Running two mri_em_register"
         -mask brainmask.mgz \
         nu.mgz \
         ../../distribution/average/RB_all_2016-05-10.vc700.gca \
-        talairach.run_two_0.lta >& ../run_two_$OMP_NUM_THREADS_0.log &
+        talairach.run_two_0.lta >& ../run_two_${OMP_NUM_THREADS}_0.log &
 
 ../mri_em_register \
         -uns 3 \
         -mask brainmask.mgz \
         nu.mgz \
         ../../distribution/average/RB_all_2016-05-10.vc700.gca \
-        talairach.run_two_1.lta >& ../run_two_$OMP_NUM_THREADS_1.log &
+        talairach.run_two_1.lta >& ../run_two_${OMP_NUM_THREADS}_1.log &
 
 wait

--- a/mri_em_register/run_two.tcsh
+++ b/mri_em_register/run_two.tcsh
@@ -4,14 +4,14 @@ cd testdata
 
 echo "Running two mri_em_register"
 
-../mri_em_register \
+$PERF ../mri_em_register \
         -uns 3 \
         -mask brainmask.mgz \
         nu.mgz \
         ../../distribution/average/RB_all_2016-05-10.vc700.gca \
         talairach.run_two_0.lta >& ../run_two_${OMP_NUM_THREADS}_0.log &
 
-../mri_em_register \
+$PERF ../mri_em_register \
         -uns 3 \
         -mask brainmask.mgz \
         nu.mgz \

--- a/mri_em_register/run_two.tcsh
+++ b/mri_em_register/run_two.tcsh
@@ -9,13 +9,13 @@ echo "Running two mri_em_register"
         -mask brainmask.mgz \
         nu.mgz \
         ../../distribution/average/RB_all_2016-05-10.vc700.gca \
-        talairach.run_two_0.lta >& ../run_two_0.log &
+        talairach.run_two_0.lta >& ../run_two_$OMP_NUM_THREADS_0.log &
 
 ../mri_em_register \
         -uns 3 \
         -mask brainmask.mgz \
         nu.mgz \
         ../../distribution/average/RB_all_2016-05-10.vc700.gca \
-        talairach.run_two_1.lta >& ../run_two_1.log &
+        talairach.run_two_1.lta >& ../run_two_$OMP_NUM_THREADS_1.log &
 
 wait

--- a/mri_em_register/run_two.tcsh
+++ b/mri_em_register/run_two.tcsh
@@ -1,0 +1,21 @@
+#!/bin/tcsh -f
+
+cd testdata
+
+echo "Running two mri_em_register"
+
+../mri_em_register \
+        -uns 3 \
+        -mask brainmask.mgz \
+        nu.mgz \
+        ../../distribution/average/RB_all_2016-05-10.vc700.gca \
+        talairach.run_two_0.lta >& ../run_two_0.log &
+
+../mri_em_register \
+        -uns 3 \
+        -mask brainmask.mgz \
+        nu.mgz \
+        ../../distribution/average/RB_all_2016-05-10.vc700.gca \
+        talairach.run_two_1.lta >& ../run_two_1.log &
+
+wait


### PR DESCRIPTION
Scripts to compare OpenMP performance of mri_em_register when more than one copy is run at a time. The basic script to run is run_compare, which in turn calls run_one and run_two to run one or two copies of mri_em_register, and time them.