### PR TITLE
VisitCounter Unit Tests 08

### DIFF
--- a/GEMS2/Testing/testatlasmeshvisitcounter.cpp
+++ b/GEMS2/Testing/testatlasmeshvisitcounter.cpp
@@ -559,7 +559,7 @@ BOOST_AUTO_TEST_CASE( AutoCornersLargeImageLargeTetrahedronCPU )
   kvl::AtlasMeshVisitCounterCPUWrapper visitCounter;
 
   // Generate large tetrahedron on large cube
-  AutoCorners( &visitCounter, 3, 3  );
+  AutoCorners( &visitCounter, 4, 4  );
 }
 
 #ifdef CUDA_FOUND
@@ -631,11 +631,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( AutoCornersLargeImageLargeTetrahedronGPUSimple, I
   ImplType visitCounter;
 
   // Generate large tetrahedron on large cube
-  AutoCorners( &visitCounter, 3, 3  );
+  AutoCorners( &visitCounter, 4, 4  );
 }
 #endif
 
-BOOST_DATA_TEST_CASE( ConsistencyCheck, boost::unit_test::data::xrange(1,7), scale )
+BOOST_DATA_TEST_CASE( ConsistencyCheck, boost::unit_test::data::xrange(1,2), scale )
 {
   kvl::AtlasMeshVisitCounterCPUWrapper visitCounter;
 

--- a/GEMS2/cuda/cudaimage.hpp
+++ b/GEMS2/cuda/cudaimage.hpp
@@ -158,6 +158,10 @@ namespace kvl {
 	return this->dims;
       }
 
+      size_t ElementCount() const {
+	return this->dims.ElementCount();
+      }
+
       cudaExtent GetCudaExtent() const {
 	// Creates the CudaExtent from the dims
 	cudaExtent res;
@@ -168,7 +172,7 @@ namespace kvl {
 	if( nDims >= 2 ) {
 	  res.height = this->dims[nDims-2];
 	  
-	  for( int i=0; i<nDims-2; i++ ) {
+	  for( unsigned char i=0; i<nDims-2; i++ ) {
 	    res.depth *= this->dims[i];
 	  }
 	}

--- a/GEMS2/cuda/visitcountersimplecudaimpl.cu
+++ b/GEMS2/cuda/visitcountersimplecudaimpl.cu
@@ -250,8 +250,8 @@ namespace kvl {
 			     const CudaImage<T,3,size_t>& d_tetrahedra ) {
       const unsigned int nBlockx = 1024;
 
-      const unsigned int nThreadsx = 32;
-      const unsigned int nThreadsy = 32;
+      const unsigned int nThreadsx = 16;
+      const unsigned int nThreadsy = 16;
       const unsigned int nThreadsz = 1;
 
       dim3 grid, threads;

--- a/GEMS2/cuda/visitcountersimplecudaimpl.cu
+++ b/GEMS2/cuda/visitcountersimplecudaimpl.cu
@@ -251,8 +251,8 @@ namespace kvl {
 
       // Compute the average number of voxels in each tetrahedron
       const float avgTetVol = nVoxels / nTetrahedra;
-      // Compute the equivalent average cube
-      const float avgCubeSize = powf( avgTetVol, 0.3333333f );
+      // Compute the equivalent average cube (factor of 6 to get volume of bounding box)
+      const float avgCubeSize = powf( 6 * avgTetVol, 0.3333333f );
 
       // Check to see if we need to increase blockSize
       if( avgCubeSize > 32 ) {

--- a/GEMS2/cuda/visitcountersimplecudaimpl.cu
+++ b/GEMS2/cuda/visitcountersimplecudaimpl.cu
@@ -245,18 +245,38 @@ void SimpleVisitCounterKernel( kvl::cuda::Image_GPU<int,3,unsigned short> output
 
 namespace kvl {
   namespace cuda {
+
+    unsigned int GetBlockSize( const size_t nVoxels, const size_t nTetrahedra ) {
+      unsigned int blockSize = 8;
+
+      // Compute the average number of voxels in each tetrahedron
+      const float avgTetVol = nVoxels / nTetrahedra;
+      // Compute the equivalent average cube
+      const float avgCubeSize = powf( avgTetVol, 0.3333333f );
+
+      // Check to see if we need to increase blockSize
+      if( avgCubeSize > 32 ) {
+	blockSize = 16;
+	if( avgCubeSize > 64 ) {
+	  blockSize = 32;
+	}
+      }
+      return blockSize;
+    }
+
     template<typename T,typename Internal>
     void SimpleVisitCounter( CudaImage<int,3,unsigned short>& d_output,
 			     const CudaImage<T,3,size_t>& d_tetrahedra ) {
       const unsigned int nBlockx = 1024;
 
-      const unsigned int nThreadsx = 16;
-      const unsigned int nThreadsy = 16;
+      const size_t nTetrahedra = d_tetrahedra.GetDimensions()[0];
+
+      const unsigned int nThreadsx = GetBlockSize( d_output.ElementCount(), nTetrahedra );
+      const unsigned int nThreadsy = GetBlockSize( d_output.ElementCount(), nTetrahedra );
       const unsigned int nThreadsz = 1;
 
       dim3 grid, threads;
 
-      const size_t nTetrahedra = d_tetrahedra.GetDimensions()[0];
       
       if( nTetrahedra > nBlockx ) {
 	grid.x = nBlockx;


### PR DESCRIPTION
Update 'large tetrahedron' tests after consideration of floating point issues
Dynamically compute the block size to use in the CUDA kernel, based on the average tetrahedron size