### PR TITLE
Extra Unit Tests for VisitCounter

### DIFF
--- a/GEMS2/CMakeLists.txt
+++ b/GEMS2/CMakeLists.txt
@@ -34,7 +34,7 @@ OPTION( BUILD_GUI "Build GUI components (requires FLTK and VTK)" OFF )
 OPTION( BUILD_MATLAB "Build Matlab wrappers" OFF )
 
 # Enable C++11 syntax
-SET(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "-g -std=c++11 ${CMAKE_CXX_FLAGS}")
 
 # Find CUDA
 FIND_PACKAGE( CUDA )

--- a/GEMS2/Testing/testatlasmeshvisitcounter.cpp
+++ b/GEMS2/Testing/testatlasmeshvisitcounter.cpp
@@ -421,6 +421,20 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( NoVerticesGPUSimple, ImplType, SimpleCUDAImplType
  
   NoVertices( &visitCounter );
 }
+
+BOOST_AUTO_TEST_CASE_TEMPLATE( LowerCornerExactGPUSimple, ImplType, SimpleCUDAImplTypes )
+{
+  ImplType visitCounter;
+ 
+  LowerCornerExact( &visitCounter );
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE( UpperCornerExactGPUSimple, ImplType, SimpleCUDAImplTypes )
+{
+  ImplType visitCounter;
+ 
+  UpperCornerExact( &visitCounter );
+}
 #endif
 
 

--- a/GEMS2/Testing/testatlasmeshvisitcounter.cpp
+++ b/GEMS2/Testing/testatlasmeshvisitcounter.cpp
@@ -378,20 +378,6 @@ void GenerateSpecificCornerTetrahedron( float verts[nVertices][nDims], const uns
   }
 }
 
-const ImageType* GetImageOnUnitCube( kvl::AtlasMesh::Pointer targetMesh,
-				     kvl::interfaces::AtlasMeshVisitCounter* visitCounter ) {
-  const int imageSize = 2;
-  
-  ImageType::Pointer image = CreateImageCube( imageSize, 0 );
-  BOOST_TEST_CHECKPOINT("Image created");
-  
-  visitCounter->SetRegions( image->GetLargestPossibleRegion() );
-  visitCounter->VisitCount( targetMesh );
-  BOOST_TEST_CHECKPOINT("VisitCounter complete");
-  
-  return visitCounter->GetImage();
-}
-
 ImageType::ConstPointer ApplyVisitCounterToMesh( kvl::interfaces::AtlasMeshVisitCounter* visitCounter,
 						 const ImageType* targetImage,
 						 Mesh::Pointer targetMesh ) {

--- a/GEMS2/Testing/testatlasmeshvisitcounter.cpp
+++ b/GEMS2/Testing/testatlasmeshvisitcounter.cpp
@@ -573,6 +573,13 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( UpperCornerExactGPUSimple, ImplType, SimpleCUDAIm
  
   UpperCornerExact( &visitCounter );
 }
+
+BOOST_AUTO_TEST_CASE_TEMPLATE( AutoCornersGPUSimple, ImplType, SimpleCUDAImplTypes )
+{
+  ImplType visitCounter;
+ 
+  AutoCorners( &visitCounter );
+}
 #endif
 
 


### PR DESCRIPTION
Adding extra tests for VisitCounter, which systematically create tetrahedra in a variety of orientations and check edge cases for the 'inside tetrahedron' function
Add special cases to the simple GPU visit counter
Unfortunately, lots of these tests are currently failing