### PR TITLE
The function returns a pointer, return false should be return NULL

### DIFF
--- a/freeview/RenderView3D.cpp
+++ b/freeview/RenderView3D.cpp
@@ -1108,7 +1108,7 @@ SurfaceROI* RenderView3D::InitializeSurfaceROI( int posX, int posY )
 
   if ( !surf )
   {
-    return false;
+    return NULL;
   }
 
   lc_surf->SetActiveLayer( surf );


### PR DESCRIPTION
The function returns a pointer, not a boolean.

Prior to this fix, this specific return returned false rather than NULL which has the same 'zero' value but gcc 7.2 is complaining about it.