### PR TITLE
Nf bevin performance improvements

### DIFF
--- a/include/matrix.h
+++ b/include/matrix.h
@@ -52,7 +52,7 @@ typedef struct
 MATRIX, VECTOR ;
 
 
-#ifdef BEVIN
+#ifdef BEVIN_SERIAL
 typedef struct		// This case is so important it should be optimized 
 {
   float x,y,z;
@@ -196,7 +196,7 @@ MATRIX *MatrixReadFrom(FILE *fp, MATRIX *m) ;
 #define VECTOR_LOAD   VECTOR3_LOAD
 #define V3_LOAD       VECTOR3_LOAD
 
-#ifdef BEVIN
+#ifdef BEVIN_SERIAL
 #include <math.h>
 #include "macros.h"
 

--- a/include/matrix.h
+++ b/include/matrix.h
@@ -51,6 +51,15 @@ typedef struct
 }
 MATRIX, VECTOR ;
 
+
+#ifdef BEVIN
+typedef struct		// This case is so important it should be optimized 
+{
+  float x,y,z;
+} XYZ;
+#endif
+
+
 typedef struct
 {
   float  real ;
@@ -186,6 +195,39 @@ MATRIX *MatrixReadFrom(FILE *fp, MATRIX *m) ;
                                   VECTOR_ELT(v,3)=z) ;
 #define VECTOR_LOAD   VECTOR3_LOAD
 #define V3_LOAD       VECTOR3_LOAD
+
+#ifdef BEVIN
+#include <math.h>
+#include "macros.h"
+
+#define XYZ_LOAD(v,x,y,z)             do { XYZ* xyz = &v; xyz.x=x, xyz.y=y, xyz.z=z; } while 0
+static void XYZ_NORMALIZED_LOAD(XYZ* xyz, float* xyz_length, float x, float y, float z)
+{
+  float len = *xyz_length =
+	   sqrt(
+	       (double)x*(double)x +
+	       (double)y*(double)y +
+	       (double)z*(double)z);
+	       
+  if (len == 0.0f)
+  {
+    xyz->x = 1.0f;
+    xyz->y = 0.0f;
+    xyz->z = 0.0f;
+  } else
+  {
+    float len_inv = 1.0f / len;
+    xyz->x = x * len_inv;
+    xyz->y = y * len_inv;
+    xyz->z = z * len_inv;
+  }
+} 
+
+
+float XYZApproxAngle(XYZ const * normalizedXYZ, float x2, float y2, float z2);
+
+#endif
+
 
 double Vector3Angle(VECTOR *v1, VECTOR *v2) ;
 float  VectorLen( const VECTOR *v ) ;

--- a/mris_diff/mris_diff.c
+++ b/mris_diff/mris_diff.c
@@ -263,7 +263,7 @@ static const char* printHistograms() {
   //	99%   should be within 1
   //
   const double vertexRequiredFit[9] = {0.0, 0.0, 0.0, 0.05, 0.1, 0.5, 0.95, 0.99, -1};
-  const double otherRequiredFit [9] = {0.2, 0.7, 0.95, 0.99, -1};
+  const double otherRequiredFit [9] = {0.2, 0.6, 0.95, 0.99, -1};
   
   printOneHistogram(&vertexXyzHistogram   , "vertex xyz"   , vertexRequiredFit, &badHistogram);
   printOneHistogram(&vertexNxnynzHistogram, "vertex nxnynz", otherRequiredFit,  &badHistogram);

--- a/mris_diff/mris_diff.c
+++ b/mris_diff/mris_diff.c
@@ -262,8 +262,8 @@ static const char* printHistograms() {
   // 	95%   should be within 0.09
   //	99%   should be within 1
   //
-  const double vertexRequiredFit[9] = {0.0, 0.0, 0.0, 0.05, 0.1, 0.5, 0.9, 0.99, -1};
-  const double otherRequiredFit [9] = {0.1, 0.5, 0.9, 0.99, -1};
+  const double vertexRequiredFit[9] = {0.0, 0.0, 0.0, 0.05, 0.1, 0.5, 0.95, 0.99, -1};
+  const double otherRequiredFit [9] = {0.2, 0.7, 0.95, 0.99, -1};
   
   printOneHistogram(&vertexXyzHistogram   , "vertex xyz"   , vertexRequiredFit, &badHistogram);
   printOneHistogram(&vertexNxnynzHistogram, "vertex nxnynz", otherRequiredFit,  &badHistogram);

--- a/mris_sphere/mris_sphere.c
+++ b/mris_sphere/mris_sphere.c
@@ -208,7 +208,7 @@ main(int argc, char *argv[])
   int n_omp_threads = 1;
 #pragma omp parallel
   { 
-    n_omp_threads = omp_get_num_threads(); 
+    n_omp_threads = omp_get_max_threads(); 
   }
   printf("\n== Number of threads available to %s for OpenMP = %d == \n",
          Progname, n_omp_threads);
@@ -425,7 +425,7 @@ main(int argc, char *argv[])
           (float)msec/(1000.0f*60.0f*60.0f));
   // Output formatted so it can be easily grepped
 #ifdef HAVE_OPENMP
-  n_omp_threads = omp_get_num_threads();
+  n_omp_threads = omp_get_max_threads();
   printf("FSRUNTIME@ mris_sphere %7.4f hours %d threads\n",msec/(1000.0*60.0*60.0),n_omp_threads);
 #else
   printf("FSRUNTIME@ mris_sphere %7.4f hours %d threads\n",msec/(1000.0*60.0*60.0),1);

--- a/mris_sphere/mris_sphere.c
+++ b/mris_sphere/mris_sphere.c
@@ -421,7 +421,7 @@ main(int argc, char *argv[])
   if(rusage_file) WriteRUsage(RUSAGE_SELF, "", rusage_file);
 
   msec = TimerStop(&then) ;
-  fprintf(stderr, "spherical transformation took %2.2f hours\n",
+  fprintf(stderr, "spherical transformation took %2.4f hours\n",
           (float)msec/(1000.0f*60.0f*60.0f));
   // Output formatted so it can be easily grepped
 #ifdef HAVE_OPENMP

--- a/utils/matrix.c
+++ b/utils/matrix.c
@@ -2830,7 +2830,7 @@ Vector3Angle(VECTOR *v1, VECTOR *v2)
   return(angle) ;
 }
 
-#ifdef BEVIN
+#ifdef BEVIN_SERIAL
 float XYZApproxAngle(XYZ const * normalizedXYZ, float x2, float y2, float z2) {
 
   double x1 = normalizedXYZ->x;

--- a/utils/mri_tess.c
+++ b/utils/mri_tess.c
@@ -43,7 +43,9 @@
 
 extern const char* Progname;
 
+#ifndef SQR	// BEVIN - the header files might include the one that defines SQR
 #define SQR(x) ((x)*(x))
+#endif
 
 #define MAXFACES    3000000
 #define MAXVERTICES 1500000


### PR DESCRIPTION
These changes were tested by comparing the ../surf/lh.qsphere.nofix output file from the command

    mris_sphere/mris_sphere -seed 1234 -O smoothwm.nofix ../surf/lh.inflated.nofix ../surf/lh.qsphere.nofix

BEVIN is a macro that turn on some additional or changed OMP parallelism.
Using the default gcc build, these changes reduce the execution time on a quad core i7 from 0.5 hours to 0.44 hours

BEVIN_SERIAL is a macro that turns on some changes to the most expensive serial code.
Using the default gcc build, these changes reduce the execution time on a quad core i7 from 0.5 hours to 0.35 hours

The combined BEVIN and BEVIN_SERIAL changes reduce the time to 0.29 hours

BEVIN_IMPLEMENTATION in mris_diff.c changes to do a different comparison of surfaces that detects whether they are similar enough rather than identical.   It produces histograms of the sizes of the changes and has builtin numbers for whether the number of changes of each size is acceptable.  This is necessary because the algorithm is numerically unstable, and merely changing compilers or compiler versions can cause it to get slightly different results.