### PR TITLE
bugfix: initialized x y z to 0

### DIFF
--- a/utils/label.c
+++ b/utils/label.c
@@ -4032,6 +4032,7 @@ LabelAddVoxel(LABEL *area, int xv, int yv, int zv, int coords, int *vertices, in
   double  min_dist, dist, x, y, z, vx, vy, vz, dx, dy, dz ;
   VERTEX    *v ;
 
+  x = y = z = 0 ;  // quick bug fix. should review whether code is correct
 
   if (pnvertices)
     *pnvertices = 0 ;


### PR DESCRIPTION
a quick fix to suppress the uninitialized warning preventing builds on centOS6... though this error might highlight an actual bug