### PR TITLE
FIX: Increase buffers in readVolGeom to ensure valid read

### DIFF
--- a/utils/transform.c
+++ b/utils/transform.c
@@ -391,7 +391,8 @@ void readVolGeom(FILE *fp, VOL_GEOM *vg)
       counter++;
     }
     else if (!strcmp(param, "filename")) {
-      if (sscanf(line, "%s %s %s\n", param, eq, buf) >= 3) {
+      // 1023 = STRLEN - 1
+      if (sscanf(line, "%s %s %1023s%*s\n", param, eq, buf) >= 3) {
         strcpy(vg->fname, buf);
       }
       counter++;

--- a/utils/transform.c
+++ b/utils/transform.c
@@ -373,10 +373,10 @@ void writeVolGeom(FILE *fp, const VOL_GEOM *vg)
 
 void readVolGeom(FILE *fp, VOL_GEOM *vg)
 {
-  char line[256];
+  char line[STRLEN + 16];
   char param[64];
   char eq[2];
-  char buf[256];
+  char buf[STRLEN];
   int vgRead = 0;
   char *p = 0;
   int counter = 0;
@@ -422,7 +422,7 @@ void readVolGeom(FILE *fp, VOL_GEOM *vg)
       sscanf(line, "%s %s %f %f %f\n", param, eq, &vg->c_r, &vg->c_a, &vg->c_s);
       counter++;
     }
-    // rememver the current position
+    // remember the current position
     pos = ftell(fp);  // if fail = 0, then ok
   };
   if (p)  // we read one more line


### PR DESCRIPTION
This pull request proposes an increase in buffer size to allow for long filenames in volume geometries being read.

Note, however, that this will only fix `readVolGeom` when reading geometries written by `writeVolGeom`.

The problem (described in detail below) occurs when the length of a line and that of the buffer match. If another source permits longer line lengths, the possibility of a buffer-size/line-length coincidence remains.

I'm not sure what the best way of handling that specific case is. Could check to see if `line` ends with a newline, and, if not, gobble characters until a newline is hit.

# Problem statement

It is currently possible to create a valid VolGeom string that will break readVolGeom, by setting the length of the line beginning "filename = " to be 255 characters (+ `'\n'`).

The filename is defined to be a 1024 byte string, and so up to 1023 characters:

https://github.com/freesurfer/freesurfer/blob/9b79bf0eef76710a70a5b73142a8f6e2bab1a6b6/include/transform.h#L54

So, in writeVolGeom, a line may be written that is up to 1035 characters long (`"filename = "` + 1023 + `'\n'`):

https://github.com/freesurfer/freesurfer/blob/9b79bf0eef76710a70a5b73142a8f6e2bab1a6b6/utils/transform.c#L365

If the line is exactly 255 characters long (excluding newline), then the `fgets` call will retrieve the entire contents of the line (256 characters - terminating `'\NUL'`) without retrieving a newline. The next call to `fgets` will then get a line of length 0, resulting in a premature termination of the loop.

# How to reproduce

To observe an effect of this issue, consider the following LTA file:

```
type      = 0 # LINEAR_VOX_TO_VOX
nxforms   = 1
mean      = 0.0000 0.0000 0.0000
sigma     = 1.0000
1 4 4
2.327464342117310e+00 4.245608299970627e-02 3.455499932169914e-02 -1.319661331176758e+01 
-7.824462652206421e-02 3.904805898666382e+00 2.233271896839142e-01 -5.291442871093750e-01 
-4.939173907041550e-02 -1.728723645210266e-01 4.818737983703613e+00 7.657078552246094e+01 
0.000000000000000e+00 0.000000000000000e+00 0.000000000000000e+00 1.000000000000000e+00 
src volume info
valid = 1  # volume info valid
filename = /scratch/03763/oesteban/fmriprep-phase1/work/ds000110/fmriprep_wf/single_subject_07_wf/func_preproc_task_IncidentalencodingtaskusingPosnercueingparadigmwithobjectvgreeblejudgment_run_05_wf/bold_reg_wf/bbreg_wf/bbregister/ants_susceptibility_War
volume = 64 64 30
voxelsize = 3.437500000000000e+00 3.437500000000000e+00 4.000000000000000e+00
xras   = 1.000000000000000e+00 0.000000000000000e+00 0.000000000000000e+00
yras   = 0.000000000000000e+00 9.979115724563599e-01 -6.459446996450424e-02
zras   = 0.000000000000000e+00 6.459447741508484e-02 9.979115724563599e-01
cras   = 3.437500000000000e+00 8.357086181640625e-01 4.582891845703125e+01
dst volume info
valid = 1  # volume info valid
filename = /scratch/03763/oesteban/fmriprep-phase1/work/ds000110/fmriprep_wf/single_subject_07_wf/anat_preproc_wf/t1_merge/sub-07_T1w_ras_template.nii.gz
volume = 124 256 256
voxelsize = 1.500000000000000e+00 8.593999743461609e-01 8.593999743461609e-01
xras   = 9.998608827590942e-01 1.065783575177193e-02 -1.283265277743340e-02
yras   = -9.511843323707581e-03 9.962262511253357e-01 8.627174794673920e-02
zras   = 1.370369549840689e-02 -8.613768219947815e-02 9.961889982223511e-01
cras   = -3.533935546875000e-01 5.862289428710938e+00 -1.128549194335938e+01
subject sub-07
fscale 0.100000
```

If you save this as `test.lta`, the following command fails in an unexpected way:

```Shell
$ lta_convert --inlta truncated.lta --outlta out.lta
$Id: lta_convert.cpp,v 1.9.2.1 2016/08/09 02:33:22 zkaufman Exp $

--inlta: truncated.lta input LTA transform.
--outlta: out.lta output LTA.
LTAchangeType: dst geometry must be valid
```

The offending line is:

```
filename = /scratch/03763/oesteban/fmriprep-phase1/work/ds000110/fmriprep_wf/single_subject_07_wf/func_preproc_task_IncidentalencodingtaskusingPosnercueingparadigmwithobjectvgreeblejudgment_run_05_wf/bold_reg_wf/bbreg_wf/bbregister/ants_susceptibility_War
```

Add or remove a character and the command proceeds without error. However, supposing you add a character (and, critically, convert between `RAS_TO_RAS` and `VOX_TO_VOX`):

```Shell
$ lta_convert --inlta extended.lta --outlta out1.lta             
$Id: lta_convert.cpp,v 1.9.2.1 2016/08/09 02:33:22 zkaufman Exp $

--inlta: extended.lta input LTA transform.
--outlta: out1.lta output LTA.
 LTA read, type : 1
 1.01550   0.01035   0.02607  -3.12509;
-0.00760   0.97176  -0.10423   6.51772;
-0.02702   0.10772   1.03053  -46.97261;
 0.00000   0.00000   0.00000   1.00000;
Writing  LTA to file out1.lta...
lta_convert successful.
$ lta_convert --inlta out1.lta --outlta out2.lta --ltavox2vox
$Id: lta_convert.cpp,v 1.9.2.1 2016/08/09 02:33:22 zkaufman Exp $

--inlta: out1.lta input LTA transform.
--outlta: out2.lta output LTA.
--ltavox2vox: output LTA as VOX_TO_VOX transform.
 LTA read, type : 1
 1.01550   0.01035   0.02607  -3.12509;
-0.00760   0.97176  -0.10423   6.51772;
-0.02702   0.10772   1.03053  -46.97261;
 0.00000   0.00000   0.00000   1.00000;
LTAchangeType: dst geometry must be valid
```

This is a result of the truncation that occurs during the read.