### PR TITLE
MRISread() fix

### DIFF
--- a/mris_inflate/Makefile.am
+++ b/mris_inflate/Makefile.am
@@ -41,7 +41,14 @@ mris_inflate_cuda_LINK = $(LIBTOOL) --tag=CC $(AM_LIBTOOLFLAGS) \
 
 endif
 
-TESTS=$(top_builddir)/scripts/help_xml_validate
+# trick to get test data into the build directory
+foo_SOURCES=
+foo:
+	if ! test -f "$(top_builddir)/mris_inflate/testdata.tar.gz"; then \
+		cp -v $(top_srcdir)/mris_inflate/testdata.tar.gz \
+					$(top_builddir)/mris_inflate/; fi;
+
+TESTS=$(top_builddir)/scripts/help_xml_validate test_fs_posix
 
 clean-local:
 	rm -f $(BUILT_SOURCES) 

--- a/mris_inflate/test_fs_posix
+++ b/mris_inflate/test_fs_posix
@@ -1,0 +1,67 @@
+#!/bin/tcsh -f
+
+# test_fs_posix
+# Paul Wighton 2017/05/19
+#
+# Script to test the behaviour of mris_inflate with and without the env var 
+# FS_POSIX set.  When FS_POSIX is set, and output filenames do not specify a 
+# path, the filename should resolve to the the current working directory 
+# (as per POSIX 4:11).  When FS_POSIX is not set and output filenames do not 
+# specify a path the filename should resolve to the directory of the input
+# surface file (legacy behviour)
+#
+
+#
+# extract test data
+#
+gunzip -c testdata.tar.gz | tar xvf -
+
+cd testdata
+mkdir -p outdir
+cd outdir
+
+set log = (../../test_fs_posix.log)
+if (-e $log) rm -f $log
+
+# Test legacy behaviour
+set cmd=(../../mris_inflate ../rh.smoothwm.nofix rh.inflated.nofix)
+
+echo "\n\n $cmd \n\n" |& tee -a $log
+$cmd |& tee -a $log
+
+if ( $status != 0 ) then
+  echo "mris_inflate/test_fs_posix -- Legacy bahviour test: FAILED (status code is non-zero)" |& tee -a $log
+  exit 1
+endif
+if ( ! -f "../rh.inflated.nofix" ) then
+  echo "mris_inflate/test_fs_posix -- Legacy bahviour test: FAILED (output file in wrong place)" |& tee -a $log
+  exit 1
+endif
+
+echo "" |& tee -a $log
+echo "" |& tee -a $log
+echo "" |& tee -a $log
+
+# Test POSIX behaviour
+setenv FS_POSIX 1
+set cmd=(../../mris_inflate ../rh.smoothwm.nofix rh.inflated.nofix)
+echo "\n\n $cmd \n\n" |& tee -a $log
+$cmd |& tee -a $log
+if ( $status != 0 ) then
+  echo "mris_sphere/test_fs_posix -- POSIX bahviour test: FAILED (status code is non-zero)" |& tee -a $log
+  exit 1
+endif
+if ( ! -f "./rh.inflated.nofix" ) then
+  echo "mris_sphere/test_fs_posix -- POSIX bahviour test: FAILED (output file in wrong place)" |& tee -a $log
+  exit 1
+endif
+
+#
+# cleanup
+#
+cd ../..
+rm -Rf testdata
+
+echo "" |& tee -a $log
+echo "test_mris_inflate passed all tests" |& tee -a $log
+exit 0

--- a/mris_jacobian/Makefile.am
+++ b/mris_jacobian/Makefile.am
@@ -16,7 +16,14 @@ foo_DATA=mris_jacobian.help.xml
 foo2dir=$(prefix)/docs/html
 foo2_DATA=mris_jacobian.help.xml.html
 
-TESTS=$(top_builddir)/scripts/help_xml_validate
+# trick to get test data into the build directory
+foo_SOURCES=
+foo:
+	if ! test -f "$(top_builddir)/mris_jacobian/testdata.tar.gz"; then \
+		cp -v $(top_srcdir)/mris_jacobian/testdata.tar.gz \
+					$(top_builddir)/mris_jacobian/; fi;
+
+TESTS=$(top_builddir)/scripts/help_xml_validate test_fs_posix
 
 clean-local:
 	rm -f $(BUILT_SOURCES) 

--- a/mris_jacobian/test_fs_posix
+++ b/mris_jacobian/test_fs_posix
@@ -1,0 +1,67 @@
+#!/bin/tcsh -f
+
+# test_fs_posix
+# Paul Wighton 2017/05/19
+#
+# Script to test the behaviour of mris_jacobian with and without the env var 
+# FS_POSIX set.  When FS_POSIX is set, and output filenames do not specify a 
+# path, the filename should resolve to the the current working directory 
+# (as per POSIX 4:11).  When FS_POSIX is not set and output filenames do not 
+# specify a path the filename should resolve to the directory of the input
+# surface file (legacy behviour)
+#
+
+#
+# extract test data
+#
+gunzip -c testdata.tar.gz | tar xvf -
+
+cd testdata
+mkdir -p outdir
+cd outdir
+
+set log = (../../test_fs_posix.log)
+if (-e $log) rm -f $log
+
+# Test legacy behaviour
+set cmd=(../../mris_jacobian ../rh.white ../rh.sphere.reg rh.jacobian_white)
+
+echo "\n\n $cmd \n\n" |& tee -a $log
+$cmd |& tee -a $log
+
+if ( $status != 0 ) then
+  echo "mris_jacobian/test_fs_posix -- Legacy bahviour test: FAILED (status code is non-zero)" |& tee -a $log
+  exit 1
+endif
+if ( ! -f "../rh.jacobian_white" ) then
+  echo "mris_jacobian/test_fs_posix -- Legacy bahviour test: FAILED (output file in wrong place)" |& tee -a $log
+  exit 1
+endif
+
+echo "" |& tee -a $log
+echo "" |& tee -a $log
+echo "" |& tee -a $log
+
+# Test POSIX behaviour
+setenv FS_POSIX 1
+set cmd=(../../mris_jacobian ../rh.white ../rh.sphere.reg rh.jacobian_white)
+echo "\n\n $cmd \n\n" |& tee -a $log
+$cmd |& tee -a $log
+if ( $status != 0 ) then
+  echo "mris_jacobian/test_fs_posix -- POSIX bahviour test: FAILED (status code is non-zero)" |& tee -a $log
+  exit 1
+endif
+if ( ! -f "./rh.jacobian_white" ) then
+  echo "mris_jacobian/test_fs_posix -- POSIX bahviour test: FAILED (output file in wrong place)" |& tee -a $log
+  exit 1
+endif
+
+#
+# cleanup
+#
+cd ../..
+#rm -Rf testdata
+
+echo "" |& tee -a $log
+echo "test_fs_posix passed all tests" |& tee -a $log
+exit 0

--- a/mris_smooth/Makefile.am
+++ b/mris_smooth/Makefile.am
@@ -16,7 +16,14 @@ foo_DATA=mris_smooth.help.xml
 foo2dir=$(prefix)/docs/html
 foo2_DATA=mris_smooth.help.xml.html
 
-TESTS=$(top_builddir)/scripts/help_xml_validate
+# trick to get test data into the build directory
+foo_SOURCES=
+foo:
+	if ! test -f "$(top_builddir)/mris_registetr/testdata.tar.gz"; then \
+		cp -v $(top_srcdir)/mris_registetr/testdata.tar.gz \
+					$(top_builddir)/mris_registetr/; fi;
+
+TESTS=$(top_builddir)/scripts/help_xml_validate test_fs_posix
 
 EXTRA_DIST=$(foo_DATA) $(BUILT_SOURCES)
 

--- a/mris_smooth/test_fs_posix
+++ b/mris_smooth/test_fs_posix
@@ -1,0 +1,67 @@
+#!/bin/tcsh -f
+
+# test_fs_posix
+# Paul Wighton 2017/05/16
+#
+# Script to test the behaviour of mris_register with and without the env var 
+# FS_POSIX set.  When FS_POSIX is set, and output filenames do not specify a 
+# path, the filename should resolve to the the current working directory 
+# (as per POSIX 4:11).  When FS_POSIX is not set and output filenames do not 
+# specify a path the filename should resolve to the directory of the input
+# surface file (legacy behviour)
+#
+
+#
+# extract test data
+#
+gunzip -c testdata.tar.gz | tar xvf -
+
+cd testdata
+mkdir -p outdir
+cd outdir
+
+set log = (../../test_fs_posix.log)
+if (-e $log) rm -f $log
+
+# Test legacy behaviour
+set cmd=(../../mris_smooth -n 1 -nw ../lh.orig.nofix lh.smoothwm.nofix)
+
+echo "\n\n $cmd \n\n" |& tee -a $log
+$cmd |& tee -a $log
+
+if ( $status != 0 ) then
+  echo "mris_smooth/test_fs_posix -- Legacy bahviour test: FAILED (status code is non-zero)" |& tee -a $log
+  exit 1
+endif
+if ( ! -f "../lh.smoothwm.nofix" ) then
+  echo "mris_smooth/test_fs_posix -- Legacy bahviour test: FAILED (output file in wrong place)" |& tee -a $log
+  exit 1
+endif
+
+echo "" |& tee -a $log
+echo "" |& tee -a $log
+echo "" |& tee -a $log
+
+# Test POSIX behaviour
+setenv FS_POSIX 1
+set cmd=(../../mris_smooth -n 1 -nw ../lh.orig.nofix lh.smoothwm.nofix)
+echo "\n\n $cmd \n\n" |& tee -a $log
+$cmd |& tee -a $log
+if ( $status != 0 ) then
+  echo "mris_smooth/test_fs_posix -- POSIX bahviour test: FAILED (status code is non-zero)" |& tee -a $log
+  exit 1
+endif
+if ( ! -f "./lh.smoothwm.nofix" ) then
+  echo "mris_smooth/test_fs_posix -- POSIX bahviour test: FAILED (output file in wrong place)" |& tee -a $log
+  exit 1
+endif
+
+#
+# cleanup
+#
+cd ../..
+rm -Rf testdata
+
+echo "" |& tee -a $log
+echo "test_fs_posix passed all tests" |& tee -a $log
+exit 0

--- a/mris_sphere/Makefile.am
+++ b/mris_sphere/Makefile.am
@@ -54,7 +54,7 @@ foo:
 
 check_PROGRAMS=foo
 
-TESTS=test_mris_sphere $(top_builddir)/scripts/help_xml_validate
+TESTS=test_mris_sphere test_fs_posix $(top_builddir)/scripts/help_xml_validate
 
 clean-local:
 	rm -f $(BUILT_SOURCES)

--- a/mris_sphere/test_fs_posix
+++ b/mris_sphere/test_fs_posix
@@ -46,6 +46,7 @@ echo "" |& tee -a $log
 echo "" |& tee -a $log
 
 # Test POSIX behaviour
+setenv FS_POSIX 1
 set cmd=(../../mris_sphere -seed 1234 ../rh.inflated rh.posix.sphere)
 echo "\n\n $cmd \n\n" |& tee -a $log
 $cmd |& tee -a $log

--- a/mris_sphere/test_fs_posix
+++ b/mris_sphere/test_fs_posix
@@ -1,0 +1,69 @@
+#!/bin/tcsh -f
+
+# test_fs_posix
+# Paul Wighton 2017/05/16
+#
+# Script to test the behaviour of mris_sphere with and without the env var 
+# FS_POSIX set.  When FS_POSIX is set, and output filenames do not specify a 
+# path, the filename should resolve to the the current working directory 
+# (as per POSIX 4:11).  When FS_POSIX is not set and output filenames do not 
+# specify a path the filename should resolve to the directory of the input
+# surface file (legacy behviour)
+#
+
+#
+# extract test data
+#
+gunzip -c testdata.tar.gz | tar xvf -
+
+cd testdata
+mkdir -p outdir
+cd outdir
+
+set log = (../../test_fs_posix.log)
+if (-e $log) rm -f $log
+
+pwd
+ls -l ../../mris_sphere
+
+# Test legacy behaviour
+set cmd=(../../mris_sphere -seed 1234 ../rh.inflated rh.posix.sphere)
+
+echo "\n\n $cmd \n\n" |& tee -a $log
+$cmd |& tee -a $log
+
+if ( $status != 0 ) then
+  echo "mris_sphere/test_fs_posix -- Legacy bahviour test: FAILED (status code is non-zero)" |& tee -a $log
+  exit 1
+endif
+if ( ! -f "../rh.posix.sphere" ) then
+  echo "mris_sphere/test_fs_posix -- Legacy bahviour test: FAILED (output file in wrong place)" |& tee -a $log
+  exit 1
+endif
+
+echo "" |& tee -a $log
+echo "" |& tee -a $log
+echo "" |& tee -a $log
+
+# Test POSIX behaviour
+set cmd=(../../mris_sphere -seed 1234 ../rh.inflated rh.posix.sphere)
+echo "\n\n $cmd \n\n" |& tee -a $log
+$cmd |& tee -a $log
+if ( $status != 0 ) then
+  echo "mris_sphere/test_fs_posix -- POSIX bahviour test: FAILED (status code is non-zero)" |& tee -a $log
+  exit 1
+endif
+if ( ! -f "./rh.posix.sphere" ) then
+  echo "mris_sphere/test_fs_posix -- POSIX bahviour test: FAILED (output file in wrong place)" |& tee -a $log
+  exit 1
+endif
+
+#
+# cleanup
+#
+cd ../..
+rm -Rf testdata
+
+echo "" |& tee -a $log
+echo "test_mris_sphere passed all tests" |& tee -a $log
+exit 0

--- a/mris_sphere/test_fs_posix
+++ b/mris_sphere/test_fs_posix
@@ -27,7 +27,7 @@ pwd
 ls -l ../../mris_sphere
 
 # Test legacy behaviour
-set cmd=(../../mris_sphere -seed 1234 ../rh.inflated rh.posix.sphere)
+set cmd=(../../mris_sphere -q -seed 1234 ../rh.inflated rh.posix.sphere)
 
 echo "\n\n $cmd \n\n" |& tee -a $log
 $cmd |& tee -a $log
@@ -47,7 +47,7 @@ echo "" |& tee -a $log
 
 # Test POSIX behaviour
 setenv FS_POSIX 1
-set cmd=(../../mris_sphere -seed 1234 ../rh.inflated rh.posix.sphere)
+set cmd=(../../mris_sphere -q -seed 1234 ../rh.inflated rh.posix.sphere)
 echo "\n\n $cmd \n\n" |& tee -a $log
 $cmd |& tee -a $log
 if ( $status != 0 ) then


### PR DESCRIPTION
Fix for [issue #82](https://github.com/freesurfer/freesurfer/issues/82)

This affects `mris_smooth`, `mris_jacobian`, `mris_inflate`, `mris_register` and `mris_sphere`.  When only an output filename is given, the path is resolved to the current working directory instead of the directory of the input surface file.  This change in behavior only occurs when the FS_POSIX environment varible is set.

The test for `mris_sphere` uses the existing testdata.tar.gz.  A test for mris_regsiter is not included (takes a long time).  Test data for the other 3 binaries can be found here

- `mris_inflate`
  - https://gate.nmr.mgh.harvard.edu/filedrop2/index.php?p=8ust1f3db34
- `mris_jacobian`
  - https://gate.nmr.mgh.harvard.edu/filedrop2/index.php?p=7eui1tma1px
- `mris_smooth`
  - https://gate.nmr.mgh.harvard.edu/filedrop2/index.php?p=3runbk7dp4n

To test:

### Testing `mris_sphere`
```
cd ./mris_sphere
make check
```

### Testing `mris_inflate`
```
cd ./mris_inflate
curl -o ./testdata.tar.gz https://gate.nmr.mgh.harvard.edu/filedrop2/index.php?p=8ust1f3db34
make check
```

### Testing `mris_jacobian`
```
cd ./mris_jacobian
curl -o ./testdata.tar.gz https://gate.nmr.mgh.harvard.edu/filedrop2/index.php?p=7eui1tma1px
make check
```
### Testing  `mris_smooth`
```
cd ./mris_smooth
curl -o ./testdata.tar.gz https://gate.nmr.mgh.harvard.edu/filedrop2/index.php?p=3runbk7dp4n
make check
```