### PR TITLE
Add more python 3 compatibility

### DIFF
--- a/scripts/aparcstats2table
+++ b/scripts/aparcstats2table
@@ -377,14 +377,14 @@ if __name__=="__main__":
             parc_measure_map = parsed.parse(options.meas)
             l.debug('-- Parsed Parcs and Measures --')
             l.debug(parc_measure_map)
-        except BadFileError, e:
+        except BadFileError as e:
             if options.skipflag:
                 print('Skipping ' + str(e))
                 continue
             else:
                 print("");
                 if(not os.path.exists(str(e))):
-                    print('ERROR: Cannot find stats file '+str(e);)
+                    print('ERROR: Cannot find stats file '+str(e))
                 else:
                     print('ERROR: The stats file '+str(e)+' is too small to be a valid statsfile')
                     print('Use --skip flag to automatically skip bad stats files')

--- a/scripts/asegstats2table
+++ b/scripts/asegstats2table
@@ -431,14 +431,14 @@ def sanitize_table(options, disorganized_table):
     if pl_ids:
         tmp_pl_ids = pl_ids.copy()
         itmp_pl_ids = tmp_pl_ids.iteritems()
-        plid,plname = itmp_pl_ids.next()
+        plid,plname = next(itmp_pl_ids)
         try:
             for _spec, _id_name_map, _measl in _t:
                 for _id in _id_name_map.keys():
                     if _id == plid:
                         if _id_name_map[plid] != 'Placeholder_Segmentation':
                             pl_ids[plid] = _id_name_map[plid]
-                            plid,plname = itmp_pl_ids.next()
+                            plid,plname = next(itmp_pl_ids)
         except StopIteration:
             pass
 
@@ -551,7 +551,7 @@ if __name__=="__main__":
             l.debug(id_name_map)
             l.debug('-- Measures --')
             l.debug(measurelist)
-        except BadFileError, e:
+        except BadFileError as e:
             if options.skipflag:
                 print('Skipping ' + str(e))
                 continue

--- a/scripts/datastruct_utils.py
+++ b/scripts/datastruct_utils.py
@@ -22,7 +22,7 @@ class Ddict(dict):
         self.default = default
 
     def __getitem__(self, key):
-        if not self.has_key(key):
+        if key not in self:
             self[key] = self.default()
         return dict.__getitem__(self, key)
 

--- a/scripts/long_mris_slopes
+++ b/scripts/long_mris_slopes
@@ -658,7 +658,7 @@ if __name__=="__main__":
         slopelogger.debug('Processing file ' + options.qdec)
         qdectable = LongQdecTable(options.qdec)
         #subjects_tp_map, variables, subjectdir = qdecparse.parse()
-    except BadFileError, e:
+    except BadFileError as e:
         print('ERROR: qdec table '+options.qdec+' not found or empty?')
         sys.exit(1)
     
@@ -704,7 +704,7 @@ if __name__=="__main__":
     if subjectsdir is None:
         subjectsdir = qdectable.subjectsdir
     if subjectsdir is None:
-        print'\nERROR: no subjects dir specified, use --sd <fullpath>'
+        print('\nERROR: no subjects dir specified, use --sd <fullpath>')
         sys.exit(1)
     print('\nWorking in SUBJECTS_DIR: '+subjectsdir+'\n')
     os.environ['SUBJECTS_DIR'] =  subjectsdir

--- a/scripts/long_qdec_table
+++ b/scripts/long_qdec_table
@@ -141,7 +141,7 @@ if __name__=="__main__":
         mylogger.debug('Processing file ' + options.qdec)
         longqdec = LongQdecTable(options.qdec)
 #        subjects_tp_map, variables, subjectdir = qdecparse.parse()
-    except BadFileError, e:
+    except BadFileError as e:
         print('ERROR: qdec table '+str(e)+' not found or wrong format!')
         sys.exit(1)
     

--- a/scripts/long_stats_combine
+++ b/scripts/long_stats_combine
@@ -225,7 +225,7 @@ if __name__=="__main__":
         slopelogger.debug('Processing file ' + options.qdec)
         qdectable = LongQdecTable(options.qdec)
         #subjects_tp_map, variables, subjectdir = qdecparse.parse()
-    except BadFileError, e:
+    except BadFileError as e:
         print('ERROR: qdec table '+str(e)+' not found!')
         sys.exit(1)
     

--- a/scripts/long_stats_slopes
+++ b/scripts/long_stats_slopes
@@ -346,7 +346,7 @@ if __name__=="__main__":
         slopelogger.debug('Processing file ' + options.qdec)
         qdectable = LongQdecTable(options.qdec)
         #subjects_tp_map, variables, subjectdir = qdecparse.parse()
-    except BadFileError, e:
+    except BadFileError as e:
         print('ERROR: qdec table '+str(e)+' not found!')
         sys.exit(1)
         

--- a/scripts/long_stats_tps
+++ b/scripts/long_stats_tps
@@ -215,7 +215,7 @@ if __name__=="__main__":
         slopelogger.debug('Processing file ' + options.qdec)
         qdectable = LongQdecTable(options.qdec)
         #subjects_tp_map, variables, subjectdir = qdecparse.parse()
-    except BadFileError, e:
+    except BadFileError as e:
         print('ERROR: qdec table '+str(e)+' not found!')
         sys.exit(1)
     

--- a/scripts/long_submit_jobs
+++ b/scripts/long_submit_jobs
@@ -99,7 +99,7 @@ def submit(fname,nodes,mem,queue):
     args = shlex.split(pbcmd)
     try:
         retcode = subprocess.call(args)
-    except OSError, e:
+    except OSError as e:
         print("job submission failed:", e )
         sys.exit(1)
         
@@ -128,7 +128,7 @@ def wait_jobs(maxjobs):
         #  first try if qstat can be run:
         try:
             p1 = subprocess.Popen(["qstat"], stdout=subprocess.PIPE)
-        except OSError, e:
+        except OSError as e:
             print("qstat execution failed:", e )
             return
         # concat with grep
@@ -548,7 +548,7 @@ def run_cross(qdectable,options):
                         
             # check if cross dir exists:
             if not os.path.exists(os.path.join(options.cdir,tpid)):
-                print("ERROR [cross]: "+tpid+" does not exist in "+options.cdir+"\n";)
+                print("ERROR [cross]: "+tpid+" does not exist in "+options.cdir+"\n")
                 notexist.append( (subjectid,tpid) )
                 if options.simulate:
                     continue
@@ -578,7 +578,7 @@ def run_cross(qdectable,options):
             # check if read/write access:
             tpcdir = os.path.join(options.cdir,tpid)
             if not os.access(tpcdir,os.R_OK) or not os.access(tpcdir,os.X_OK) or not os.access(tpcdir,os.W_OK):
-                print("ERROR [cross]: "+tpid+" no rwx rights "+options.cdir+"\n";)
+                print("ERROR [cross]: "+tpid+" no rwx rights "+options.cdir+"\n")
                 norights.append( (subjectid,tpid) )
                 if options.simulate:
                     continue
@@ -655,7 +655,7 @@ def run_base(qdectable,options):
 
         basedir   = os.path.join(options.bdir,subjectid)
         if os.path.exists(basedir) and not ( os.access(basedir,os.R_OK) and os.access(basedir,os.X_OK)and os.access(basedir,os.W_OK)):
-            print("ERROR [base]: "+subjid+" missing rwx rights in "+options.bdir+"\n";)
+            print("ERROR [base]: "+subjid+" missing rwx rights in "+options.bdir+"\n")
             norightsB.append( subjectid )
             if options.simulate:
                 continue
@@ -693,8 +693,8 @@ def run_base(qdectable,options):
             status = check_file(options.cdir,tpid,requirement)
             
             if status >= 2: # not there and not running:
-                print("ERROR [base]: "+tpid+" ("+crossdepend+") does not exist or not readable in "+options.cdir;)
-                print("               and no IsRunning.lh+rh found!\n";)
+                print("ERROR [base]: "+tpid+" ("+crossdepend+") does not exist or not readable in "+options.cdir)
+                print("               and no IsRunning.lh+rh found!\n")
                 notexist.append( (subjectid,tpid) )
                 if options.simulate:
                     continue # check other time points
@@ -716,14 +716,14 @@ def run_base(qdectable,options):
     
             #if simulate don't wait or create links
             if options.simulate:
-                continue;
+                continue
 
             # wait for crossdepend in cross dirs
             tpincdir =  os.path.join(options.cdir,tpid)
             status = wait_file(options.cdir,tpid,requirement,60)
             if status >= 2: # not there and not running:
-                print("ERROR [base]: "+tpid+" ("+crossdepend+") does not exist or not readable in "+options.cdir;)
-                print("               and no IsRunning.lh+rh found!\n";)
+                print("ERROR [base]: "+tpid+" ("+crossdepend+") does not exist or not readable in "+options.cdir)
+                print("               and no IsRunning.lh+rh found!\n")
                 notexist.append( (subjectid,tpid) )
                 if options.simulate:
                     continue # check other time points
@@ -826,8 +826,8 @@ def run_long(qdectable,options):
         status = check_file(options.bdir,subjectid,requirement)
             
         if status >= 2: # not there and not running:
-            print("ERROR [long]: "+subjectid+" not complete (or not readable) in "+options.bdir;)
-            print("               and no IsRunning.lh+rh found!\n";)
+            print("ERROR [long]: "+subjectid+" not complete (or not readable) in "+options.bdir)
+            print("               and no IsRunning.lh+rh found!\n")
             nobase.append( subjectid )
             if options.skip > 0:
                 print("  ... skipping instead of exit ...")
@@ -845,8 +845,8 @@ def run_long(qdectable,options):
             if not options.simulate:
                 status = wait_file(options.bdir,subjectid,requirement,60)
                 if status >= 2: # not there and not running anymore:
-                    print("ERROR [long]: "+subjectid+" not complete (or not readable) in "+options.bdir;)
-                    print("               and no IsRunning.lh+rh found!\n";)
+                    print("ERROR [long]: "+subjectid+" not complete (or not readable) in "+options.bdir)
+                    print("               and no IsRunning.lh+rh found!\n")
                     nobase.append( subjectid )
                     if options.skip > 0:
                         print("  ... skipping instead of exit ...")
@@ -874,8 +874,8 @@ def run_long(qdectable,options):
             status = check_file(options.cdir,tpid,requirement)
 
             if status >= 2: # not there and not running:
-                print("ERROR [long]: "+tpid+" ("+crossdepend+") does not exist or not readable in "+options.cdir;)
-                print("               and no IsRunning.lh+rh found!\n";)
+                print("ERROR [long]: "+tpid+" ("+crossdepend+") does not exist or not readable in "+options.cdir)
+                print("               and no IsRunning.lh+rh found!\n")
                 notexist.append( (subjectid,tpid) )
                 if options.simulate:
                     continue # check other time points
@@ -896,13 +896,13 @@ def run_long(qdectable,options):
                 
             #if simulate don't wait or create links
             if options.simulate:
-                continue;
+                continue
 
             # wait for requirement in cross dirs
             status = wait_file(options.cdir,tpid,requirement,60)
             if status >= 2: # not there and not running:
-                print("ERROR [long]: "+tpid+" ("+crossdepend+") does not exist or not readable in "+options.cdir;)
-                print("               and no IsRunning.lh+rh found!\n";)
+                print("ERROR [long]: "+tpid+" ("+crossdepend+") does not exist or not readable in "+options.cdir)
+                print("               and no IsRunning.lh+rh found!\n")
                 notexist.append( (subjectid,tpid) )
                 if options.simulate:
                     continue # check other time points
@@ -950,7 +950,7 @@ def run_long(qdectable,options):
                 
             tpiddir = os.path.join(options.ldir,tpid+".long."+subjectid)
             if os.path.exists(tpiddir) and not (os.access(tpiddir,os.R_OK) and os.access(tpiddir,os.X_OK) and os.access(tpiddir,os.W_OK)):
-                print("ERROR [long]: "+tpid+".long."+subjectid+" missing rwx rights in "+options.ldir+"\n";)
+                print("ERROR [long]: "+tpid+".long."+subjectid+" missing rwx rights in "+options.ldir+"\n")
                 norights.append( (subjectid,tpid) )
                 if options.simulate:
                     continue
@@ -1012,10 +1012,10 @@ def check_long(qdectable,options):
         print('[CHECK] Subject: '+subjectid+'\n')
 
         # check / wait for ALL norm.mgz in cross tps
-        done = 0;
+        done = 0
         for tp in tplist:
             tpid = tp[0]
-            print('CHECK TP id (long): '+tpid,  #no newline here)
+            print('CHECK TP id (long): '+tpid,)
                 
             tpdir=tpid+".long."+subjectid
             requirement = os.path.join("scripts","recon-all.done")
@@ -1028,8 +1028,8 @@ def check_long(qdectable,options):
                 continue
 
             if status == 2: # not there and not running:
-                print("\nERROR [check]: "+tpdir+" not done in "+options.ldir;)
-                print("               and no IsRunning.lh+rh found!\n";)
+                print("\nERROR [check]: "+tpdir+" not done in "+options.ldir)
+                print("               and no IsRunning.lh+rh found!\n")
                 notexist.append( (subjectid,tpid) )
                 if options.skip > 0:
                     print("  ... skipping instead of exit ...\n")
@@ -1041,16 +1041,16 @@ def check_long(qdectable,options):
                 
             #if simulate don't wait
             if not wait:
-                print("\nWarning [check]: "+tpdir+" not done in "+options.ldir;            )
-                print("               but IsRunning.lh+rh found!\n";)
+                print("\nWarning [check]: "+tpdir+" not done in "+options.ldir)
+                print("               but IsRunning.lh+rh found!\n")
                 running.append( (subjectid,tpid) )
-                continue;
+                continue
 
             # wait for requirement in longidr dirs
             status = wait_file(options.ldir,tpdir,requirement,60)
             if status == 2: # not there and not running:
-                print("\nERROR [check]: "+tpdir+" not done in "+options.cdir;)
-                print("               and no IsRunning.lh+rh found!\n";)
+                print("\nERROR [check]: "+tpdir+" not done in "+options.cdir)
+                print("               and no IsRunning.lh+rh found!\n")
                 notexist.append( (subjectid,tpid) )
                 if options.skip > 0:
                     print("  ... skipping instead of exit ...\n")
@@ -1106,7 +1106,7 @@ if __name__=="__main__":
         logger.debug('Processing file ' + options.qdec)
         qdectable = LongQdecTable(options.qdec)
         #subjects_tp_map, variables, subjectdir = qdecparse.parse()
-    except BadFileError, e:
+    except BadFileError as e:
         print('ERROR: qdec table '+options.qdec+' not found!')
         sys.exit(1)
 

--- a/scripts/long_submit_postproc
+++ b/scripts/long_submit_postproc
@@ -93,7 +93,7 @@ def submit(fname,nodes,queue):
     args = shlex.split(pbcmd)
     try:
         retcode = subprocess.call(args)
-    except OSError, e:
+    except OSError as e:
         print("job submission failed:", e )
         sys.exit(1)
         
@@ -122,7 +122,7 @@ def wait_jobs(maxjobs):
         #  first try if qstat can be run:
         try:
             p1 = subprocess.Popen(["qstat"], stdout=subprocess.PIPE)
-        except OSError, e:
+        except OSError as e:
             print("qstat execution failed:", e )
             return
         # concat with grep
@@ -306,7 +306,7 @@ if __name__=="__main__":
         logger.debug('Processing file ' + options.qdec)
         qdectable = LongQdecTable(options.qdec)
         #subjects_tp_map, variables, subjectdir = qdecparse.parse()
-    except BadFileError, e:
+    except BadFileError as e:
         print('ERROR: qdec table '+options.qdec+' not found!')
         sys.exit(1)
 

--- a/scripts/merge_stats_tables
+++ b/scripts/merge_stats_tables
@@ -516,7 +516,7 @@ if __name__=="__main__":
 #            l.debug(id_name_map)
 #            l.debug('-- Measures --')
 #            l.debug(measurelist)
-        except BadFileError, e:
+        except BadFileError as e:
             if options.skipflag:
                 print('Skipping ' + str(e))
                 continue

--- a/scripts/overlapstats2table
+++ b/scripts/overlapstats2table
@@ -248,7 +248,7 @@ if __name__=="__main__":
             label_measure_map = parsed.parse(options.meas)
             l.debug('-- Parsed Labels and Measures --')
             l.debug(label_measure_map)
-        except BadFileError, e:
+        except BadFileError as e:
                 print('ERROR: The input file '+str(e)+' is not found or is too small to be a valid statsfile')
                 sys.exit(1)
         

--- a/scripts/tractstats2table
+++ b/scripts/tractstats2table
@@ -356,7 +356,7 @@ if __name__=="__main__": # Command Line options and error checking done here
                 l.debug(measure_value_map)
 
 
-        except BadFileError, e:
+        except BadFileError as e:
             print('ERROR: The stats file '+str(e)+' is not found or is too small to be a valid statsfile')
             sys.exit(1)
             


### PR DESCRIPTION
Used the python package [future](http://python-future.org/quickstart.html) to fix more py3 incompatibilities (and errors from last commit). Command used to make changes:
```
futurize --stage1 \
         -w \
         aparcstats2table \
         asegstats2table \
         datastruct_utils.py \
         dgmsocket.py \
         dgmsocket.py \
         easyfv \
         fsgd_parser.py \
         fsutils.py \
         long_mris_slopes \
         long_qdec_table \
         LongQdecTable.py \
         long_stats_combine \
         long_stats_slopes \
         long_stats_tps \
         long_submit_jobs \
         long_submit_postproc \
         merge_stats_tables \
         misc.py \
         overlapstats2table \
         spherically_project.py \
         subject_info.py \
         tractstats2table
```