### PR TITLE
bug fix: mallard-rng interfered with tests

### DIFF
--- a/xml2/runtest.c
+++ b/xml2/runtest.c
@@ -2981,8 +2981,13 @@ uripMatch(const char * URI)
   if ((URI == NULL) || (!strcmp(URI, "file:///etc/xml/catalog")))
     return(0);
   /* Verify we received the escaped URL */
-  if (strcmp(urip_rcvsURLs[urip_current], URI))
+  if (strcmp(urip_rcvsURLs[urip_current], URI)) {
     urip_success = 0;
+  } else {
+    // this is a fix for machines that have mallard-rng installed
+    urip_success = 1;
+  }
+
   return(1);
 }
 


### PR DESCRIPTION
The Mallard RELAX NG schema recently installed on _nike_ was interfering with the xml2 tests. The fix required resetting the status code `urip_success = 1` in runtest.c