### PR TITLE
bugfix: disabled openmp for gcc 4.4

### DIFF
--- a/mris_watershed/mris_watershed.c
+++ b/mris_watershed/mris_watershed.c
@@ -364,7 +364,8 @@ MRISfindMostSimilarBasins(MRI_SURFACE *mris, MRI *mri, int *pb2)
     memset(nbr_vertices, 0, nbasins*sizeof(*nbr_vertices)) ;
     memset(avg_grad, 0, nbasins*sizeof(*avg_grad)) ;
     max_basin = 0 ;
-#ifdef HAVE_OPENMP
+// reductions for min and max aren't available in earlier openmp
+#if defined(HAVE_OPENMP) && GCC_VERSION > 40408
 #pragma omp parallel for reduction(max:max_basin)
 #endif
     for (vno = 0 ;  vno < mris->nvertices ; vno++)


### PR DESCRIPTION
The openmp version associated with gcc 4.4 doesn’t support reductions for `max` - based on [this thread](http://forum.openmp.org/forum/viewtopic.php?f=3&t=781)