### PR TITLE
Some performance improvements

### DIFF
--- a/include/matrix.h
+++ b/include/matrix.h
@@ -52,12 +52,10 @@ typedef struct
 MATRIX, VECTOR ;
 
 
-#ifdef BEVIN_SERIAL
 typedef struct		// This case is so important it should be optimized 
 {
   float x,y,z;
 } XYZ;
-#endif
 
 
 typedef struct
@@ -196,7 +194,6 @@ MATRIX *MatrixReadFrom(FILE *fp, MATRIX *m) ;
 #define VECTOR_LOAD   VECTOR3_LOAD
 #define V3_LOAD       VECTOR3_LOAD
 
-#ifdef BEVIN_SERIAL
 #include <math.h>
 #include "macros.h"
 
@@ -225,8 +222,6 @@ static void XYZ_NORMALIZED_LOAD(XYZ* xyz, float* xyz_length, float x, float y, f
 
 
 float XYZApproxAngle(XYZ const * normalizedXYZ, float x2, float y2, float z2);
-
-#endif
 
 
 double Vector3Angle(VECTOR *v1, VECTOR *v2) ;

--- a/utils/matrix.c
+++ b/utils/matrix.c
@@ -2830,7 +2830,6 @@ Vector3Angle(VECTOR *v1, VECTOR *v2)
   return(angle) ;
 }
 
-#ifdef BEVIN_SERIAL
 float XYZApproxAngle(XYZ const * normalizedXYZ, float x2, float y2, float z2) {
 
   double x1 = normalizedXYZ->x;
@@ -2903,7 +2902,6 @@ float XYZApproxAngle(XYZ const * normalizedXYZ, float x2, float y2, float z2) {
   
   return(angle) ;
 }
-#endif
 
 int
 MatrixWriteTxt(const char *fname, MATRIX *mat)


### PR DESCRIPTION
Remove the conditionals, since this code will pass with the pulled mris_diff

There are two basic ideas enabled here.   

1: normalize a vector once to simplify its repeated usage.  

2:  calculate the angle using a quadratic approximation for arccos(x) when x is very close to 1.0, which is almost always the case for our usage. 