### PR TITLE
travis reporting log tail when compile fails, but skip tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,6 @@ script:
   - ./setup_configure
   - ./configure --prefix=/usr/local/freesurfer/dev --with-pkgs-dir=${PWD}/centos6-x86_64-packages --disable-Werror --disable-GUI-build
   - travis_wait 40 ./travis_make.sh || travis_terminate 1
-  - tail -n 20 build.log
   # run tests
   - if [[ "$TESTS" != "" ]]; then travis_wait 60 ./run_selected_tests ; fi
 

--- a/travis_make.sh
+++ b/travis_make.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-set -ex
+#set -ex
 
 make -j4 >& build.log
-
+EXITSTATUS=$?
+tail -n 20 build.log
+exit $EXITSTATUS


### PR DESCRIPTION
Moved log tail command into travis_make script: 
-tail of log was not printed when compilation failed (and especially then we'd like to see the tail)
- now we always print the tail of log and return the exitstatus of the make command
- this way we can still terminate the process and skip testing after compile failure
(I could not test this, as compilation always worked for me. For working compile, the behaviour is as expected).