### PR TITLE
write out surf volume ?h cmd to log files

### DIFF
--- a/scripts/recon-all
+++ b/scripts/recon-all
@@ -4394,6 +4394,7 @@ if($DoPialSurfs || $DoT2pial || $DoFLAIRpial || $DoSurfVolume) then
     cd $subjdir/surf > /dev/null
     $PWD |& tee -a $LF
     set cmd = (vertexvol --s $subjid --$hemi -$TH3Opt)
+    echo "\n $cmd \n"|& tee -a $LF |& tee -a $CF
     if($RunIt) $fs_time $cmd |& tee -a $LF
     if($status) goto error_exit;
     echo $cmd > $touchdir/$hemi.surfvolume.touch


### PR DESCRIPTION
Before this, the `recon-all.cmd` file was blank for the `-surfvolume` step:
```
#--------------------------------------------
#@# Surf Volume lh Wed Jan 18 23:26:30 EST 2017
#--------------------------------------------
#@# Surf Volume rh Wed Jan 18 23:26:33 EST 2017
```
Now the commands are written out:
```
#--------------------------------------------
#@# Surf Volume lh Fri Jun  2 17:09:27 EDT 2017

 vertexvol --s sub-02 --lh --th3 

#--------------------------------------------
#@# Surf Volume rh Fri Jun  2 17:09:27 EDT 2017

 vertexvol --s sub-02 --rh --th3 
```
I tested this running `recon-all -dontrun` to see the cmd file has the correct info written out
