### PR TITLE
recon-all -T2pial exits with error because aseg.mgz is not found.

### DIFF
--- a/scripts/recon-all
+++ b/scripts/recon-all
@@ -4346,7 +4346,7 @@ if($DoT2pial || $DoFLAIRpial) then
         -orig_white white \
         -orig_pial wo${t2flair}.pial)
     if ($UseAseg) then
-      set cmd = ($cmd -aseg ../mri/aseg)
+      set cmd = ($cmd -aseg ../mri/aseg.presurf)
     else
       set cmd = ($cmd -noaseg)
     endif


### PR DESCRIPTION
`aseg.mgz` is created at the later stage, therefore `aseg.presurf` is necessary to use here instead.