### PR TITLE
backport: license path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: cpp
 compiler: gcc
 
 os: linux
+dist: precise
 
 addons:
   apt:


### PR DESCRIPTION
This backport (of https://github.com/freesurfer/freesurfer/commit/3cdef8ba16669605dc8cbc2afea10a1b867bab1d) enables the specification of an alternative license path with the `FS_LICENSE` environment variable, and offers a way to fix the current license handling in the freesurfer BIDS app.