### PR TITLE
Nf bevin conditionalize minc

### DIFF
--- a/configure.in.without_minc
+++ b/configure.in.without_minc
@@ -1,0 +1,4062 @@
+########################################################################
+#
+#                          -*- Autoconf -*-
+# configure.in
+# by y.tosa
+# June 17, 2004
+#
+# Process this file with autoconf to produce a configure script.
+#
+# CVS Revision Info:
+#    $Author: ah221 $
+#    $Date: 2017/02/14 22:38:31 $
+#    $Revision: 1.681 $
+#
+########################################################################
+AC_PREREQ(2.57)
+AC_INIT(Freesurfer, dev, freesurfer@nmr.mgh.harvard.edu)
+# if $FREESURFER_HOME is defined, then use that as default install dir:
+if test ! "x${FREESURFER_HOME}" = "x"; then
+  ac_default_prefix=${FREESURFER_HOME}
+else
+# else use this as default install dir:
+  ac_default_prefix=/usr/local/freesurfer/${PACKAGE_VERSION}
+fi
+AC_PREFIX_DEFAULT($ac_default_prefix)
+AC_CONFIG_AUX_DIR([config])
+# create special dir for intermediate files
+AC_MSG_NOTICE(Setting System...)
+# set target, build, host etc.
+AC_CANONICAL_SYSTEM
+
+AC_CONFIG_MACRO_DIR([m4])
+
+########################################################################
+# To use the Intel C/C++ compiler, assuming it is installed here:
+#   /somepath/intel
+# do this prior to configuring:
+#   source /somepath/intel/bin/iccvars.csh -arch intel64 -platform linux
+#   setenv CC icc
+#   setenv CXX icpc
+#   setenv LD icpc
+#   setenv LDFLAGS "-L/somepath/intel/lib"
+#   setenv AR xiar
+########################################################################
+
+##############################################################
+# allow user to specify root of multi-package directory,
+# such as one containing all freesurfer dependencies.
+##############################################################
+pkgs_dir="/usr/pubsw/packages"
+
+AC_ARG_WITH(pkgs-dir,
+[  --with-pkgs-dir=DIR     where the root of multiple pkgs are installed.],
+  [  pkgs_dir="$withval"
+  ])
+
+if test -e "$pkgs_dir"; then
+  PACKAGES_DIR=${pkgs_dir}
+  AC_MSG_RESULT([using '${PACKAGES_DIR}'])
+else
+  AC_MSG_ERROR([FATAL: ${pkgs_dir} not found])
+fi
+
+################################################################
+# AMD Open64 Compiler
+# Note: libmv.so* should be renamed to force usage of libmv.a,
+# otherwise binaries wont run on systems w/o compiler installed.
+################################################################
+ac_open64_includes="NO"
+ac_open64_libraries="NO"
+ac_open64_binaries="NO"
+LIBS_OPEN64=""
+
+AC_MSG_CHECKING(AMD Open64 compiler directories)
+
+AC_ARG_WITH(open64-dir,
+  [  --with-open64-dir=DIR    where the root of Open64 is installed.],
+  [  ac_open64_binaries="$withval/bin"
+     CC="${ac_open64_binaries}/opencc"
+     CFLAGS="-Wno-uninitialized -OPT:Olimit=0"
+     CXX="${ac_open64_binaries}/openCC"
+     CXXFLAGS="-Wno-uninitialized -OPT:Olimit=0"
+     LD="${ac_open64_binaries}/openCC"
+     F77="${ac_open64_binaries}/openf90"
+     FFLAGS="-extend_source"
+  ])
+
+AC_ARG_WITH(open64-include,
+  [  --with-open64-include=DIR    root of Open64 include directory.],
+  [  ac_open64_includes="$withval"
+  ])
+
+AC_ARG_WITH(open64-libraries,
+  [  --with-open64-libraries=DIR  root of Open64 lib directory.],
+  [  ac_open64_libraries="$withval"
+     LDFLAGS="-L${ac_open64_libraries}"
+     LIBS_OPEN64="-lm ${ac_open64_libraries}/libmv.a ${ac_open64_libraries}/libopen64rt.a "
+  ])
+
+if test ! "$ac_open64_binaries" = "NO"; then
+  AC_MSG_RESULT(Open64 bin directory is ${ac_open64_binaries})
+else
+  AC_MSG_RESULT(Open64 directory is not supplied)
+fi
+
+AC_SUBST(LIBS_OPEN64)AM_CONDITIONAL(HAVE_OPEN64_COMPILER, ! test "x$ac_open64_binaries" = "xNO")
+
+
+#####################################################################
+# perform our own vendor string customizations...
+#####################################################################
+if test -e /etc/redhat-release ; then
+  # Centos6
+  cat /etc/redhat-release | grep CentOS | grep 6 >& /dev/null
+  if test "$?" = "0"; then
+    build_vendor="centos6"
+    host_vendor="centos6"
+    if test "x$host" = "xi686-redhat-linux-gnu"; then
+      host="Linux-centos6"
+    fi
+    if test "x$host" = "xx86_64-redhat-linux-gnu"; then
+      host="Linux-centos6_x86_64"
+    fi
+  fi
+  # Centos5
+  cat /etc/redhat-release | grep CentOS | grep 5 >& /dev/null
+  if test "$?" = "0"; then
+    build_vendor="centos5"
+    host_vendor="centos5"
+    if test "x$host" = "xi686-redhat-linux-gnu"; then
+      host="Linux-centos5"
+    fi
+    if test "x$host" = "xx86_64-redhat-linux-gnu"; then
+      host="Linux-centos5_x86_64"
+    fi
+  fi
+  # Centos4
+  cat /etc/redhat-release | grep CentOS | grep 4 >& /dev/null
+  if test "$?" = "0"; then
+    build_vendor="centos4"
+    host_vendor="centos4"
+    if test "x$host" = "xi686-redhat-linux-gnu"; then
+      host="Linux-centos4"
+    fi
+    if test "x$host" = "xx86_64-redhat-linux-gnu"; then
+      host="Linux-centos4_x86_64"
+    fi
+  fi
+  # RedHat9
+  cat /etc/redhat-release | grep "Red Hat Linux" | grep 9 >& /dev/null
+  if test "$?" = "0"; then
+    build_vendor="rh9"
+    host_vendor="rh9"
+    if test "x$host" = "xi686-pc-linux-gnu"; then
+      host="Linux-rh9"
+    fi
+  fi
+fi
+if test -e /etc/debian_version ; then
+  # Debian3
+  cat /etc/debian_version | grep 3 >& /dev/null
+  if test "$?" = "0"; then
+    build_vendor="debian3"
+    host_vendor="debian3"
+    if test "x$host" = "xi686-unknown-linux-gnu"; then
+      host="Linux-debian3"
+    fi
+    if test "x$host" = "xx86_64-unknown-linux-gnu"; then
+      host="Linux-debian3_x86_64"
+    fi
+  fi
+fi
+if test -d /etc/susehelp.d ; then
+  # SuSE
+  build_vendor="suse"
+  host_vendor="suse"
+  if test "x$host" = "xia64-unknown-linux-gnu"; then
+    host="Linux-suse-ia64"
+  fi
+fi
+AC_SUBST(build_vendor)
+AC_SUBST(host_vendor)
+AC_SUBST(host)
+AM_INIT_AUTOMAKE(tar-ustar)
+#AM_INIT_AUTOMAKE([subdir-objects no-exeext tar-ustar])
+AC_CONFIG_SRCDIR([config.h.in])
+AM_CONFIG_HEADER([config.h])
+
+#####################################################################
+# if CFLAGS and CXXFLAGS are not already set, then set to empty,
+# otherwise, AC_PROG_CPP and AC_PROG_CXX will automatically append
+# "-g -O2", flags over which we'd rather have explicit control per OS
+#####################################################################
+if test "x$CFLAGS" = "x"; then
+  CFLAGS=""
+  AC_SUBST(CFLAGS)
+fi
+if test "x$CXXFLAGS" = "x"; then
+  CXXFLAGS=""
+  AC_SUBST(CXXFLAGS)
+fi
+
+###############################################################
+# Checks for programs.
+###############################################################
+AC_PROG_CXX
+AC_PROG_AWK
+AC_PROG_CC
+AM_PROG_CC_C_O # allows flag override in Makefile.am, ex. tksurfer_CFLAGS=$(CFLAGS) -O2
+AC_PROG_CPP
+AC_PROG_INSTALL
+AC_PROG_LN_S
+AC_PROG_MAKE_SET
+AC_PROG_LIBTOOL
+AC_LIBTOOL_CXX
+# use Intel Fortran compiler if using Intel C compiler
+if test "x$CC" = "xicc"; then
+  F77="ifort"
+fi
+AC_PROG_F77
+if test "x$F77" = "x"; then
+	AC_MSG_ERROR([FATAL: A Fortran 77 compiler is required!])
+fi
+
+# check for gcc 4.4 and higher which supports openmp.
+ac_have_gcc_44="no"
+if (test "${CC}" = "gcc"); then
+  gcc --version | grep " 4\.@<:@4-9@:>@" >& /dev/null
+  if test "$?" = "0"; then
+    AC_MSG_NOTICE(Have gcc 4.x where x >= 4)
+    ac_have_gcc_44="yes"
+  else
+    AC_MSG_NOTICE(Do not have gcc 4.x where x >= 4)
+  fi
+fi
+
+# When the version of gcc and installed autools
+# begins to "diverge", the configure script needs
+# to copy libtool from /usr/bin (/opt/local/bin on OSX)
+# into dev. If gcc autotools are "around the same"
+# than this copying doesnt need to occur.
+# But since it doesnt hurt lets just always do it.
+if test ! `uname -s` = "Darwin"; then
+    AC_MSG_NOTICE(Copying /usr/bin/libtool overtop the PROG_LIBTOOL)
+    cp /usr/bin/libtool .
+fi
+
+if test `uname -s` = "Darwin"; then
+    AC_MSG_NOTICE(Copying /opt/local/bin/glibtool overtop the PROG_LIBTOOL)
+    cp /opt/local/bin/glibtool ./libtool
+fi
+
+# Temporary fix until I can get all version of OSX building
+#if (test `uname -n` = "gust.nmr.mgh.harvard.edu"); then
+#    AC_MSG_NOTICE(Copying /usr/pubsw/packages/autotools/bin/libtool overtop the PROG_LIBTOOL)
+#    cp /usr/pubsw/packages/autotools/bin/libtool .
+#fi
+
+# Temporary fix until I can get all version of OSX building
+# if (test `uname -n` = "aspasia.nmr.mgh.harvard.edu"); then
+#    AC_MSG_NOTICE(Copying /usr/pubsw/packages/autotools/bin/libtool overtop the PROG_LIBTOOL)
+#    cp /usr/pubsw/packages/autotools/bin/libtool .
+# fi
+
+################################################################
+# Checks for header files.
+################################################################
+AC_HEADER_DIRENT
+AC_HEADER_STDC
+AC_HEADER_SYS_WAIT
+AC_CHECK_HEADERS([\
+  arpa/inet.h \
+  fcntl.h \
+  float.h \
+  limits.h \
+  locale.h \
+  malloc.h \
+  memory.h \
+  netdb.h \
+  netinet/in.h \
+  stddef.h \
+  stdlib.h \
+  string.h \
+  strings.h \
+  sys/file.h \
+  sys/ioctl.h \
+  sys/param.h \
+  sys/socket.h \
+  sys/time.h \
+  sys/timeb.h \
+  unistd.h \
+  values.h \
+  wctype.h])
+# the following is needed on Mac OS Darwin
+AC_CHECK_HEADERS(sys/types.h stdint.h)
+
+################################################################
+# Checks for typedefs, structures, and compiler characteristics.
+################################################################
+AC_C_CONST
+AC_C_INLINE
+AC_TYPE_MODE_T
+AC_TYPE_OFF_T
+AC_TYPE_SIZE_T
+AC_HEADER_TIME
+AC_STRUCT_TM
+AC_CHECK_TYPES([ptrdiff_t])
+
+################################################################
+# Checks for library functions.
+# autoscan says freesurfer uses these:
+################################################################
+AC_FUNC_CLOSEDIR_VOID
+AC_FUNC_ERROR_AT_LINE
+AC_FUNC_LSTAT
+AC_FUNC_LSTAT_FOLLOWS_SLASHED_SYMLINK
+AC_FUNC_MMAP
+AC_FUNC_SELECT_ARGTYPES
+AC_TYPE_SIGNAL
+AC_FUNC_STAT
+AC_FUNC_STRTOD
+AC_FUNC_VPRINTF
+AC_C_VOLATILE
+AC_FUNC_FORK
+#AC_FUNC_MALLOC (can redefine malloc as rpl_malloc)
+AC_FUNC_MEMCMP
+#AC_FUNC_REALLOC
+AC_HEADER_STDBOOL
+AC_TYPE_PID_T
+# autoscan says freesurfer uses these functions:
+AC_CHECK_FUNCS([\
+  bzero \
+  calloc \
+  dup2 \
+  floor \
+  ftime \
+  getdelim \
+  getenv \
+  getcwd \
+  getpagesize \
+  gettimeofday \
+  isascii \
+  memmove \
+  memset \
+  mkdir \
+  munmap \
+  pow \
+  putenv \
+  rint \
+  select \
+  setenv \
+  sqrt \
+  strcasecmp \
+  strchr \
+  strcspn \
+  strdup \
+  strerror \
+  strncasecmp \
+  strrchr \
+  strspn \
+  strstr \
+  strtol \
+  uname])
+
+# many linux systems dont have libg2c.so, the shared lib supporting g77,
+# so build using the static lib if available, so that distro is more
+# widely compatible. the talairach_avi/Makefile.am file uses LIB_G2C_A
+LIB_G2C_A=""
+if test -e /usr/local/lib/libg2c.a ; then
+  LIB_G2C_A="/usr/local/lib/libg2c.a"
+fi
+if test -e /usr/lib/libg2c.a ; then
+  LIB_G2C_A="/usr/lib/libg2c.a"
+fi
+if test -e /usr/lib64/libg2c.a ; then
+  LIB_G2C_A="/usr/lib64/libg2c.a"
+fi
+if test "$host" = "powerpc64-suse-linux"; then
+  if test -e /usr/lib/libg2c.a ; then
+    LIB_G2C_A="/usr/lib/libg2c.a"
+  fi
+fi
+AC_SUBST(LIB_G2C_A)
+
+# as the law of unintended consequences would have it, when linking
+# against -lblas and -llapack, it uses the shared versions (.so) which
+# expect that shared libg2c exists, which it may not if we are forcing the
+# use of a static libg2c.a, so find the static libblas and liblapack.
+# the fem_elastic build dir uses LIB_BLAS_A and LIB_LAPACK_A
+LIB_BLAS=""
+if test -e /usr/local/lib/libblas.a ; then
+  LIB_BLAS="/usr/local/lib/libblas.a"
+fi
+if test -e /usr/lib/libblas.a ; then
+  LIB_BLAS="/usr/lib/libblas.a"
+fi
+if test -e /usr/lib64/libblas.a ; then
+  LIB_BLAS="/usr/lib64/libblas.a"
+fi
+if test "$host" = "powerpc64-suse-linux"; then
+  if test -e /usr/lib/libblas.a ; then
+    LIB_BLAS="/usr/lib/libblas.a"
+  fi
+fi
+AC_SUBST(LIB_BLAS)
+
+LIB_LAPACK=""
+if test -e /usr/local/lib/liblapack.a ; then
+  LIB_LAPACK="/usr/local/lib/liblapack.a"
+elif test -e /usr/lib/liblapack.a ; then
+  LIB_LAPACK="/usr/lib/liblapack.a"
+elif test -e /usr/lib64/liblapack.a ; then
+  LIB_LAPACK="/usr/lib64/liblapack.a"
+elif test -e /usr/lib/lapack/liblapack.a ; then
+  LIB_LAPACK="/usr/lib/lapack/liblapack.a"
+fi
+if test "$host" = "powerpc64-suse-linux"; then
+  if test -e /usr/lib/liblapack.a ; then
+    LIB_LAPACK="/usr/lib/liblapack.a"
+  fi
+fi
+AC_SUBST(LIB_LAPACK)
+
+# libnetcdf is now installed by default on centos6 computers
+# at the Center. We want it to compile against the static
+# version found in the mni library so that libnetcdf does
+# not become a dependancy for users outside the Center.
+LIB_NETCDF=""
+if test -e ${PACKAGES_DIR}/mni/current/lib/libnetcdf.a ; then
+  LIB_NETCDF="${PACKAGES_DIR}/mni/current/lib/libnetcdf.a"
+else
+  LIB_NETCDF="-lnetcdf"
+fi
+AC_SUBST(LIB_NETCDF)
+
+################################################################
+# Most of our scripts use /bin/tcsh, so make sure it exists
+################################################################
+AC_CHECK_FILE(/bin/tcsh,[],
+  [AC_MSG_ERROR([FATAL: /bin/tcsh is required!])])
+
+# links with g++ rather than gcc (and check for Intel and AMD Compilers)
+CCLD=g++
+if test "x$CC" = "xicc"; then
+  CCLD=icpc
+fi
+if test "x$CC" = "x${ac_open64_binaries}/opencc"; then
+  CCLD=${ac_open64_binaries}/openCC
+fi
+AC_SUBST(CCLD)
+
+# two programs used for compress/decompress files
+# cannot make AC_MSG_ERROR work inside the AC_CHECK_PROG so
+# that I took it out.
+AC_CHECK_PROG([HAS_ZCAT],[zcat],[1],[])
+if test ! "$HAS_ZCAT" = "1"; then
+  AC_MSG_ERROR([FATAL: zcat is required in handling mgz etc. \
+Put it in the path.])
+fi
+
+AC_CHECK_PROG([HAS_GZIP],[gzip],[1],[])
+if test ! "$HAS_GZIP" = "1"; then
+  AC_MSG_ERROR([FATAL: gzip is required in creating mgz etc. \
+Put it in the path.])
+fi
+
+#
+# latex is optionally used to regenerate some fsfast docs
+AC_CHECK_PROG(LATEX, latex, latex)
+AM_CONDITIONAL(HAVE_LATEX, ! test -z "$LATEX")
+
+#
+# xxd is optionally used to convert .xml to a .h, for .c data incorporation
+AC_CHECK_PROG(XXD, xxd, xxd)
+AM_CONDITIONAL(HAVE_XXD, ! test -z "$XXD")
+
+#
+# xmllint is optionally used to check the help.xml files for correctness
+AC_CHECK_PROG(XMLLINT, xmllint, xmllint)
+AM_CONDITIONAL(HAVE_XMLLINT, ! test -z "$XMLLINT")
+
+################################################################
+# set platform related variable defaults for (Teem) NrrdIO
+# in utils
+################################################################
+TEEM_DIO=0
+TEEM_32BIT=1
+TEEM_ENDIAN=4321
+TEEM_QNANHIBIT=1
+AC_SUBST(TEEM_DIO)
+AC_SUBST(TEEM_QNANHIBIT)
+
+################################################################
+# define OS
+################################################################
+AC_C_BIGENDIAN_CROSS
+echo "byte order is " $BYTEORDER
+AC_SUBST(BYTEORDER)
+TEEM_ENDIAN=$BYTEORDER
+
+# Support for files >2GB (Large File Support)
+LFS_CFLAGS="-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE"
+
+# -Wno-unknown-pragmas suppresses warnings about unknown gcc pragmas,
+# like pragma indent
+NUPRAG="-Wno-unknown-pragmas"
+
+# Freesurfer should compile with -Wall (which enables all warnings)
+# and -Werror (which escalates warnings to errors, thus stopping the
+# build), but here we allow a bypass:
+WALL="-Wall"
+WERROR="-Werror"
+AC_ARG_ENABLE(Wall,
+ [  --disable-Wall          do not add -Wall to compiler flags],
+ [ WALL="" ],
+ [ WALL="-Wall" ])
+AC_ARG_ENABLE(Werror,
+ [  --disable-Werror        do not add -Werror to compiler flags],
+ [ WERROR="" ],
+ [ WERROR="-Werror" ])
+# the Intel C/C++ compiler issues warnings not yet fixed in the code, so
+# include -diag-disable <errorno> flag to disable specific icc warnings
+# so that escalating warnings to errors (which stops the build) is still
+# possible.
+if test "x$CC" = "xicc"; then
+  WERROR="$WERROR -diag-disable 1268"
+  # warning #1268: support for exported templates is disabled
+fi
+
+# to strip unused code when using Linux gcc.
+# but not on cent4 because for some reason it fails
+# on certain binaries.
+if (test "$host" = "Linux-centos4_x86_64"); then
+  DEADCODE_STRIP=""
+else
+  DEADCODE_STRIP="-fdata-sections -ffunction-sections -Wl,--gc-sections"
+fi
+# and on the Mac:
+DEADCODE_STRIP_MAC="-dead_strip"
+
+ac_have_sse_mathfun=no
+FCLIBS=""
+AC_MSG_NOTICE(Setting OS from target...)
+case "${target}" in
+ i*86-*-linux-gnu*)
+ OS=Linux
+ OS_CPPFLAGS="$DEADCODE_STRIP"
+ OS_LDFLAGS="$DEADCODE_STRIP"
+ DYNAMIC_LIB_EXT=".so"
+ SHARED_CFLAGS="-fPIC "
+ SHARED_LDFLAGS="-shared "
+ CPPFLAGS="-g -O3 -msse2 -mfpmath=sse $WALL $WERROR $LFS_CFLAGS"
+ FFLAGS="-g -O3 -msse2 -mfpmath=sse"
+ ac_have_sse_mathfun=yes
+ ;;
+ x86_64-*linux*)
+ OS=Linux
+ OS_CPPFLAGS="$DEADCODE_STRIP"
+ OS_LDFLAGS="$DEADCODE_STRIP"
+ LDFLAGS="-L/usr/lib64 -L/usr/X11R6/lib64 $LDFLAGS"
+ DYNAMIC_LIB_EXT=".so"
+ SHARED_CFLAGS="-fPIC"
+ SHARED_LDFLAGS="-shared"
+ if test "x$CC" = "xicc"; then
+  # Intel compiler vector options defined later
+  CPPFLAGS="-g -O3 $WALL $WERROR"
+ else
+  # note: gcc 4.4 flags -ftree-vectorize -msse4.1 dont help over just -msse2
+  CPPFLAGS="-g -O3 -msse2 -mfpmath=sse $WALL $WERROR"
+ fi
+ if test "x$F77" = "xifort"; then
+  # Intel compiler vector options defined later
+  FFLAGS="-g -O3"
+ else
+  FFLAGS="-g -O3 -msse2 -mfpmath=sse"
+ fi
+ ac_have_sse_mathfun=yes
+ TEEM_32BIT=0
+ ;;
+ ia64-*)
+ OS=Linux
+ OS_CPPFLAGS=
+ OS_LDFLAGS=
+ DYNAMIC_LIB_EXT=".so"
+ SHARED_CFLAGS="-fPIC"
+ SHARED_LDFLAGS="-shared"
+ CPPFLAGS="-g -O2 $WALL $WERROR $LFS_CFLAGS"
+ TEEM_32BIT=0
+ ;;
+ *-apple-darwin*)
+ # Mac OS X
+ OS=Darwin
+ OS_CPPFLAGS=
+ OS_LDFLAGS="$DEADCODE_STRIP_MAC"
+ DYNAMIC_LIB_EXT=".dylib"
+ SHARED_CFLAGS="-fno-common"
+ SHARED_LDFLAGS="-dynamiclib"
+ CPPFLAGS="-g -O3 -msse2 -mfpmath=sse $WALL $WERROR $LFS_CFLAGS"
+ FFLAGS="-g -O3 -msse2 -mfpmath=sse"
+ FCLIBS="-L/usr/lib -lgcc"
+ ;;
+ i*86-*-solaris*)
+ OS=SunOS
+ OS_CPPFLAGS=
+ OS_LDFLAGS=
+ DYNAMIC_LIB_EXT=".so"
+ SHARED_CFLAGS="-fPIC "
+ SHARED_LDFLAGS="-shared "
+ CPPFLAGS="-g -O2 $WALL $WERROR $NUPRAG"
+ ;;
+ i*86-pc-cygwin)
+ OS=Windows_NT
+ OS_CPPFLAGS=
+ OS_LDFLAGS=
+ DYNAMIC_LIB_EXT=
+ SHARED_CFLAGS=
+ SHARED_LDFLAGS=
+ CPPFLAGS="-g -O2 $WALL $WERROR $NUPRAG"
+ ;;
+ powerpc64-*-linux-gnu*)
+ OS=Linux
+ OS_CPPFLAGS="$DEADCODE_STRIP"
+ OS_LDFLAGS="$DEADCODE_STRIP"
+ DYNAMIC_LIB_EXT=".so"
+ SHARED_CFLAGS="-fPIC "
+ SHARED_LDFLAGS="-shared "
+ CPPFLAGS="-g -O2 $WALL $WERROR $LFS_CFLAGS"
+ ;;
+ powerpc64-suse-linux)
+ OS=Linux
+ OS_CPPFLAGS="$DEADCODE_STRIP"
+ OS_LDFLAGS="$DEADCODE_STRIP"
+ DYNAMIC_LIB_EXT=".so"
+ SHARED_CFLAGS="-fPIC "
+ SHARED_LDFLAGS="-shared "
+ CPPFLAGS="-g -O2 $WALL $WERROR $LFS_CFLAGS"
+  ;;
+esac
+AC_SUBST(OS)
+AC_SUBST(OS_CPPFLAGS)
+AC_SUBST(OS_LDFLAGS)
+AC_SUBST(DYNAMIC_LIB_EXT)
+AC_SUBST(TEEM_32BIT)
+AC_SUBST(TEEM_ENDIAN)
+
+# export
+AC_SUBST(SHARED_CFLAGS)
+AC_SUBST(SHARED_LDFLAGS)
+
+AC_SUBST(FCLIBS)
+
+AC_MSG_NOTICE(OS is $OS)
+
+AM_CONDITIONAL(HAVE_MAC_OSX, test "x$OS" = "xDarwin" )
+
+################################################################
+# Mac 64-bit 32-bit concerns
+################################################################
+MAC_64="NO"
+machine_hardware=`uname -m`
+if (test "$OS" = "Darwin") && (test "$machine_hardware" = "x86_64"); then
+  MAC_64="YES"
+fi
+
+# On 64-bit Mac systems, the 32bit versions of tkmedit, tksurfer,
+# tkregister, and qdec are installed by default.
+install_Mac32_GUIs="NO"
+if test x$MAC_64 = xYES; then
+   install_Mac32_GUIs="YES"
+fi
+
+disable_gui_build="NO"
+AC_ARG_ENABLE(GUI-build,
+ [  --disable-GUI-build     disable building Tcl/Tk, ITK, VTK/KWWidgets, wxWidgets and OpenGL-based apps],
+ [ disable_gui_build="YES"
+ ])
+
+AM_CONDITIONAL(INSTALL_MAC32_GUIS, test "x$install_Mac32_GUIs" = "xYES" )
+
+################################################################
+# gfortran
+################################################################
+# Centos 5 needs libgfortran when linking fem_elastic/surf2vol
+LIB_GFORTRAN=""
+# NOTE! OS was just defined, so dont move this section
+if test ! "$OS" = "Darwin"; then
+  AC_CHECK_LIB([gfortran], [_gfortran_compare_string],\
+                           [LIB_GFORTRAN="-lgfortran"],[])
+fi
+
+if test "x$MAC_64" = "xYES"; then
+  if test ! "x$F77" = "xgfortran"; then
+    AC_MSG_ERROR([FATAL: gfortran (not $F77) required for 64-bit Mac OSX systems.])
+  else
+    FFLAGS="$FFLAGS -m64"
+  fi
+fi
+
+# many linux systems, namedly Ubuntu, dont have libgfortran.so installed
+# by default, so build using the static lib if available, so that
+# distro is more widely compatible.
+if test -e /usr/lib/libgfortran.a ; then
+  LIB_GFORTRAN="/usr/lib/libgfortran.a"
+fi
+if test -e /usr/lib64/libgfortran.a ; then
+  LIB_GFORTRAN="/usr/lib64/libgfortran.a"
+fi
+# ubuntu 16.04 installation location
+if test -e /usr/lib/gcc/x86_64-linux-gnu/4.8/libgfortran.a ; then
+  LIB_GFORTRAN="/usr/lib/gcc/x86_64-linux-gnu/4.8/libgfortran.a"
+fi
+
+
+
+AC_SUBST(LIB_GFORTRAN)
+AM_CONDITIONAL(HAVE_GFORTRAN, test ! "x$LIB_GFORTRAN" = "x" )
+# note: gcc 4.4 might give 'undefined reference to _gfortran_ errors, and so
+# the following may be necessary to get around this, as root:
+# cd /usr/lib64
+# rm libgfortran.so;
+# ln -s libgfortran.so.1.0.0 libgfortran.so
+
+################################################################
+# SSE matrix and math functions (affine.h, sse_mathfun.h)
+################################################################
+#ac_have_sse_mathfun is initialized in OS target section above
+AC_ARG_ENABLE(sse_mathfun,
+ [  --disable-sse_mathfun   disable SSE math function support],
+ [ ac_have_sse_mathfun=no
+   AC_MSG_NOTICE(Disabling usage of SSE math functions)
+ ])
+# note that if compiling with x86, ac_have_sse_mathfun is set to 'yes'
+# (see OS target stuff), so --disable-sse_mathfun is used to disable for testing
+if test "x$ac_have_sse_mathfun" = "xyes"; then
+  CPPFLAGS="$CPPFLAGS -DUSE_SSE_MATHFUN"
+fi
+AM_CONDITIONAL(USE_SSE_MATHFUN, test "x$ac_have_sse_mathfun" = "xyes")
+
+
+##############################################################
+# OpenMP
+##############################################################
+ac_have_openmp=no
+OPENMP_FLAG=""
+AC_ARG_ENABLE(openmp,
+ [  --enable-openmp         enable OpenMP multi-core support],
+ [ ac_have_openmp=yes
+   AC_MSG_NOTICE(Using OpenMP)
+   if test "${CC}" = "icc"; then
+     OPENMP_FLAG="-qopenmp"
+     CPPFLAGS="-D_OPENMP $OPENMP_FLAG $CPPFLAGS"
+   else
+     OPENMP_FLAG="-fopenmp"
+     CPPFLAGS="-D_OPENMP $OPENMP_FLAG $CPPFLAGS"
+   fi
+ ])
+
+# gcc 4.4 supports openmp, so enable it by default (no harm in doing so)
+if test "$ac_have_gcc_44" = "yes"; then
+  ac_have_openmp=yes
+  OPENMP_FLAG="-fopenmp"
+  CPPFLAGS="$CPPFLAGS $OPENMP_FLAG -DHAVE_OPENMP"
+  LDFLAGS="$LDFLAGS $OPENMP_FLAG"
+  AC_MSG_NOTICE(Using OpenMP with gcc 4.x)
+fi
+
+# Intel icc supports openmp, so enable it by default (no harm in doing so)
+if test "x$CC" = "xicc"; then
+  ac_have_openmp=yes
+  OPENMP_FLAG="-qopenmp"
+  CPPFLAGS="$CPPFLAGS $OPENMP_FLAG -DHAVE_OPENMP"
+  LDFLAGS="$LDFLAGS $OPENMP_FLAG"
+  AC_MSG_NOTICE(Using OpenMP with Intel Compiler)
+fi
+
+AM_CONDITIONAL(HAVE_OPENMP, test "x$ac_have_openmp" = "xyes")
+AC_SUBST(OPENMP_FLAG)
+
+
+##############################################################
+# Avx2 Architecture
+##############################################################
+ac_have_avx2=no
+AC_ARG_ENABLE(avx2,
+ [  --enable-avx2           enable avx2 instruction set],
+ [ ac_have_avx2=yes
+   AC_MSG_NOTICE(Using avx2)
+   CPPFLAGS="-march=core-avx2 -mno-fma $CPPFLAGS"
+ ])
+
+##############################################################
+# OpenCV
+##############################################################
+AC_ARG_WITH([opencv],
+   [  --with-opencv=PATH         prefix where opencv is installed])
+
+use_opencv="no"
+OPENCV_DIR="no"
+if test -n "$with_opencv"; then
+  OPENCV_DIR="$with_opencv"
+else
+  if test -e ${PACKAGES_DIR}/opencv/current ; then
+    OPENCV_DIR="${PACKAGES_DIR}/opencv/current"
+  fi
+fi
+if( test ! "x$OPENCV_DIR" = "xno" ) then
+  use_opencv="yes"
+  LIB_OPENCV=""
+  OPENCV_CXXFLAGS="-I$OPENCV_DIR/include"
+  OPENCV_LIBS="-L$OPENCV_DIR/lib -lm -lopencv_core -lopencv_imgproc -lopencv_highgui -lopencv_ml"
+fi
+
+AC_SUBST(OPENCV_CXXFLAGS)
+AC_SUBST(OPENCV_LIBS)
+AC_SUBST(OPENCV_DIR)
+
+# if --without-opencv was specified, disable opencv build
+AM_CONDITIONAL(BUILDOPENCV, test x$use_opencv = xyes)
+
+##############################################################
+# OPENCL enabling - added by Dan Ginsburg
+##############################################################
+AC_ARG_WITH([opencl],
+   [  --with-opencl=PATH         prefix where opencl is installed])
+
+use_opencl="no"
+
+OPENCL_LIB_EXT="lib" # Use /lib by default
+case "${target}" in
+ x86_64-*)
+ OPENCL_LIB_EXT="lib64"
+ ;;
+esac
+
+OPENCL_INCDIR=""
+if test "$OS" = "Darwin"; then
+    # On Mac OS X 10.6, OpenCL is provided by Apple so look for these
+    # directories by default
+
+    OPENCL_CFLAGS="-I/System/Library/Frameworks/OpenCL.framework/Headers"
+    OPENCL_LIBS="-framework OpenCL"
+    OPENCL_INCDIR="/System/Library/Frameworks/OpenCL.framework/Headers"
+elif test -n "$with_opencl"
+then
+    # For Linux, the OpenCL implementation directory should be specified
+    # using --with-opencl.  Currently, the ATI Stream SDK v2.0 and
+    # NVIDIA GPU SDK provides an OpenCL implementation.  You must
+    # also have the appropriate driver installed to get GPU support.
+    # The ATI Stream SDK provides generic CPU support across both AMD
+    # and Intel CPUs.
+
+    OPENCL_CFLAGS="-I$with_opencl/include"
+    OPENCL_LIBS="-L$with_opencl/$(OPENCL_LIB_EXT) -lOpenCL"
+    OPENCL_INCDIR="$with_opencl/include/CL"
+fi
+AC_SUBST(OPENCL_CFLAGS)
+AC_SUBST(OPENCL_LIBS)
+
+AC_CHECK_FILE($OPENCL_INCDIR/cl.h, use_opencl="yes", use_opencl="no")
+
+AM_CONDITIONAL(BUILDOPENCL, test x$use_opencl = xyes)
+
+if( test ! "x$use_opencl" = "xno" )
+then
+	AC_DEFINE([FS_OPENCL],[1],[Defined if OPENCL should be used])
+fi
+
+#############################################################
+# Nvidia CUDA enabling
+############################################################
+CUDA_DIR=""
+with_cuda=""
+AC_ARG_WITH([cuda],
+   [  --with-cuda=PATH        prefix where cuda is installed [default=auto]],
+   [  with_cuda="${withval}"],[])
+
+if test -n "$with_cuda"; then
+    CUDA_DIR="$with_cuda"
+#else
+#  if test -e ${PACKAGES_DIR}/CUDA/current ; then
+#    CUDA_DIR="${PACKAGES_DIR}/CUDA/current"
+#  else
+#    if test -e /usr/local/cuda ; then
+#      CUDA_DIR="/usr/local/cuda"
+#    fi
+#  fi
+fi
+
+if( test ! "x$CUDA_DIR" = "x" ) then
+  LIB_CUDA=""
+  AC_CHECK_LIB([cuda -L$CUDA_DIR/lib], [cuInit],[LIB_CUDA="-lcuda"],[])
+  AC_SUBST(LIB_CUDA)
+  CUDA_CFLAGS="-I$CUDA_DIR/include"
+  CUDA_LIBS="-L$CUDA_DIR/lib $LIB_CUDA -lcudart"
+  if test -e /usr/lib64 ; then
+    CUDA_LIBS="-L$CUDA_DIR/lib64 $LIB_CUDA -lcudart"
+  fi
+  NVCC="$CUDA_DIR/bin/nvcc"
+fi
+
+AC_SUBST(CUDA_CFLAGS)
+AC_SUBST(CUDA_LIBS)
+AC_SUBST(CUDA_DIR)
+AC_SUBST(NVCC)
+
+# if --without-cuda was specified, disable cuda build
+if test "x$with_cuda" = "xno"; then
+  AM_CONDITIONAL(BUILDCUDA, false)
+  NVCC=no
+  AC_SUBST(NVCC)
+else # else enable if nvcc is found and libcuda is found
+  AC_PATH_PROG([NVCC],[nvcc],[no],[$PATH:$with_cuda/bin])
+  if ((test ! "x$NVCC" = "xno") && (test ! "x$LIB_CUDA" = "x")); then
+    AM_CONDITIONAL(BUILDCUDA, true)
+  else
+  AM_CONDITIONAL(BUILDCUDA, false)
+  fi
+fi
+
+AC_ARG_ENABLE([emu],
+   [  --enable-emu            enable device emulation for CUDA],
+   [case "${enableval}" in
+       yes) EMULATION=true;;
+       no)  EMULATION=false;;
+       *) AC_MSG_ERROR([bad value ${enableval} for --enable-emu]);;
+   esac],
+   [EMULATION=false]
+)
+
+# default is to support tesla-class, this enables building for fermi-class
+ac_have_fermi_gpu=no
+AC_ARG_ENABLE(fermi-gpu,
+ [  --enable-fermi-gpu      enable NVidia Fermi GPU support],
+ [ ac_have_fermi_gpu=yes
+   AC_MSG_NOTICE(Building for Fermi-class GPU)
+ ])
+AM_CONDITIONAL(HAVE_FERMI_GPU, test "x$ac_have_fermi_gpu" = "xyes")
+
+# setup nvcc flags (default is for tesla-class, --enable-fermi-gpu overrides)
+NVIDIA_ARCH="sm_11"
+if test x$ac_have_fermi_gpu = xyes
+then
+  NVIDIA_ARCH="sm_20"
+fi
+if test x$DEBUG = xtrue
+then
+   NVCCFLAGS="-g -arch $NVIDIA_ARCH --ptxas-options=-v"
+else
+   NVCCFLAGS="-arch $NVIDIA_ARCH --ptxas-options=-v -g"
+fi
+if test x$EMULATION = xtrue
+then
+   NVCCFLAGS+=" -deviceemu"
+fi
+if test x$MAC_64 = xYES
+then
+   NVCCFLAGS+=" -m64"
+fi
+# Ubuntu hack: NVCCFLAGS+=" --compiler-bindir=/usr/bin/gcc-4.3"
+AC_SUBST(NVCCFLAGS)
+
+# warn the user about missing functionality
+if( test x$NVCC = xno ) then
+  AC_MSG_NOTICE(Nvidia CUDA nvcc compiler not found or --without-cuda used.)
+  AC_MSG_NOTICE(CUDA support will not be built.)
+  AC_MSG_NOTICE(If you have CUDA and need CUDA support,)
+  AC_MSG_NOTICE(check the path to CUDA and specify --with-cuda=/path/to/cuda)
+fi
+
+##############################################################
+# cpu optimization
+##############################################################
+CPUFLAGS=""
+if test "${CC}" = "gcc"; then
+AC_MSG_NOTICE(Setting CPU optimization...)
+CPUTYPE="NO"
+####
+#### cpu type: we support
+####     pentium3, pentium4,
+####     athlon-xp, opteron, athlon64, athlon-fx
+####
+AC_ARG_WITH(cpu,
+[  --with-cpu=CPUTYPE      where CPUTYPE is pentium4, athlon-xp, G4, G5...],
+  [CPUTYPE=$withval],[])
+# --with-cpu not used  automatically figure out
+if test "$CPUTYPE" = "NO"; then
+  case "$OS" in
+  Darwin)
+    mac_hardware=`uname -m`
+    case "$mac_hardware" in
+      i386)
+      CPUTYPE=intel-mac
+      ;;
+      x86_64)
+      CPUTYPE=x86_64
+      ;;
+      *)
+      CPUTYPE="NO"
+      echo "unknown mac cpu $mac_hardware"
+      ;;
+      esac
+    ;;
+  Linux)
+    case "${target}" in
+    i*86-*-linux-gnu*)
+      CPUCAPS=`${srcdir}/x86cpucaps/cpucaps -m | sed 's/ //g'`
+      case "$CPUCAPS" in
+        PentiumIII*)
+        CPUTYPE=pentium3
+        ;;
+        Pentium4)
+        CPUTYPE=pentium4
+        ;;
+        PentiumM*)
+        CPUTYPE=pentium4
+        ;;
+        AMDAthlonXP*)
+        CPUTYPE=athlonxp
+        ;;
+      esac
+      ;;
+    x86_64-*)
+      # this is the only was I found to determine
+      if test -e "/proc/cpuinfo" ; then
+        CPUCAPS=`cat /proc/cpuinfo | egrep "model name" | head -n1`
+      fi
+      if test "x$CPUCAPS" = "x" ; then
+        CPUCAPS=`${srcdir}/x86cpucaps/cpucaps -m | sed 's/ //g'`
+      fi
+      CPUTYPE=x86_64
+      case "$CPUCAPS" in
+        *Xeon*E5-*)
+        CPUTYPE=intel_haswell
+        ;;
+        AMDAthlon64)
+        CPUTYPE=athlon64
+        ;;
+        AMDOpteron*)
+        CPUTYPE=opteron
+        ;;
+      esac
+      ;;
+    powerpc64-*)
+      CPUTYPE=powerpc64
+      ;;
+    ia64-*)
+      CPUTYPE=itanium
+      ;;
+    esac
+    ;;
+  esac
+fi
+
+AC_MSG_NOTICE(CPUTYPE is $CPUTYPE)
+AC_MSG_CHECKING(CPU optimization...)
+AC_SUBST(CPUCAPS)
+AC_SUBST(CPUTYPE)
+
+# now set the flags
+case "$CPUTYPE" in
+  intel_haswell)
+     #CPUFLAGS="-march=core-avx2 -m64"
+     CPUFLAGS="-m64"
+     ;;
+  pentium3)
+#     CPUFLAGS="-march=pentium3"
+     CPUFLAGS=""
+     ;;
+  pentium4)
+#     CPUFLAGS="-march=pentium4"
+     CPUFLAGS=""
+     ;;
+  athlonxp)
+#     CPUFLAGS="-march=pentium3"
+     CPUFLAGS=""
+     ;;
+  opteron)
+#     CPUFLAGS="-march=x86-64"
+     CPUFLAGS="-m64"
+     ;;
+  itanium)
+     CPUFLAGS="-mtune=itanium2"
+     ;;
+  athlon64)
+#     CPUFLAGS="-march=x86-64"
+     CPUFLAGS="-m64"
+     ;;
+  athlon-fx)
+#     CPUFLAGS="-march=x86-64"
+     CPUFLAGS="-m64"
+     ;;
+  x86_64)
+     CPUFLAGS="-m64"
+     ;;
+  G4)
+     CPUFLAGS="-mtune=G4 -mcpu=G4 -faltivec"
+     ;;
+  G5)
+     # maintain G4 backwards compatibility
+     CPUFLAGS="-mtune=G4 -mcpu=G4 -faltivec"
+     ;;
+  power4)
+     CPUFLAGS="-mtune=power4 -mcpu=power4"
+     ;;
+  power5)
+     CPUFLAGS="-mtune=power5 -mcpu=power5"
+     ;;
+  powerpc64)
+     CPUFLAGS="-mpowerpc64 -m32"
+     ;;
+  intel-mac)
+     CPUFLAGS="-fast"
+     ;;
+  *)
+     echo "cpu optimization not set"
+     ;;
+esac
+
+found=$CPUFLAGS
+# set the value
+
+AC_MSG_RESULT($found)
+
+#####
+# if gcc
+fi
+
+# if using the AMD Open64 compiler, flags for the fastest optimization dont work.
+# -Ofast equals -O3, -IPA, -OPT:Ofast, -fno-math-errno, and -ffast-math
+# Note! Dont use -ffast-math  Results from mri_ca_normalize differ too much
+# from the reference.  -IPA gives all kinds of compile errors.
+if test "x$CC" = "x${ac_open64_binaries}/opencc"; then
+  AC_MSG_NOTICE(Setting AMD Open64 Compiler optimizations...)
+  CPUFLAGS="-march=anyx86 -m64 $CPUFLAGS"
+  #CPUFLAGS="-Ofast $CPUFLAGS"
+  #LDFLAGS="-ipa $LDFLAGS"
+  #CPPFLAGS=`echo $CPPFLAGS | sed /-O2//`
+fi
+
+###############################################################
+# verify that CPUFLAGS work
+###############################################################
+ac_save_CFLAGS=$CFLAGS
+CFLAGS="$CPUFLAGS $CFLAGS"
+echo "$as_me:$LINENO: checking whether $CC accepts $CPUFLAGS" >&5
+echo $ECHO_N "checking whether $CC accepts $CPUFLAGS... $ECHO_C" >&6
+if test "${ac_cv_prog_cc_cpuflags+set}" = set; then
+  echo $ECHO_N "(cached) $ECHO_C" >&6
+else
+  cat >conftest.$ac_ext <<_ACEOF
+#line $LINENO "configure"
+/* confdefs.h.  */
+_ACEOF
+cat confdefs.h >>conftest.$ac_ext
+cat >>conftest.$ac_ext <<_ACEOF
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+rm -f conftest.$ac_objext
+if { (eval echo "$as_me:$LINENO: \"$ac_compile\"") >&5
+  (eval $ac_compile) 2>&5
+  ac_status=$?
+  echo "$as_me:$LINENO: \$? = $ac_status" >&5
+  (exit $ac_status); } &&
+         { ac_try='test -s conftest.$ac_objext'
+  { (eval echo "$as_me:$LINENO: \"$ac_try\"") >&5
+  (eval $ac_try) 2>&5
+  ac_status=$?
+  echo "$as_me:$LINENO: \$? = $ac_status" >&5
+  (exit $ac_status); }; }; then
+  ac_cv_prog_cc_cpuflags=yes
+else
+  echo "$as_me: failed program was:" >&5
+sed 's/^/| /' conftest.$ac_ext >&5
+
+ac_cv_prog_cc_cpuflags=no
+fi
+rm -f conftest.$ac_objext conftest.$ac_ext
+fi
+
+echo "$as_me:$LINENO: result: $ac_cv_prog_cc_cpuflags" >&5
+echo "${ECHO_T}$ac_cv_prog_cc_cpuflags" >&6
+
+if test $ac_cv_prog_cc_cpuflags = no; then
+ AC_MSG_NOTICE([$CC on this PC cannot accept $CPUFLAGS. $CC may be too old?])
+ CPUFLAGS=""
+fi
+# write the flag file
+echo "CPUFLAGS=$CPUFLAGS" > cpuflags.mak
+
+CFLAGS=$ac_save_CFLAGS
+
+# append these CPUFLAGS to our existing CPPFLAGS
+CPPFLAGS="$CPPFLAGS $CPUFLAGS"
+
+
+##############################################################
+# This macro figures out how to build C programs using
+# POSIX threads.
+##############################################################
+if test ! "$OS" = "SunOS"; then
+  ACX_PTHREAD
+fi
+
+##############################################################
+# get the path for X includes and X libraries
+##############################################################
+AC_PATH_X
+
+if test "x$x_includes" = "xNONE"; then
+  # Mac sets it to NONE, but this is really ""
+  if test -d "/usr/X11R6/include" ; then
+    x_includes=/usr/X11R6/include
+  fi
+  if test -d "/usr/X11/include" ; then
+    x_includes=/usr/X11/include
+  fi
+fi
+if test "x$x_includes" = "x"; then
+  if test -d "/usr/X11R6/include" ; then
+    x_includes=/usr/X11R6/include
+  fi
+  if test -d "/usr/X11/include" ; then
+    x_includes=/usr/X11/include
+  fi
+fi
+AC_MSG_NOTICE([x_includes set to $x_includes  \
+If not correct specify using --x-includes=])
+
+# the path to the X libs is not always defined, so find it...
+if test "x$x_libraries" = "xNONE"; then
+  # Mac sets empty to NONE, we want ""
+  x_libraries=
+fi
+if test "x$x_libraries" = "x"; then
+  # most common location
+  if test -d "/usr/X11R6/lib" ; then
+    x_libraries=/usr/X11R6/lib
+  fi
+  # replace with lib64 if that exists
+  if test -d "/usr/lib64" ; then
+    x_libraries=/usr/lib64
+  fi
+  if test -d "/usr/lib/x86_64-linux-gnu" ; then
+    x_libraries=/usr/lib/x86_64-linux-gnu
+  fi
+  if test -d "/usr/X11R6/lib64" ; then
+    x_libraries=/usr/X11R6/lib64
+  fi
+  # centos7 location
+  if test -e "/lib64/libX11.so" ; then
+    x_libraries=/lib64
+  fi
+
+
+fi
+AC_MSG_NOTICE([x_libraries set to $x_libraries  \
+If not correct specify using --x-libraries=])
+
+# find two necessary X libs
+if test ! "x$x_libraries" = "x"; then
+  AC_CHECK_LIB([X11 -L$x_libraries],[XOpenDisplay],
+                    [X_LIBS="$X_LIBS -L$x_libraries -lX11"],[])
+  AC_CHECK_LIB([Xmu -L$x_libraries],[XmuClientWindow],
+                    [X_LIBS="$X_LIBS -L$x_libraries -lXmu"],[])
+fi
+AC_SUBST(X_LIBS)
+
+
+AC_MSG_NOTICE([Checking for directory specification of 3rd-party libraries...])
+
+#############################################################
+# MNI
+#############################################################
+ac_mni_includes=NO
+ac_mni_libraries=NO
+MNI_CFLAGS=""
+MNI_LIBS=""
+MNI_DIR=""
+
+#if test 0; then
+#   AC_MSG_CHECKING(MNI directory)
+#   
+#   AC_ARG_WITH(mni-dir,
+#   [  --with-mni-dir=DIR      where the root of MNI is installed.],
+#     [  ac_mni_includes="$withval"/include
+#        ac_mni_libraries="$withval"/lib
+#        MNI_DIR="$withval"
+#     ])
+#   
+#   if test "x$MNI_DIR" = "x"; then
+#     # if an MNI root was not supplied, but one exists in the
+#     # default packages path at the NMR Center, then use that:
+#     if test -d "${PACKAGES_DIR}/mni/current" ; then
+#       withval=${PACKAGES_DIR}/mni/current
+#       MNI_DIR="$withval"
+#       ac_mni_includes="$withval"/include
+#       ac_mni_libraries="$withval"/lib
+#     fi
+#   fi
+#   
+#   if test ! "$ac_mni_includes" = "NO"; then
+#     AC_MSG_RESULT(MNI directory is $withval)
+#     MNI_CFLAGS=-I$ac_mni_includes
+#   else
+#     AC_MSG_RESULT(MNI directory is not supplied)
+#   fi
+#   
+#   if test ! "$ac_mni_libraries" = "NO"; then
+#     MNI_LIBS=-L$ac_mni_libraries
+#   fi
+#   
+#   
+#   LIB_VOLUME_IO=""
+#   if test -e ${PACKAGES_DIR}/mni/current/lib/libvolume_io.a ; then
+#     LIB_VOLUME_IO="${PACKAGES_DIR}/mni/current/lib/libvolume_io.a"
+#   else
+#     LIB_VOLUME_IO="-lvolume_io"
+#   fi
+#   
+#   LIB_MINC=""
+#   if test -e ${PACKAGES_DIR}/mni/current/lib/libminc.a ; then
+#     LIB_MINC="${PACKAGES_DIR}/mni/current/lib/libminc.a"
+#   else
+#     LIB_MINC="-lminc"
+#   fi
+#   
+#   # these are the libs used by freesurfer:
+#   MINC2=NO
+#   if test -e "$ac_mni_libraries/libminc2.a" ; then
+#     # newer build of the MNI tools
+#     LIBS_MNI="$LIB_NETCDF -lhdf5 -lvolume_io2 -lminc2"
+#     MINC2=YES
+#   else
+#     LIBS_MNI="$LIB_VOLUME_IO $LIB_MINC $LIB_NETCDF"
+#   fi
+#fi
+
+AC_SUBST(MNI_CFLAGS)
+AC_SUBST(MNI_LIBS)
+AC_SUBST(MNI_DIR)
+AC_SUBST(LIBS_MNI)
+
+
+################################################################
+# NIfTI
+################################################################
+ac_nifti_includes="NO"
+ac_nifti_libraries="NO"
+ac_nifti_bindir="NO"
+ac_nifti_dir="NO"
+NIFTI_CFLAGS=""
+NIFTI_LIBS=""
+NIFTI_LIB=""
+NIFTI_DIR=""
+LIBS_NIFTI=""
+
+AC_MSG_CHECKING(NIfTI directory)
+
+AC_ARG_WITH(nifti-dir,
+  [  --with-nifti-dir=DIR    where the root of NIfTI is installed.],
+  [  ac_nifti_includes="$withval"/include
+     ac_nifti_libraries="$withval"/lib
+     ac_nifti_bindir="$withval"/bin
+     ac_nifti_dir="$withval"
+  ])
+
+AC_ARG_WITH(nifti-include,
+  [  --with-nifti-include=DIR    root of NIfTI include directory.],
+  [  ac_nifti_includes="$withval"
+  ])
+
+AC_ARG_WITH(nifti-libraries,
+  [  --with-nifti-libraries=DIR  root of NIfTI lib directory.],
+  [  ac_nifti_libraries="$withval"
+  ])
+
+if test ! "$ac_nifti_includes" = "NO"; then
+  AC_MSG_RESULT(NIfTI directory is $withval)
+  NIFTI_CFLAGS=-I$ac_nifti_includes
+  NIFTI_DIR=$ac_nifti_dir
+else
+  AC_MSG_RESULT(NIfTI directory is not supplied)
+fi
+
+if test ! "$ac_nifti_libraries" = "NO"; then
+  NIFTI_LIB=$ac_nifti_libraries
+  NIFTI_LIBS=-L$ac_nifti_libraries
+fi
+
+AC_SUBST(NIFTI_CFLAGS)
+AC_SUBST(NIFTI_LIBS)
+AC_SUBST(NIFTI_LIB)
+AC_SUBST(NIFTI_DIR)
+
+AM_CONDITIONAL(HAVE_NIFTI_LIBS, ! test "x$ac_nifti_dir" = "xNO")
+
+
+################################################################
+# VXL
+################################################################
+ac_vxl_includes="NO"
+ac_vxl_libraries="NO"
+VXL_CFLAGS=""
+VXL_LIBS=""
+VXL_LIB=""
+AC_MSG_CHECKING(VXL directory)
+
+AC_ARG_WITH(vxl-dir,
+  [  --with-vxl-dir=DIR      where the root of VXL is installed.],
+  [  # v1.7.0 has new vxl dir, earlier versions do not!
+     if test -d "$withval/include/vxl"; then
+        vxl_i="$withval/include/vxl"
+     else
+        vxl_i="$withval/include"
+     fi
+     ac_vxl_includes="$vxl_i/core $vxl_i/vcl $vxl_i/v3p/netlib $vxl_i/v3p/netlib/opt"
+     ac_vxl_libraries="$withval"/lib
+     VXL_DIR="$withval"
+     AC_SUBST(VXL_DIR)
+  ])
+
+# NJS: --with-itk-4.5.1-vxl is a temporary hack to allow building against
+# ITK v4.5.1, which doesnt seem to work with the default vxl, so we use the
+# Vxl code within itk
+AC_ARG_WITH(itk-4.5.1-vxl,
+  [  --with-itk-4.5.1-vxl     set paths to use VXL in NMR Center ITK v4.5.1.],
+  [  ac_vxl_includes="$withval"/include/ITK-4.5
+     ac_vxl_libraries="$withval"/lib
+     VXL_DIR="$withval"
+     itk_45_vxl="yes"
+     AC_SUBST(VXL_DIR)
+  ])
+# end NJS HACK
+
+if test "x$VXL_DIR" = "x"; then
+  # if a VXL root was not supplied, but one exists in the
+  # default packages path at the NMR Center, then use that:
+  if test -d "${PACKAGES_DIR}/vxl/current" ; then
+    withval=${PACKAGES_DIR}/vxl/current
+    VXL_DIR="$withval"
+    if test -d "$withval/include/vxl"; then
+      vxl_i="$withval/include/vxl"
+    else
+      vxl_i="$withval/include"
+    fi
+    ac_vxl_includes="$vxl_i/core $vxl_i/vcl $vxl_i/v3p/netlib $vxl_i/v3p/netlib/opt"
+    ac_vxl_libraries="$withval"/lib
+  fi
+fi
+
+AC_ARG_WITH(vxl-include,
+  [  --with-vxl-include=DIR      root of VXL include directory.],
+  [  if test -d "$withval/include/vxl"; then
+        vxl_i="$withval/include/vxl"
+     else
+        vxl_i="$withval/include"
+     fi
+     ac_vxl_includes="$vxl_i/core $vxl_i/vcl $vxl_i/v3p/netlib $vxl_i/v3p/netlib/opt"
+  ])
+
+AC_ARG_WITH(vxl-libraries,
+  [  --with-vxl-libraries=DIR    root of VXL lib directory.],
+  [  ac_vxl_libraries="$withval"
+  ])
+
+if test ! "$ac_vxl_includes" = "NO"; then
+  AC_MSG_RESULT(VXL directory is $withval)
+  for item in $ac_vxl_includes; do
+      VXL_CFLAGS="${VXL_CFLAGS} -I${item}"
+  done
+else
+  AC_MSG_RESULT(VXL directory is not supplied)
+fi
+
+if test ! "$ac_vxl_libraries" = "NO"; then
+  VXL_LIBS=-L$ac_vxl_libraries
+  VXL_LIB=$ac_vxl_libraries
+fi
+
+# these are the VXL libs used by freesurfer:
+LIBS_VXL="-lvnl_algo -lvnl -lvcl -lnetlib -lv3p_netlib"
+# NJS HACK ITK 4.5.1 has these:
+if test "x$itk_45_vxl" = "xyes"; then
+  LIBS_VXL="-litkvnl_algo-4.5 -litkvnl-4.5 -litkvcl-4.5 -litkv3p_netlib-4.5"
+fi
+
+AC_SUBST(VXL_CFLAGS)
+AC_SUBST(VXL_LIBS)
+AC_SUBST(VXL_LIB)
+AC_SUBST(LIBS_VXL)
+
+################################################################
+# PETSc
+################################################################
+ac_petsc_includes="NO"
+ac_petsc_libraries="NO"
+ac_petsc_bindir="NO"
+ac_petsc_dir="NO"
+PETSC_CFLAGS=""
+PETSC_LIBS=""
+PETSC_LIB=""
+PETSC_DIR=""
+
+AC_MSG_CHECKING(PETSc directory)
+
+AC_ARG_WITH(petsc-dir,
+  [  --with-petsc-dir=DIR    where the root of PETSc is installed.],
+  [  petsc_i="$withval"/include
+     ac_petsc_includes="$petsc_i"
+     ac_petsc_libraries="$withval"/lib
+     ac_petsc_bindir="$withval"/bin
+     ac_petsc_dir="$withval"
+     PETSC_DIR="$withval"
+     AC_SUBST(PETSC_DIR)
+  ])
+
+if test "x$PETSC_DIR" = "x"; then
+  # if a PETSC root was not supplied, but one exists in the
+  # default packages path at the NMR Center, then use that:
+  if test -d "${PACKAGES_DIR}/petsc/current" ; then
+    withval=${PACKAGES_DIR}/petsc/current
+    PETSC_DIR="$withval"
+    ac_petsc_dir="$withval"
+    petsc_i="$withval"/include
+    ac_petsc_includes="$petsc_i"
+    ac_petsc_libraries="$withval"/lib
+  fi
+fi
+
+AC_ARG_WITH(petsc-include,
+  [  --with-petsc-include=DIR    root of PETSc include directory.],
+  [  ac_petsc_includes="$withval"
+  ])
+
+AC_ARG_WITH(petsc-libraries,
+  [  --with-petsc-libraries=DIR  root of PETSc lib directory.],
+  [  ac_petsc_libraries="$withval"
+  ])
+
+if test ! "$ac_petsc_includes" = "NO"; then
+  AC_MSG_RESULT(PETSc directory is $withval)
+  for item in $ac_petsc_includes; do
+    PETSC_CFLAGS="${PETSC_CFLAGS} -I${item}"
+  done
+  PETSC_DIR=$ac_petsc_dir
+else
+  AC_MSG_RESULT(PETSc directory is not supplied)
+fi
+
+if test ! "$ac_petsc_libraries" = "NO"; then
+  PETSC_LIB=$ac_petsc_libraries
+  PETSC_LIBS=-L$ac_petsc_libraries
+fi
+
+AC_SUBST(PETSC_CFLAGS)
+AC_SUBST(PETSC_LIBS)
+AC_SUBST(PETSC_LIB)
+AC_SUBST(PETSC_DIR)
+
+AM_CONDITIONAL(HAVE_PETSC_LIBS, ! test "x$ac_petsc_dir" = "xNO")
+
+
+################################################################
+# MPI
+################################################################
+ac_mpi_includes="NO"
+ac_mpi_libraries="NO"
+ac_mpi_bindir="NO"
+ac_mpi_dir="NO"
+MPI_CFLAGS=""
+MPI_LIBS=""
+MPI_LIB=""
+MPI_DIR=""
+
+AC_MSG_CHECKING(MPI directory)
+
+AC_ARG_WITH(mpi-dir,
+  [  --with-mpi-dir=DIR      where the root of MPI is installed.],
+  [  ac_mpi_includes="$withval"/include
+     ac_mpi_libraries="$withval"/lib
+     ac_mpi_bindir="$withval"/bin
+     ac_mpi_dir="$withval"
+  ])
+
+AC_ARG_WITH(mpi-include,
+  [  --with-mpi-include=DIR      root of MPI include directory.],
+  [  ac_mpi_includes="$withval"
+  ])
+
+AC_ARG_WITH(mpi-libraries,
+  [  --with-mpi-libraries=DIR    root of MPI lib directory.],
+  [  ac_mpi_libraries="$withval"
+  ])
+
+if test ! "$ac_mpi_includes" = "NO"; then
+  AC_MSG_RESULT(MPI directory is $withval)
+  MPI_CFLAGS=-I$ac_mpi_includes
+  MPI_DIR=$ac_mpi_dir
+else
+  AC_MSG_RESULT(MPI directory is not supplied)
+fi
+
+if test ! "$ac_mpi_libraries" = "NO"; then
+  MPI_LIB=$ac_mpi_libraries
+  MPI_LIBS=-L$ac_mpi_libraries
+fi
+
+AC_SUBST(MPI_CFLAGS)
+AC_SUBST(MPI_LIBS)
+AC_SUBST(MPI_LIB)
+AC_SUBST(MPI_DIR)
+
+AM_CONDITIONAL(HAVE_MPI_LIBS, ! test "x$ac_mpi_dir" = "xNO")
+
+
+################################################################
+# BOOST
+################################################################
+ac_boost_includes="NO"
+ac_boost_libraries="NO"
+ac_boost_dir="NO"
+BOOST_CFLAGS=""
+BOOST_LIBS=""
+BOOST_LIB=""
+BOOST_DIR=""
+
+AC_MSG_CHECKING(BOOST directory)
+
+AC_ARG_WITH(boost-dir,
+  [  --with-boost-dir=DIR    where the root of BOOST is installed.],
+  [  ac_boost_includes="$withval"/include
+     ac_boost_libraries="$withval"/lib
+     ac_boost_dir="$withval"
+  ])
+
+if test "x$BOOST_DIR" = "x"; then
+  # if a Boost root was not supplied, but one exists in the
+  # default packages path at the NMR Center, AND this is a mac,
+  # then use that:
+  # if test "$OS" = "Darwin"; then
+    if test -d "${PACKAGES_DIR}/boost/current" ; then
+      withval=${PACKAGES_DIR}/boost/current
+      BOOST_DIR="$withval"
+      ac_boost_dir="$withval"
+      boost_i="$withval"/include
+      ac_boost_includes="$boost_i"
+      ac_boost_libraries="$withval"/lib
+    fi
+  # fi
+fi
+
+AC_ARG_WITH(boost-include,
+  [  --with-boost-include=DIR    root of BOOST include directory.],
+  [  ac_boost_includes="$withval"
+  ])
+
+AC_ARG_WITH(boost-libraries,
+  [  --with-boost-libraries=DIR  root of BOOST lib directory.],
+  [  ac_boost_libraries="$withval"
+  ])
+
+if test ! "$ac_boost_includes" = "NO"; then
+  AC_MSG_RESULT(BOOST directory is $withval)
+  BOOST_CFLAGS=-I$ac_boost_includes
+  BOOST_DIR=$ac_boost_dir
+else
+  AC_MSG_RESULT(BOOST directory is not supplied)
+fi
+
+if test ! "$ac_boost_libraries" = "NO"; then
+  BOOST_LIB=$ac_boost_libraries
+  BOOST_LIBS=-L$ac_boost_libraries
+fi
+
+AC_SUBST(BOOST_CFLAGS)
+AC_SUBST(BOOST_LIBS)
+AC_SUBST(BOOST_LIB)
+AC_SUBST(BOOST_DIR)
+
+AM_CONDITIONAL(HAVE_BOOST_LIBS, ! test "x$ac_boost_libraries" = "xNO")
+
+
+################################################################
+# ANN (Approximate Nearest Neighbors library)
+################################################################
+ac_ann_includes="NO"
+ac_ann_libraries="NO"
+ac_ann_dir="NO"
+ANN_CFLAGS=""
+ANN_LIBS=""
+ANN_LIB=""
+ANN_DIR=""
+
+AC_MSG_CHECKING(ANN Approximate Nearest Neighbors directory)
+
+AC_ARG_WITH(ann-dir,
+  [  --with-ann-dir=DIR      where the root of ANN is installed.],
+  [  ac_ann_includes="$withval"/include
+     ac_ann_libraries="$withval"/lib
+     ac_ann_dir="$withval"
+     ANN_DIR="$withval"
+     AC_SUBST(ANN_DIR)
+  ])
+
+if test "x$ANN_DIR" = "x"; then
+  # if a ANN root was not supplied, but one exists in the
+  # default packages path at the NMR Center, then use that:
+  if test -d "${PACKAGES_DIR}/ann/current" ; then
+    withval=${PACKAGES_DIR}/ann/current
+    ANN_DIR="$withval"
+    ac_ann_includes="$withval"/include
+    ac_ann_libraries="$withval"/lib
+  fi
+fi
+
+AC_ARG_WITH(ann-include,
+  [  --with-ann-include=DIR      root of ANN include directory.],
+  [  ac_ann_includes="$withval"
+  ])
+
+AC_ARG_WITH(ann-libraries,
+  [  --with-ann-libraries=DIR    root of ANN lib directory.],
+  [  ac_ann_libraries="$withval"
+  ])
+
+if test ! "$ac_ann_includes" = "NO"; then
+  AC_MSG_RESULT(ANN directory is $withval)
+  ANN_CFLAGS=-I$ac_ann_includes
+  ANN_DIR=$ac_ann_dir
+else
+  AC_MSG_RESULT(ANN directory is not supplied)
+fi
+
+if test ! "$ac_ann_libraries" = "NO"; then
+  ANN_LIB=$ac_ann_libraries
+  ANN_LIBS=-L$ac_ann_libraries
+fi
+
+AC_SUBST(ANN_CFLAGS)
+AC_SUBST(ANN_LIBS)
+AC_SUBST(ANN_LIB)
+AC_SUBST(ANN_DIR)
+
+AM_CONDITIONAL(HAVE_ANN_LIBS, ! test "x$ac_ann_libraries" = "xNO")
+
+
+############################################################
+# Catch-all flag to disable OpenGL, Tcl/Tk, ITK and KWW apps
+############################################################
+tcltk_apps="NO"
+itk_apps="NO"
+kww_apps="NO"
+AC_ARG_ENABLE(GUI-build,
+ [  --disable-GUI-build     disable building Tcl/Tk, ITK, VTK/KWWidgets, wxWidgets and OpenGL-based apps],
+ [ tcltk_apps="NO"
+   itk_apps="NO"
+   vtk_apps="NO"
+   kww_apps="NO"
+   wxw_apps="NO"
+   need_opengl="NO"
+ ])
+
+AC_ARG_ENABLE(gl-apps,
+ [  --disable-gl-apps       disable building OpenGL-based apps],
+ [ need_opengl="NO"
+ ])
+
+
+####################################################
+# Tcl/Tk
+####################################################
+ac_tcl_includes="NO"
+ac_tcl_libraries="NO"
+TCL_CFLAGS=""
+TCL_LIBS=""
+TCL_LIB=""
+TCL_DIR=""
+
+AC_MSG_CHECKING(Tcl/Tk config)
+
+AC_ARG_WITH(tcl-dir,
+[  --with-tcl-dir=DIR      where the root of Tcl/Tk is installed.],
+  [  ac_tcl_includes="$withval"/include
+     ac_tcl_libraries="$withval"/lib
+     ac_tcl_dir="$withval"
+  ])
+
+if test "x$ac_tcl_dir" = "x"; then
+  # if a Tcl/Tk/Tix/BLT root was not supplied, but one exists in the
+  # default packages path at the NMR Center, then use that:
+  if test -d "${PACKAGES_DIR}/tcltktixblt/current" ; then
+    withval=${PACKAGES_DIR}/tcltktixblt/current
+    ac_tcl_dir="$withval"
+    ac_tcl_includes="$withval"/include
+    ac_tcl_libraries="$withval"/lib
+  fi
+fi
+
+AC_ARG_WITH(tcl-include,
+  [  --with-tcl-include=DIR      root of Tcl/Tk include directory.],
+  [  ac_tcl_includes="$withval"
+  ])
+
+AC_ARG_WITH(tcl-libraries,
+  [  --with-tcl-libraries=DIR    root of Tcl/Tk lib directory.],
+  [  ac_tcl_libraries="$withval"
+  ])
+
+if test ! "$ac_tcl_includes" = "NO"; then
+  AC_MSG_RESULT([Tcl directory is $withval])
+  TCL_CFLAGS=-I$ac_tcl_includes
+fi
+
+if test ! "$ac_tcl_libraries" = "NO"; then
+  TCL_LIBS=-L$ac_tcl_libraries
+  TCL_LIB=$ac_tcl_libraries
+  TCL_DIR=$ac_tcl_dir
+  tcltk_apps="yes"
+fi
+
+AC_ARG_ENABLE(tcltk-apps,
+ [  --disable-tcltk-apps    disable building Tcl/Tk-based apps],
+ [ tcltk_apps="NO"
+ ])
+
+if test "$disable_gui_build" = "YES"; then
+  tcltk_apps="NO"
+fi
+
+# Disable building of tcltk apps on Mac 64bit systems
+# due to issues with the tcltkixblt package.
+if test x$MAC_64 = xYES
+then
+   tcltk_apps="NO"
+fi
+
+if test "$tcltk_apps" = "yes"; then
+  AC_MSG_RESULT([Enabled building of Tcl/Tk apps.])
+  # enable testing for OpenGL libs:
+  need_opengl=yes
+else
+  AC_MSG_RESULT([Not building Tcl/Tk apps.])
+fi
+
+AM_CONDITIONAL(ENABLE_TCLTK_APPS, test "$tcltk_apps" = "yes")
+
+AC_SUBST(TCL_CFLAGS)
+AC_SUBST(TCL_LIBS)
+AC_SUBST(TCL_LIB)
+AC_SUBST(LIBS_TCL)
+AC_SUBST(TCL_DIR)
+
+
+##################################################################
+# allow user to specify tixwish
+AC_ARG_WITH(tixwish,
+[  --with-tixwish=TIXWISH  where you specify the file for tixwish],
+  [TIXWISH=$withval],[])
+# if TIXWISH has been set, then it does not do anything
+AC_PATH_PROG([TIXWISH],[tixwish],[])
+if test "x$TIXWISH" = "x"; then
+  AC_PATH_PROG([TIXWISH],[tixwish8.1.8.3],[])
+  if test "x$TIXWISH" = "x"; then
+    AC_PATH_PROG([TIXWISH],[tixwish8.1.8.4],[])
+  fi
+fi
+# and check
+if test "x$TIXWISH" = "x"; then
+  if test "x$tcltk_apps" = "xyes"; then
+    AC_MSG_RESULT([INFO: tixwish not found. Use --with-tixwish=... to specify])
+  fi
+fi
+
+AC_SUBST(TIXWISH)
+
+
+################################################################
+# BLT
+################################################################
+ac_blt_includes="NO"
+ac_blt_libraries="NO"
+ac_blt_bindir="NO"
+BLT_CFLAGS=""
+BLT_LIBS=""
+if test "$OS" = "SunOS"; then
+  BLT_LIBS="-lm "
+fi
+AC_MSG_CHECKING(BLT directory)
+
+AC_ARG_WITH(BLT-dir,
+[  --with-BLT-dir=DIR      where the root of BLT is installed.],
+  [  ac_blt_includes="$withval"/include
+     ac_blt_libraries="$withval"/lib
+     ac_blt_bindir="$withval"/bin
+  ])
+
+if test ! "$ac_blt_includes" = "NO"; then
+  AC_MSG_RESULT(BLT directory is $withval)
+  BLT_CFLAGS=-I$ac_blt_includes
+else
+  AC_MSG_RESULT(BLT directory is not supplied)
+fi
+if test ! "$ac_blt_libraries" = "NO"; then
+  BLT_LIBS=-L$ac_blt_libraries
+fi
+
+TCL_CFLAGS="$BLT_CFLAGS $TCL_CFLAGS"
+AC_SUBST(TCL_CFLAGS)
+AC_SUBST(BLT_CFLAGS)
+AC_SUBST(BLT_LIBS)
+
+
+################################################################
+# XawPlus - the nmovie app uses this
+################################################################
+ac_xawplus_includes="NO"
+ac_xawplus_libraries="NO"
+ac_xawplus_dir="NO"
+xawplus_apps="NO"
+XAWPLUS_CFLAGS=""
+XAWPLUS_CXXFLAGS=""
+XAWPLUS_LIBS=""
+
+AC_MSG_CHECKING(XawPlus directory)
+
+AC_ARG_WITH(xawplus-dir,
+  [  --with-xawplus-dir=DIR  where the root of XawPlus is installed.],
+  [  ac_xawplus_includes="$withval"/include
+     ac_xawplus_libraries="$withval"/lib
+     ac_xawplus_dir="$withval"
+  ])
+
+if test "x$ac_xawplus_dir" = "xNO"; then
+  # if a Xawplus root was not supplied, but one exists in the
+  # default packages path at the NMR Center, then use that:
+  if test -d "${PACKAGES_DIR}/xawplus/current" ; then
+    withval=${PACKAGES_DIR}/xawplus/current
+    ac_xawplus_dir="$withval"
+    ac_xawplus_includes="$withval"/include
+    ac_xawplus_libraries="$withval"/lib
+  fi
+fi
+
+if test ! "$ac_xawplus_includes" = "NO"; then
+  AC_MSG_RESULT(XawPlus directory is $withval)
+  for item in $ac_xawplus_includes; do
+    XAWPLUS_CFLAGS="${XAWPLUS_CFLAGS} -I${item}"
+    XAWPLUS_CXXFLAGS="${XAWPLUS_CXXFLAGS} -I${item}"
+  done
+  XAWPLUS_DIR=$ac_xawplus_dir
+  AC_SUBST(XAWPLUS_DIR)
+  xawplus_apps="yes"
+else
+  AC_MSG_RESULT(XawPlus directory is not supplied)
+fi
+
+if test ! "$ac_xawplus_libraries" = "NO"; then
+  for item in $ac_xawplus_libraries; do
+    XAWPLUS_LIBS="${XAWPLUS_LIBS} -L${item}"
+  done
+  XAWPLUS_LIBS="${XAWPLUS_LIBS}"
+  AC_SUBST(XAWPLUS_LIBS)
+fi
+
+AC_ARG_ENABLE(xawplus-apps,
+ [  --enable-xawplus-apps   enable building XawPlus-based apps],
+ [ xawplus_apps="yes"
+ ])
+
+
+AC_ARG_ENABLE(xawplus-apps,
+ [  --disable-tcltk-apps    disable building XawPlus-based apps],
+ [ xawplus_apps="NO"
+ ])
+
+
+if test "$disable_gui_build" = "YES"; then
+  xawplus_apps="NO"
+fi
+
+if test "$xawplus_apps" = "yes"; then
+  AC_MSG_RESULT([Enabled building of XawPlus apps.])
+  # enable testing for OpenGL libs:
+  need_opengl=yes
+fi
+
+AM_CONDITIONAL(ENABLE_XAWPLUS_APPS, test "$xawplus_apps" = "yes")
+
+AC_SUBST(XAWPLUS_CFLAGS)
+AC_SUBST(XAWPLUS_CXXFLAGS)
+AC_SUBST(XAWPLUS_LIBS)
+
+
+################################################################
+# tiff
+################################################################
+# default is to use the libtiff included in freesurfer src tree,
+# local libtiff static lib declared later in LIBS_MGH.
+# allow someone to override with their own using --with-tiff-dir:
+ac_tiff_includes="NO"
+ac_tiff_libraries="NO"
+ac_tiff_bindir="NO"
+TIFF_CFLAGS=""
+TIFF_LIBS=""
+LIB_TIFF=""
+AC_MSG_CHECKING(Tiff directory)
+
+AC_ARG_WITH(tiff-dir,
+[  --with-tiff-dir=DIR     where the root of Tiff is installed.],
+  [  ac_tiff_includes="$withval"/include
+     ac_tiff_libraries="$withval"/lib
+     ac_tiff_bindir="$withval"/bin
+  ])
+
+if test ! "$ac_tiff_includes" = "NO"; then
+  AC_MSG_RESULT(Tiff directory is $withval)
+  TIFF_CFLAGS=-I$ac_tiff_includes
+else
+  AC_MSG_RESULT(Tiff directory is not supplied)
+fi
+if test ! "$ac_tiff_libraries" = "NO"; then
+  TIFF_LIBS=-L$ac_tiff_libraries
+  LIB_TIFF="-ltiff"
+fi
+
+AM_CONDITIONAL(USE_LOCAL_TIFF, test "$ac_tiff_libraries" = "NO")
+
+AC_SUBST(TIFF_CFLAGS)
+AC_SUBST(TIFF_LIBS)
+AC_SUBST(LIB_TIFF)
+
+
+################################################################
+# jpeg
+################################################################
+# default is to use the libjpeg included in freesurfer src tree,
+# allow someone to override with their own using --with-jpeg-dir.
+# local libjpeg static lib declared later in LIBS_MGH:
+ac_jpeg_includes="NO"
+ac_jpeg_libraries="NO"
+ac_jpeg_bindir="NO"
+JPEG_CFLAGS=""
+JPEG_LIBS=""
+LIB_JPEG="-ljpeg"
+AC_MSG_CHECKING(Jpeg directory)
+
+AC_ARG_WITH(jpeg-dir,
+  [  --with-jpeg-dir=DIR     where the root of Jpeg is installed.],
+  [  ac_jpeg_includes="$withval"/include
+     ac_jpeg_libraries="$withval"/lib
+     ac_jpeg_bindir="$withval"/bin
+  ])
+
+if test ! "$ac_jpeg_includes" = "NO"; then
+  AC_MSG_RESULT(Jpeg directory is $withval)
+  JPEG_CFLAGS=-I$ac_jpeg_includes
+else
+  AC_MSG_RESULT(Jpeg directory is not supplied)
+fi
+if test ! "$ac_jpeg_libraries" = "NO"; then
+  JPEG_LIBS=-L$ac_jpeg_libraries
+fi
+
+# use static lib if found
+if test -e "$ac_tcl_libraries/libjpeg.a"; then
+  LIB_JPEG="$ac_tcl_libraries/libjpeg.a"
+fi
+if test -e "/usr/lib/libjpeg.a"; then
+  LIB_JPEG="/usr/lib/libjpeg.a"
+fi
+if test -e "/usr/lib64/libjpeg.a"; then
+  LIB_JPEG="/usr/lib64/libjpeg.a"
+fi
+if test -e "${PACKAGES_DIR}/tiffjpegglut/current/lib/libjpeg.a"; then
+  LIB_JPEG="${PACKAGES_DIR}/tiffjpegglut/current/lib/libjpeg.a"
+fi
+if test -e "$ac_jpeg_libraries/libjpeg.a"; then
+  LIB_JPEG="$ac_jpeg_libraries/libjpeg.a"
+fi
+
+AM_CONDITIONAL(USE_LOCAL_JPEG, test "$ac_jpeg_libraries" = "NO")
+
+# BLT check (later in this file) needs a prebuilt libjpeg, use what we have
+# since we can't use the locally built libjpeg
+LIB_BLT_JPEG="$LIB_JPEG"
+
+AC_SUBST(JPEG_CFLAGS)
+AC_SUBST(JPEG_LIBS)
+AC_SUBST(LIB_JPEG)
+AC_SUBST(LIB_BLT_JPEG)
+
+
+################################################################
+# eXpat
+################################################################
+# default is to use the libexpat included in freesurfer src tree,
+# local libexpat static lib declared later in LIBS_MGH.
+# allow someone to override with their own using --with-expat-dir:
+ac_expat_includes="NO"
+ac_expat_libraries="NO"
+ac_expat_bindir="NO"
+EXPAT_CFLAGS=""
+EXPAT_LIBS=""
+LIB_EXPAT=""
+AC_MSG_CHECKING(Expat directory)
+
+AC_ARG_WITH(expat-dir,
+[  --with-expat-dir=DIR    where the root of Expat is installed.],
+  [  ac_expat_includes="$withval"/include
+     ac_expat_libraries="$withval"/lib
+     ac_expat_bindir="$withval"/bin
+  ])
+
+if test ! "$ac_expat_includes" = "NO"; then
+  AC_MSG_RESULT(Expat directory is $withval)
+  EXPAT_CFLAGS=-I$ac_expat_includes
+else
+  AC_MSG_RESULT(Expat directory is not supplied)
+fi
+if test ! "$ac_expat_libraries" = "NO"; then
+  EXPAT_LIBS=-L$ac_expat_libraries
+  LIB_EXPAT="-lexpat"
+fi
+
+AM_CONDITIONAL(USE_LOCAL_EXPAT, test "$ac_expat_libraries" = "NO")
+
+AC_SUBST(EXPAT_CFLAGS)
+AC_SUBST(EXPAT_LIBS)
+AC_SUBST(LIB_EXPAT)
+
+#
+# these are used by the local freesurfer expat source,
+# declared in config.h
+#
+AC_DEFINE([XML_NS], 1,
+[Define to make XML Namespaces functionality available.])
+AC_DEFINE([XML_DTD], 1,
+[Define to make parameter entity parsing functionality available.])
+AC_DEFINE([XML_CONTEXT_BYTES], 1024,
+[Define to specify how much context to retain around the current parse point.])
+
+
+################################################################
+# Qt
+################################################################
+QT_PATH=""
+QT_COMPONENTS="opengl script scripttools x11extras"
+if test x$MAC_64 = xYES; then
+   QT_COMPONENTS="opengl script scripttools"
+fi
+if test "$disable_gui_build" = "YES"; then
+  QT_PATH=""
+else
+  m4_include([m4/autotroll.m4])
+  AT_WITH_QT([$QT_COMPONENTS])
+fi
+
+AM_CONDITIONAL(ENABLE_QT_APPS, ! test "x$QT_PATH" = "x")
+AM_CONDITIONAL(USING_QT_5, test "$QT_VERSION_MAJOR" = "5")
+
+# hack: make sure our QT_LIBS overrides /usr/lib64 native Qt install
+# this is problematic on Centos6, where qt 4.6.3 is installed, but
+# we (at the NMR Center) want to use v4.7.1 in ${PACKAGES_DIR}/qt
+# and link-time errors (problem with 'detach_grow') appear if
+# qt 4.6.3 attempts to link because it is in /usr/lib64. this forces
+# an override:
+if test ! "x$QT_LIBS" = "x"; then
+  QTLIBS=`echo $QT_LIBS | awk '{print $1}'`
+  LDFLAGS="$QTLIBS $LDFLAGS"
+fi
+
+################################################################
+# CPPUNIT
+################################################################
+ac_cppunit_includes="NO"
+ac_cppunit_libraries="NO"
+ac_cppunit_bindir="NO"
+ac_cppunit_dir="NO"
+CPPUNIT_CFLAGS=""
+CPPUNIT_LIBS=""
+CPPUNIT_LIB=""
+CPPUNIT_DIR=""
+
+AC_MSG_CHECKING(CppUnit directory)
+
+AC_ARG_WITH(cppunit-dir,
+  [  --with-cppunit-dir=DIR  where the root of CppUnit is installed.],
+  [  ac_cppunit_includes="$withval"/include
+     ac_cppunit_libraries="$withval"/lib
+     ac_cppunit_bindir="$withval"/bin
+     ac_cppunit_dir="$withval"
+  ])
+
+if test "x$ac_cppunit_dir" = "xNO"; then
+  # if a CppUnit root was not supplied, but one exists in the
+  # default packages path at the NMR Center, then use that:
+  if test -d "${PACKAGES_DIR}/cppunit/current" ; then
+    withval=${PACKAGES_DIR}/cppunit/current
+    ac_cppunit_includes="$withval"/include
+    ac_cppunit_libraries="$withval"/lib
+    ac_cppunit_bindir="$withval"/bin
+    ac_cppunit_dir="$withval"
+  fi
+fi
+
+if test ! "$ac_cppunit_includes" = "NO"; then
+  AC_MSG_RESULT(CppUnit directory is $withval)
+  CPPUNIT_CFLAGS=-I$ac_cppunit_includes
+  CPPUNIT_DIR=$ac_cppunit_dir
+else
+  AC_MSG_RESULT(CppUnit directory is not supplied)
+fi
+
+if test ! "$ac_cppunit_libraries" = "NO"; then
+  CPPUNIT_LIB=$ac_cppunit_libraries
+  CPPUNIT_LIBS=-L$ac_cppunit_libraries
+fi
+
+AC_SUBST(CPPUNIT_CFLAGS)
+AC_SUBST(CPPUNIT_LIBS)
+AC_SUBST(CPPUNIT_LIB)
+AC_SUBST(CPPUNIT_DIR)
+
+AM_CONDITIONAL(HAVE_CPPUNIT, ! test "x$ac_cppunit_dir" = "xNO")
+
+
+################################################################
+# VTK
+################################################################
+ac_vtk_includes="NO"
+ac_vtk_libraries="NO"
+ac_vtk_dir="NO"
+VTK_CFLAGS=""
+VTK_CXXFLAGS=""
+VTK_LIBS=""
+VTK_LIB=""
+VTK_LIB_VTK=""
+VTK_DIR=""
+
+AC_MSG_CHECKING(VTK config)
+
+AC_ARG_WITH(vtk-dir,
+  [  --with-vtk-dir=DIR      where the root of VTK is installed.],
+  [  ac_vtk_includes="$withval/include"
+     ac_vtk_libraries="$withval"/lib
+     ac_vtk_dir="$withval"
+     VTK_DIR=$ac_vtk_dir
+  ])
+
+if test ! "$disable_gui_build" = "YES"; then
+  if test "x$VTK_DIR" = "x"; then
+    # if a VTK root was not supplied, but one exists in the
+    # default packages path at the NMR Center, then use that:
+    if test -d "${PACKAGES_DIR}/vtk/current" ; then
+      withval=${PACKAGES_DIR}/vtk/current
+      ac_vtk_includes="$withval/include"
+      ac_vtk_libraries="$withval"/lib
+      ac_vtk_dir="$withval"
+      VTK_DIR=$ac_vtk_dir
+    fi
+  fi
+fi
+
+AC_ARG_WITH(vtk-include,
+  [  --with-vtk-include=DIR      root of VTK include directory.],
+  [  vtk_i="$withval/include"
+     ac_vtk_includes="$vtk_i"
+  ])
+
+AC_ARG_WITH(vtk-libraries,
+  [  --with-vtk-libraries=DIR    root of VTK lib directory.],
+  [  ac_vtk_libraries="$withval"
+  ])
+
+if test ! "$ac_vtk_includes" = "NO"; then
+  AC_MSG_RESULT(VTK directory is $withval)
+  if test -e $ac_vtk_includes/vtk-5.10 ; then
+    ac_vtk_includes="$ac_vtk_includes/vtk-5.10"
+  elif test -e $ac_vtk_includes/vtk-5.6 ; then
+    ac_vtk_includes="$ac_vtk_includes/vtk-5.6"
+  elif test -e $ac_vtk_includes/vtk-5.5 ; then
+    ac_vtk_includes="$ac_vtk_includes/vtk-5.5"
+  elif test -e $ac_vtk_includes/vtk-5.4 ; then
+    ac_vtk_includes="$ac_vtk_includes/vtk-5.4"
+  elif test -e $ac_vtk_includes/vtk-5.3 ; then
+    ac_vtk_includes="$ac_vtk_includes/vtk-5.3"
+  elif test -e $ac_vtk_includes/vtk-5.2 ; then
+    ac_vtk_includes="$ac_vtk_includes/vtk-5.2"
+  elif test -e $ac_vtk_includes/vtk-5.1 ; then
+    ac_vtk_includes="$ac_vtk_includes/vtk-5.1"
+  elif test -e $ac_vtk_includes/vtk-5.0 ; then
+    ac_vtk_includes="$ac_vtk_includes/vtk-5.0"
+  elif test -e $ac_vtk_includes/vtk ; then
+    ac_vtk_includes="$ac_vtk_includes/vtk"
+  fi
+  VTK_CFLAGS="${VTK_CFLAGS} -I$ac_vtk_includes"
+  VTK_CXXFLAGS="${VTK_CXXFLAGS} -I$ac_vtk_includes"
+fi
+
+if test ! "$ac_vtk_libraries" = "NO"; then
+  VTK_LIBS=-L$ac_vtk_libraries
+  VTK_LIB=$ac_vtk_libraries
+  if test -e $ac_vtk_libraries/vtk-5.10 ; then
+    VTK_LIB_VTK="$ac_vtk_libraries/vtk-5.10"
+    VTK_LIBS=-L$ac_vtk_libraries/vtk-5.10
+    VTK_LIB=$ac_vtk_libraries/vtk-5.10
+  elif test -e $ac_vtk_libraries/vtk-5.6 ; then
+    VTK_LIB_VTK="$ac_vtk_libraries/vtk-5.6"
+    VTK_LIBS=-L$ac_vtk_libraries/vtk-5.6
+    VTK_LIB=$ac_vtk_libraries/vtk-5.6
+  elif test -e $ac_vtk_libraries/vtk-5.5 ; then
+    VTK_LIB_VTK="$ac_vtk_libraries/vtk-5.5"
+    VTK_LIBS=-L$ac_vtk_libraries/vtk-5.5
+    VTK_LIB=$ac_vtk_libraries/vtk-5.5
+  elif test -e $ac_vtk_libraries/vtk-5.4 ; then
+    VTK_LIB_VTK="$ac_vtk_libraries/vtk-5.4"
+    VTK_LIBS=-L$ac_vtk_libraries/vtk-5.4
+    VTK_LIB=$ac_vtk_libraries/vtk-5.4
+  elif test -e $ac_vtk_libraries/vtk-5.3 ; then
+    VTK_LIB_VTK="$ac_vtk_libraries/vtk-5.3"
+    VTK_LIBS=-L$ac_vtk_libraries/vtk-5.3
+    VTK_LIB=$ac_vtk_libraries/vtk-5.3
+  elif test -e $ac_vtk_libraries/vtk-5.2 ; then
+    VTK_LIB_VTK="$ac_vtk_libraries/vtk-5.2"
+    VTK_LIBS=-L$ac_vtk_libraries/vtk-5.2
+    VTK_LIB=$ac_vtk_libraries/vtk-5.2
+  elif test -e $ac_vtk_libraries/vtk-5.1 ; then
+    VTK_LIB_VTK="$ac_vtk_libraries/vtk-5.1"
+  elif test -e $ac_vtk_libraries/vtk-5.0 ; then
+    VTK_LIB_VTK="$ac_vtk_libraries/vtk-5.0"
+  elif test -e $ac_vtk_libraries/vtk ; then
+    VTK_LIB_VTK="$ac_vtk_libraries/vtk"
+  fi
+fi
+
+AM_CONDITIONAL(HAVE_VTK_LIBS, test ! "x$VTK_DIR" = "x")
+
+AC_SUBST(VTK_CFLAGS)
+AC_SUBST(VTK_CXXFLAGS)
+AC_SUBST(VTK_LIBS)
+AC_SUBST(VTK_LIB)
+AC_SUBST(VTK_LIB_VTK)
+AC_SUBST(VTK_DIR)
+
+
+################################################################
+# VTK for Freeview in Mac
+################################################################
+# This is a static build of Cocoa VTK because KWWidgets doesn't play
+# nice with this VTK. Hence different VTK for different things
+ac_vtk_cocoa_includes="NO"
+ac_vtk_cocoa_libraries="NO"
+ac_vtk_cocoa_dir="NO"
+VTK_COCOA_CFLAGS=""
+VTK_COCOA_CXXFLAGS=""
+VTK_COCOA_LIBS=""
+VTK_COCOA_LIB=""
+VTK_COCOA_LIB_VTK=""
+VTK_COCOA_DIR=""
+
+AC_MSG_CHECKING(Cocoa VTK config)
+
+AC_ARG_WITH(vtk-cocoa-dir,
+  [  --with-vtk-cocoa-dir=DIR      where the root of VTK is installed.],
+  [  ac_vtk_cocoa_includes="$withval/include"
+     ac_vtk_cocoa_libraries="$withval"/lib
+     ac_vtk_cocoa_dir="$withval"
+     VTK_COCOA_DIR=$ac_vtk_cocoa_dir
+  ])
+
+if test ! "$disable_gui_build" = "YES"; then
+  if test "x$VTK_COCOA_DIR" = "x"; then
+    # if a VTK cocoa root was not supplied, but one exists in the
+    # default packages path at the NMR Center, then use that:
+    if test -d "${PACKAGES_DIR}/vtk/5.6.1_cocoa" ; then
+      withval=${PACKAGES_DIR}/vtk/5.6.1_cocoa
+      ac_vtk_cocoa_includes="$withval/include"
+      ac_vtk_cocoa_libraries="$withval"/lib
+      ac_vtk_cocoa_dir="$withval"
+      VTK_COCOA_DIR=$ac_vtk_cocoa_dir
+    fi
+  fi
+fi
+
+if test ! "$ac_vtk_cocoa_includes" = "NO"; then
+  AC_MSG_RESULT(VTK cocoa directory is $withval)
+  if test -e $ac_vtk_cocoa_includes/vtk-5.10 ; then
+    ac_vtk_cocoa_includes="$ac_vtk_cocoa_includes/vtk-5.10"
+  elif test -e $ac_vtk_cocoa_includes/vtk-5.6 ; then
+    ac_vtk_cocoa_includes="$ac_vtk_cocoa_includes/vtk-5.6"
+  elif test -e $ac_vtk_cocoa_includes/vtk-5.5 ; then
+    ac_vtk_cocoa_includes="$ac_vtk_cocoa_includes/vtk-5.5"
+  elif test -e $ac_vtk_cocoa_includes/vtk-5.4 ; then
+    ac_vtk_cocoa_includes="$ac_vtk_cocoa_includes/vtk-5.4"
+  elif test -e $ac_vtk_cocoa_includes/vtk-5.3 ; then
+    ac_vtk_cocoa_includes="$ac_vtk_cocoa_includes/vtk-5.3"
+  elif test -e $ac_vtk_cocoa_includes/vtk-5.2 ; then
+    ac_vtk_cocoa_includes="$ac_vtk_cocoa_includes/vtk-5.2"
+  elif test -e $ac_vtk_cocoa_includes/vtk-5.1 ; then
+    ac_vtk_cocoa_includes="$ac_vtk_cocoa_includes/vtk-5.1"
+  elif test -e $ac_vtk_cocoa_includes/vtk-5.0 ; then
+    ac_vtk_cocoa_includes="$ac_vtk_cocoa_includes/vtk-5.0"
+  elif test -e $ac_vtk_cocoa_includes/vtk ; then
+    ac_vtk_cocoa_includes="$ac_vtk_cocoa_includes/vtk"
+  fi
+  VTK_COCOA_CFLAGS="${VTK_COCOA_CFLAGS} -I$ac_vtk_cocoa_includes"
+  VTK_COCOA_CXXFLAGS="${VTK_COCOA_CXXFLAGS} -I$ac_vtk_cocoa_includes"
+fi
+
+if test ! "$ac_vtk_libraries" = "NO"; then
+  VTK_COCOA_LIBS=-L$ac_vtk_cocoa_libraries
+  VTK_COCOA_LIB=$ac_vtk_cocoa_libraries
+  if test -e $ac_vtk_cocoa_libraries/vtk-5.10 ; then
+    VTK_COCOA_LIB_VTK="$ac_vtk_cocoa_libraries/vtk-5.10"
+    VTK_COCOA_LIBS=-L$ac_vtk_cocoa_libraries/vtk-5.10
+    VTK_COCOA_LIB=$ac_vtk_cocoa_libraries/vtk-5.10
+  elif test -e $ac_vtk_cocoa_libraries/vtk-5.6 ; then
+    VTK_COCOA_LIB_VTK="$ac_vtk_cocoa_libraries/vtk-5.6"
+    VTK_COCOA_LIBS=-L$ac_vtk_cocoa_libraries/vtk-5.6
+    VTK_COCOA_LIB=$ac_vtk_cocoa_libraries/vtk-5.6
+  elif test -e $ac_vtk_cocoa_libraries/vtk-5.5 ; then
+    VTK_COCOA_LIB_VTK="$ac_vtk_cocoa_libraries/vtk-5.5"
+    VTK_COCOA_LIBS=-L$ac_vtk_cocoa_libraries/vtk-5.5
+    VTK_COCOA_LIB=$ac_vtk_cocoa_libraries/vtk-5.5
+  elif test -e $ac_vtk_cocoa_libraries/vtk-5.4 ; then
+    VTK_COCOA_LIB_VTK="$ac_vtk_cocoa_libraries/vtk-5.4"
+    VTK_COCOA_LIBS=-L$ac_vtk_cocoa_libraries/vtk-5.4
+    VTK_COCOA_LIB=$ac_vtk_cocoa_libraries/vtk-5.4
+  elif test -e $ac_vtk_cocoa_libraries/vtk-5.3 ; then
+    VTK_COCOA_LIB_VTK="$ac_vtk_cocoa_libraries/vtk-5.3"
+    VTK_COCOA_LIBS=-L$ac_vtk_cocoa_libraries/vtk-5.3
+    VTK_COCOA_LIB=$ac_vtk_cocoa_libraries/vtk-5.3
+  elif test -e $ac_vtk_cocoa_libraries/vtk-5.2 ; then
+    VTK_COCOA_LIB_VTK="$ac_vtk_cocoa_libraries/vtk-5.2"
+    VTK_COCOA_LIBS=-L$ac_vtk_cocoa_libraries/vtk-5.2
+    VTK_COCOA_LIB=$ac_vtk_cocoa_libraries/vtk-5.2
+  elif test -e $ac_vtk_cocoa_libraries/vtk-5.1 ; then
+    VTK_COCOA_LIB_VTK="$ac_vtk_cocoa_libraries/vtk-5.1"
+  elif test -e $ac_vtk_cocoa_libraries/vtk-5.0 ; then
+    VTK_COCOA_LIB_VTK="$ac_vtk_cocoa_libraries/vtk-5.0"
+  elif test -e $ac_vtk_cocoa_libraries/vtk ; then
+    VTK_COCOA_LIB_VTK="$ac_vtk_cocoa_libraries/vtk"
+  fi
+fi
+
+AM_CONDITIONAL(HAVE_COCOA_VTK_LIBS, test ! "x$VTK_COCOA_DIR" = "x")
+
+AC_SUBST(VTK_COCOA_CFLAGS)
+AC_SUBST(VTK_COCOA_CXXFLAGS)
+AC_SUBST(VTK_COCOA_LIBS)
+AC_SUBST(VTK_COCOA_LIB)
+AC_SUBST(VTK_COCOA_LIB_VTK)
+AC_SUBST(VTK_COCOA_DIR)
+
+
+################################################################
+# KWWidgets
+################################################################
+ac_kwwidgets_includes="NO"
+ac_kwwidgets_libraries="NO"
+ac_kwwidgets_dir="NO"
+KWWIDGETS_CFLAGS=""
+KWWIDGETS_CXXFLAGS=""
+KWWIDGETS_LIBS=""
+KWWIDGETS_DIR=""
+
+AC_MSG_CHECKING(KWWidgets config)
+
+AC_ARG_WITH(kwwidgets-dir,
+  [  --with-kwwidgets-dir=DIR where the root of KWWidgets is installed.],
+  [  ac_kwwidgets_includes="$withval"/include/KWWidgets
+     ac_kwwidgets_libraries="$withval"/lib/KWWidgets
+     ac_kwwidgets_dir="$withval"
+     KWWIDGETS_DIR=$ac_kwwidgets_dir
+  ])
+
+if test "x$KWWIDGETS_DIR" = "x"; then
+  # if a KWWidgets root was not supplied, but one exists in the
+  # default packages path at the NMR Center, then use that:
+  if test -d "${PACKAGES_DIR}/KWWidgets/current" ; then
+    withval=${PACKAGES_DIR}/KWWidgets/current
+    ac_kwwidgets_includes="$withval"/include/KWWidgets
+    ac_kwwidgets_libraries="$withval"/lib/KWWidgets
+    ac_kwwidgets_dir="$withval"
+    KWWIDGETS_DIR=$ac_kwwidgets_dir
+    kww_apps="yes"
+  fi
+fi
+
+if test ! "$ac_kwwidgets_includes" = "NO"; then
+  AC_MSG_RESULT(KWWidgets directory is $withval)
+  for item in $ac_kwwidgets_includes; do
+    KWWIDGETS_CFLAGS="${KWWIDGETS_CFLAGS} -I${item}"
+    KWWIDGETS_CXXFLAGS="${KWWIDGETS_CXXFLAGS} -I${item}"
+  done
+  KWWIDGETS_DIR=$ac_kwwidgets_dir
+  kww_apps="yes"
+fi
+
+if test ! "$ac_kwwidgets_libraries" = "NO"; then
+  for item in $ac_kwwidgets_libraries; do
+    KWWIDGETS_LIBS="${KWWIDGETS_LIBS} -L${item}"
+  done
+  KWWIDGETS_LIBS="${KWWIDGETS_LIBS}"
+  kww_apps="yes"
+fi
+
+AC_ARG_ENABLE(kww-apps,
+ [  --disable-kww-apps      disable building KWWidgets-based apps],
+ [ kww_apps="NO"
+ ])
+
+if test "$disable_gui_build" = "YES"; then
+  kww_apps="NO"
+fi
+
+if test "$kww_apps" = "yes"; then
+  AC_MSG_RESULT([Enabled building of KWWidgets apps.])
+  # enable testing for OpenGL libs:
+  need_opengl=yes
+else
+  AC_MSG_RESULT([Not building KWWidgets apps.])
+fi
+
+AM_CONDITIONAL(ENABLE_KWWIDGETS_APPS, test "$kww_apps" = "yes")
+
+AC_SUBST(KWWIDGETS_CFLAGS)
+AC_SUBST(KWWIDGETS_CXXFLAGS)
+AC_SUBST(KWWIDGETS_LIBS)
+AC_SUBST(KWWIDGETS_DIR)
+
+
+################################################################
+# wxWidgets
+################################################################
+WXWIDGETS_CFLAGS=""
+WXWIDGETS_CXXFLAGS=""
+WXWIDGETS_LIBS=""
+WXWIDGETS_GL_LIBS=""
+WXWIDGETS_OPTIONAL_LIBS=""
+WXWIDGETS_DIR=""
+
+AC_MSG_CHECKING(wxWidgets config)
+
+AC_ARG_WITH(wxwidgets-dir,
+  [  --with-wxwidgets-dir=DIR where the root of wxWidgets is installed.],
+  [  WXWIDGETS_DIR="$withval"
+     wxw_apps="yes"
+  ])
+
+if test "x$WXWIDGETS_DIR" = "x"; then
+  # if a wxWidgets root was not supplied, but one exists in the
+  # default packages path at the NMR Center, then use that:
+  if test -d "${PACKAGES_DIR}/wxWidgets/current" ; then
+    WXWIDGETS_DIR=${PACKAGES_DIR}/wxWidgets/current
+    wxw_apps="yes"
+  fi
+fi
+
+# use the handy wx-config utility to get the compiler and linker flags
+if test ! "x$WXWIDGETS_DIR" = "x"; then
+  WXCONFIG="${WXWIDGETS_DIR}/bin/wx-config"
+  WXWIDGETS_CFLAGS="`${WXCONFIG} --cflags`"
+  WXWIDGETS_CXXFLAGS="`${WXCONFIG} --cxxflags`"
+  # we want to use the local / static jpeg, tiff and expat libs
+  WXWIDGETS_LIBS="`${WXCONFIG} --libs | sed 's/-ljpeg/..\/jpeg\/libjpeg.a/g' | sed 's/-ltiff/..\/tiff\/libtiff.a/g' | sed 's/-lexpat/..\/expat\/libexpat.a/g'`"
+  WXWIDGETS_GL_LIBS="`${WXCONFIG} --libs gl | sed 's/-ljpeg/..\/jpeg\/libjpeg.a/g' | sed 's/-ltiff/..\/tiff\/libtiff.a/g' | sed 's/-lexpat/..\/expat\/libexpat.a/g'`"
+
+  # except wx-config isn't so handy in including some header paths on Linux:
+  if test -d /usr/include/gtk-2.0 ; then
+  WXWIDGETS_GTK_CFLAGS="-D__WXGTK20__"
+  WXWIDGETS_GTK_CFLAGS="$WXWIDGETS_GTK_CFLAGS	-I/usr/include/gtk-2.0"
+  WXWIDGETS_GTK_CFLAGS="$WXWIDGETS_GTK_CFLAGS	-I/usr/lib/gtk-2.0/include"
+  WXWIDGETS_GTK_CFLAGS="$WXWIDGETS_GTK_CFLAGS	-I/usr/include/gdk-pixbuf-2.0"
+  WXWIDGETS_GTK_CFLAGS="$WXWIDGETS_GTK_CFLAGS	-I/usr/lib64/gtk-2.0/include"
+  WXWIDGETS_GTK_CFLAGS="$WXWIDGETS_GTK_CFLAGS	-I/usr/include/glib-2.0"
+  WXWIDGETS_GTK_CFLAGS="$WXWIDGETS_GTK_CFLAGS	-I/usr/lib/glib-2.0/include"
+  WXWIDGETS_GTK_CFLAGS="$WXWIDGETS_GTK_CFLAGS	-I/usr/lib64/glib-2.0/include"
+  WXWIDGETS_GTK_CFLAGS="$WXWIDGETS_GTK_CFLAGS	-I/usr/include/pango-1.0"
+  WXWIDGETS_GTK_CFLAGS="$WXWIDGETS_GTK_CFLAGS	-I/usr/include/cairo"
+  WXWIDGETS_GTK_CFLAGS="$WXWIDGETS_GTK_CFLAGS	-I/usr/include/atk-1.0"
+  WXWIDGETS_CFLAGS="$WXWIDGETS_CFLAGS	$WXWIDGETS_GTK_CFLAGS"
+  WXWIDGETS_CXXFLAGS="$WXWIDGETS_CXXFLAGS	$WXWIDGETS_GTK_CFLAGS"
+  fi
+
+  # seems like we gotta manually check for these...
+  if test -e ${WXWIDGETS_DIR}/lib/libwx_gtk2_gl-2.8.a ; then
+    WXWIDGETS_LIBS="$WXWIDGETS_LIBS -lwx_gtk2_gl-2.8"
+  fi
+  if test -e ${WXWIDGETS_DIR}/lib/libwx_gtk2u_gl-2.9.a ; then
+    WXWIDGETS_LIBS="$WXWIDGETS_LIBS -lwx_gtk2u_gl-2.9"
+  fi
+  WXWIDGETS_OPTIONAL_LIBS=
+  if test -e ${WXWIDGETS_DIR}/lib/libwx_gtk2u_aui-2.9.a ; then
+    WXWIDGETS_LIBS="$WXWIDGETS_LIBS -lwx_gtk2u_aui-2.9"
+    WXWIDGETS_OPTIONAL_LIBS="`${WXCONFIG} --optional-libs aui`"
+  fi
+  if test -e ${WXWIDGETS_DIR}/lib/libwx_gtk2u_core-2.9.a ; then
+    WXWIDGETS_LIBS="$WXWIDGETS_LIBS -lwx_gtk2u_core-2.9"
+  fi
+fi
+
+AC_ARG_ENABLE(wxw-apps,
+ [  --disable-wxw-apps      disable building wxWidgets-based apps],
+ [ wxw_apps="NO"
+ ])
+
+if test "$wxw_apps" = "yes"; then
+  AC_MSG_RESULT([Enabled building of wxWidgets apps.])
+  # enable testing for OpenGL libs:
+  need_opengl=yes
+else
+  AC_MSG_RESULT([Not building wxWidgets apps.])
+fi
+
+AM_CONDITIONAL(ENABLE_WXWIDGETS_APPS, test "$wxw_apps" = "yes")
+
+AC_SUBST(WXWIDGETS_CFLAGS)
+AC_SUBST(WXWIDGETS_CXXFLAGS)
+AC_SUBST(WXWIDGETS_LIBS)
+AC_SUBST(WXWIDGETS_GL_LIBS)
+AC_SUBST(WXWIDGETS_OPTIONAL_LIBS)
+AC_SUBST(WXWIDGETS_DIR)
+
+################################################################
+# GTS
+################################################################
+GTS_CFLAGS=""
+GTS_LIBS=""
+GTS_DIR=""
+
+AC_MSG_CHECKING(GTS config)
+
+AC_ARG_WITH(gts-dir,
+  [  --with-gts-dir=DIR where the root of GTS is installed.],
+  [  GTS_DIR="$withval" ])
+
+if test "x$GTS_DIR" = "x"; then
+  # if a gts root was not supplied, but one exists in the
+  # default packages path at the NMR Center, then use that:
+  if test -d "${PACKAGES_DIR}/gts/current" ; then
+    GTS_DIR=${PACKAGES_DIR}/gts/current
+  fi
+else
+  if ! test -d "$GTS_DIR" ; then
+    GTS_DIR=""
+  fi
+fi
+
+# use the handy wx-config utility to get the compiler and linker flags
+if ! test "x$GTS_DIR" = "x"; then
+  AC_MSG_RESULT([Enabled building of GTS apps.])
+  GTSCONFIG="${GTS_DIR}/bin/gts-config"
+  GTS_CFLAGS="`${GTSCONFIG} --cflags`"
+  # we want to use the local / static jpeg, tiff and expat libs
+  GTS_LIBS="`${GTSCONFIG} --libs`"
+else
+  AC_MSG_RESULT([Not building GTS apps.])
+fi
+
+AM_CONDITIONAL(HAVE_GTS_LIBS, test ! "x$GTS_DIR" = "x")
+
+AC_SUBST(GTS_CFLAGS)
+AC_SUBST(GTS_LIBS)
+AC_SUBST(GTS_DIR)
+
+
+################################################################
+# ITK
+################################################################
+ac_itk_includes="NO"
+ac_itk_libraries="NO"
+ITK_CFLAGS=""
+ITK_LIBS=""
+ITK_LIB=""
+LIBS_ITK=""
+ITK_DIR=""
+AC_MSG_CHECKING(ITK directory)
+
+AC_ARG_WITH(itk-dir,
+  [  --with-itk-dir=DIR      where the root of ITK is installed.],
+  [  itk_i="$withval/include/InsightToolkit"
+     ac_itk_includes="$itk_i $itk_i/Algorithms $itk_i/BasicFilters $itk_i/Common $itk_i/IO $itk_i/Numerics $itk_i/Numerics/Statistics $itk_i/Review $itk_i/Review/Statistics $itk_i/SpatialObject $itk_i/Utilities"
+     ac_itk_libraries="$withval"/lib/InsightToolkit
+     ITK_DIR="$withval"
+     itk_apps="yes"
+     AC_SUBST(ITK_DIR)
+  ])
+
+# NJS: --with-itk-4.5.1 is a temporary hack to allow building against ITK v4.5.1
+# Note: use with --with-itk-4.5.1-vxl flag, since default vxl doesnt work w4.5.1
+AC_ARG_WITH(itk-4.5.1,
+  [  --with-itk-4.5.1        set paths to use NMR Center ITK v4.5.1.],
+  [  ac_itk_includes="$withval"/include/ITK-4.5
+     ac_itk_libraries="$withval"/lib
+     ITK_DIR="$withval"
+     itk_apps="yes"
+     itk_45="yes"
+     AC_SUBST(ITK_DIR)
+  ])
+# end NJS HACK
+
+AC_ARG_WITH(itk-include,
+  [  --with-itk-include=DIR      root of ITK include directory.],
+  [  itk_i="$withval"
+     ac_itk_includes="$itk_i"
+     itk_apps="yes"
+  ])
+
+AC_ARG_WITH(itk-libraries,
+  [  --with-itk-libraries=DIR    root of ITK lib directory.],
+  [  ac_itk_libraries="$withval/InsightToolkit"
+     itk_apps="yes"
+  ])
+
+# if --without-itk-dir was specified:
+if test "x$ITK_DIR" = "xno"; then
+   itk_apps="NO"
+fi
+
+if test "x$ITK_DIR" = "x"; then
+  # if an ITK root was not supplied, but one exists in the
+  # default packages path at the NMR Center, then use that:
+  if test -d "${PACKAGES_DIR}/itk/current" ; then
+    withval=${PACKAGES_DIR}/itk/current
+    itk_i="$withval/include/InsightToolkit"
+    ac_itk_includes="$itk_i $itk_i/Algorithms $itk_i/BasicFilters $itk_i/Common $itk_i/IO $itk_i/Numerics $itk_i/Numerics/Statistics $itk_i/Review $itk_i/Review/Statistics $itk_i/SpatialObject $itk_i/Utilities"
+    ac_itk_libraries="$withval"/lib/InsightToolkit
+    ITK_DIR="$withval"
+    itk_apps="yes"
+    AC_SUBST(ITK_DIR)
+  fi
+fi
+
+if test ! "$ac_itk_includes" = "NO"; then
+  AC_MSG_RESULT(ITK directory is $withval)
+  for item in $ac_itk_includes; do
+      ITK_CFLAGS="${ITK_CFLAGS} -I${item}"
+  done
+fi
+
+if test ! "$ac_itk_libraries" = "NO"; then
+  ITK_LIBS=-L$ac_itk_libraries
+  ITK_LIB=$ac_itk_libraries
+fi
+
+AC_ARG_ENABLE(itk-apps,
+ [  --disable-itk-apps      disable building ITK-based apps],
+ [ itk_apps="NO"
+ ])
+
+if test "$itk_apps" = "yes"; then
+  AC_MSG_RESULT([Enabled building of ITK apps.])
+
+  # these are the minimum ITK libs necessary to support Nrrd IO,
+  # notice they are all static (avoiding LD_LIBRARY_PATH usage)
+  LIBS_ITK="\
+  $ac_itk_libraries/libITKIO.a \
+  $ac_itk_libraries/libITKAlgorithms.a \
+  $ac_itk_libraries/libITKCommon.a \
+  $ac_itk_libraries/libITKNumerics.a \
+  $ac_itk_libraries/libITKMetaIO.a \
+  $ac_itk_libraries/libITKniftiio.a \
+  $ac_itk_libraries/libITKNrrdIO.a \
+  $ac_itk_libraries/libitkpng.a \
+  $ac_itk_libraries/libitksys.a \
+  $ac_itk_libraries/libitktiff.a \
+  $ac_itk_libraries/libitkv3p_netlib.a \
+  $ac_itk_libraries/libitkzlib.a \
+  $ac_itk_libraries/libitkgdcm.a \
+  $ac_itk_libraries/libitkopenjpeg.a \
+  $ac_itk_libraries/libitkjpeg8.a \
+  $ac_itk_libraries/libitkjpeg12.a \
+  $ac_itk_libraries/libitkjpeg16.a \
+  $ac_itk_libraries/libITKDICOMParser.a"
+
+  # NJS HACK ITK 4.5.1 uses these:
+  if test "x$itk_45" = "xyes"; then
+    LIBS_ITK="\
+    $ac_itk_libraries/libITKIONRRD-4.5.a \
+    $ac_itk_libraries/libITKIOImageBase-4.5.a \
+    $ac_itk_libraries/libITKCommon-4.5.a \
+    $ac_itk_libraries/libITKMetaIO-4.5.a \
+    $ac_itk_libraries/libITKniftiio-4.5.a \
+    $ac_itk_libraries/libITKNrrdIO-4.5.a \
+    $ac_itk_libraries/libitkpng-4.5.a \
+    $ac_itk_libraries/libitksys-4.5.a \
+    $ac_itk_libraries/libitktiff-4.5.a \
+    $ac_itk_libraries/libitkv3p_netlib-4.5.a \
+    $ac_itk_libraries/libitkzlib-4.5.a \
+    $ac_itk_libraries/libitkopenjpeg-4.5.a \
+    $ac_itk_libraries/libITKDICOMParser-4.5.a"
+  fi
+
+  # ITK v3.16.0 needs libuuid for function `gdcm::Util::GenerateUUID'
+  if test -e /usr/lib/libuuid.a ; then
+     LIB_UUID="/usr/lib/libuuid.a"
+     AC_SUBST(LIB_UUID)
+  elif test -e /usr/lib64/libuuid.a ; then
+     LIB_UUID="/usr/lib64/libuuid.a"
+     AC_SUBST(LIB_UUID)
+  elif test -e /usr/lib/x86_64-linux-gnu/libuuid.a ; then
+     LIB_UUID="/usr/lib/x86_64-linux-gnu/libuuid.a"
+     AC_SUBST(LIB_UUID)
+  elif test -e /usr/lib64/libuuid.so ; then
+     LIB_UUID="/usr/lib64/libuuid.so"
+     AC_SUBST(LIB_UUID)
+  fi
+  LIBS_ITK="$LIBS_ITK $LIB_UUID"
+else
+  AC_MSG_RESULT([Not building ITK apps.])
+fi
+
+AM_CONDITIONAL(ENABLE_ITK_APPS, test "$itk_apps" = "yes")
+AM_CONDITIONAL(HAVE_ITK_LIBS, test "$itk_apps" = "yes")
+AM_CONDITIONAL(HAVE_ITK45, test "$itk_45" = "yes")
+
+
+AC_SUBST(ITK_CFLAGS)
+AC_SUBST(ITK_LIBS)
+AC_SUBST(ITK_LIB)
+AC_SUBST(LIBS_ITK)
+
+################################################################
+# GDCM (Grassroots DICOM)
+################################################################
+ac_gdcm_includes="NO"
+ac_gdcm_libraries="NO"
+GDCM_CFLAGS=""
+GDCM_LIBS=""
+GDCM_LIB=""
+LIBS_GDCM=""
+GDCM_DIR=""
+AC_MSG_CHECKING(GDCM directory)
+
+if test "x$GDCM_DIR" = "x"; then
+  if test -d "${PACKAGES_DIR}/gdcm/current" ; then
+    withval=${PACKAGES_DIR}/gdcm/current
+    gdcm_i="$withval/include/gdcm-2.4"
+    ac_gdcm_includes="$gdcm_i $gdcm_i/gdcmjpeg $gdcm_i/gdcmopenjpeg $gdcm_i/gdcmcharls $gdcm_i/socketxx"
+    ac_gdcm_libraries="$withval/lib"
+    GDCM_DIR="$withval"
+    gdcm_apps="yes"
+    AC_SUBST(GDCM_DIR)
+  fi
+fi
+
+if test ! "$ac_gdcm_includes" = "NO"; then
+  AC_MSG_RESULT(GDCM directory is $withval)
+  for item in $ac_gdcm_includes; do
+      GDCM_CFLAGS="${GDCM_CFLAGS} -I${item}"
+  done
+fi
+
+if test ! "$ac_gdcm_libraries" = "NO"; then
+  GDCM_LIBS=-L$ac_gdcm_libraries
+  GDCM_LIB=$ac_gdcm_libraries
+fi
+
+if test "$gdcm_apps" = "yes"; then
+  AC_MSG_RESULT([Enabled building of GDCM apps.])
+  LIBS_GDCM="-lgdcmcharls -lgdcmCommon -lgdcmDICT -lgdcmDSED -lgdcmexpat \
+             -lgdcmIOD -lgdcmjpeg12 -lgdcmjpeg16 -lgdcmjpeg8 -lgdcmMEXD  \
+             -lgdcmMSFF -lgdcmopenjpeg -lgdcmuuid -lgdcmzlib -lsocketxx"
+  LDFLAGS="$GDCM_LIBS $LDFLAGS"
+else
+  AC_MSG_RESULT([Not building GDCM apps.])
+fi
+
+AM_CONDITIONAL(ENABLE_GDCM_APPS, test "$gdcm_apps" = "yes")
+AM_CONDITIONAL(HAVE_GDCM_LIBS, test "$gdcm_apps" = "yes")
+
+AC_SUBST(GDCM_CFLAGS)
+AC_SUBST(GDCM_LIBS)
+AC_SUBST(GDCM_LIB)
+AC_SUBST(LIBS_GDCM)
+
+# OpenGL
+#####################################################
+AC_MSG_NOTICE(Getting OpenGL info...)
+mac_gl_libs=
+#####
+# GL
+#####
+ac_gl_includes="NO"
+ac_gl_libraries="NO"
+ac_gl_bindir="NO"
+# these are lower-case because later AX_CHECK_GL trounces
+# GL_CLFLAGS and GL_LIBS:
+gl_cflags=""
+gl_libs=""
+AC_MSG_CHECKING(GL directory)
+
+AC_ARG_WITH(gl-dir,
+  [  --with-gl-dir=DIR       where the root of OpenGL is installed.],
+  [  ac_gl_includes="$withval"/include
+     ac_gl_libraries="$withval"/lib
+     ac_gl_bindir="$withval"/bin
+  ])
+
+if test ! "$ac_gl_includes" = "NO"; then
+  AC_MSG_RESULT(gl directory is $withval)
+  gl_cflags=-I$ac_gl_includes
+else
+  AC_MSG_RESULT(OpenGL directory is not supplied)
+fi
+if test ! "$ac_gl_libraries" = "NO"; then
+  gl_libs=-L$ac_gl_libraries
+fi
+
+# stupid Mac OS Leopard fix:
+if test "$OS" = "Darwin"; then
+  X_DIR=""
+  if test -d "/usr/X11R6"; then
+    X_DIR="/usr/X11R6"
+  fi
+  if test -d "/usr/X11"; then
+    X_DIR="/usr/X11"
+  fi
+  if test ! "X$X_DIR" = "X"; then 
+    gl_cflags="-I${X_DIR}/include -I${X_DIR}/include/GL"
+    gl_libs="-L${X_DIR}/lib $X_LIBS -Wl,-dylib_file,\
+/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib:\
+/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib"
+    mac_gl_libs=$gl_libs
+  fi
+fi
+
+AC_SUBST(gl_cflags)
+AC_SUBST(gl_libs)
+
+
+#####################################################
+# AX_CHECK_GL produces GL_CFLAGS GL_LIBS
+ac_save_cflags=$CFLAGS
+ac_save_ldflags=$LDFLAGS
+CFLAGS="$gl_cflags $CFLAGS"
+# bug in AX_CHECK_GL: assumes HAVE_WINDOWS_H is defined, so fix CFLAGS
+# (note: Mac doesnt have this bug)
+if test ! "$OS" = "Darwin"; then
+  CFLAGS="-DHAVE_WINDOWS_H=0 $CFLAGS"
+fi
+LDFLAGS="$gl_libs $LDFLAGS"
+AX_CHECK_GL
+if test "X$no_gl" = "Xyes"; then
+  if test "X$need_opengl" = "Xyes"; then
+    AC_MSG_ERROR([FATAL: GL not found. Use --with-gl-dir=... to specify])
+  else
+    AC_MSG_RESULT([GL not found])
+  fi
+else
+  AC_MSG_RESULT([GL found:
+Setting GL_CFLAGS='$GL_CFLAGS $gl_cflags'
+and GL_LIBS='$GL_LIBS'])
+  GL_CFLAGS="$GL_CFLAGS $gl_cflags"
+  LIBS_OPENGL="$GL_LIBS $mac_gl_libs"
+fi
+if test ! "X$gl_cflags" = "X"; then
+  GL_CFLAGS="$GL_CFLAGS $gl_cflags"
+  LIBS_OPENGL="$GL_LIBS $mac_gl_libs"
+fi
+
+CFLAGS="$ac_save_cflags"
+LDFLAGS=$ac_save_ldflags
+#####################################################
+# AX_CHECK_GLU produces GLU_CFLAGS GLU_LIBS
+ac_save_cflags=$CFLAGS
+ac_save_ldflags=$LDFLAGS
+CFLAGS="$gl_cflags $CFLAGS"
+LDFLAGS="$gl_libs $LDFLAGS"
+AX_CHECK_GLU
+if test "X$no_glu" = "Xyes"; then
+  if test "X$need_opengl" = "Xyes"; then
+    AC_MSG_ERROR([FATAL: GLu not found. Use --with-gl-dir=... to specify])
+  else
+    AC_MSG_RESULT([GLu not found])
+  fi
+else
+  AC_MSG_RESULT([GLu found:
+Setting GLU_CFLAGS='$GLU_CFLAGS'
+and GLU_LIBS='$GLU_LIBS'])
+  LIBS_OPENGL="$GLU_LIBS $mac_gl_libs"
+fi
+CFLAGS=$ac_save_cflags
+LDFLAGS=$ac_save_ldflags
+
+AC_SUBST(LIBS_OPENGL)
+
+###################################################################
+# Install NMR Martinos Center files (not included in distribution)
+###################################################################
+AC_ARG_ENABLE(nmr-install,
+ [  --enable-nmr-install    install NMR Center-only files],
+   [case "${enableval}" in
+        yes) nmrinstall=true ;;
+        no)  nmrinstall=false  ;;
+        *)   AC_MSG_ERROR(bad value ${enableval} for --enable-nmr-install) ;;
+    esac],
+[nmrinstall=false])
+
+if test "x$nmrinstall" = "xtrue"; then
+    AC_MSG_RESULT([Performing an NMR installation.])
+else
+    AC_MSG_RESULT([Performing an off-site installation.])
+fi
+
+AM_CONDITIONAL(NMR_INSTALL, test x$nmrinstall = xtrue)
+
+
+################################################
+LIBDIRS_MGH="utils rgb unix dicom hipsstubs"
+AC_SUBST(LIBDIRS_MGH)
+
+# stupid circular dependency on iopen swapInt etc.
+LIBS_MGH="\
+  utils/libutils.a \
+  fsgdf/libfsgdf.a \
+  rgb/librgb.a \
+  unix/libunix.a \
+  dicom/libdicom.a \
+  hipsstubs/libhipsstubs.a \
+  log/liblog.a \
+  xml2/libxml2.a"
+
+# use local libjpeg if --with-jpeg-dir not used:
+if test "$ac_jpeg_libraries" = "NO"; then
+  LIB_JPEG=""
+  LIBS_MGH="${LIBS_MGH} jpeg/libjpeg.a"
+fi
+# use local libtiff if --with-tiff-dir not used:
+if test "$ac_tiff_libraries" = "NO"; then
+  LIB_TIFF=""
+  LIBS_MGH="${LIBS_MGH} tiff/libtiff.a"
+fi
+# use local libexpat if --with-expat-dir not used:
+if test "$ac_expat_libraries" = "NO"; then
+  LIB_EXPAT=""
+  LIBS_MGH="${LIBS_MGH} expat/libexpat.a"
+fi
+
+# to support CUDA, use libutils_cuda instead of libutils:
+LIBS_CUDA_MGH=`echo ${LIBS_MGH} | sed 's/libutils/libutils_cuda/g'`
+
+AC_SUBST(LIBS_MGH)
+AC_SUBST(LIBS_CUDA_MGH)
+AC_SUBST(LIB_JPEG)
+AC_SUBST(LIB_TIFF)
+AC_SUBST(LIB_EXPAT)
+
+
+#####################################################
+# generic mods
+#####################################################
+CPPFLAGS="$CPPFLAGS -D$OS -DANSI $OS_CPPFLAGS"
+LDFLAGS="$LDFLAGS $OS_LDFLAGS"
+
+#####################################################
+# Checks for libraries.
+# the order is important
+#####################################################
+# the entire libs here is passed as LIBS
+# thus save the current one, along with flags, which
+# are restored upon completion of these checks
+ac_save_libs=$LIBS
+ac_save_cppflags=$CPPFLAGS
+ac_save_ldflags=$LDFLAGS
+CPPFLAGS="$CPPFLAGS $EXPAT_CFLAGS $TIFF_CFLAGS $JPEG_CFLAGS \
+$PETSC_CFLAGS $ITK_CFLAGS $ANN_CFLAGS \
+$MNI_CFLAGS $TCL_CFLAGS $CPPUNIT_CFLAGS $VXL_CFLAGS $NIFTI_CFLAGS \
+$GL_CFLAGS $GLU_CFLAGS $VTK_CFLAGS $KWWIDGETS_CFLAGS"
+LDFLAGS="$LDFLAGS $MNI_LIBS $TCL_LIBS $VXL_LIBS \
+$EXPAT_LIBS $TIFF_LIBS $JPEG_LIBS \
+$gl_libs $GL_LIBS $GLU_LIBS $VTK_LIBS $ITK_LIBS $KWWIDGETS_LIBS \
+$PETSC_LIBS $NIFTI_LIBS $XAWPLUS_LIBS $ANN_LIBS"
+AC_MSG_NOTICE(Making sure that all libraries can be compiled...)
+# AC_MSG_NOTICE(CPPFLAGS: $CPPFLAGS)
+# AC_MSG_NOTICE(LDFLAGS: $LDFLAGS)
+AC_CHECK_LIB([m], [floor])
+AC_CHECK_LIB([z], [gzopen])
+AC_CHECK_LIB([crypt], [crypt],[],[echo "(Note: Mac OS X doesn't use crypt)"])
+LIB_CRYPT="-lcrypt"
+if test "$OS" = "Darwin"; then
+  LIB_CRYPT=""
+fi
+AC_SUBST(LIB_CRYPT)
+
+# test for libtiff only if --with-tiff-dir was used:
+if test ! "$ac_tiff_libraries" = "NO"; then
+  CPPFLAGS="$CPPFLAGS $TIFF_CFLAGS"
+  LDFLAGS="$LDFLAGS $TIFF_LIBS"
+  AC_CHECK_LIB([tiff], [TIFFGetVersion],[],
+    [AC_MSG_ERROR([FATAL: tiff lib not found. \
+Please install tiff header files and libs.])] )
+fi
+
+# test for libjpeg only if --with-jpeg-dir was used:
+if test ! "$ac_jpeg_libraries" = "NO"; then
+  CPPFLAGS="$CPPFLAGS $JPEG_CFLAGS"
+  LDFLAGS="$LDFLAGS $JPEG_LIBS"
+  AC_CHECK_LIB([jpeg], [jpeg_start_compress],[],
+    [AC_MSG_ERROR([FATAL: jpeg lib not found. Please install jpeg lib.])] )
+fi
+
+# three mni libs
+#   AC_CHECK_LIB([netcdf], [nccreate],[],
+#     [AC_MSG_ERROR([FATAL: netcdf lib not found. \
+#   Set LDFLAGS or --with-mni-dir.])] )
+#   if test "x$MINC2" = "xYES"; then
+#     # check for newer build of mni tools
+#     AC_CHECK_LIB([minc2 -lhdf5], [miopen], [],
+#       [AC_MSG_ERROR([FATAL: minc2 lib not found. \
+#     Set LDFLAGS or --with-mni-dir.])] )
+#     AC_CHECK_LIB([volume_io2], [transform_point],[],
+#       [AC_MSG_ERROR([FATAL: volume_io2 lib not found. \
+#     Set LDFLAGS or --with-mni-dir.])] )
+#   else
+#     AC_CHECK_LIB([minc], [miopen], [],
+#       [AC_MSG_ERROR([FATAL: minc lib not found. \
+#     Set LDFLAGS or --with-mni-dir.])] )
+#     AC_CHECK_LIB([volume_io], [transform_point],[],
+#       [AC_MSG_ERROR([FATAL: volume_io lib not found. \
+#     Set LDFLAGS or --with-mni-dir.])] )
+#   fi
+
+# VXL check
+AC_CHECK_FILE($VXL_LIB/libvnl$DYNAMIC_LIB_EXT,
+  [if test "x$LD_LIBRARY_PATH" = "x"; then
+     export LD_LIBRARY_PATH=$VXL_LIB
+   else
+     export LD_LIBRARY_PATH="$VXL_LIB":"$LD_LIBRARY_PATH"
+   fi],[])
+if test ! "x$itk_45_vxl" = "xyes"; then
+AC_CHECK_LIB([vnl], [main],[],
+  [AC_MSG_ERROR([FATAL: vnl lib not found. \
+Set LDFLAGS or --with-vxl-dir.])] )
+AC_CHECK_LIB([vnl_algo], [main],[],
+  [AC_MSG_ERROR([FATAL: vnl_algo lib not found. \
+Set LDFLAGS or --with-vxl-dir.])] )
+fi
+
+# ANN check
+if test ! "x$ac_ann_dir" = "xNO"; then
+  # if --with-ann-dir was used, make sure necessary libs exist
+  AC_CHECK_LIB([ANN], [main],[],
+    [AC_MSG_ERROR([FATAL: ANN Approximate Nearest Neighbors lib not found. \
+  Set LDFLAGS or --with-ann-dir.])] )
+fi
+
+# PETSc check
+if test ! "x$ac_petsc_dir" = "xNO"; then
+  # if --with-petsc-dir was used, make sure necessary libs exist
+  if test "$OS" = "Darwin"; then
+    PMPICH=-lpmpich
+  else
+    PMPICH=
+  fi
+  AC_CHECK_LIB([petsc -lmpich -lpthread ${PMPICH}], [PetscInitialize],[],
+    [AC_MSG_ERROR([FATAL: petsc lib not found. \
+  Set LDFLAGS or --with-petsc-dir.])] )
+fi
+
+# BOOST check
+BOOST_PO_LIB=""
+# if --with-boost-dir was used, make sure necessary lib(s) exist,
+# namely, boost_program_options, used by fem_elastic build dir
+if test ! "x$ac_boost_dir" = "xNO"; then
+  BOOST_PO_LIB="${BOOST_LIBS} -lboost_program_options-mt"
+  if test -e ${BOOST_LIB}/libboost_program_options-mt.a ; then
+    BOOST_PO_LIB=${BOOST_LIB}/libboost_program_options-mt.a
+    AC_MSG_RESULT([found '$BOOST_PO_LIB'])
+  else
+    if test -e ${BOOST_LIB}/libboost_program_options.a ; then
+      BOOST_PO_LIB=${BOOST_LIB}/libboost_program_options.a
+      AC_MSG_RESULT([found '$BOOST_PO_LIB'])
+    fi
+  fi
+else
+  # else check for native install of boost program options lib
+  if test -e /usr/lib/libboost_program_options.a ; then
+    BOOST_PO_LIB=/usr/lib/libboost_program_options.a
+    AC_MSG_RESULT([found '$BOOST_PO_LIB'])
+    AM_CONDITIONAL(HAVE_BOOST_LIBS, ! test "x$BOOST_PO_LIB" = "xNO")
+  fi
+  if test -e /usr/lib64/libboost_program_options.a ; then
+    BOOST_PO_LIB=/usr/lib64/libboost_program_options.a
+    BOOST_LIB=/usr/lib64
+    BOOST_LIBS=-L/usr/lib64
+    AC_SUBST(BOOST_LIB)
+    AC_SUBST(BOOST_LIBS)
+    AC_MSG_RESULT([found '$BOOST_PO_LIB'])
+    AM_CONDITIONAL(HAVE_BOOST_LIBS, ! test "x$BOOST_PO_LIB" = "xNO")
+  else
+    if test -e /usr/lib64/libboost_program_options.so ; then
+      # note: centos 6 doesnt have the .a lib, so the shared is used instead
+      BOOST_PO_LIB=-lboost_program_options
+      BOOST_LIB=/usr/lib64
+      BOOST_LIBS=-L/usr/lib64
+      AC_SUBST(BOOST_LIB)
+      AC_SUBST(BOOST_LIBS)
+      AC_MSG_RESULT([found '$BOOST_PO_LIB'])
+      AM_CONDITIONAL(HAVE_BOOST_LIBS, ! test "x$BOOST_PO_LIB" = "xNO")
+    fi
+  fi
+fi
+AC_SUBST(BOOST_PO_LIB)
+
+# NIfTI check
+if test ! "x$ac_nifti_dir" = "xNO"; then
+  # if --with-nifti-dir was used, make sure necessary libs exist
+  AC_CHECK_LIB([znz], [znzread],[],
+    [AC_MSG_ERROR([FATAL: NIfTI znz lib not found. \
+  Set LDFLAGS or --with-nifti-dir.])] )
+  AC_CHECK_LIB([niftiio -lznz], [is_nifti_file],[],
+    [AC_MSG_ERROR([FATAL: niftiio lib not found. \
+  Set LDFLAGS or --with-nifti-dir.])] )
+  LIBS_NIFTI="-lznz -lniftiio"
+else
+  # check if libs installed natively somewhere
+  AC_CHECK_LIB([znz], [znzread],
+    [AC_CHECK_LIB([niftiio -lznz], [is_nifti_file],
+      [AM_CONDITIONAL(HAVE_NIFTI_LIBS, test "1" = "1")
+       LIBS_NIFTI="-lznz -lniftiio"],[])], [])
+fi
+AC_SUBST(LIBS_NIFTI)
+
+# test for vtk versions of system libs, and if not found (ie, not
+# built when vtk was built), then use the system lib
+
+# use local libexpat if --with-expat-dir not used:
+if test "$ac_expat_libraries" = "NO"; then
+  if test ! "$OS" = "Darwin"; then
+    VTK_EXPAT_LIB=../expat/libexpat.a
+  else
+  # else use whatever we can find
+    AC_CHECK_LIB([vtkexpat], [main],
+                 [VTK_EXPAT_LIB="-lvtkexpat"],
+                 [AC_CHECK_LIB([expat],[main],[VTK_EXPAT_LIB="-lexpat"],
+                 [AC_MSG_ERROR([FATAL: libvtkexpat or libexpat not found.])])])
+  fi
+fi
+AC_SUBST(VTK_EXPAT_LIB)
+
+AC_CHECK_LIB([vtkfreetype], [FTC_Manager_LookupSize],
+  [VTK_FREETYPE_LIB="-lvtkfreetype"],
+  [AC_CHECK_LIB([vtkfreetype], [vtk_freetype_FTC_Manager_LookupSize], [VTK_FREETYPE_LIB="-lvtkfreetype"],
+    [AC_CHECK_LIB([freetype],[FTC_Manager_LookupSize],[VTK_FREETYPE_LIB="-lfreetype"],
+    [AC_MSG_ERROR([FATAL: libvtkfreetype or libfreetype not found.])])])])
+AC_SUBST(VTK_FREETYPE_LIB)
+
+AC_CHECK_LIB([vtkzlib], [gzopen],
+             [VTK_Z_LIB="-lvtkzlib"],
+             [AC_CHECK_LIB([z],[gzopen],[VTK_Z_LIB="-lz"],
+             [AC_MSG_ERROR([FATAL: libvtkzlib or libz not found.])])])
+AC_SUBST(VTK_Z_LIB)
+
+# use local libjpeg if --with-jpeg-dir not used:
+if test "$ac_jpeg_libraries" = "NO"; then
+  if test ! "$OS" = "Darwin"; then
+    VTK_JPEG_LIB=../jpeg/libjpeg.a
+  else
+  # else use whatever we can find
+    AC_CHECK_LIB([vtkjpeg], [vtk_jpeg_start_compress],
+                 [VTK_JPEG_LIB="-lvtkjpeg"],
+                 [VTK_JPEG_LIB="-ljpeg"])
+  fi
+fi
+AC_SUBST(VTK_JPEG_LIB)
+
+# use local libtiff if --with-tiff-dir not used:
+if test "$ac_tiff_libraries" = "NO"; then
+  if test ! "$OS" = "Darwin"; then
+    VTK_TIFF_LIB=../tiff/libtiff.a
+  else
+  # else use whatever we can find
+    AC_CHECK_LIB([vtktiff $VTK_JPEG_LIB $VTK_Z_LIB], [vtk_TIFFGetVersion],
+                 [VTK_TIFF_LIB="-lvtktiff"],
+                 [VTK_TIFF_LIB="-ltiff"])
+  fi
+fi
+AC_SUBST(VTK_TIFF_LIB)
+
+AC_CHECK_LIB([vtkpng $VTK_Z_LIB], [main],
+             [VTK_PNG_LIB="-lvtkpng"],
+             [AC_CHECK_LIB([png],[main],[VTK_PNG_LIB="-lpng"],
+             [AC_MSG_ERROR([FATAL: libvtkpng or libpng not found.])])])
+AC_SUBST(VTK_PNG_LIB)
+
+# check for VTK libs
+AC_CHECK_FILE($VTK_LIB/libvtkCommon$DYNAMIC_LIB_EXT,
+  [if test "x$LD_LIBRARY_PATH" = "x"; then
+     export LD_LIBRARY_PATH=$VTK_LIB
+   else
+     export LD_LIBRARY_PATH="$VTK_LIB":"$LD_LIBRARY_PATH"
+   fi],[])
+AC_CHECK_LIB([vtkCommon -lstdc++], [main],[],
+  [AC_MSG_RESULT([INFO: vtkCommon lib not found. \
+Try setting LDFLAGS, LD_LIBRARY_PATH and-or --with-vtk-dir.])] )
+
+# libverdict appeared in VTK v5.1.0, and is required by libvtkHybrid,
+# and libvtkGraphics (in v5.2.0), but doesnt exist in earlier versions of VTK
+VTK_VERDICT_LIB=""
+AC_CHECK_LIB([verdict], [main], [VTK_VERDICT_LIB="-lverdict"],
+  [AC_CHECK_LIB([vtkverdict], [main], [VTK_VERDICT_LIB="-lvtkverdict"], [])])
+AC_SUBST(VTK_VERDICT_LIB)
+
+# ditto for libvtksqlite
+VTK_SQLITE_LIB=""
+AC_CHECK_LIB([vtksqlite], [main], [VTK_SQLITE_LIB="-lvtksqlite"], [])
+AC_SUBST(VTK_SQLITE_LIB)
+
+# libvtkMPEG2Encode disappeared from VTK v5.1.0, so test for it
+VTK_MPEG2ENCODE_LIB=""
+AC_CHECK_LIB([vtkMPEG2Encode], [main],
+                               [VTK_MPEG2ENCODE_LIB="-lvtkMPEG2Encode"], [])
+AC_SUBST(VTK_MPEG2ENCODE_LIB)
+
+# libvtkmetaio appeared in VTK v5.1.0, so check for it
+# and, ugggg... it requires vtkpng and vtkzlib
+VTK_METAIO_LIB=""
+AC_CHECK_LIB([vtkmetaio], [main], [VTK_METAIO_LIB="-lvtkmetaio"
+  AC_CHECK_LIB([vtkpng], [main], [VTK_PNG_LIB="-lvtkpng"], [])
+  AC_CHECK_LIB([vtkzlib], [main], [VTK_Z_LIB="-lvtkzlib"], [])
+], [])
+AC_SUBST(VTK_METAIO_LIB)
+
+# vtkhdf5, vtkNetCDF_cxx and LSDyna appeared in VTK v5.10.0, so check for them
+VTK_HDF5_LIB=""
+AC_CHECK_LIB([vtkhdf5], [main], [VTK_HDF5_LIB="-lvtkhdf5_hl -lvtkhdf5"], [])
+AC_SUBST(VTK_HDF5_LIB)
+VTK_NETCDFCXX_LIB=""
+AC_CHECK_LIB([vtkNetCDF_cxx], [main], [VTK_NETCDFCXX_LIB="-lvtkNetCDF_cxx"], [])
+AC_SUBST(VTK_NETCDFCXX_LIB)
+VTK_LSDYNA_LIB=""
+AC_CHECK_LIB([LSDyna], [main], [VTK_LSDYNA_LIB="-lLSDyna"], [])
+AC_SUBST(VTK_LSDYNA_LIB)
+
+#
+# check tcl/tk/tix/blt only if tcl/tk apps are enabled
+#
+if test "x$tcltk_apps" = "xyes"; then
+  ################## Tcl
+  # check tcl8.5
+  # NJS NOTE! here temp changed to 8.4 until tcl8.5 works
+  AC_CHECK_LIB([tcl8.4],[Tcl_Init],
+    [LIB_TCL=-ltcl8.4],
+  # check tcl8.4
+    [
+    AC_CHECK_LIB([tcl8.4],[Tcl_Init],
+      [LIB_TCL=-ltcl8.4],
+  # check tcl8.3
+      [
+        AC_CHECK_LIB([tcl8.3],[Tcl_Init],
+        [LIB_TCL=-ltcl8.3],
+  # check tcl83
+        [
+          AC_CHECK_LIB([tcl83],[Tcl_Init],
+          [LIB_TCL=-ltcl83],
+  # check tcl
+          [ AC_CHECK_LIB([tcl],[Tcl_Init],
+            [LIB_TCL=-ltcl],
+  # check tclstub
+            [ AC_CHECK_LIB([tclstub],[Tcl_Init],
+              [LIB_TCL=-ltclstub],
+              [AC_MSG_ERROR([FATAL: libtcl not found. \
+Check config.log. Set LDFLAGS or --with-tcl-dir.])
+              ])
+            ])
+          ])
+        ])
+      ])
+    ])
+  AC_SUBST(LIB_TCL)
+
+  #################### Tk needs X11 (or Aqua)
+  LIBS="$X_LIBS $LIBS"
+  CPPFLAGS="$GL_CFLAGS $CPPFLAGS"
+  LDFLAGS="$X_LIBS $LDFLAGS"
+  # check tk8.5
+  # NJS NOTE! here temp changed to 8.4 until tcl8.5 works
+  AC_CHECK_LIB([tk8.4],[Tk_Init],
+    [LIB_TK=-ltk8.4],
+  # check tk8.4
+    [
+    AC_CHECK_LIB([tk8.4],[Tk_Init],
+      [LIB_TK=-ltk8.4],
+  # check tk8.3
+      [
+        AC_CHECK_LIB([tk8.3],[Tk_Init],
+        [LIB_TK=-ltk8.3],
+  # check tk83
+        [
+          AC_CHECK_LIB([tk83],[Tk_Init],
+          [LIB_TK=-ltk83],
+  # check tk
+          [
+            AC_CHECK_LIB([tk],[Tk_Init],
+            [LIB_TK=-ltk],
+            [AC_MSG_ERROR([FATAL: libtk not found. \
+Check config.log. Set LDFLAGS or --with-tcl-dir.])
+            ])
+          ])
+        ])
+      ])
+    ])
+  AC_SUBST(LIB_TK)
+
+  ##################### Tix
+  LIBS="$X_LIBS $LIB_TK $LIB_TCL $LIBS"
+  # check Tix8.4.2 first, as that is known to work best with tcl/tk 8.5
+  AC_CHECK_LIB([Tix8.4.2], [Tix_Init],
+  [LIB_TIX=-lTix8.4.2],
+  [
+    # check tix8.1.8.4, as that is known to work best with tcl/tk 8.4
+    AC_CHECK_LIB([tix8.1.8.4], [Tix_Init],
+    [LIB_TIX=-ltix8.1.8.4],
+    [
+    # check tix8.1.8.3
+      AC_CHECK_LIB([tix8.1.8.3], [Tix_Init],
+      [LIB_TIX=-ltix8.1.8.3],
+      [
+    # check tix8183
+        AC_CHECK_LIB([tix8183], [Tix_Init],
+        [LIB_TIX=-ltix8183],
+        [
+    # check tix8.4
+          AC_CHECK_LIB([Tix8.4], [Tix_Init],
+          [LIB_TIX=-lTix8.4],
+          [
+    # check tix
+            AC_CHECK_LIB([tix],[Tix_Init],
+              [LIB_TIX=-ltix],
+              [AC_MSG_ERROR([FATAL: libtix not found. \
+Check config.log. Set LDFLAGS or --with-tcl-dir.])
+              ])
+            ])
+          ])
+        ])
+      ])
+    ])
+  AC_SUBST(LIB_TIX)
+
+  ######## BLT (we cannot build BLT in Aqua) must use X11
+  AC_CHECK_LIB([BLT25 $LIB_BLT_JPEG],[Blt_Init],
+    [LIB_BLT=-lBLT25],
+    [
+    AC_CHECK_LIB([BLT $LIB_BLT_JPEG],[Blt_Init],
+      [LIB_BLT=-lBLT],
+    # check BLT.2 (MacOSX)
+      [
+        AC_CHECK_LIB([BLT.2 $LIB_BLT_JPEG],[Blt_Init],
+        [LIB_BLT=-lBLT.2],
+        [
+    # check BLT24 (Fedora)
+          AC_CHECK_LIB([BLT24 $LIB_BLT_JPEG],[Blt_Init],
+          [LIB_BLT=-lBLT24],
+              [AC_MSG_NOTICE([FATAL: libBLT not found. \
+Check config.log. Set LDFLAGS or --with-BLT-dir.])
+          ])
+        ])
+      ])
+    ])
+  AC_SUBST(LIB_BLT)
+fi
+
+# check for KWWidget libs only if kww app building is enabled
+if test ! "x$kww_apps" = "xNO"; then
+  LDFLAGS="$LDFLAGS $LIB_TCL"
+  AC_CHECK_LIB([KWWidgets], [main],[],
+    [AC_MSG_ERROR([FATAL: KWWidgets lib not found. \
+  Set LDFLAGS or --with-KWWidgets-dir.])] )
+fi
+
+# check for XawPlus lib only if xawplus app building is enabled
+if test ! "x$xawplus_apps" = "xNO"; then
+  # with and without libXpm (Centos 6 doesnt have it)
+  AC_CHECK_LIB([X11 -lXt -lXpm -lXawPlus], [XawInitializeWidgetSet],
+    [LIBS_XAWPLUS="-lXt -lXpm -lXawPlus"],
+    [AC_CHECK_LIB([X11 -lXt -lXawPlus], [XawInitializeWidgetSet],
+    [LIBS_XAWPLUS="-lXt -lXawPlus"],
+    [AC_MSG_ERROR([FATAL: XawPlus lib not found. \
+  Set LDFLAGS or --with-xawplus-dir.])])])
+  AC_SUBST(LIBS_XAWPLUS)
+fi
+
+
+###########################################################
+# More Intel C/C++ compiler stuff
+###########################################################
+LIBS_ICC=""
+if test "x$CC" = "xicc"; then
+  AC_MSG_NOTICE(Setting Intel Compiler libs...)
+  LIBS_ICC="-lirc -lsvml -limf"
+fi
+
+AC_SUBST(LIBS_ICC)
+AM_CONDITIONAL(HAVE_INTEL_COMPILER, test "x$CC" = "xicc" )
+
+
+#
+# recover previous settings, from prior to checks.
+# let each Makefile.am set as appropriate, choose from:
+# MNI_CFLAGS, MNI_LIBS
+# JPEG_CFLAGS, JPEG_LIBS
+# TIFF_CFLAGS, TIFF_LIBS
+# TCL_CFLAGS, TCL_LIBS, LIB_TCL, ENABLE_TCLTK_APPS
+# TK_CFLAGS, TK_LIBS, LIB_TK, LIB_TIX
+# BLT_CFLAGS, BLT_LIBS, LIB_BLT
+# GL_CFLAGS, GL_LIBS
+# GLU_CFLAGS, GLU_LIBS
+# VXL_CFLAGS, VXL_LIBS
+# VTK_CFLAGS, VTK_LIBS
+# KWWIDGETS_CFLAGS, KWWIDGETS_LIBS, ENABLE_KWWIDGETS_APPS
+# ITK_CFLAGS, ITK_LIBS
+LIBS=$ac_save_libs
+CPPFLAGS=$ac_save_cppflags
+LDFLAGS=$ac_save_ldflags
+
+# ...or use combined flags
+LDFLAGS_TCL="$BLT_LIBS $TCL_LIBS"
+if test "$OS" = "Darwin"; then
+  LDFLAGS_TCL="-bind_at_load $LDFLAGS_TCL"
+fi
+LIBS_TCL="$LIB_BLT $LIB_TIX $LIB_TK $LIB_TCL"
+LIBS_TCL_OPENGL="$LIBS_TCL $LIBS_OPENGL"
+AC_SUBST(LDFLAGS_TCL)
+AC_SUBST(LIBS_TCL)
+AC_SUBST(LIBS_TCL_OPENGL)
+
+# if using the Intel compiler, enable additional interprocedural
+# optimizations for single file compilation, and enable auto-parallelization.
+# this is done here because if added earlier -ipo breaks the OpenGL check
+if test "x$CC" = "xicc"; then
+  AC_MSG_NOTICE(Setting Intel Compiler optimizations...)
+  CPPFLAGS="$CPPFLAGS -ip -axCORE-AVX2"
+  CPPFLAGS="$CPPFLAGS -parallel"
+  CPPFLAGS="$CPPFLAGS -qopt-report=5" # -guide-par
+  LDFLAGS="$LDFLAGS -ip"
+fi
+if test "x$F77" = "xifort"; then
+  FFLAGS="$FFLAGS -xCORE-AVX2"
+fi
+
+###########################################################
+# some common flags and libs
+###########################################################
+CPPFLAGS="$CPPFLAGS $MNI_CFLAGS"
+LDFLAGS="$LDFLAGS $JPEG_LIBS $TIFF_LIBS $MNI_LIBS $VXL_LIBS $NIFTI_LIBS \
+$ITK_LIBS $EXPAT_LIBS"
+# The order is important here. When adding or removing a lib, be sure
+# to test the link line to make sure you don't need to adjust the
+# order.
+if test "x$CC" = "xicc"; then
+  AC_MSG_NOTICE(Using Intel Math Kernel Library)
+  MATH_LIBS="-lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core"
+  MATH_LIBS="$MATH_LIBS -liomp5 -lm"
+else
+  MATH_LIBS="-lm"
+fi
+LIBS="-lz $MATH_LIBS $LIB_CRYPT -ldl -lpthread $LIBS"
+LIBS="$LIBS $LIB_JPEG"
+LIBS="$LIBS $LIB_TIFF"
+LIBS="$LIBS $LIB_EXPAT"
+LIBS="$LIBS $LIBS_MNI"
+LIBS="$LIBS $LIBS_VXL"
+LIBS="$LIBS $LIBS_NIFTI"
+LIBS="$LIBS_ITK $LIBS"
+LIBS="$LIBS_ICC $LIBS"
+LIBS="$LIBS_OPEN64 $LIBS"
+
+AC_SUBST(CPPFLAGS)
+AC_SUBST(LDFLAGS)
+AC_SUBST(LIBS)
+
+
+########################################################################
+# check whether needs Itcl_Init() and Itk_Init()
+# except when using Tcl8.4, which doesn't contain Itcl_Init or Itk_Init
+########################################################################
+if test "x$tcltk_apps" = "xyes"; then
+   # NJS NOTE! tcl8.5 doesnt work yet with freesurfer (blt/tix)
+#  if ! test "$LIB_TCL" = "-ltcl8.5"; then
+    if ! test "$LIB_TCL" = "-ltcl8.4"; then
+      if ! test "$LIB_TCL" = "-ltcl83"; then
+        AX_TIX_INITCHECK($TCL_CFLAGS, $LDFLAGS_TCL, $LIBS_TCL)
+      fi
+#    fi
+  fi
+fi
+
+
+########################################################################
+# Indicate whether we have OpenGL (HAVE_OPENGL is undefined if not)
+########################################################################
+HAVE_OPENGL="-DHAVE_OPENGL"
+if test "x$GL_LIBS" = "x"; then
+  HAVE_OPENGL=""
+fi
+AC_SUBST(HAVE_OPENGL)
+AM_CONDITIONAL(HAVE_OPENGL_LIBS, ! test "X$GL_LIBS" = "X")
+
+
+#########################################################################
+# 'make check' environment setup
+#########################################################################
+#
+# When 'make check' is run, the tests specified in TESTS will inherit
+# these environment variable.  The first one bypasses the need for a
+# license in FREESURFER_HOME, the others specify necessary libs.
+#
+TESTS_ENVIRONMENT="SURFER_FRONTDOOR=1 LD_LIBRARY_PATH=$TCL_LIB:$VTK_LIB"
+if (! test "x$ac_cppunit_dir" = "xNO"); then
+  TESTS_ENVIRONMENT="$TESTS_ENVIRONMENT:$CPPUNIT_LIB"
+fi
+AC_SUBST(TESTS_ENVIRONMENT)
+
+#########################################################################
+# output
+#########################################################################
+
+
+AC_OUTPUT([Makefile
+           BrainstemSS/Makefile
+           BrainstemSS/linux_x86_64/Makefile
+           BrainstemSS/mac_osx/Makefile
+           check_siemens_dir/Makefile
+           cudatest/Makefile
+           cudatest/gcatest/Makefile
+           cudatest/volumecopy/Makefile
+           cudatest/mrilabeltest/Makefile
+           dicom/Makefile
+           distribution/Makefile
+           distribution/average/Makefile
+           distribution/average/surf/Makefile
+           distribution/average/Yeo_JNeurophysiol11_MNI152/Makefile
+           distribution/average/Buckner_JNeurophysiol11_MNI152/Makefile
+           distribution/average/Choi_JNeurophysiol12_MNI152/Makefile
+           distribution/docs/Makefile
+           distribution/diffusion/Makefile
+           distribution/diffusion/mgh-dti-seqpack/Makefile
+           distribution/trctrain/Makefile
+           distribution/fsafd/Makefile
+           distribution/lib/Makefile
+           distribution/lib/bem/Makefile
+           distribution/sessions/Makefile
+           distribution/subjects/Makefile
+           distribution/fsl-extra/Makefile
+           dmri_tensoreig/Makefile
+           dngtester/Makefile
+           dummy/Makefile
+           dummy_qt/Makefile
+           expat/Makefile
+           fem_elastic/Makefile
+           fsfast/Makefile
+           fsfast/bin/Makefile
+           fsfast/docs/Makefile
+           fsfast/toolbox/Makefile
+           fsgdf/Makefile
+           fslutils/Makefile
+           glut/Makefile
+           gpu_utils/Makefile
+           opencl_algorithms/Makefile
+           hiam_make_surfaces/Makefile
+           hiam_register/Makefile
+           hiam_make_template/Makefile
+           HippoSF/Makefile
+           HippoSF/linux_x86_64/Makefile
+           HippoSF/mac_osx/Makefile
+           hipsstubs/Makefile
+           histo_segment/Makefile
+           histo_synthesize/Makefile
+           histo_register/Makefile
+           histo_register/SimpleBaseLib/Makefile
+           histo_register/ParticleVideoLib/Makefile
+           histo_compute_joint_density/Makefile
+           histo_register_block/Makefile
+           images/Makefile
+           include/Makefile
+           include/NrrdIO/Makefile
+           include/dicom/Makefile
+           include/xview/Makefile
+           include/pixrect/Makefile
+           include/sys/Makefile
+           include/topology/Makefile
+           include/fs_vnl/Makefile
+           itkio/Makefile
+           itkutils/Makefile
+           jpeg/Makefile
+           label_area/Makefile
+           label_border/Makefile
+           label2patch/Makefile
+           label2flat/Makefile
+           log/Makefile
+           lta_convert/Makefile
+           matlab/Makefile
+           mkxsubjreg/Makefile
+           mri_bias/Makefile
+           mri_train_autoencoder/Makefile
+           mri_log_likelihood/Makefile
+           mri_add_xform_to_header/Makefile
+           mri_annotation2label/Makefile
+           mri_aparc2aseg/Makefile
+           mri_aparc2wmseg/Makefile
+           mri_apply_inu_correction/Makefile
+           mri_aseg_edit_train/Makefile
+           mri_aseg_edit_reclassify/Makefile
+           mri_auto_fill/Makefile
+           mri_average/Makefile
+           mri_dct_align/Makefile
+           mri_bc_sc_bias_correct/Makefile
+           mri_binarize/Makefile
+           mri_build_priors/Makefile
+           mri_cal_renormalize_gca/Makefile
+           mri_ca_label/Makefile
+           mri_ca_normalize/Makefile
+           mri_ca_register/Makefile
+           mri_ca_tissue_parms/Makefile
+           mri_ca_train/Makefile
+           mri_correct_segmentations/Makefile
+           mri_divide_segmentation/Makefile
+           mri_gtmpvc/Makefile
+           mri_rf_label/Makefile
+           mri_rf_train/Makefile
+           mri_gcab_train/Makefile
+           mri_gtmseg/Makefile
+           mri_cc/Makefile
+           mri_cht2p/Makefile
+           mri_cnr/Makefile
+           mri_compile_edits/Makefile
+           mri_coreg/Makefile
+           mri_update_gca/Makefile
+           mri_compute_overlap/Makefile
+           mri_compute_seg_overlap/Makefile
+           mri_concat/Makefile
+           mri_concatenate_gcam/Makefile
+           mri_concatenate_lta/Makefile
+           mri_convert/Makefile
+           mri_mosaic/Makefile
+           mri_convert_mdh/Makefile
+           mri_copy_values/Makefile
+           mri_cor2label/Makefile
+           mri_cvs_register/Makefile
+           mri_deface/Makefile
+           mri_diff/Makefile
+           mri_distance_transform/Makefile
+           mri_edit_segmentation/Makefile
+           mri_edit_segmentation_with_surfaces/Makefile
+           mri_edit_wm_with_aseg/Makefile
+           mri_em_register/Makefile
+           mri_estimate_tissue_parms/Makefile
+           mri_evaluate_morph/Makefile
+           mri_extract/Makefile
+           mri_extract_conditions/Makefile
+           mri_extract_label/Makefile
+           mri_extract_largest_CC/Makefile
+           mri_extract_fcd_features/Makefile
+           mri_fcili/Makefile
+           mri_fdr/Makefile
+           mri_fieldsign/Makefile
+           mri_fill/Makefile
+           mri_fit_bias/Makefile
+           mri_fslmat_to_lta/Makefile
+           mri_fwhm/Makefile
+           mri_gca_ambiguous/Makefile
+           mri_gcut/Makefile
+           mri_gdfglm/Makefile
+           mri_glmfit/Makefile
+           mri_head/Makefile
+           mri_hires_register/Makefile
+           mri_otl/Makefile
+           mri_histo_eq/Makefile
+           mri_histo_normalize/Makefile
+           histo_fix_topology/Makefile
+           mri_ibmc/Makefile
+           mri_iic/Makefile
+           mri_info/Makefile
+           mri_and/Makefile
+           mri_hausdorff_dist/Makefile
+           mri_fuse_segmentations/Makefile
+           mri_fuse_intensity_images/Makefile
+           mri_sbbr/Makefile
+           mri_simulate_atrophy/Makefile
+           mri_joint_density/Makefile
+           mri_label2label/Makefile
+           mri_label2vol/Makefile
+           mri_label_histo/Makefile
+           mri_label_vals/Makefile
+           mri_label_volume/Makefile
+           mri_linear_register/Makefile
+           mri_compute_structure_transforms/Makefile
+           mri_make_bem_surfaces/Makefile
+           mri_make_density_map/Makefile
+           mri_make_labels/Makefile
+           mri_make_register/Makefile
+           mri_make_template/Makefile
+           mri_map_cpdat/Makefile
+           mri_mark_temporal_lobe/Makefile
+           mri_mask/Makefile
+           mri_matrix_multiply/Makefile
+           mri_mc/Makefile
+           mri_mi/Makefile
+           mri_mcsim/Makefile
+           mri_modify/Makefile
+           mri_morphology/Makefile
+           mri_jacobian/Makefile
+           mri_compute_volume_fractions/Makefile
+           mri_interpolate/Makefile
+           mri_ms_EM/Makefile
+           mri_ms_EM_with_atlas/Makefile
+           mri_ms_LDA/Makefile
+           mri_ms_fitparms/Makefile
+           mri_elastic_energy/Makefile
+           mri_nlfilter/Makefile
+           mri_normalize/Makefile
+           mri_normalize_tp2/Makefile
+           mri_paint/Makefile
+           mri_parse_sdcmdir/Makefile
+           mri_parselabel/Makefile
+           mri_partial_ribbon/Makefile
+           mri_path2label/Makefile
+           mri_polv/Makefile
+           mri_probe_ima/Makefile
+           mri_probedicom/Makefile
+           mri_reduce/Makefile
+           mri_register/Makefile
+           mri_relabel_hypointensities/Makefile
+           mri_relabel_nonwm_hypos/Makefile
+           mri_remove_neck/Makefile
+           mri_ribbon/Makefile
+           mri_rigid_register/Makefile
+           mri_robust_register/Makefile
+           mri_seg_diff/Makefile
+           mri_seghead/Makefile
+           mri_segment/Makefile
+           mri_segment_tumor/Makefile
+           mri_segment_wm_damage/Makefile
+           mri_segreg/Makefile
+           mri_segstats/Makefile
+           mri_stats2seg/Makefile
+           mri_strip_nonwhite/Makefile
+           mri_strip_subject_info/Makefile
+           mri_surf2surf/Makefile
+           mri_surf2vol/Makefile
+           mri_surfacemask/Makefile
+           mri_surfcluster/Makefile
+           mri_synthesize/Makefile
+           mri_tessellate/Makefile
+           mri_threshold/Makefile
+           mri_topologycorrection/Makefile
+           mri_train/Makefile
+           mri_classify/Makefile
+           mri_transform/Makefile
+           mri_transform_to_COR/Makefile
+           mri_twoclass/Makefile
+           mri_vol2roi/Makefile
+           mri_vol2surf/Makefile
+           mri_vol2vol/Makefile
+           mris_copy_header/Makefile
+           mris_segmentation_stats/Makefile
+           mris_simulate_atrophy/Makefile
+           mris_rf_label/Makefile
+           mris_rf_train/Makefile
+           mri_rf_long_train/Makefile
+           mri_rf_long_label/Makefile
+           mri_volcluster/Makefile
+           mri_voldiff/Makefile
+           mri_volsynth/Makefile
+           mri_warp_convert/Makefile
+           mri_watershed/Makefile
+           mri_watershed/brain_volume/Makefile
+           mri_wbc/Makefile
+           mri_wmfilter/Makefile
+           mri_xcorr/Makefile
+           mri_xvolavg/Makefile
+           mri_z2p/Makefile
+           mri_label_accuracy/Makefile
+           mri_multispectral_segment/Makefile
+           mri_multiscale_segment/Makefile
+           mri_compute_change_map/Makefile
+           mris2rgb/Makefile
+           mris_hausdorff_dist/Makefile
+           mris_map_cuts/Makefile
+           mris_merge_parcellations/Makefile
+           mris_distance_transform/Makefile
+           mris_add_template/Makefile
+           mris_aseg_distance/Makefile
+           mris_density/Makefile
+           mris_fill/Makefile
+           mris_fbirn_annot/Makefile
+           mris_anatomical_stats/Makefile
+           mris_transmantle_dysplasia_paths/Makefile
+           mris_annot_to_segmentation/Makefile
+           mris_apply_reg/Makefile
+           mris_average_curvature/Makefile
+           mris_ca_label/Makefile
+           mris_divide_parcellation/Makefile
+           mris_ca_train/Makefile
+           mris_svm_classify/Makefile
+           mris_svm_train/Makefile
+           mris_calc/Makefile
+           mris_classify_thickness/Makefile
+           mris_compute_acorr/Makefile
+           mris_compute_lgi/Makefile
+           mris_compute_overlap/Makefile
+           mris_compute_parc_overlap/Makefile
+           mris_congeal/Makefile
+           mris_convert/Makefile
+           mris_distance_map/Makefile
+           mris_curvature/Makefile
+           mris_curvature_stats/Makefile
+           mris_decimate/Makefile
+           mris_decimate_gui/Makefile
+           mris_diff/Makefile
+           mris_distance_to_label/Makefile
+           mris_entropy/Makefile
+           mris_errors/Makefile
+           mris_euler_number/Makefile
+           mris_expand/Makefile
+           mris_find_flat_regions/Makefile
+           mris_fix_topology/Makefile
+           mris_topo_fixer/Makefile
+           mris_flatten/Makefile
+           mris_fwhm/Makefile
+           mris_glm/Makefile
+           mris_inflate/Makefile
+           mris_info/Makefile
+           mris_jacobian/Makefile
+           mris_label_area/Makefile
+           mris_label_calc/Makefile
+           mris_label_mode/Makefile
+           mris_label2annot/Makefile
+           mris_make_average_surface/Makefile
+           mris_make_surfaces/Makefile
+           mris_make_map_surfaces/Makefile
+           mris_make_template/Makefile
+           mris_mesh_subdivide/Makefile
+           mris_morph_stats/Makefile
+           mris_deform/Makefile
+           mris_ms_refine/Makefile
+           mris_ms_surface_CNR/Makefile
+           mris_multiscale_stats/Makefile
+           mris_niters2fwhm/Makefile
+           mris_pmake/Makefile
+           mris_register/Makefile
+           mris_register_label_map/Makefile
+           mris_left_right_register/Makefile
+           mris_register_to_volume/Makefile
+           mris_init_global_tractography/Makefile
+           mris_interpolate_warp/Makefile
+           mris_remove_variance/Makefile
+           mris_resample/Makefile
+           mris_rescale/Makefile
+           mris_reverse/Makefile
+           mris_rotate/Makefile
+           mris_sample_label/Makefile
+           mris_sample_parc/Makefile
+           mris_segment_vals/Makefile
+           mris_segment/Makefile
+           mris_seg2annot/Makefile
+           mris_shrinkwrap/Makefile
+           mris_show/Makefile
+           mris_smooth/Makefile
+           mris_parcellate_connectivity/Makefile
+           mris_make_face_parcellation/Makefile
+           mris_sphere/Makefile
+           mris_spherical_average/Makefile
+           mris_average_parcellation/Makefile
+           mris_surface_stats/Makefile
+           mris_surface_to_vol_distances/Makefile
+           mris_talairach/Makefile
+           mris_thickness/Makefile
+           mris_surface_change/Makefile
+           mris_BA_segment/Makefile
+           mris_compute_optimal_kernel/Makefile
+           mris_thickness_comparison/Makefile
+           mris_thickness_diff/Makefile
+           mris_transform/Makefile
+           mris_translate_annotation/Makefile
+           mris_twoclass/Makefile
+           mris_volume/Makefile
+           mris_warp/Makefile
+           mris_watershed/Makefile
+           mris_volmask/Makefile
+           mris_w_to_curv/Makefile
+           mrisp_paint/Makefile
+           mris_longitudinal_surfaces/Makefile
+           mris_compute_volume_fractions/Makefile
+           nmovie/Makefile
+           oct_train/Makefile
+           oct_register_mosaic/Makefile
+                 nmovie_qt/Makefile
+           optseq2/Makefile
+           orient_mri/Makefile
+           qdec/Makefile
+           rbftest/Makefile
+           regdat2xfm/Makefile
+           repair_siemens_file/Makefile
+           rgb/Makefile
+           scripts/Makefile
+           freeview/Makefile
+           connectgraph/Makefile
+           spherical_stats/Makefile
+           spline3/Makefile
+           stat_normalize/Makefile
+           stim_polar/Makefile
+           svm-lib/Makefile
+           swi_processing/Makefile
+           talairach_afd/Makefile
+           talairach_avi/Makefile
+           template/Makefile
+           test_makevol/Makefile
+           tetgen/Makefile
+           tiff/Makefile
+           tkmedit/Makefile
+           tkregister2/Makefile
+           tkregister2/cmdl/Makefile
+           tksurfer/Makefile
+           trc/Makefile
+           tridec/Makefile
+           unix/Makefile
+           utils/Makefile
+           utils/cephes/Makefile
+           utils/NrrdIO/Makefile
+           utils/test/Makefile
+           utils/test/mriBuildVoronoiDiagramFloat/Makefile
+           utils/test/MRIScomputeBorderValues/Makefile
+           utils/test/mrishash/Makefile
+           utils/test/MRISpositionSurface/Makefile
+           utils/test/mriSoapBubbleFloat/Makefile
+           utilscpp/Makefile
+           utilscpp/test/Makefile
+           qdec_glmfit/Makefile
+           qdecproject/Makefile
+           vtkfsio/Makefile
+           vtkutils/Makefile
+           lineprof/Makefile
+           xml2/Makefile])
+
+########################################################################
+
+builddir=`pwd`
+AC_MSG_RESULT(
+[
+FreeSurfer is now configured for ${host}
+
+  Source directory:  ${srcdir}
+  Build directory:   ${builddir}
+  Install directory: ${prefix}
+
+  C compiler:   ${CC} ${CPPFLAGS} ${CFLAGS}
+  C++ compiler: ${CXX} ${CPPFLAGS} ${CXXFLAGS}
+  Fortran:      ${F77} ${FFLAGS}
+  Linker:       ${LD} ${LDFLAGS}
+  Libs:         ${LIBS}
+])

--- a/dmri_tensoreig/dmri_tensoreig.c
+++ b/dmri_tensoreig/dmri_tensoreig.c
@@ -40,7 +40,7 @@ char *MRI_INFO_VERSION = "$Revision$";
 #include "mri.h"
 #include "mri2.h"
 #include "gcamorph.h"
-#include "volume_io.h"
+#include "minc_volume_io.h"
 #include "analyze.h"
 #include "mri_identify.h"
 #include "error.h"

--- a/dmri_tensoreig/dmri_tensoreig.c
+++ b/dmri_tensoreig/dmri_tensoreig.c
@@ -32,6 +32,8 @@ char *MRI_INFO_VERSION = "$Revision$";
 #include <string.h>
 #include <ctype.h>
 #include <time.h>
+#include <errno.h>
+
 #include "macros.h"
 #include "const.h"
 #include "machine.h"

--- a/fem_elastic/morph.cpp
+++ b/fem_elastic/morph.cpp
@@ -416,7 +416,7 @@ DeltaTransform3d::tCoords
 DeltaTransform3d::doOwnImg(const tCoords& pt) const
 {
 
-  Real val;
+  double val;
   tCoords retVal;
 
   // sample the mask first - do this on a nearest neighbor method

--- a/fem_elastic/surf_utils.cpp
+++ b/fem_elastic/surf_utils.cpp
@@ -21,7 +21,7 @@ convert_surf_to_vox(MRI_SURFACE* mris,
                     MRI* vol)
 {
   double cx, cy, cz;
-  Real vx, vy, vz;
+  double vx, vy, vz;
 
   VERTEX* pvtx = &( mris->vertices[0] );
   unsigned int nvertices = (unsigned int)mris->nvertices;
@@ -61,7 +61,7 @@ convert_vox_to_surf(MRI_SURFACE* mris,
                     MRI* vol)
 {
   double cx, cy, cz;
-  Real   vx, vy, vz;
+  double vx, vy, vz;
 
   VERTEX* pvtx = &( mris->vertices[0] );
   unsigned int nvertices = (unsigned int)mris->nvertices;

--- a/freeview/FSVolume.cpp
+++ b/freeview/FSVolume.cpp
@@ -787,8 +787,8 @@ bool FSVolume::MRIWrite( const QString& filename, int nSampleMethod, bool resamp
     {
       // find out the output voxel bounds
       float cornerFactor[3];
-      Real RAS[4] = {0, 0, 0, 1}, index[3];
-      Real indexBounds[6];
+      double RAS[4] = {0, 0, 0, 1}, index[3];
+      double indexBounds[6];
       indexBounds[0] = indexBounds[2] = indexBounds[4] = 1e10;
       indexBounds[1] = indexBounds[3] = indexBounds[5] = -1e10;
       for ( cornerFactor[2] = 0; cornerFactor[2] <= 1; cornerFactor[2]++ )
@@ -869,7 +869,7 @@ bool FSVolume::MRIWrite( const QString& filename, int nSampleMethod, bool resamp
 
       if (!m_bCropToOriginal)
       {
-        Real p0[3];
+        double p0[3];
         ::MRIvoxelToWorld( m_MRITemp,
                            (int)indexBounds[0],
             (int)indexBounds[2],
@@ -903,7 +903,7 @@ bool FSVolume::MRIWrite( const QString& filename, int nSampleMethod, bool resamp
       // no resample, just modify the header
       MATRIX* old_v2r = extract_i_to_r(m_MRITemp);
       /*
-      Real p0[4] = {0, 0, 0, 1};
+      double p0[4] = {0, 0, 0, 1};
       ::MRIvoxelToWorld( m_MRITemp,
                          0, 0, 0,
                          &p0[0], &p0[1], &p0[2] );
@@ -1247,7 +1247,7 @@ int FSVolume::OriginalIndexToRAS( float iIdxX, float iIdxY, float iIdxZ,
     return 1;
   }
 
-  Real ix, iy, iz, wx, wy, wz;
+  double ix, iy, iz, wx, wy, wz;
   int r;
 
   ix = iIdxX;
@@ -1270,12 +1270,12 @@ int FSVolume::RASToOriginalIndex ( float iRASX, float iRASY, float iRASZ,
     return 1;
   }
 
-  Real ix, iy, iz, wx, wy, wz;
+  double ix, iy, iz, wx, wy, wz;
   int r;
 
   if (m_matReg)
   {
-    Real v[4] = {iRASX, iRASY, iRASZ, 1};
+    double v[4] = {iRASX, iRASY, iRASZ, 1};
     MATRIX* matNative = MRItkReg2Native(this->m_MRIRef, m_MRI, m_matReg);
     double m[16];
     for ( int i = 0; i < 16; i++ )
@@ -1317,12 +1317,12 @@ int FSVolume::RASToOriginalIndex ( float iRASX, float iRASY, float iRASZ,
   }
   return r;
   */
-  Real wx, wy, wz;
+  double wx, wy, wz;
   int r;
 
   if (m_matReg)
   {
-    Real v[4] = {iRASX, iRASY, iRASZ, 1};
+    double v[4] = {iRASX, iRASY, iRASZ, 1};
     MATRIX* matNative = MRItkReg2Native(this->m_MRIRef, m_MRI, m_matReg);
     double m[16];
     for ( int i = 0; i < 16; i++ )
@@ -1349,7 +1349,7 @@ int FSVolume::RASToOriginalIndex ( float iRASX, float iRASY, float iRASZ,
 
 bool FSVolume::RASToTalairachVoxel(const double *pos_in, double *pos_out)
 {
-  Real x, y, z;
+  double x, y, z;
   if (m_MRI->linear_transform)
   {
     ::MRIworldToTalairachVoxel(m_MRI, pos_in[0], pos_in[1], pos_in[2], &x, &y, &z);
@@ -1364,7 +1364,7 @@ bool FSVolume::RASToTalairachVoxel(const double *pos_in, double *pos_out)
 
 void FSVolume::TalairachVoxelToRAS(const double *pos_in, double *pos_out)
 {
-  Real x, y, z;
+  double x, y, z;
   ::MRItalairachVoxelToWorld(m_MRI, pos_in[0], pos_in[1], pos_in[2], &x, &y, &z);
   pos_out[0] = x;
   pos_out[1] = y;
@@ -1375,8 +1375,8 @@ MRI* FSVolume::CreateTargetMRI( MRI* src, MRI* refTarget, bool bAllocatePixel, b
 {
   MRI* mri = NULL;
   float cornerFactor[3];
-  Real RAS[3], index[3];
-  Real indexBounds[6];
+  double RAS[3], index[3];
+  double indexBounds[6];
   indexBounds[0] = indexBounds[2] = indexBounds[4] = 1e10;
   indexBounds[1] = indexBounds[3] = indexBounds[5] = -1e10;
   for ( cornerFactor[2] = 0; cornerFactor[2] <= 1; cornerFactor[2]++ )
@@ -1449,7 +1449,7 @@ MRI* FSVolume::CreateTargetMRI( MRI* src, MRI* refTarget, bool bAllocatePixel, b
 
     MRIcopyHeader( refTarget, mri );
 
-    //    Real p0[3];
+    //    double p0[3];
     //    ::MRIvoxelToWorld( refTarget,
     //                       (int)(indexBounds[0]),
     //                       (int)(indexBounds[2]),
@@ -1540,7 +1540,7 @@ MRI* FSVolume::CreateTargetMRI( MRI* src, MRI* refTarget, bool bAllocatePixel, b
 
     MRIcopyHeader( refTarget, mri );
     MRIsetResolution( mri, pixelSize[0], pixelSize[1], pixelSize[2] );
-    Real p0[3];
+    double p0[3];
     ::MRIvoxelToWorld( refTarget,
                        indexBounds[0]+0.5*pixelSize[0]/refTarget->xsize,
         indexBounds[2]+0.5*pixelSize[1]/refTarget->ysize,
@@ -1551,7 +1551,7 @@ MRI* FSVolume::CreateTargetMRI( MRI* src, MRI* refTarget, bool bAllocatePixel, b
     if (true)
     {
       // make sure voxel boundaries are aligned
-      Real cpt[3], cpt_ext[3];
+      double cpt[3], cpt_ext[3];
       ::MRIworldToVoxel(mri, refTarget->c_r, refTarget->c_a, refTarget->c_s, &cpt[0], &cpt[1], &cpt[2]);
       ::MRIworldToVoxel(mri, mri->c_r, mri->c_a, mri->c_s, &cpt_ext[0], &cpt_ext[1], &cpt_ext[2]);
       //        double vs[3] = { mri->xsize, mri->ysize, mri->zsize };
@@ -1926,7 +1926,7 @@ bool FSVolume::CreateImage( MRI* rasMRI )
   }
   else if ( m_volumeRef )
   {
-    Real ras[3], cindex[3];
+    double ras[3], cindex[3];
 
     ::MRIvoxelToWorld( rasMRI, 0., 0., 0., &ras[0], &ras[1], &ras[2] );
     ::MRIworldToVoxel( m_volumeRef->m_MRITarget,
@@ -1955,7 +1955,7 @@ bool FSVolume::CreateImage( MRI* rasMRI )
     //    qDebug() << cindex[0] << cindex[1] << cindex[2];
 
     /*
-    Real ras[3], ras2[3];
+    double ras[3], ras2[3];
     ::MRIvoxelToWorld( rasMRI, 0., 0., 0., &ras[0], &ras[1], &ras[2] );
     ::MRIvoxelToWorld( m_volumeRef->m_MRITarget, 0., 0., 0., &ras2[0], &ras2[1], &ras2[2] );
     m_volumeRef->GetImageOutput()->GetOrigin( origin );
@@ -2067,8 +2067,8 @@ bool FSVolume::ResizeRotatedImage( MRI* rasMRI, MRI* refTarget, vtkImageData* re
 
   /*
   float cornerFactor[3];
-  Real RAS[3], index[3];
-  Real indexBounds[6];
+  double RAS[3], index[3];
+  double indexBounds[6];
   indexBounds[0] = indexBounds[2] = indexBounds[4] = 1e10;
   indexBounds[1] = indexBounds[3] = indexBounds[5] = -1e10;
   for ( cornerFactor[2] = 0; cornerFactor[2] <= 1; cornerFactor[2]++ )
@@ -2101,7 +2101,7 @@ bool FSVolume::ResizeRotatedImage( MRI* rasMRI, MRI* refTarget, vtkImageData* re
   origin[2] += indexBounds[4] * refTarget->zsize;
   */
 
-  Real vox[3], tvox[3];
+  double vox[3], tvox[3];
   ::MRIworldToVoxel( rasMRI,
                      rasPoint[0], rasPoint[1], rasPoint[2],
       &vox[0], &vox[1], &vox[2] );
@@ -2595,7 +2595,7 @@ void FSVolume::GetBounds( MRI* mri, float oRASBounds[6] )
 
   // For each corner, convert to RAS, and get the bounds.
   float cornerFactor[3];
-  Real RAS[3];
+  double RAS[3];
   for ( cornerFactor[2] = 0; cornerFactor[2] <= 1; cornerFactor[2]++ )
   {
     for ( cornerFactor[1] = 0; cornerFactor[1] <= 1; cornerFactor[1]++ )
@@ -2770,7 +2770,7 @@ void FSVolume::TargetToRAS( const double* pos_in, double* pos_out )
     pos[i] = ( pos_in[i] - origin[i] ) / vs[i];
   }
 
-  Real fpos[3];
+  double fpos[3];
   ::MRIvoxelToWorld( m_MRITarget,
                      (float)pos[0], (float)pos[1], (float)pos[2],
       &fpos[0], &fpos[1], &fpos[2] );
@@ -2820,7 +2820,7 @@ void FSVolume::TargetToRAS( const float* pos_in, float* pos_out )
 
 void FSVolume::RASToTarget( const double* pos_in, double* pos_out )
 {
-  Real pos[4] = { 0 };
+  double pos[4] = { 0 };
   ::MRIworldToVoxel( m_MRITarget,
                      (float)pos_in[0],
       (float)pos_in[1],

--- a/freeview/FSVolume.cpp
+++ b/freeview/FSVolume.cpp
@@ -1349,9 +1349,10 @@ int FSVolume::RASToOriginalIndex ( float iRASX, float iRASY, float iRASZ,
 
 bool FSVolume::RASToTalairachVoxel(const double *pos_in, double *pos_out)
 {
-  double x, y, z;
+#if !defined(BEVIN_EXCLUDE_MINC)
   if (m_MRI->linear_transform)
   {
+    double x, y, z;
     ::MRIworldToTalairachVoxel(m_MRI, pos_in[0], pos_in[1], pos_in[2], &x, &y, &z);
     pos_out[0] = x;
     pos_out[1] = y;
@@ -1359,6 +1360,7 @@ bool FSVolume::RASToTalairachVoxel(const double *pos_in, double *pos_out)
     return true;
   }
   else
+#endif
     return false;
 }
 

--- a/freeview/SurfaceSpline.cpp
+++ b/freeview/SurfaceSpline.cpp
@@ -148,9 +148,9 @@ void SurfaceSpline::RebuildActors()
     double pos[3];
     for (int i = 0; i < m_mri->height; i++)
     {
-      Real x = ::MRIgetVoxVal(m_mri, m_nActiveVertex, i, 0, 0);
-      Real y = ::MRIgetVoxVal(m_mri, m_nActiveVertex, i, 1, 0);
-      Real z = ::MRIgetVoxVal(m_mri, m_nActiveVertex, i, 2, 0);
+      double x = ::MRIgetVoxVal(m_mri, m_nActiveVertex, i, 0, 0);
+      double y = ::MRIgetVoxVal(m_mri, m_nActiveVertex, i, 1, 0);
+      double z = ::MRIgetVoxVal(m_mri, m_nActiveVertex, i, 2, 0);
       if (i == 0 && x == 0 && y == 0 && z == 0)
       {
         emit SplineChanged();

--- a/glut/glut_menu.c
+++ b/glut/glut_menu.c
@@ -976,9 +976,9 @@ glutCreateMenu(GLUTselectCB selectFunc)
      CWSaveUnder, ie. using Mesa 3D.  See earlier comments. */
   wa.save_under = True;
   menu->win = XCreateWindow(__glutDisplay, __glutRoot,
-                            /* Real position determined when mapped. */
+                            /* actual position determined when mapped. */
                             0, 0,
-                            /* Real size will be determined when menu is manged. */
+                            /* actual size will be determined when menu is manged. */
                             1, 1,
                             MENU_BORDER, menuDepth, InputOutput, menuVisual,
                             CWOverrideRedirect | CWBackPixel | CWBorderPixel |

--- a/glut/glut_win.c
+++ b/glut/glut_win.c
@@ -1037,7 +1037,7 @@ glutMotionFunc(GLUTmotionCB motionFunc)
         ButtonPressMask | ButtonReleaseMask, True);
     }
   }
-  /* Real work of selecting for passive mouse motion.  */
+  /* actual work of selecting for passive mouse motion.  */
   __glutChangeWindowEventMask(
     Button1MotionMask | Button2MotionMask | Button3MotionMask,
     motionFunc != NULL);

--- a/hiam_make_surfaces/hiam_make_surfaces.c
+++ b/hiam_make_surfaces/hiam_make_surfaces.c
@@ -452,7 +452,7 @@ mrisFindneighborlabel(MRI_SURFACE *mris, char surftype[10], MRI *mri_label[5], M
   int           vno, type=0, tt;
   VERTEX        *v;
   float         x, y, z, step;
-  Real          xw, yw, zw, val=0;
+  double        xw, yw, zw, val=0;
 
   for (tt=0; tt<4; tt++) {
     if ( !strcmp(surftype,surf[tt]) ) type = tt;
@@ -560,7 +560,7 @@ mrisFindneighborlabel(MRI_SURFACE *mris, char surftype[10], MRI *mri_label[5], M
   int           vno, type=0, tt;
   VERTEX        *v;
   float         x, y, z, step;
-  Real          xw, yw, zw, val=0;
+  double        xw, yw, zw, val=0;
 
   for (tt=0; tt<4; tt++) {
     if ( !strcmp(surftype,surf[tt]) ) type = tt;
@@ -621,7 +621,7 @@ mrisComputeLabelTerm1(MRI_SURFACE *mris, double weight_label, MRI *mri_smooth[5]
   int     vno;
   VERTEX  *v ;
   float   x, y, z, dx=0, dy=0, dz=0, nx=0, ny=0, nz=0;
-  Real    xw, yw, zw, dn, xw1, yw1, zw1, outlabel=0, inlabel=0;
+  double  xw, yw, zw, dn, xw1, yw1, zw1, outlabel=0, inlabel=0;
 
   if (FZERO(weight_label))
     return(NO_ERROR) ;
@@ -910,7 +910,7 @@ mrisComputeTangentialSpringEnergy(MRI_SURFACE *mris) {
 static double
 mrisComputeLabelEnergy(MRI_SURFACE *mris, MRI *mri_smooth[5],MRI *mri_label[5], MRI *mri_orig) {
   int           vno ;
-  Real          xw, yw, zw, inval=0, outval=0;
+  double        xw, yw, zw, inval=0, outval=0;
   float         x, y, z;
   //float         target_I = 0.5;
   VERTEX        *v;

--- a/histo_register/SimpleBaseLib/external/CDT/CDT.h
+++ b/histo_register/SimpleBaseLib/external/CDT/CDT.h
@@ -120,27 +120,27 @@ inline Llist::~Llist()
 #define Y 1
 #define Z 2
 
-typedef double Real;
+typedef double CDT_real;
 typedef bool Boolean;
 
 class Vector2d {
 public:
-	Real x, y;
+	CDT_real x, y;
 	void *tag;
 	Vector2d()				{ x = 0; y = 0; tag = 0; }
-	Vector2d(Real a, Real b)		{ x = a; y = b; tag = 0; }
-	Vector2d(Real a, Real b, void *t)	{ x = a; y = b; tag = t; }
+	Vector2d(CDT_real a, CDT_real b)		{ x = a; y = b; tag = 0; }
+	Vector2d(CDT_real a, CDT_real b, void *t)	{ x = a; y = b; tag = t; }
 	Vector2d(const Vector2d &v)		{ x = v.x; y = v.y; tag = v.tag; }
-	Real& operator[](int i)			{ return ((Real *)this)[i]; }
-	const Real& operator[](int i) const	{ return ((Real *)this)[i]; }
-	Real norm() const;
+	CDT_real& operator[](int i)			{ return ((CDT_real *)this)[i]; }
+	const CDT_real& operator[](int i) const	{ return ((CDT_real *)this)[i]; }
+	CDT_real norm() const;
 	void normalize();
 	bool operator==(const Vector2d&) const;
 	Vector2d operator+(const Vector2d&) const;
 	Vector2d operator-(const Vector2d&) const;
-	Real     operator|(const Vector2d&) const;
-	friend Vector2d operator*(Real, const Vector2d&);
-	friend Vector2d operator/(const Vector2d&, Real);
+	CDT_real     operator|(const Vector2d&) const;
+	friend Vector2d operator*(CDT_real, const Vector2d&);
+	friend Vector2d operator/(const Vector2d&, CDT_real);
 //	friend istream& operator>>(istream&, Vector2d&);
 //	friend ostream& operator<<(ostream&, const Vector2d&);
 };
@@ -152,23 +152,23 @@ public:
 	Line()	{}
 	Line(const Point2d&, const Point2d&);
 	void set(const Point2d&, const Point2d&);
-	Real eval(const Point2d&) const;
+	CDT_real eval(const Point2d&) const;
 	int classify(const Point2d&) const;
 	Point2d intersect(const Point2d&, const Point2d&) const;
 private:
-	Real a, b, c;
+	CDT_real a, b, c;
 };
 
 // Vector2d:
 
-inline Real Vector2d::norm() const
+inline CDT_real Vector2d::norm() const
 {
 	return sqrt(x * x + y * y);
 }
 
 inline void Vector2d::normalize()
 {
-	Real len;
+	CDT_real len;
 
 	if ((len = sqrt(x * x + y * y)) == 0.0)
 		printf( "Vector2d::normalize: Division by 0\n" );
@@ -193,17 +193,17 @@ inline bool Vector2d::operator==(const Vector2d& v) const
 	return (*this - v).norm() <= EPS;
 }
 
-inline Real Vector2d::operator|(const Vector2d& v) const
+inline CDT_real Vector2d::operator|(const Vector2d& v) const
 {
 	return x * v.x + y * v.y;
 }
 
-inline Vector2d operator*(Real c, const Vector2d& v)
+inline Vector2d operator*(CDT_real c, const Vector2d& v)
 {
 	return Vector2d(c * v.x, c * v.y);
 }
 
-inline Vector2d operator/(const Vector2d& v, Real c)
+inline Vector2d operator/(const Vector2d& v, CDT_real c)
 {
 	return Vector2d(v.x / c, v.y / c);
 }
@@ -215,7 +215,7 @@ inline Line::Line(const Point2d& p, const Point2d& q)
 // points p and q.
 {
 	Vector2d t = q - p;
-	Real len = t.norm();
+	CDT_real len = t.norm();
 
 	a =   t.y / len;
 	b = - t.x / len;
@@ -230,7 +230,7 @@ inline void Line::set(const Point2d& p, const Point2d& q)
 	*this = Line(p, q);
 }
 
-inline Real Line::eval(const Point2d& p) const
+inline CDT_real Line::eval(const Point2d& p) const
 // Plugs point p into the line equation.
 {
 	return (a * p.x + b* p.y + c);
@@ -241,7 +241,7 @@ inline Point2d Line::intersect(const Point2d& p1, const Point2d& p2) const
 {
         // assumes that segment (p1,p2) crosses the line
         Vector2d d = p2 - p1;
-        Real t = - eval(p1) / (a*d[X] + b*d[Y]);
+        CDT_real t = - eval(p1) / (a*d[X] + b*d[Y]);
         return (p1 + t*d);
 }
 
@@ -249,7 +249,7 @@ inline int Line::classify(const Point2d& p) const
 // Returns -1, 0, or 1, if p is to the left of, on,
 // or right of the line, respectively.
 {
-	Real d = eval(p);
+	CDT_real d = eval(p);
 	return (d < -EPS) ? -1 : (d > EPS ? 1 : 0);
 }
 
@@ -257,7 +257,7 @@ inline Boolean operator==(const Point2d& point, const Line& line)
 // Returns TRUE if point is on the line (actually, on the EPS-slab
 // around the line).
 {
-	Real tmp = line.eval(point);
+	CDT_real tmp = line.eval(point);
 	return(fabs(tmp) <= EPS);
 }
 
@@ -355,7 +355,7 @@ class Mesh {
 	Mesh(const Point2d&, const Point2d&, const Point2d&, const Point2d&);
 	Edge *MakeEdge(Boolean);
 	Edge *MakeEdge(Point2d*, Point2d*, Boolean);
-	Edge *InsertSite(const Point2d&, Real dist = EPS);
+	Edge *InsertSite(const Point2d&, CDT_real dist = EPS);
 	void InsertEdge(const Point2d&, const Point2d&);
 	int  numEdges() const	{ return edges.length(); }
 	void Draw() const;

--- a/histo_register_block/histo_register_block.c
+++ b/histo_register_block/histo_register_block.c
@@ -610,7 +610,7 @@ compute_alignment_error(MRI *mri_src, MRI *mri_dst, MRI *mri_seg, DENSITY *pdf, 
 static double
 compute_ml_alignment_error(MRI *mri_src, MRI *mri_dst, MRI *mri_seg, DENSITY *pdf, MATRIX *m_total, int skip, int level) {
   double sse, num, error ;
-  Real   val_src, val_dst, xs, ys, thick ;
+  double val_src, val_dst, xs, ys, thick ;
   int    x, y, oob, nseg ;
   VECTOR *v_src, *v_dst ;
   MATRIX *m_inv ;
@@ -809,7 +809,7 @@ write_snapshot(MRI *mri, MRI *mri1, MRI *mri2, MATRIX *m, char *base, int n, int
 
 static MRI *
 mri_apply_slice_xform(MRI *mri_src, MRI *mri_dst, MATRIX *m, int slice) {
-  Real   val, xs, ys ;
+  double val, xs, ys ;
   int    x, y ;
   VECTOR *v_src, *v_dst ;
 
@@ -890,7 +890,7 @@ compute_optimal_translation(MRI *mri_src, MRI *mri_dst, MRI *mri_seg, MATRIX *m_
 static double
 compute_cr_alignment_error(MRI *mri_src, MRI *mri_dst, MRI *mri_seg, DENSITY *pdf,
                            MATRIX *m_total, int skip, int level) {
-  Real   val_src, val_dst, xs, ys, thick ;
+  double val_src, val_dst, xs, ys, thick ;
   int    x, y, oob, i ;
   VECTOR *v_src, *v_dst ;
   MATRIX *m_inv ;
@@ -1020,7 +1020,7 @@ rotate_image(MRI *mri_src, MRI *mri_dst, double rotate_radians) {
   MATRIX   *m_rot, *m_total, *m_origin, *m_origin_inv ;
   VECTOR   *v_src, *v_dst ;
   float    xs, ys ;
-  Real     val_src ;
+  double   val_src ;
   int      x, y ;
 
   if (!mri_dst)
@@ -1089,7 +1089,7 @@ MRIeraseImageBorder(MRI *mri, int width) {
 }
 static double
 compute_overlap(MRI *mri_src, MRI *mri_dst, MATRIX *m_total) {
-  Real   xs, ys, thick ;
+  double xs, ys, thick ;
   int    x, y, nvox, ntotal ;
   VECTOR *v_src, *v_dst ;
   MATRIX *m_inv ;

--- a/include/gcamorphtestutils.hpp
+++ b/include/gcamorphtestutils.hpp
@@ -77,12 +77,13 @@ private:
   //! Indicies into small arrays defining the dimensions
   enum dimIndices { iX, iY, iZ };
 
+#if !defined(BEVIN_EXCLUDE_MINC)
   //! Map of variable names and types
   std::map<std::string,nc_type> varTypeMap;
 
   //! Map of the scalar names and types
   std::map<std::string,nc_type> scalarTypeMap;
-
+#endif
 
   //! Number of dimensions we will store
   static const unsigned int nDims = 3;

--- a/include/gcarray.h
+++ b/include/gcarray.h
@@ -44,8 +44,10 @@ typedef struct
   int       sdepth ;
   int       nvars ;     /* # of inputs */
   GCLASSIFY ****gcs ;
+#if !defined(BEVIN_EXCLUDE_MINC)
   Transform *transform ;
   Transform *inverse_transform ;
+#endif
   double    xstart ;     /* coord. of (0,0,0) in Talairach space */
   double    ystart ;
   double    zstart ;
@@ -56,8 +58,10 @@ GCARRAY ;
 GCARRAY    *GCarrayAlloc(MRI *mri_template, int scale, int nvars);
 GCARRAY    *GCarrayTrainAll(GCARRAY *gcarray, char *training_file_name,
                             int scale, int nvars) ;
+#if !defined(BEVIN_EXCLUDE_MINC)
 int     GCarraySetTransform(GCARRAY *gcarray, Transform *transform,
                             Transform *inverse_transform) ;
+#endif
 int     GCarrayFree(GCARRAY **pgcarray) ;
 int     GCarrayTrain(GCARRAY *gcarray, MRI *mri_src,MRI *mri_norm,
                      MRI *mri_target);

--- a/include/gmm/gmm_dense_Householder.h
+++ b/include/gmm/gmm_dense_Householder.h
@@ -272,7 +272,7 @@ namespace gmm {
   }
 
   /* ********************************************************************* */
-  /*    Real and complex Givens rotations                                  */
+  /*    real and complex Givens rotations                                  */
   /* ********************************************************************* */
 
   template <typename T> void Givens_rotation(T a, T b, T &c, T &s) {

--- a/include/gmm/gmm_solver_idgmres.h
+++ b/include/gmm/gmm_solver_idgmres.h
@@ -95,7 +95,7 @@ namespace gmm {
       FOM and GMRES, numerical applied mathematics,
       (30) 2-3 (1999) pp191-212.
       
-      @param A Real or complex unsymmetric matrix.
+      @param A real or complex unsymmetric matrix.
       @param x initial guess vector and final result.
       @param b right hand side
       @param M preconditionner

--- a/include/label.h
+++ b/include/label.h
@@ -28,7 +28,10 @@
 #ifndef LABEL_H
 #define LABEL_H
 
+#if !defined(BEVIN_EXCLUDE_MINC)
 #include "minc_volume_io.h"
+#endif
+
 #include "matrix.h"
 #include "const.h"
 #include "mri.h"
@@ -55,9 +58,11 @@ typedef struct
   char   name[STRLEN] ;       /* name of label file */
   char   subject_name[STRLEN] ;  /* name of subject */
   LV     *lv ;                /* labeled vertices */
+#if !defined(BEVIN_EXCLUDE_MINC)
   General_transform transform ;   /* the next two are from this struct */
   Transform         *linear_transform ;
   Transform         *inverse_linear_transform ;
+#endif
   char   space[100];          /* space description of the coords */
   double avg_stat ;
   int    *vertex_label_ind ; // mris->nvertices long - < 0 means it isn't in the label
@@ -99,7 +104,9 @@ int     LabelAddToSurfaceMark(LABEL *area, MRI_SURFACE *mris, int mark_to_add)  
 int     LabelToOriginal(LABEL *area, MRI_SURFACE *mris) ;
 int     LabelToWhite(LABEL *area, MRI_SURFACE *mris) ;
 int     LabelFromCanonical(LABEL *area, MRI_SURFACE *mris) ;
+#if !defined(BEVIN_EXCLUDE_MINC)
 int     LabelFromTalairach(LABEL *area, MRI_SURFACE *mris) ;
+#endif
 int     LabelToFlat(LABEL *area, MRI_SURFACE *mris) ;
 int     LabelRipRestOfSurface(LABEL *area, MRI_SURFACE *mris) ;
 int     LabelRipRestOfSurfaceWithThreshold(LABEL *area,

--- a/include/macros.h
+++ b/include/macros.h
@@ -50,6 +50,14 @@
 #define UINT         unsigned int
 #endif
 
+#ifndef FALSE
+#define FALSE  	     0
+#endif
+
+#ifndef TRUE
+#define TRUE         1
+#endif
+
 #define ISOPTION(c)  ((c) == '-')
 
 /* these are defined in hipl_format.h */

--- a/include/minc_volume_io.h
+++ b/include/minc_volume_io.h
@@ -26,6 +26,12 @@
 #ifndef MINC_VOLUME_IO_H
 #define MINC_VOLUME_IO_H
 
+#if defined(BEVIN_EXCLUDE_MINC)
+
+
+#else
+
+
 /*
  * Wrapper for MNI's volume_io.h, which has some annoyances which
  * must be circumvented.
@@ -52,9 +58,13 @@
 #ifdef Windows_NT
 #undef ERROR
 #endif // Windows_NT
+
 #include <volume_io.h> //from MNI
+
 /* remove unwanted warnings between hips_basic.h vs. volume_io/basic.h */
 #undef ABS
 #undef SIGN
+
+#endif
 
 #endif // MINC_VOLUME_IO_H

--- a/include/mri.h
+++ b/include/mri.h
@@ -207,9 +207,11 @@ typedef struct
   BUFTYPE       ***slices ;
   int           scale ;
   char          transform_fname[STR_LEN] ;
+#if !defined(BEVIN_EXCLUDE_MINC)
   General_transform transform ;   /* the next two are from this struct */
   Transform         *linear_transform ;
   Transform         *inverse_linear_transform ;
+#endif
   int           free_transform ;   /* are we responsible for freeing it? */
   int           nframes ;          /* # of concatenated images */
 
@@ -386,7 +388,9 @@ MRI   *MRIallocSequence(int width, int height,int depth,int type,int nframes);
 MRI   *MRIallocHeader(int width, int height, int depth, int type, int nframes) ;
 int   MRIallocIndices(MRI *mri) ;
 int   MRIsetResolution(MRI *mri, float xres, float yres, float zres) ;
+#if !defined(BEVIN_EXCLUDE_MINC)
 int   MRIsetTransform(MRI *mri,   General_transform *transform) ;
+#endif
 MRI * MRIallocChunk(int width, int height, int depth, int type, int nframes);
 int   MRIchunk(MRI **pmri);
 

--- a/include/mriBSpline.h
+++ b/include/mriBSpline.h
@@ -38,7 +38,9 @@ extern "C" {
 #endif
 
 #include "mri.h"
-//BEVIN #include "transform.h"
+#if !defined(BEVIN_EXCLUDE_MINC)
+#include "transform.h"
+#endif
 
 /** BSpline structure has degree, coefficient image (float), source type and
     if the source had negative values */
@@ -78,7 +80,7 @@ MRI *MRIlinearTransformBSpline(const MRI_BSPLINE *bspline, MRI *mri_dst, MATRIX 
 MRI *MRIapplyRASlinearTransformBSpline(const MRI_BSPLINE *bspline, MRI *mri_dst, MATRIX *mA) ;
 
 
-#ifdef BEVIN_MRI_BSPLINE_LTA
+#if !defined(BEVIN_EXCLUDE_MINC)
 /** Based on pre-computed B-spline coefficients interpolate image using LTA*/
 MRI *LTAtransformBSpline(const MRI_BSPLINE *bspline, MRI *mri_dst, LTA *lta) ;
 #endif

--- a/include/mriBSpline.h
+++ b/include/mriBSpline.h
@@ -38,7 +38,7 @@ extern "C" {
 #endif
 
 #include "mri.h"
-#include "transform.h"
+//BEVIN #include "transform.h"
 
 /** BSpline structure has degree, coefficient image (float), source type and
     if the source had negative values */
@@ -77,9 +77,11 @@ MRI *MRIlinearTransformBSpline(const MRI_BSPLINE *bspline, MRI *mri_dst, MATRIX 
 /** Based on pre-computed B-spline coefficients interpolate image using RAS map MATRIX*/
 MRI *MRIapplyRASlinearTransformBSpline(const MRI_BSPLINE *bspline, MRI *mri_dst, MATRIX *mA) ;
 
+
+#ifdef BEVIN_MRI_BSPLINE_LTA
 /** Based on pre-computed B-spline coefficients interpolate image using LTA*/
 MRI *LTAtransformBSpline(const MRI_BSPLINE *bspline, MRI *mri_dst, LTA *lta) ;
-
+#endif
 
 
 /** Direct methods for downsample (based on simplified algorithm) */

--- a/include/mriVolume.h
+++ b/include/mriVolume.h
@@ -311,6 +311,7 @@ Volm_tErr Volm_ConvertIdxToRAS     ( mriVolumeRef this,
 Volm_tErr Volm_ConvertRASToIdx     ( mriVolumeRef this,
                                      xVoxelRef    iRAS,
                                      xVoxelRef    oIdx );
+#if !defined(BEVIN_EXCLUDE_MINC)
 Volm_tErr Volm_ConvertIdxToMNITal  ( mriVolumeRef this,
                                      xVoxelRef    iIdx,
                                      xVoxelRef    oMNITal );
@@ -320,6 +321,7 @@ Volm_tErr Volm_ConvertIdxToTal     ( mriVolumeRef this,
 Volm_tErr Volm_ConvertTalToIdx     ( mriVolumeRef this,
                                      xVoxelRef    iTal,
                                      xVoxelRef    oIdx );
+#endif
 Volm_tErr Volm_ConvertIdxToScanner ( mriVolumeRef this,
                                      xVoxelRef    iIdx,
                                      xVoxelRef    oScanner );

--- a/include/mrinorm.h
+++ b/include/mrinorm.h
@@ -99,8 +99,10 @@ MRI *MRIhistoNormalize(MRI *mri_src,MRI *mri_norm, MRI *mri_template, int low,
                        int high);
 MRI *MRIsplineNormalize(MRI *mri_src, MRI *mri_dst, MRI **pmri_bias,
                         float *inputs, float *outputs, int npoints) ;
+#if !defined(BEVIN_EXCLUDE_MINC)
 MRI *MRIadaptiveHistoNormalize(MRI *mri_src, MRI *mri_norm, MRI *mri_template,
                                int wsize, int hsize, int low) ;
+#endif
 MRI *MRIhistoNormalizeRegion(MRI *mri_src, MRI *mri_norm, MRI *mri_template,
                              int low, MRI_REGION *wreg, MRI_REGION *h_src_reg,
                              MRI_REGION *h_tmp_reg) ;

--- a/include/signa.h
+++ b/include/signa.h
@@ -196,9 +196,9 @@
 #define IHDR_WINDOW     143  /* Default Window*/
 #define IHDR_LEVEL      144  /* Default Level*/
 #define IHDR_IFBLKS     145  /* Number of Blocks in File*/
-#define IHDR_NEX        146  /* Number of excitations (Real .*/
-#define IHDR_PSAR       148  /* Value of peak SAR (Real .*/
-#define IHDR_ASAR       150  /* Value of average SAR (Real .*/
+#define IHDR_NEX        146  /* Number of excitations - real*/
+#define IHDR_PSAR       148  /* Value of peak SAR - real*/
+#define IHDR_ASAR       150  /* Value of average SAR - real*/
 #define IHDR_MONITOR    152  /* SAR monitored ?*/
 #define IHDR_CONTIG     153  /* Contiguous slices ?*/
 #define IHDR_HRT_RT     154  /* Cardiac Heart Rate*/

--- a/include/stats.h
+++ b/include/stats.h
@@ -27,7 +27,10 @@
 #ifndef STATS_H
 #define STATS_H
 
+#if !defined(BEVIN_EXCLUDE_MINC)
 #include "minc_volume_io.h"
+#endif
+
 #include "matrix.h"
 #include "mri.h"
 
@@ -126,9 +129,11 @@ typedef struct
   MRI       *mri_avg_dofs[MAX_EVENTS] ;
   MRI       *mri_std_dofs[MAX_EVENTS] ;
 
+#if !defined(BEVIN_EXCLUDE_MINC)
   General_transform transform ;
   Transform         *linear_transform ;
   Transform         *inverse_linear_transform ;
+#endif
 }
 STAT_VOLUME, SV  ;
 

--- a/include/stats.h
+++ b/include/stats.h
@@ -184,8 +184,10 @@ int       StatAccumulateTalairachVolume(SV *sv_tal,
 int       StatAccumulateSurfaceVolume(SV *sv_tal,
                                       SV *sv,
                                       MRI_SURFACE *mris) ;
+#if !defined(BEVIN_EXCLUDE_MINC)
 int       StatReadTransform(STAT_VOLUME *sv,
                             const char *name) ;
+#endif
 int       StatVolumeExists(const char *prefix) ;
 
 STAT_TABLE *LoadStatTable(const char *statfile);

--- a/label2flat/label2flat.c
+++ b/label2flat/label2flat.c
@@ -42,7 +42,10 @@
 
 int main(int argc, char *argv[]) ;
 static int get_option(int argc, char *argv[]) ;
+
+#if !defined(BEVIN_EXCLUDE_MINC)
 static Transform *load_transform(char *subject_name, General_transform *xform);
+#endif
 
 static void print_usage(void) ;
 void print_help(void) ;
@@ -62,9 +65,10 @@ static int nclose = 0 ;
 
 static char subjects_dir[NAME_LEN] = "" ;
 
+#if !defined(BEVIN_EXCLUDE_MINC)
 static General_transform    transform ;
 static Transform            *linear_transform ;
-
+#endif
 
 static char *output_subject = NULL ;
 
@@ -135,7 +139,9 @@ main(int argc, char *argv[]) {
   sprintf(label_fname, "%s/%s/label/%s.label",
           subjects_dir, subject_name, label_name) ;
 
+#if !defined(BEVIN_EXCLUDE_MINC)
   linear_transform = load_transform(subject_name, &transform) ;
+#endif
 
   cp = strrchr(patch_name, '.') ;
   if (!cp)
@@ -269,6 +275,8 @@ get_option(int argc, char *argv[]) {
 
   return(nargs) ;
 }
+
+#if !defined(BEVIN_EXCLUDE_MINC)
 static Transform *
 load_transform(char *subject_name, General_transform *transform) {
   char xform_fname[100] ;
@@ -283,6 +291,7 @@ load_transform(char *subject_name, General_transform *transform) {
     fprintf(stderr, "transform read successfully from %s\n", xform_fname) ;
   return(get_linear_transform_ptr(transform)) ;
 }
+#endif
 
 static void
 print_usage(void) {

--- a/label2flat/label2flat.c
+++ b/label2flat/label2flat.c
@@ -31,7 +31,7 @@
 
 #include "mri.h"
 #include "macros.h"
-#include "volume_io.h"
+#include "minc_volume_io.h"
 #include "error.h"
 #include "diag.h"
 #include "proto.h"

--- a/label2patch/label2patch.c
+++ b/label2patch/label2patch.c
@@ -31,7 +31,7 @@
 
 #include "mri.h"
 #include "macros.h"
-#include "volume_io.h"
+#include "minc_volume_io.h"
 #include "error.h"
 #include "diag.h"
 #include "proto.h"

--- a/label_area/label_area.c
+++ b/label_area/label_area.c
@@ -31,7 +31,7 @@
 
 #include "mri.h"
 #include "macros.h"
-#include "volume_io.h"
+#include "minc_volume_io.h"
 #include "error.h"
 #include "diag.h"
 #include "proto.h"

--- a/label_border/label_border.c
+++ b/label_border/label_border.c
@@ -31,7 +31,7 @@
 
 #include "mri.h"
 #include "macros.h"
-#include "volume_io.h"
+#include "minc_volume_io.h"
 #include "error.h"
 #include "diag.h"
 #include "proto.h"

--- a/mri_add_xform_to_header/mri_add_xform_to_header.c
+++ b/mri_add_xform_to_header/mri_add_xform_to_header.c
@@ -30,7 +30,7 @@
 #include "utils.h"
 #include "mri.h"
 #include "macros.h"
-#include "volume_io.h"
+#include "minc_volume_io.h"
 #include "error.h"
 #include "diag.h"
 #include "proto.h"
@@ -138,6 +138,7 @@ main(int argc, char *argv[])
 
   if (! CopyNameOnly)
   {
+#if !defined(BEVIN_EXCLUDE_MINC)
     // why do we need to load the transform at this time
     // mri is removed anyway???? -- good point, added -s for noload
     if (input_transform_file(xform_fname, &mri->transform) != OK)
@@ -149,6 +150,11 @@ main(int argc, char *argv[])
     mri->inverse_linear_transform =
       get_inverse_linear_transform_ptr(&mri->transform) ;
     mri->free_transform = 1 ;
+#else
+    ErrorPrintf(ERROR_NO_MEMORY,
+                  "%s: does not support xform files such as '%s'\n",
+                  Progname, xform_fname);
+#endif
   }
   strcpy(mri->transform_fname, xform_fname) ;
 

--- a/mri_annotation2label/mri_annotation2label.c
+++ b/mri_annotation2label/mri_annotation2label.c
@@ -31,6 +31,7 @@
 #include <sys/utsname.h>
 #include <unistd.h>
 #include <string.h>
+#include <errno.h>
 
 #include "MRIio_old.h"
 #include "error.h"

--- a/mri_auto_fill/mri_auto_fill.c
+++ b/mri_auto_fill/mri_auto_fill.c
@@ -501,15 +501,15 @@ static int neighbors_on(MRI *mri, int x0, int y0, int z0, int label) ;
 static int
 MRIfillVolume(MRI *mri)
 {
-  Real     wm_rh_tal_x = 29.0 ;
-  Real     wm_rh_tal_y = -12.0 ;
-  Real     wm_rh_tal_z = 28.0 ;
-  Real     wm_lh_tal_x = -29.0 ;
-  Real     wm_lh_tal_y = -12.0 ;
-  Real     wm_lh_tal_z = 28.0 ;
+  double   wm_rh_tal_x = 29.0 ;
+  double   wm_rh_tal_y = -12.0 ;
+  double   wm_rh_tal_z = 28.0 ;
+  double   wm_lh_tal_x = -29.0 ;
+  double   wm_lh_tal_y = -12.0 ;
+  double   wm_lh_tal_z = 28.0 ;
   int      wm_lh_x, wm_lh_y, wm_lh_z, wm_rh_x, wm_rh_y, wm_rh_z,xi,yi,zi,
   x, y, z, xnew, ynew,znew;
-  Real     xr, yr, zr, dist, min_dist, xd, yd, zd ;
+  double   xr, yr, zr, dist, min_dist, xd, yd, zd ;
   MRI      *mri_fg, *mri_bg ;
 #if 0
   BUFTYPE  val ;

--- a/mri_average/mri_average.c
+++ b/mri_average/mri_average.c
@@ -79,8 +79,8 @@ MRI  *MRIsumSquare(MRI *mri1, MRI *mri2, MRI *mri_dst) ;
 int
 MRIsqrtAndNormalize(MRI *mri, float num)
 {
-  int   x, y, z ;
-  Real  val ;
+  int    x, y, z ;
+  double val ;
 
   for (x = 0 ; x < mri->width ; x++)
   {
@@ -103,8 +103,8 @@ MRIsqrtAndNormalize(MRI *mri, float num)
 MRI  *
 MRIsumSquare(MRI *mri1, MRI *mri2, MRI *mri_dst)
 {
-  int   x, y, z, f ;
-  Real  val1, val2, val_dst ;
+  int    x, y, z, f ;
+  double val1, val2, val_dst ;
 
   if (!mri_dst)
     mri_dst = MRIclone(mri1, NULL) ;

--- a/mri_ca_normalize/mri_ca_normalize.c
+++ b/mri_ca_normalize/mri_ca_normalize.c
@@ -1103,7 +1103,7 @@ find_control_points
 
 	    if (gca->ninputs > 1)  // 1st input is norm.mgz and we can depend on its intensities
 	    {
-	      Real val_T1 ;
+	      double val_T1 ;
 	      MRIsampleVolumeFrame(mri_in, xv, yv, zv, 0, &val_T1) ;
 	      if (val_T1 < MIN_WM_BIAS_PCT * DEFAULT_DESIRED_WHITE_MATTER_VALUE  ||
 		  val_T1 > MAX_WM_BIAS_PCT  * DEFAULT_DESIRED_WHITE_MATTER_VALUE )
@@ -1115,7 +1115,7 @@ find_control_points
 	    }
 	    else  // be more conservative
 	    {
-	      Real val_T1 ;
+	      double val_T1 ;
 	      MRIsampleVolumeFrame(mri_in, xv, yv, zv, 0, &val_T1) ;
 	      if (val_T1 < .75*MIN_WM_BIAS_PCT * DEFAULT_DESIRED_WHITE_MATTER_VALUE  ||
 		  val_T1 > 1.25*MAX_WM_BIAS_PCT  * DEFAULT_DESIRED_WHITE_MATTER_VALUE )
@@ -1516,7 +1516,7 @@ uniform_region(GCA *gca, MRI *mri, TRANSFORM *transform,
                float nsigma)
 {
   int   xk, yk, zk, whalf, xi, yi, zi, n ;
-  Real   val0, val, sigma, min_val,max_val, thresh ;
+  double val0, val, sigma, min_val,max_val, thresh ;
   MATRIX *m ;
   GC1D   *gc ;
 
@@ -1531,7 +1531,7 @@ uniform_region(GCA *gca, MRI *mri, TRANSFORM *transform,
   for (n = 0 ; n < gca->ninputs ; n++)
   {
     sigma = sqrt(*MATRIX_RELT(m, n+1, n+1)) ;
-    MRIsampleVolumeFrame(mri, (Real)x, (Real)y, (Real)z, n, &val0) ;
+    MRIsampleVolumeFrame(mri, (double)x, (double)y, (double)z, n, &val0) ;
     if (sigma < 0.05*val0)   /* don't let it be too small */
     {
       sigma = 0.05*val0 ;
@@ -1553,7 +1553,7 @@ uniform_region(GCA *gca, MRI *mri, TRANSFORM *transform,
         {
           zi = mri->zi[z+zk] ;
           MRIsampleVolumeFrame
-          (mri, (Real)xi, (Real)yi, (Real)zi, n, &val) ;
+          (mri, (double)xi, (double)yi, (double)zi, n, &val) ;
           if (val < min_val)
           {
             min_val = val ;
@@ -1584,7 +1584,7 @@ discard_unlikely_control_points(GCA *gca, GCA_SAMPLE *gcas, int nsamples,
   int    i, xv, yv, zv, n, peak, start, end, num ;
   HISTO *h, *hsmooth ;
   float  fmin, fmax ;
-  Real   val,  mean_ratio, min_T1, max_T1 ;
+  double val,  mean_ratio, min_T1, max_T1 ;
 
   if (nsamples == 0)
     return(NO_ERROR) ;
@@ -1609,7 +1609,7 @@ discard_unlikely_control_points(GCA *gca, GCA_SAMPLE *gcas, int nsamples,
 
       if (n >= 1)
       {
-	Real val_T1 ;
+	double val_T1 ;
 	MRIsampleVolumeFrame(mri_in, gcas[i].x,gcas[i].y,gcas[i].z, 0, &val_T1) ;
 	if (val_T1 < min_T1 || val_T1 > max_T1)
 	  continue ;
@@ -1636,7 +1636,7 @@ discard_unlikely_control_points(GCA *gca, GCA_SAMPLE *gcas, int nsamples,
       {
         mean_ratio += hsmooth->bins[peak] / gcas[i].means[n];
       }
-      mean_ratio /= (Real)nsamples ;
+      mean_ratio /= (double)nsamples ;
       HISTOclearBins(hsmooth, hsmooth, hsmooth->bins[start], hsmooth->bins[end])  ;
       if (niter++ > 5)
       {
@@ -1775,7 +1775,7 @@ normalizeFromLabel(MRI *mri_in, MRI *mri_dst, MRI *mri_seg, double *fas)
   int    x, y, z, width, height, depth, num, total, input, T1_index, i ;
   float   bias ;
   double  mean, sigma, max_fa ;
-  Real    val ;
+  double  val ;
 
   max_fa = fas[T1_index = 0] ;
   for (i = 1 ; i < mri_in->nframes ; i++)
@@ -1983,7 +1983,7 @@ normalizeChannelFromLabel(MRI *mri_in, MRI *mri_dst, MRI *mri_seg,
   int    x, y, z, width, height, depth, num, total;
   float   bias ;
   double  mean, sigma;
-  Real    val ;
+  double  val ;
 
   width = mri_in->width ;
   height = mri_in->height ;

--- a/mri_ca_normalize/mri_cal_normalize.c
+++ b/mri_ca_normalize/mri_cal_normalize.c
@@ -996,7 +996,7 @@ uniform_region(GCA *gca, MRI *mri, TRANSFORM *transform,
                float nsigma)
 {
   int   xk, yk, zk, whalf, xi, yi, zi, n, frame ;
-  Real   val0, val, sigma, min_val,max_val, thresh ;
+  double val0, val, sigma, min_val,max_val, thresh ;
   MATRIX *m ;
   GC1D   *gc ;
 
@@ -1009,7 +1009,7 @@ uniform_region(GCA *gca, MRI *mri, TRANSFORM *transform,
   for (n = 0 ; n < gca->ninputs ; n++)
   {
     sigma = sqrt(*MATRIX_RELT(m, n+1, n+1)) ;
-    MRIsampleVolumeFrame(mri, (Real)x, (Real)y, (Real)z, n, &val0) ;
+    MRIsampleVolumeFrame(mri, (double)x, (double)y, (double)z, n, &val0) ;
     if (sigma < 0.05*val0)   /* don't let it be too small */
       sigma = 0.05*val0 ;
     if (sigma > 0.1*val0)    /* don't let it be too big */
@@ -1028,7 +1028,7 @@ uniform_region(GCA *gca, MRI *mri, TRANSFORM *transform,
         {
           zi = mri->zi[z+zk] ;
           MRIsampleVolumeFrame
-            (mri, (Real)xi, (Real)yi, (Real)zi, frame, &val) ;
+            (mri, (double)xi, (double)yi, (double)zi, frame, &val) ;
           if (val < min_val)
             min_val = val ;
           if (val > max_val)
@@ -1052,7 +1052,7 @@ discard_unlikely_control_points(GCA *gca, GCA_SAMPLE *gcas, int nsamples,
   int    i, xv, yv, zv, n, peak, start, end, num ;
   HISTO *h, *hsmooth ;
   float  fmin, fmax ;
-  Real   val,  mean_ratio ;
+  double val,  mean_ratio ;
 
   if (nsamples == 0)
     return(NO_ERROR) ;
@@ -1102,7 +1102,7 @@ discard_unlikely_control_points(GCA *gca, GCA_SAMPLE *gcas, int nsamples,
       {
         mean_ratio += hsmooth->bins[peak] / gcas[i].means[0];
       }
-      mean_ratio /= (Real)nsamples ;
+      mean_ratio /= (double)nsamples ;
       HISTOclearBins
         (hsmooth, hsmooth, hsmooth->bins[start], hsmooth->bins[end])  ;
       if (niter++ > 5)

--- a/mri_ca_register/mri_ca_register.c
+++ b/mri_ca_register/mri_ca_register.c
@@ -2408,7 +2408,7 @@ remove_bright_stuff(MRI *mri, GCA *gca, TRANSFORM *transform)
   int              peak, num, end, x, y, z, xi, yi, zi,
                    xk, yk, zk, i, n, erase, five_mm ;
   float            thresh ;
-  Real             val, new_val ;
+  double           val, new_val ;
   MRI              *mri_tmp, *mri_nonbrain, *mri_tmp2 ;
   GCA_PRIOR        *gcap ;
   MRI_SEGMENTATION *mriseg ;

--- a/mri_ca_train/mri_ca_train.c
+++ b/mri_ca_train/mri_ca_train.c
@@ -1619,8 +1619,8 @@ lateralize_hypointensities(MRI *mri_seg)
 static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
 {
   int x, y, z, label, errors=0;
-  Real xw=0.0, yw=0.0, zw=0.0; // RAS coords
-  Real xmt=0.0, ymt=0.0, zmt=0.0; // MNI tal coords
+  double xw=0.0, yw=0.0, zw=0.0; // RAS coords
+  double xmt=0.0, ymt=0.0, zmt=0.0; // MNI tal coords
   float xt=0.0, yt=0.0, zt=0.0; // 'real' tal coords
   MRI *mri_fixed = NULL;
 

--- a/mri_ca_train/mri_ca_train.c
+++ b/mri_ca_train/mri_ca_train.c
@@ -1642,6 +1642,10 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
     mri_fixed = MRIcopy(mri_seg,NULL);
   }
 
+#if defined(BEVIN_EXCLUDE_MINC)
+    ErrorExit(ERROR_BADFILE,
+              "ERROR: mri_ca_train: talairach not supported!\n");
+#else
   if (NULL == mri_seg->linear_transform)
   {
     ErrorExit(ERROR_BADFILE,
@@ -1844,6 +1848,7 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
   printf("min_xtal_r_amygdala = %4.1f\n",min_xtal_r_amygdala);
   printf("min_xtal_r_putamen  = %4.1f\n",min_xtal_r_putamen);
   printf("min_xtal_r_pallidum = %4.1f\n",min_xtal_r_pallidum);
+#endif
   
   if ( do_fix_badsubjs && errors)
   {

--- a/mri_cc/mri_cc.c
+++ b/mri_cc/mri_cc.c
@@ -44,13 +44,6 @@
 #include "cma.h"
 #include "version.h"
 #include "error.h"
-
-#if !defined(BEVIN_EXCLUDE_MINC)
-#include "volume_io/geom_structs.h"
-#else
-#info this is probably the wrong fix
-#endif
-
 #include "transform.h"
 #include "talairachex.h"
 #include "matrix.h"
@@ -249,7 +242,7 @@ main(int argc, char *argv[])
     MRI *mri_norm ;
 
     sprintf(ifname,"%s/%s/mri/%s",data_dir,argv[1], aseg_fname) ;
-    print("reading aseg from %s\n", ifname);
+    printf("reading aseg from %s\n", ifname);
     mri_aseg = MRIread(ifname) ;
     if (mri_aseg == NULL)
       ErrorExit(ERROR_NOFILE, "%s: could not read aseg volume from %s",
@@ -277,7 +270,7 @@ main(int argc, char *argv[])
     }
 
     sprintf(ifname,"%s/%s/mri/norm.mgz",data_dir,argv[1]) ;
-    print("reading norm from %s\n", ifname);
+    printf("reading norm from %s\n", ifname);
     mri_norm = MRIread(ifname) ;
     if (mri_norm == NULL)
       ErrorExit(ERROR_NOFILE, "%s: could not read aseg volume from %s",
@@ -292,7 +285,7 @@ main(int argc, char *argv[])
   else
   {
     sprintf(ifname,"%s/%s/%s",data_dir,argv[1],wmvolume) ;
-    print("reading white matter volume from %s\n", ifname);
+    printf("reading white matter volume from %s\n", ifname);
     mri_wm = MRIread(ifname) ;
 
     sprintf(ifname,"%s/%s/mri/transforms/talairach.xfm",data_dir,argv[1]) ;
@@ -753,8 +746,11 @@ find_corpus_callosum(MRI *mri_tal,
 
   // this function is called with mri being talairached volume
   // get the talairach coords (0,0,0) in the voxel space
+  if (
 #if !defined(BEVIN_EXCLUDE_MINC)
-  if (mri_tal->linear_transform || lta)
+  mri_tal->linear_transform || 
+#endif
+  lta)
   {
     MRIworldToVoxel(mri_tal, 0.0, 0.0, 0.0,
                     &xr, &yr, &zr);   /* everything is now in tal coords */
@@ -763,7 +759,6 @@ find_corpus_callosum(MRI *mri_tal,
     zv = nint(zr) ;
   }
   else
-#endif
   {
     xv = x0;
     yv = region.y+region.dy/2;

--- a/mri_cc/mri_cc.c
+++ b/mri_cc/mri_cc.c
@@ -73,9 +73,9 @@ char            *Progname ;
 static int      dxi=2;  // thickness on either side of midline
 static int      x_edge=0, y_edge=0;
 static int      write_cc = 0 ;
-static Real cc_tal_x = 0.0 ;
-static Real cc_tal_y = 0.0 ;
-static Real cc_tal_z = 27.0 ;
+static double cc_tal_x = 0.0 ;
+static double cc_tal_y = 0.0 ;
+static double cc_tal_z = 27.0 ;
 static int fornix = 0 ;
 static int lh_only = 0 ;
 static int rh_only = 0 ;
@@ -91,13 +91,13 @@ static int cc_cutting_plane_correct(MRI *mri_aseg,
                                     VOXEL_LIST *vl_left_wm,
                                     VOXEL_LIST *vl_right_wm, int debug);
 static MRI *find_cc_with_aseg(MRI *mri_aseg, MRI *mri_cc, LTA **plta,
-                              Real *pxc, Real *pyc, Real *pzc, int thick,
+                              double *pxc, double *pyc, double *pzc, int thick,
                               MRI *mri_norm, MRI *mri_fornix) ;
 static int find_cc_slice(MRI *mri,
-                         Real *pccx, Real *pccy, Real *pccz,
+                         double *pccx, double *pccy, double *pccz,
                          const LTA *lta, MRI *mri_tal_cc) ;
 static int find_corpus_callosum(MRI *mri,
-                                Real *ccx, Real *ccy, Real *ccz,
+                                double *ccx, double *ccy, double *ccz,
                                 const LTA *lta, MRI *mri_tal_cc) ;
 static MRI *remove_fornix(MRI *mri_filled, int xv, int yv, int zv);
 static int edge_detection(MRI *mri_temp, int edge_count,int signal);
@@ -163,7 +163,7 @@ main(int argc, char *argv[])
 {
   char        ifname[STRLEN], ofname[STRLEN],  data_dir[STRLEN], *cp ;
   int         nargs, msec, y, z, xi, temp, i, j, k ;
-  Real        xc,yc,zc, xv, yv, zv;
+  double      xc,yc,zc, xv, yv, zv;
   MATRIX      *mrot = NULL, *mtrans = NULL;
   struct timeb  then ;
   MRI         *mri_tal=NULL, *mri_talheader=NULL, *mri_header=NULL, *mri_cc;
@@ -725,13 +725,13 @@ main(int argc, char *argv[])
 
 static int
 find_corpus_callosum(MRI *mri_tal,
-                     Real *pccx, Real *pccy, Real *pccz,
+                     double *pccx, double *pccy, double *pccz,
                      const LTA *lta, MRI *mri_cc_tal)
 {
   int         xv, yv, zv, max_y, max_thick=0, thickness=0,
                                  y1, xcc, ycc, x, y,x0, extension=50 ;
   int         flag=0, counts=0;
-  Real        xr, yr, zr ;
+  double      xr, yr, zr ;
   MRI_REGION  region ;
   int cc_spread, min_thickness, max_thickness, slice_size;
   double voxsize=findMinSize(mri_tal);
@@ -841,7 +841,7 @@ find_corpus_callosum(MRI *mri_tal,
 
 static int
 find_cc_slice(MRI *mri_tal,
-              Real *pccx, Real *pccy, Real *pccz,
+              double *pccx, double *pccy, double *pccz,
               const LTA *lta, MRI *mri_cc_tal)
 {
   // here we can handle only up to .5 mm voxel size
@@ -849,7 +849,7 @@ find_cc_slice(MRI *mri_tal,
               min_area, min_slice, slice, offset,xv,yv,zv,
               i, total_area=0, left=0, right=0;
   MRI         *mri_slice, *mri_filled ;
-  Real        x_tal, y_tal, z_tal, x, y, z, xvv, yvv, zvv;
+  double      x_tal, y_tal, z_tal, x, y, z, xvv, yvv, zvv;
   MRI_REGION  region ;
   char        fname[STRLEN] ;
   int         half_slices, ii, jj;
@@ -1510,7 +1510,7 @@ get_option(int argc, char *argv[])
 
 static MRI *
 find_cc_with_aseg(MRI *mri_aseg_orig, MRI *mri_cc, LTA **plta,
-                  Real *pxc, Real *pyc, Real *pzc,
+                  double *pxc, double *pyc, double *pzc,
                   int thick, MRI *mri_norm, MRI *mri_fornix)
 {
   LTA         *lta ;
@@ -1982,9 +1982,9 @@ find_cc_with_aseg(MRI *mri_aseg_orig, MRI *mri_cc, LTA **plta,
   VectorFree(&v1) ;
   VectorFree(&v2) ;
   *plta = lta ;
-  *pxc = (Real)best_slice ;
-  *pyc = (Real)y0_best ;
-  *pzc = (Real)z0_best ;
+  *pxc = (double)best_slice ;
+  *pyc = (double)y0_best ;
+  *pzc = (double)z0_best ;
 
   mri_tmp = MRIclone(mri_cc, NULL) ;
   if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON)

--- a/mri_cc/mri_cc.c
+++ b/mri_cc/mri_cc.c
@@ -44,7 +44,13 @@
 #include "cma.h"
 #include "version.h"
 #include "error.h"
+
+#if !defined(BEVIN_EXCLUDE_MINC)
 #include "volume_io/geom_structs.h"
+#else
+#info this is probably the wrong fix
+#endif
+
 #include "transform.h"
 #include "talairachex.h"
 #include "matrix.h"
@@ -235,7 +241,7 @@ main(int argc, char *argv[])
         "could not open cc volume measurement file %s",
         ifname));
     }
-    print("writing results to %s\n",ifname);
+    printf("writing results to %s\n",ifname);
   }
 
   if (use_aseg)
@@ -747,6 +753,7 @@ find_corpus_callosum(MRI *mri_tal,
 
   // this function is called with mri being talairached volume
   // get the talairach coords (0,0,0) in the voxel space
+#if !defined(BEVIN_EXCLUDE_MINC)
   if (mri_tal->linear_transform || lta)
   {
     MRIworldToVoxel(mri_tal, 0.0, 0.0, 0.0,
@@ -756,6 +763,7 @@ find_corpus_callosum(MRI *mri_tal,
     zv = nint(zr) ;
   }
   else
+#endif
   {
     xv = x0;
     yv = region.y+region.dy/2;

--- a/mri_cc_medial_axis/mri_cc_medial_axis.c
+++ b/mri_cc_medial_axis/mri_cc_medial_axis.c
@@ -90,9 +90,9 @@ typedef struct medial_axis_type_ {
 atom_type, MEDATOM ;
 
 
-static Real cc_tal_x = 64 ;
-static Real cc_tal_y = 55 ;
-static Real cc_tal_z = 64 ;
+static double cc_tal_x = 64 ;
+static double cc_tal_y = 55 ;
+static double cc_tal_z = 64 ;
 static LTA *lta = 0;
 static int rotatevolume();
 static int find_mid_plane_wm(char *subject) ;
@@ -112,8 +112,8 @@ static MEDATOM *compute_normal(MEDATOM *medial_axis, int length) ;
 static MEDATOM *medial_axis_refine_leaf(MEDATOM *medial_axis, MRI *cc_boundary, MRI *cc_smoothed, int length);
 static float    compute_error(MEDATOM *medial_axis,MRI *cc_boundary, MRI *cc_smoothed, int length, int new_length, int flag);
 static float    sample_distance_map(MRI *cc_boundary, MRI *cc_smoothed, float x, float y) ;
-static int      find_cc_slice(MRI *mri, Real *pccx, Real *pccy, Real *pccz, const LTA *lta) ;
-static int      find_corpus_callosum(MRI *mri, Real *ccx, Real *ccy, Real *ccz, const LTA *lta) ;
+static int      find_cc_slice(MRI *mri, double *pccx, double *pccy, double *pccz, const LTA *lta) ;
+static int      find_corpus_callosum(MRI *mri, double *ccx, double *ccy, double *ccz, const LTA *lta) ;
 static MRI     *cc_slice_correction(MRI *mri_filled, int xv, int yv, int zv);
 static int      edge_detection(MRI *mri_temp, int edge_count,int signal);
 
@@ -222,11 +222,11 @@ main(int argc, char *argv[]) {
 static int find_mid_plane_wm(char *subject) {
   char        ifname[200], ofname[200],  data_dir[400], *cp ;
   int         y, z, xi, yi_low=256, yi_high=0, zi_low=256, zi_high=0, temp;
-  Real        xc,yc,zc;
+  double      xc,yc,zc;
   MATRIX      *mrot, *mtrans;
   int         i, j, k;
   MRI         *mri_talheader, *mri_header, *mri_cc, *mri_tal;
-  Real        xv, yv, zv;
+  double      xv, yv, zv;
   FILE        *fp;
   LTA         *lta2 = 0;
   float       volume[5];
@@ -482,7 +482,7 @@ rotatevolume() {
   int   y_rotate, z_rotate, x, y_alpha, z_alpha, xi, yi, zi, yk, zk ;
   int  whalf, p_x, p_y, p_z;
   int   x_center, y_center, z_center, xshift, i, j, k ;
-  Real        val=0;
+  double      val=0;
   float       ey_x, ey_y, ey_z, ez_x, ez_y, ez_z, x1_x, x1_y, x1_z, xbase, ybase, zbase;
   /*  BUFTYPE     *pdst, *pptr ; */
   MRI   *mri_temp, *mri_tal;
@@ -621,10 +621,10 @@ rotatevolume() {
 #define MAX_THICKNESS   20
 
 static int
-find_corpus_callosum(MRI *mri_tal, Real *pccx, Real *pccy, Real *pccz, const LTA *lta) {
+find_corpus_callosum(MRI *mri_tal, double *pccx, double *pccy, double *pccz, const LTA *lta) {
   int         xv, yv, zv, max_y, max_thick=0, thickness=0, y1, xcc, ycc, x, y,x0, extension=50 ;
   int         flag=0, counts=0;
-  Real        xr, yr, zr ;
+  double      xr, yr, zr ;
   MRI_REGION  region ;
   int cc_spread, min_thickness, max_thickness, slice_size;
   double voxsize=findMinSize(mri_tal);
@@ -709,12 +709,12 @@ find_corpus_callosum(MRI *mri_tal, Real *pccx, Real *pccy, Real *pccz, const LTA
 
 
 static int
-find_cc_slice(MRI *mri_tal, Real *pccx, Real *pccy, Real *pccz, const LTA *lta) {
+find_cc_slice(MRI *mri_tal, double *pccx, double *pccy, double *pccz, const LTA *lta) {
   // here we can handle only up to .5 mm voxel size
   int         area[MAX_SLICES*2], flag[MAX_SLICES*2], min_area, min_slice, slice, offset,xv,yv,zv,
   xo, yo ,i, total_area=0, left=0, right=0;
   MRI         *mri_slice, *mri_filled ;
-  Real        aspect, x_tal, y_tal, z_tal, x, y, z, xvv, yvv, zvv;
+  double      aspect, x_tal, y_tal, z_tal, x, y, z, xvv, yvv, zvv;
   MRI_REGION  region ;
   char        fname[STRLEN] ;
   int         half_slices, ii, jj;
@@ -749,7 +749,7 @@ find_cc_slice(MRI *mri_tal, Real *pccx, Real *pccy, Real *pccz, const LTA *lta) 
       mri_slice = MRIextractPlane(mri_tal, NULL, MRI_SAGITTAL, xv);
       mri_filled =  MRIfillFG(mri_slice, NULL, zv, yv,0,WM_MIN_VAL,CC_VAL,&area[slice]);
       MRIboundingBox(mri_filled, 1, &region) ;
-      aspect = (Real)region.dy / (Real)region.dx ;
+      aspect = (double)region.dy / (double)region.dx ;
       if (i++) fprintf(stdout,"moved %d in slice %d \n", i-1, slice);
     }
     /* don't trust slices that extend to the border of the image */
@@ -1232,7 +1232,7 @@ static MEDATOM *find_medial_axis(MEDATOM *medial_axis, int length, int n_sample,
   float x1, x2, y1, y2, x, y, dx, dy ;
   FILE  *fp;
   double  dist, space, fraction;
-  Real   val = 0, mean_val=0;
+  double val = 0, mean_val=0;
 
   cc_smoothed = MRIextractPlane(mri_cc_tal, NULL, MRI_SAGITTAL, cc_tal_x);
   cc_smoothed = smooth_cc(cc_smoothed);
@@ -1304,7 +1304,7 @@ static MEDATOM *find_medial_axis(MEDATOM *medial_axis, int length, int n_sample,
 #endif
 
   if (0) {
-    Real xw,yw,zw;
+    double xw,yw,zw;
     for (j=0; j<length; j++) {
       MRIvoxelToWorld(mri_cc_tal, cc_tal_x, medial_axis[j].y, medial_axis[j].x, &xw, &yw, &zw) ;
       fprintf(stdout, "0 %.2f %.2f %.2f 0\n", xw,yw,zw);
@@ -1364,7 +1364,7 @@ static MEDATOM *find_medial_axis(MEDATOM *medial_axis, int length, int n_sample,
   space = dist/(n_sample+1);
   j=0;
   for (n=1; n<=n_sample; n++) {
-    Real upmid, downmid;
+    double upmid, downmid;
     float radius;
     dist = n*space;
     for (;medial_axis[j].odx<dist&&j<length;j++) {
@@ -2149,9 +2149,9 @@ get_option(int argc, char *argv[]) {
     TAL = 1 ;
     fprintf(stdout,"read in talairach transformed volume\n");
   } else if (!stricmp(option, "seed")) {
-    cc_tal_x = (Real)atof(argv[2]) ;
-    cc_tal_y = (Real)atof(argv[3]) ;
-    cc_tal_z = (Real)atof(argv[4]) ;
+    cc_tal_x = atof(argv[2]) ;
+    cc_tal_y = atof(argv[3]) ;
+    cc_tal_z = atof(argv[4]) ;
     nargs = 3 ;
     ROT = 0;
     fprintf(stderr, "T1 volume: cc seed at (%f %f %f)\n",

--- a/mri_cc_medial_axis/mri_cc_medial_axis.c
+++ b/mri_cc_medial_axis/mri_cc_medial_axis.c
@@ -55,7 +55,7 @@
 #include "cma.h"
 #include "version.h"
 #include "error.h"
-#include "volume_io/geom_structs.h"
+//#include "volume_io/geom_structs.h"
 #include "transform.h"
 #include "talairachex.h"
 #include "matrix.h"

--- a/mri_cnr/mri_cnr.c
+++ b/mri_cnr/mri_cnr.c
@@ -277,7 +277,7 @@ static double
 compute_volume_cnr(MRI_SURFACE *mris, MRI *mri, char *log_fname) {
   double  gray_white_cnr, gray_csf_cnr, gray_var, white_var, csf_var, gray_mean, white_mean, csf_mean ;
   float   thickness ;
-  Real    x, y, z, gray, white, csf ;
+  double  x, y, z, gray, white, csf ;
   int     vno ;
   VERTEX  *v ;
 

--- a/mri_compute_change_map/mri_compute_change_map.c
+++ b/mri_compute_change_map/mri_compute_change_map.c
@@ -361,7 +361,7 @@ MRImaskRegisteredPair(MRI *mri1, MRI *mri2, TRANSFORM *transform, MRI *mri_mask)
 {
   int       x1, y1, z1, x2, y2, z2 ;
   float     xf, yf, zf;
-  Real      val ;
+  double    val ;
 
   for (x1 = 0 ; x1 < mri1->width ; x1++)
     for (y1 = 0 ; y1 < mri1->height ; y1++)
@@ -393,7 +393,7 @@ MRIcomputeChangeMap(MRI *mri1, MRI *mri2, TRANSFORM *transform, MRI *mri_change,
   int       x1, y1, z1, nvox ;
   float     x2, y2, z2, val1, min1, max1, min2, max2, min_change, 
     max_change, dif, mask1 ;
-  Real      val2, p, logp, mask2, sigma, mean ;
+  double    val2, p, logp, mask2, sigma, mean ;
   MRI       *mri_dif, *mri_mean, *mri_used, *mri_mask1, *mri_mask2, *mri_big ;
   HISTOGRAM *h, *hs, *hg ;
   MRI       *mri_xformed ;

--- a/mri_concatenate_lta/mri_concatenate_lta.c
+++ b/mri_concatenate_lta/mri_concatenate_lta.c
@@ -658,7 +658,7 @@ get_transform:
 }
 
 
-#include "volume_io.h"
+#include "minc_volume_io.h"
 
 static int  ltaMNIwrite(LTA *lta, char *fname)
 {

--- a/mri_dct_align/mri_dct_align_binary.c
+++ b/mri_dct_align/mri_dct_align_binary.c
@@ -865,7 +865,7 @@ compute_distance_transform_sse(VOXEL_LIST *vl_target,VOXEL_LIST *vl_source,DCT *
   VECTOR  *v1, *v2 ;
   MRI     *mri_target, *mri_source ;
   double  sse, error ;
-  Real    d1, d2, xd, yd, zd ;
+  double  d1, d2, xd, yd, zd ;
   MATRIX  *m_L_inv, *m_L ;
   float   xf, yf, zf ;
 

--- a/mri_deface/mri_deface.c
+++ b/mri_deface/mri_deface.c
@@ -2319,7 +2319,7 @@ static int
 recompute_labels(MRI *mri, GCA *gca, GCA_SAMPLE *gcas,
                  int nsamples, MATRIX *m_L) {
   int            xp,yp,zp,x, y, z, label, n, i, nchanged = 0 ;
-  Real           val ;
+  double         val ;
   GCA_PRIOR      *gcap ;
   float          log_p ;
   GC1D           *gc ;

--- a/mri_distance_transform/mri_distance_transform.cpp
+++ b/mri_distance_transform/mri_distance_transform.cpp
@@ -579,9 +579,9 @@ MRIthresholdPosterior(MRI *mri_src, MRI *mri_dst, float posterior_dist)
 static float
 remove_csf_from_paths(MRI *mri_distance, MRI *mri_area, MRI *mri_csf)
 {
-  int   x, y, z, steps, xk, yk, zk, xi, yi, zi, csf_nbr,total_label_vox;
-  float xf, yf, zf, mean_csf_len, csf_len, total_csf_len ;
-  Real  dx, dy, dz, distance ;
+  int    x, y, z, steps, xk, yk, zk, xi, yi, zi, csf_nbr,total_label_vox;
+  float  xf, yf, zf, mean_csf_len, csf_len, total_csf_len ;
+  double dx, dy, dz, distance ;
   MRI   *mri_orig_csf ;
 
   mri_orig_csf = MRIcopy(mri_csf, NULL) ;

--- a/mri_edit_segmentation_with_surfaces/mri_edit_segmentation_with_surfaces.c
+++ b/mri_edit_segmentation_with_surfaces/mri_edit_segmentation_with_surfaces.c
@@ -506,7 +506,7 @@ relabel_hypointensities(MRI *mri, MRI *mri_inputs,
   MRIS_HASH_TABLE *mht ;
   VERTEX           *v ;
   float            dx, dy, dz, dot, dist, temp_x, temp_y, temp_z;
-  Real             xw, yw, zw ;
+  double           xw, yw, zw ;
  
   mri_inside = MRIclone(mri, NULL) ;
   MRISeraseOutsideOfSurface(0.5, mri_inside, mris, 128) ;
@@ -1752,7 +1752,7 @@ MRIlabelMean(MRI *mri,
 {
   int    xi, yi, zi, xk, yk, zk, nvox ;
   double mean ;
-  Real   val ;
+  double val ;
 
   mean = 0.0 ;
   nvox = 0 ;

--- a/mri_edit_segmentation_with_surfaces/mri_edit_segmentation_with_surfaces.c
+++ b/mri_edit_segmentation_with_surfaces/mri_edit_segmentation_with_surfaces.c
@@ -1074,7 +1074,7 @@ edit_hippocampal_complex(MRI *mri,
   MRIS_HASH_TABLE *mht ;
   int              x, y, z, label, changed, index, total_changed;
   int              i, vno, yi, dont_use, ystart, ind ;
-  Real             xw, yw, zw, xv, yv, zv ;
+  double           xw, yw, zw, xv, yv, zv ;
   VERTEX           *v ;
   float            dx, dy, dz, dot, dist ;
   MRI              *mri_changed, *mri_above_para, *mri_below_para,\
@@ -1607,7 +1607,7 @@ edit_unknowns(MRI *mri_aseg, MRI *mri)
 {
   int    x, y, z, label, right ;
   double mean_wm, mean_vent ;
-  Real   val ;
+  double val ;
 
   /*  find unknown voxels that border both wm and 
       inf_lat_vent, and change them to one
@@ -1789,7 +1789,7 @@ edit_calcarine(MRI *mri, MRI_SURFACE *mris, int right)
   int     vno, changed, label, index, x, y, z ;
   VERTEX  *v ;
   double  d ;
-  Real    xv, yv, zv, xs, ys, zs ;
+  double  xv, yv, zv, xs, ys, zs ;
 
   mri_calc = MRIclone(mri, NULL) ;
 

--- a/mri_extract_fcd_features/mri_extract_fcd_features.c
+++ b/mri_extract_fcd_features/mri_extract_fcd_features.c
@@ -523,7 +523,7 @@ MRIcomputeSurfaceDistanceIntensities(MRI_SURFACE *mris,  MRI *mri_ribbon, MRI *m
 	  {
 	    nx /= thickness ; ny /= thickness ; nz /= thickness ;
 	    dot = nx*snx + ny*sny + nz*snz ; angle = acos(dot) ;
-	    if (FABS(angle) > angle_threshold)
+	    if (fabs(angle) > angle_threshold)
 	      assignable = 0 ;
 	    outside_of_ribbon = 0 ;
 	    for (dist = 0 ; assignable && dist <= thickness ; dist += step_size) 

--- a/mri_extract_ma_intensity/mri_extract_ma_intensity.c
+++ b/mri_extract_ma_intensity/mri_extract_ma_intensity.c
@@ -67,9 +67,9 @@ int             main(int argc, char *argv[]) ;
 static int      get_option(int argc, char *argv[]) ;
 char            *Progname ;
 
-static Real cc_tal_x = 126 ;
-static Real cc_tal_y = 107 ;
-static Real cc_tal_z = 96 ;
+static double cc_tal_x = 126 ;
+static double cc_tal_y = 107 ;
+static double cc_tal_z = 96 ;
 
 int
 main(int argc, char *argv[]) {
@@ -78,7 +78,7 @@ main(int argc, char *argv[]) {
   MRI         *mri_pd, *mri_t1;
   FILE        *fp_in, *fp_out;
   float       x, y, radius, val=0;
-  Real        val_pd=0, val_t1=0;
+  double      val_pd=0, val_t1=0;
 
   Progname = argv[0] ;
   DiagInit(NULL, NULL, NULL) ;
@@ -147,9 +147,9 @@ get_option(int argc, char *argv[]) {
   option = argv[1] + 1 ;            /* past '-' */
 
   if (!stricmp(option, "seed")) {
-    cc_tal_x = (Real)atof(argv[2]) ;
-    cc_tal_y = (Real)atof(argv[3]) ;
-    cc_tal_z = (Real)atof(argv[4]) ;
+    cc_tal_x = atof(argv[2]) ;
+    cc_tal_y = atof(argv[3]) ;
+    cc_tal_z = atof(argv[4]) ;
     nargs = 3 ;
     fprintf(stderr, "cc seed at (%f %f %f)\n",
             cc_tal_x, cc_tal_y, cc_tal_z) ;

--- a/mri_fcili/mri_fcili.c
+++ b/mri_fcili/mri_fcili.c
@@ -54,6 +54,7 @@
 #include <sys/utsname.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <errno.h>
 
 #include "macros.h"
 #include "utils.h"

--- a/mri_fill/mri_fill.c
+++ b/mri_fill/mri_fill.c
@@ -47,7 +47,6 @@
 #include "cma.h"
 #include "version.h"
 #include "error.h"
-#include "volume_io/geom_structs.h"
 #include "tags.h"
 #include "transform.h"
 #include "talairachex.h"
@@ -2226,6 +2225,7 @@ main(int argc, char *argv[])
     lta->type = LINEAR_RAS_TO_RAS;
     // try getting from mri
     // transform is MNI transform (only COR volume reads transform)
+#if !defined(BEVIN_EXCLUDE_MINC)
     if (mri_im->linear_transform)
     {
       // linear_transform is zero based column-major array
@@ -2263,6 +2263,7 @@ main(int argc, char *argv[])
       }
     }
     else
+#endif
     {
       printf("INFO: volume does not have linear_transform "
              "set nor lta is given by option.-xform.\n") ;
@@ -3858,7 +3859,11 @@ find_cutting_plane
 
   // mri coming is a talairached volume
   /* search for valid seed point */
-  if (mri_tal->linear_transform || lta)
+  if (
+#if !defined(BEVIN_EXCLUDE_MINC)  
+  mri_tal->linear_transform || 
+#endif
+  lta)
   {
     MRIworldToVoxel(mri_tal, x_tal, y_tal,  z_tal, &x, &y, &z) ;
     // talairach volume voxel position
@@ -4608,7 +4613,11 @@ find_corpus_callosum
 
   // this function is called with mri being talairached volume
   // get the talairach coords (0,0,0) in the voxel space
-  if (mri_tal->linear_transform || lta)
+  if (
+#if !defined(BEVIN_EXCLUDE_MINC)
+      mri_tal->linear_transform || 
+#endif
+      lta)
   {
     MRIworldToVoxel
     (mri_tal, 0.0, 0.0, 0.0, &xr, &yr, &zr);   /* everything is

--- a/mri_fill/mri_fill.c
+++ b/mri_fill/mri_fill.c
@@ -135,25 +135,25 @@ static int fill_holes_flag = TRUE;
 
 /* corpus callosum seed point in Talairach coords */
 
-static Real cc_tal_x = 0.0 ;
-static Real cc_tal_y = 0.0 ;
-static Real cc_tal_z = 27.0 ;
+static double cc_tal_x = 0.0 ;
+static double cc_tal_y = 0.0 ;
+static double cc_tal_z = 27.0 ;
 
-static Real pons_tal_x = -2.0 ;
-static Real pons_tal_y = -15.0 /* -22.0 */ ;
-static Real pons_tal_z = -17.0 ;
+static double pons_tal_x = -2.0 ;
+static double pons_tal_y = -15.0 /* -22.0 */ ;
+static double pons_tal_z = -17.0 ;
 
 static int cc_seed_set = 0 ;
 static int pons_seed_set = 0 ;
 
 // seed specified in volume position ///////////////
-static Real cc_vol_x = 0;
-static Real cc_vol_y = 0;
-static Real cc_vol_z = 0;
+static double cc_vol_x = 0;
+static double cc_vol_y = 0;
+static double cc_vol_z = 0;
 
-static Real pons_vol_x = 0;
-static Real pons_vol_y = 0;
-static Real pons_vol_z = 0;
+static double pons_vol_x = 0;
+static double pons_vol_y = 0;
+static double pons_vol_z = 0;
 
 static int cc_seed_vol_set = 0;
 static int pons_seed_vol_set = 0;
@@ -162,13 +162,13 @@ static int pons_seed_vol_set = 0;
 static int lh_seed_set = 0 ;
 static int rh_seed_set = 0 ;
 
-static Real lh_tal_x ;
-static Real lh_tal_y ;
-static Real lh_tal_z ;
+static double lh_tal_x ;
+static double lh_tal_y ;
+static double lh_tal_z ;
 
-static Real rh_tal_x ;
-static Real rh_tal_y ;
-static Real rh_tal_z ;
+static double rh_tal_x ;
+static double rh_tal_y ;
+static double rh_tal_z ;
 
 static int rh_vol_x ;
 static int rh_vol_y ;
@@ -1877,11 +1877,11 @@ double findMinSize(MRI *mri)
 
 int verifyLRSplit(MRI *mri_fill,
                   LTA *lta,
-                  Real cc_tal_x,
+                  double cc_tal_x,
                   int *pbadRH, int *pbadLH, int *ptotRH, int *ptotLH)
 {
   int x, y, z;
-  Real tal_x, tal_y, tal_z;
+  double tal_x, tal_y, tal_z;
   unsigned char val;
   // gets linear transform and thus fill val
   // may have non rh_fill_val or lh_fill_val
@@ -1963,18 +1963,18 @@ int main(int argc, char *argv[]) ;
 
 static int fill_holes(MRI *mri_fill) ;
 static int fill_brain(MRI *mri_fill, MRI *mri_im, int threshold) ;
-static MRI *find_cutting_plane(MRI *mri, Real x_tal, Real y_tal,Real z_tal,
+static MRI *find_cutting_plane(MRI *mri, double x_tal, double y_tal,double z_tal,
                                int orientation, int *pxv, int *pvy, int *pzv,
                                int seed_set, const LTA *lta) ;
 static int find_slice_center(MRI *mri,  int *pxo, int *pyo) ;
 static int find_cc_seed_with_segmentation
-(MRI *mri_tal, MRI *mri_seg, Real *pcc_tal_x, Real *cc_tal_y, Real *cc_tal_z) ;
+(MRI *mri_tal, MRI *mri_seg, double *pcc_tal_x, double *cc_tal_y, double *cc_tal_z) ;
 static int find_corpus_callosum
-(MRI *mri, Real *ccx, Real *ccy, Real *ccz, const LTA *lta) ;
-static int find_pons(MRI *mri, Real *p_ponsx, Real *p_ponsy, Real *p_ponsz,
+(MRI *mri, double *ccx, double *ccy, double *ccz, const LTA *lta) ;
+static int find_pons(MRI *mri, double *p_ponsx, double *p_ponsy, double *p_ponsz,
                      int x_cc, int y_cc, int z_cc, int which) ;
 static int find_cc_slice
-(MRI *mri, Real *pccx, Real *pccy, Real *pccz, const LTA *lta) ;
+(MRI *mri, double *pccx, double *pccy, double *pccz, const LTA *lta) ;
 static int neighbors_on(MRI *mri, int x0, int y0, int z0) ;
 static int MRIfillVolume(MRI *mri_fill, MRI *mri_im, int x_seed, int y_seed,
                          int z_seed, int fill_val) ;
@@ -2002,7 +2002,7 @@ main(int argc, char *argv[])
   int     x, y, z, xd, yd, zd, xnew, ynew, znew, msec, i, found ;
   int     nargs, wm_rh_x, wm_rh_y, wm_rh_z, wm_lh_x, wm_lh_y, wm_lh_z ;
   char    input_fname[STRLEN],out_fname[STRLEN], fname[STRLEN] ;
-  Real    xr, yr, zr, dist, min_dist ;
+  double  xr, yr, zr, dist, min_dist ;
   MRI     *mri_cc = NULL, *mri_pons = NULL, *mri_norm = NULL,
            *mri_lh_fill, *mri_rh_fill, *mri_lh_im,
            *mri_rh_im /*, *mri_blur*/, *mri_labels, *mri_tal, *mri_tmp, *mri_tmp2,
@@ -2339,7 +2339,7 @@ main(int argc, char *argv[])
   // cc_seed is given by tal position
   if (cc_seed_set)
   {
-    Real xv, yv, zv;
+    double xv, yv, zv;
     printf("Using the seed to calculate the cutting plane\n");
     printf("Verify whether the seed point is inside the volume first\n");
     MRItalairachToVoxelEx
@@ -2495,12 +2495,12 @@ main(int argc, char *argv[])
 
   /* update tal coords of CC based on data (BUG FIX - BRF) */
   // the following is wrong:
-  // MRIvoxelToTalairachEx(mri_im, (Real)x_cc, (Real)y_cc, (Real)z_cc,
+  // MRIvoxelToTalairachEx(mri_im, (double)x_cc, (double)y_cc, (double)z_cc,
   //                  &cc_tal_x, &cc_tal_y, &cc_tal_z, lta) ;
 
   // find_cutting_plane returns talairach voxel position
   // change them to talairach RAS position
-  MRIvoxelToWorld(mri_tal, (Real) x_cc, (Real) y_cc, (Real) z_cc,
+  MRIvoxelToWorld(mri_tal, (double) x_cc, (double) y_cc, (double) z_cc,
                   &cc_tal_x, &cc_tal_y, &cc_tal_z);
   printf("talairach cc position changed to (%.2f, %.2f, %.2f)\n",
          cc_tal_x, cc_tal_y, cc_tal_z);
@@ -2557,7 +2557,7 @@ main(int argc, char *argv[])
     }
     else if (pons_seed_set)
     {
-      Real xv, yv, zv;
+      double xv, yv, zv;
       printf("Verify whether the seed point is inside the volume first\n");
       MRItalairachToVoxelEx
       (mri_im, pons_tal_x, pons_tal_y, pons_tal_z, &xv, &yv, &zv, lta);
@@ -3044,7 +3044,7 @@ main(int argc, char *argv[])
   {
     //    printf("x_cc = %g, y_cc = %g, z_cc = %g\n",
     // (float)x_cc, (float)y_cc, (float) z_cc);
-    Real x_cc_img, y_cc_img, z_cc_img;
+    double x_cc_img, y_cc_img, z_cc_img;
     //x_cc, y_cc, z_cc is still in the transformed space -xh
     //transform them into image space
     //note mri_cc was transformed into image space
@@ -3162,10 +3162,10 @@ main(int argc, char *argv[])
 
     fprintf(stderr, "combining hemispheres...\n") ;
     MRIvoxelToTalairachEx
-    (mri_lh_fill, (Real)wm_lh_x, (Real)wm_lh_y, (Real)wm_lh_z,
+    (mri_lh_fill, (double)wm_lh_x, (double)wm_lh_y, (double)wm_lh_z,
      &xr, &yr, &zr, lta) ;
     MRIvoxelToTalairachEx
-    (mri_rh_fill, (Real)wm_rh_x, (Real)wm_rh_y, (Real)wm_rh_z,
+    (mri_rh_fill, (double)wm_rh_x, (double)wm_rh_y, (double)wm_rh_z,
      &xr, &yr, &zr, lta) ;
 
     mri_fill = MRIcombineHemispheres(mri_lh_fill, mri_rh_fill, NULL,
@@ -3833,13 +3833,13 @@ print_help(void)
 
 static MRI *
 find_cutting_plane
-(MRI *mri_tal, Real x_tal, Real y_tal,Real z_tal,int orientation,
+(MRI *mri_tal, double x_tal, double y_tal,double z_tal,int orientation,
  int *pxv, int *pyv, int *pzv, int seed_set, const LTA *lta)
 {
   // here is the limitation on the voxsize being up to .5 mm
   MRI        *mri_slices[MAX_SLICES*2], *mri_filled[MAX_SLICES*2],
              *mri_cut=NULL, *mri_cut_vol ;
-  Real       dx, dy, dz, x, y, z, aspect,MIN_ASPECT,MAX_ASPECT,
+  double     dx, dy, dz, x, y, z, aspect,MIN_ASPECT,MAX_ASPECT,
              aspects[MAX_SLICES*2] ;
   int        slice, offset, area[MAX_SLICES*2],
              min_area0, min_slice,xo,yo,found,
@@ -3988,7 +3988,7 @@ find_cutting_plane
      2) the connected component is completely contained in the slice.
   */
   slice_size = mri_filled[0]->width;
-  aspect = (Real)region.dy / (Real)region.dx ;
+  aspect = (double)region.dy / (double)region.dx ;
   done =
     ((area[0] >= min_area) &&
      (area[0] <= max_area) &&
@@ -4093,9 +4093,9 @@ find_cutting_plane
       yv += yi - yo ;
       break ; // xv remain the same
     }
-    x = (Real)xv ;
-    y = (Real)yv ;
-    z = (Real)zv ;
+    x = (double)xv ;
+    y = (double)yv ;
+    z = (double)zv ;
     MRIvoxelToWorld(mri_tal, x, y, z, &x_tal, &y_tal, &z_tal) ;
     // got the new slice center position in talairach space
     // instead of original talairach space position
@@ -4181,7 +4181,7 @@ find_cutting_plane
                completely contained in the slice.
             */
 
-            aspect = (Real)region.dy / (Real)region.dx ;
+            aspect = (double)region.dy / (double)region.dx ;
 
             // fprintf(stderr, "area[0] = %d (min = %d, max = %d),
             // aspect = %.2f (min = %.2f, max = %.2f)\n",
@@ -4226,9 +4226,9 @@ find_cutting_plane
                 break ; // xi remains (slice value)
               }
 
-              x = (Real)xi ;
-              y = (Real)yi ;
-              z = (Real)zi ;
+              x = (double)xi ;
+              y = (double)yi ;
+              z = (double)zi ;
               // get the talairach RAS position
               MRIvoxelToWorld
               (mri_tal, x, y, z, &x_tal, &y_tal, &z_tal) ;
@@ -4245,7 +4245,7 @@ find_cutting_plane
     }
   if (Gdiag & DIAG_SHOW)
   {
-    // Real  xnv, ynv, znv ;
+    // double  xnv, ynv, znv ;
 
     MRIvoxelToWorld(mri_tal, xv, yv, zv, &x, &y, &z) ;
     // cannot use the following without knowing the src volume
@@ -4289,7 +4289,7 @@ find_cutting_plane
         MRIfillFG
         (mri_slices[slice],NULL,xo,yo,0,WM_MIN_VAL,127,&area[slice]);
       MRIboundingBox(mri_filled[slice], 1, &region) ;
-      aspects[slice] = (Real)region.dy / (Real)region.dx ;
+      aspects[slice] = (double)region.dy / (double)region.dx ;
 
 #if 0
       /* don't trust slices that extend to the border of the image */
@@ -4589,10 +4589,10 @@ find_slice_center(MRI *mri,  int *pxo, int *pyo)
 // i.e. x axis is along LR axis and y axis is along IS axis
 static int
 find_corpus_callosum
-(MRI *mri_tal, Real *pccx, Real *pccy, Real *pccz, const LTA *lta)
+(MRI *mri_tal, double *pccx, double *pccy, double *pccz, const LTA *lta)
 {
   int         xv, yv, zv, max_y, thickness, y1, xcc, ycc, x, y,x0 ;
-  Real        xr, yr, zr ;
+  double      xr, yr, zr ;
   MRI_REGION  region ;
   int cc_spread, min_thickness, max_thickness, slice_size;
   double voxsize=findMinSize(mri_tal);
@@ -4686,11 +4686,11 @@ find_corpus_callosum
 #define MIN_CONT_BRAINSTEM_HEIGHT       3
 
 static int
-find_pons(MRI *mri, Real *p_ponsx, Real *p_ponsy, Real *p_ponsz,
+find_pons(MRI *mri, double *p_ponsx, double *p_ponsy, double *p_ponsz,
           int x_cc, int y_cc, int z_cc, int method)
 {
   MRI   *mri_slice, *mri_filled, *mri_closed ;
-  Real  xr, yr, zr ;
+  double  xr, yr, zr ;
   int   xv, yv, zv, x, y, width, height, thickness, xstart, area,xmax,
         bheight ;
   MRI_REGION region ;
@@ -4718,9 +4718,9 @@ find_pons(MRI *mri, Real *p_ponsx, Real *p_ponsy, Real *p_ponsz,
   thickness = xstart = -1 ;
 
   MRIboundingBox(mri, 10, &region) ;
-  xr = (Real)(region.x+region.dx/2) ;
-  yr = (Real)(region.y+region.dy/2) ;
-  zr = (Real)(region.z+region.dz/2) ;
+  xr = (double)(region.x+region.dx/2) ;
+  yr = (double)(region.y+region.dy/2) ;
+  zr = (double)(region.z+region.dz/2) ;
 
   xv = (int)xr ;
   yv = (int)yr ;
@@ -4926,9 +4926,9 @@ find_pons(MRI *mri, Real *p_ponsx, Real *p_ponsy, Real *p_ponsz,
   // we were working on the sagittal slice i.e. x -> z, y-> y
   zv = x ;
   yv = y ;  /* convert to voxel coordinates */
-  xr = (Real)xv ;
-  yr = (Real)yv ;
-  zr = (Real)zv ;
+  xr = (double)xv ;
+  yr = (double)yv ;
+  zr = (double)zv ;
   MRIvoxelToWorld(mri, xr, yr, zr, p_ponsx, p_ponsy, p_ponsz) ;
   if (Gdiag & DIAG_SHOW)
     fprintf
@@ -4947,14 +4947,14 @@ find_pons(MRI *mri, Real *p_ponsx, Real *p_ponsy, Real *p_ponsz,
 */
 static int
 find_cc_slice(MRI *mri_tal,
-              Real *pccx, Real *pccy, Real *pccz,
+              double *pccx, double *pccy, double *pccz,
               const LTA *lta)
 {
   // here we can handle only up to .5 mm voxel size
   int         area[MAX_SLICES*2], min_area, min_slice, slice, offset,xv,yv,zv,
               xo, yo ;
   MRI         *mri_slice, *mri_filled ;
-  Real        aspect, x_tal, y_tal, z_tal, x, y, z, xvv, yvv, zvv;
+  double      aspect, x_tal, y_tal, z_tal, x, y, z, xvv, yvv, zvv;
   MRI_REGION  region ;
   char        fname[STRLEN] ;
   int half_slices;
@@ -4989,7 +4989,7 @@ find_cc_slice(MRI *mri_tal,
     mri_filled =
       MRIfillFG(mri_slice, NULL, zv, yv,0,WM_MIN_VAL,127,&area[slice]);
     MRIboundingBox(mri_filled, 1, &region) ;
-    aspect = (Real)region.dy / (Real)region.dx ;
+    aspect = (double)region.dy / (double)region.dx ;
 
     /* don't trust slices that extend to the border of the image */
     if (!region.x || !region.y || region.x+region.dx >= slice_size -1 ||
@@ -5040,7 +5040,7 @@ find_cc_slice(MRI *mri_tal,
   MRIworldToVoxel(mri_tal, x, y,  z, &xvv, &yvv, &zvv) ;
   if (Gdiag & DIAG_SHOW)
   {
-    // Real xv, yv, zv ;
+    // double xv, yv, zv ;
     // you cannot call this function without knowing the src volume
     // MRItalairachVoxelToVoxelEx(mri_tal, x, y, z, &xv, &yv, &zv, lta) ;
     // fprintf(stderr,
@@ -6259,10 +6259,10 @@ extend_to_lateral_borders(MRI *mri_src, MRI *mri_dst, int mask)
 #define WHALF ((11-1)/2)
 static int
 find_cc_seed_with_segmentation
-(MRI *mri, MRI *mri_seg, Real *pcc_tal_x, Real *pcc_tal_y, Real *pcc_tal_z)
+(MRI *mri, MRI *mri_seg, double *pcc_tal_x, double *pcc_tal_y, double *pcc_tal_z)
 {
   int  x,  y, z, label, yi, zi, yk, zk, xl, xr, rlabel, llabel, num, max_num;
-  Real xcc, ycc,  zcc ;
+  double xcc, ycc,  zcc ;
 
   xcc = ycc = zcc = 0.0  ;
   max_num = 0 ;

--- a/mri_glmfit/mri_glmfit.c
+++ b/mri_glmfit/mri_glmfit.c
@@ -525,6 +525,7 @@ double round(double x);
 #include <sys/utsname.h>
 #include <unistd.h>
 #include <float.h>
+#include <errno.h>
 
 #include "macros.h"
 #include "utils.h"

--- a/mri_gtmpvc/mri_gtmpvc.c
+++ b/mri_gtmpvc/mri_gtmpvc.c
@@ -53,6 +53,7 @@
 #include <sys/utsname.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <errno.h>
 
 #include "macros.h"
 #include "utils.h"

--- a/mri_hausdorff_dist/mri_hausdorff_dist.c
+++ b/mri_hausdorff_dist/mri_hausdorff_dist.c
@@ -39,7 +39,7 @@ char *MRI_HAUSDORFF_DIST_VERSION = "$Revision: 1.14 $";
 #include "utils.h"
 #include "mri.h"
 #include "gcamorph.h"
-#include "volume_io.h"
+#include "minc_volume_io.h"
 #include "analyze.h"
 #include "mri_identify.h"
 #include "error.h"

--- a/mri_hires_register/mri_hires_register.c
+++ b/mri_hires_register/mri_hires_register.c
@@ -1099,7 +1099,7 @@ compute_distance_transform_sse(VOXEL_LIST *vl_lowres,
   VECTOR  *v1, *v2 ;
   MRI     *mri_lowres, *mri_hires ;
   double  sse, error ;
-  Real    d1, d2, xd, yd, zd ;
+  double  d1, d2, xd, yd, zd ;
   MATRIX  *m_L_inv ;
 
   m_L_inv = MatrixInverse(m_L, NULL) ;

--- a/mri_hires_register/mri_linear_align.c
+++ b/mri_hires_register/mri_linear_align.c
@@ -592,7 +592,7 @@ compute_likelihood(VOXEL_LIST *vl_target,
   VECTOR  *v1, *v2 ;
   MRI     *mri_target, *mri_source ;
   double  sse, error ;
-  Real    d1, d2, xd, yd, zd ;
+  double  d1, d2, xd, yd, zd ;
   MATRIX  *m_L_inv ;
 
   m_L_inv = MatrixInverse(m_L, NULL) ;
@@ -696,7 +696,7 @@ compute_trimmed_likelihood(VOXEL_LIST *vl_target,
   count_thresh ;
   MRI       *mri_target, *mri_source ;
   double    sse, error, min_error, max_error, bin_size ;
-  Real      d1, d2 ;
+  double    d1, d2 ;
   MATRIX    *m_L_inv ;
   HISTOGRAM *h ;
 
@@ -1396,7 +1396,7 @@ compute_gradient_match(VOXEL_LIST *vl_target,
   VECTOR  *v1, *v2 ;
   MRI     *mri_target, *mri_source, *mri_grad_source, *mri_grad_target ;
   double  match ;
-  Real    num, xd, yd, zd, dxs, dys, dzs, dxt, dyt, dzt, dens,dx,dy,dz, 
+  double  num, xd, yd, zd, dxs, dys, dzs, dxt, dyt, dzt, dens,dx,dy,dz, 
 		      dent, ctheta, dot, norms, normt, den, e1x, e1y,e1z,e2x,e2y,e2z,
           e3x, e3y, e3z;
   MATRIX  *m_L_inv, *m_I, *m_basis ;

--- a/mri_hires_register/mri_linear_align_binary.c
+++ b/mri_hires_register/mri_linear_align_binary.c
@@ -1019,7 +1019,7 @@ compute_distance_transform_sse(VOXEL_LIST *vl_target,
   VECTOR  *v1, *v2 ;
   MRI     *mri_target, *mri_source ;
   double  sse, error ;
-  Real    d1, d2, xd, yd, zd ;
+  double  d1, d2, xd, yd, zd ;
   MATRIX  *m_L_inv ;
 
   m_L_inv = MatrixInverse(m_L, NULL) ;

--- a/mri_histo_eq/mri_histo_eq.c
+++ b/mri_histo_eq/mri_histo_eq.c
@@ -132,8 +132,13 @@ main(int argc, char *argv[]) {
   }
 
   if (adaptive_normalize)
+#if !defined(BEVIN_EXCLUDE_MINC)
     mri_eq = MRIadaptiveHistoNormalize(mri_src, NULL, mri_template,
                                        8, 32, 30) ;
+#else
+    ErrorExit(ERROR_BADPARM, "%s: adaptive_normalize not supported",
+                Progname) ;
+#endif
   else
     mri_eq = MRIhistoNormalize(mri_src, NULL, mri_template, 30, 170) ;
   MRIwrite(mri_eq, out_fname) ;

--- a/mri_ibmc/mri_ibmc.c
+++ b/mri_ibmc/mri_ibmc.c
@@ -44,6 +44,7 @@
 #include <float.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <errno.h>
 
 #include "macros.h"
 #include "utils.h"

--- a/mri_info/mri_info.c
+++ b/mri_info/mri_info.c
@@ -37,7 +37,7 @@ char *MRI_INFO_VERSION = "$Revision: 1.87 $";
 #include "utils.h"
 #include "mri.h"
 #include "gcamorph.h"
-#include "volume_io.h"
+#include "minc_volume_io.h"
 #include "analyze.h"
 #include "mri_identify.h"
 #include "error.h"

--- a/mri_info/mri_info.c
+++ b/mri_info/mri_info.c
@@ -560,7 +560,7 @@ int PrettyMatrixPrint(MATRIX *mat)
 
   if (mat->type != MATRIX_REAL)
   {
-    ErrorReturn(ERROR_BADPARM,(ERROR_BADPARM, "mat is not Real type")) ;
+    ErrorReturn(ERROR_BADPARM,(ERROR_BADPARM, "mat is not MATRIX_REAL type")) ;
   }
 
   if (mat->rows != 4 || mat->cols != 4)

--- a/mri_interpolate/mri_interpolate.c
+++ b/mri_interpolate/mri_interpolate.c
@@ -64,7 +64,7 @@ main(int argc, char *argv[]) {
   MRI          *mri_in, *mri_ctrl, *mri_out;
   int          ac, nargs=0, x, y, z ;
   char         cmdline[CMD_LINE_LEN] ;
-  Real         val;
+  double       val;
 
   make_cmd_version_string
     (argc, argv,

--- a/mri_joint_density/mri_joint_density.c
+++ b/mri_joint_density/mri_joint_density.c
@@ -60,7 +60,7 @@ main(int argc, char *argv[]) {
   MRI          *mri1, *mri2, *mri_nonbrain, *mri_tmp ;
   FILE         *fp ;
   float        fmin1, fmax1, fmin2, fmax2 ;
-  Real         val1, val2 ;
+  double       val1, val2 ;
 
   /* rkt: check for and handle version tag */
   nargs = handle_version_option (argc, argv, "$Id: mri_joint_density.c,v 1.6 2011/03/02 00:04:20 nicks Exp $", "$Name:  $");

--- a/mri_label_vals/mri_label_vals.c
+++ b/mri_label_vals/mri_label_vals.c
@@ -65,7 +65,7 @@ main(int argc, char *argv[]) {
   LABEL  *area ;
   struct timeb start ;
   MRI    *mri,  *mri_seg ;
-  Real   xw, yw, zw, xv, yv, zv, val;
+  double xw, yw, zw, xv, yv, zv, val;
 
   /* rkt: check for and handle version tag */
   nargs = handle_version_option (argc, argv, "$Id: mri_label_vals.c,v 1.16 2015/08/24 18:22:05 fischl Exp $", "$Name:  $");
@@ -192,7 +192,7 @@ main(int argc, char *argv[]) {
 #define MAX_ANNOT 10000
         int   vno, annot_counts[MAX_ANNOT], index ;
         VERTEX *v ;
-        Real  xw, yw, zw, xv, yv, zv, val ;
+        double xw, yw, zw, xv, yv, zv, val ;
         float annot_means[MAX_ANNOT] ;
         FILE  *fp ;
 

--- a/mri_make_register/mri_make_register.c
+++ b/mri_make_register/mri_make_register.c
@@ -35,7 +35,7 @@
 #include "fio.h"
 #include "utils.h"
 #include "mri.h"
-#include "volume_io.h"
+#include "minc_volume_io.h"
 #include "analyze.h"
 #include "mri_identify.h"
 #include "matrix.h"

--- a/mri_ms_fitparms/mri_ms_fitparms.c
+++ b/mri_ms_fitparms/mri_ms_fitparms.c
@@ -2830,7 +2830,7 @@ estimate_T2star(MRI **mri_flash, int nvolumes, MRI *mri_PD,
   z, different_te, width, depth, height, unique_te ;
   MRI    *mri_T2star = NULL ;
   double T2star ;
-  Real   PD = 10 ;
+  double PD = 10 ;
 
   /* first decide whether T2* can be estimated at all */
   different_te = 0 ;
@@ -3000,7 +3000,7 @@ compute_T2star_map(MRI **mri_flash, int nvolumes, int *scan_types,
   int    x, y, z, e, width, height, depth, nscans, i ;
   MRI    *mri_T2star ;
   float  T2star, cond ;
-  Real   val, xf, yf, zf ;
+  double val, xf, yf, zf ;
 
   if (lta)
   {

--- a/mri_parselabel/mri_parselabel.cpp
+++ b/mri_parselabel/mri_parselabel.cpp
@@ -147,8 +147,8 @@ static int get_option(int argc, char *argv[]) ;
 MRI *erodeRegion(MRI *mri, MRI *cur, unsigned char val);
 int selectAddedRegion(MRI *mri, MRI *orig, unsigned char val);
 
-int (*voxToRAS)(MRI *mri, Real x, Real y, Real z, Real *xs, Real *ys, Real *zs);
-int (*rasToVox)(MRI *mri, Real x, Real y, Real z, Real *xs, Real *ys, Real *zs);
+int (*voxToRAS)(MRI *mri, double x, double y, double z, double *xs, double *ys, double *zs);
+int (*rasToVox)(MRI *mri, double x, double y, double z, double *xs, double *ys, double *zs);
 
 #define V4_LOAD(v, x, y, z, r)  (VECTOR_ELT(v,1)=x, VECTOR_ELT(v,2)=y, \
                                   VECTOR_ELT(v,3)=z, VECTOR_ELT(v,4)=r) ;
@@ -366,7 +366,7 @@ int main(int argc, char *argv[]) {
   MRIcopyHeader(mriIn, mriOut);
 
   // set voxToRAS and rasToVox transform function
-  Real xv, yv, zv;
+  double xv, yv, zv;
   if (useRealRAS) {
     voxToRAS = MRIvoxelToWorld;
     rasToVox = MRIworldToVoxel;
@@ -403,7 +403,7 @@ int main(int argc, char *argv[]) {
             int x = nint(xv) + x0;
             int y = nint(yv) + y0;
             int z = nint(zv) + z0;
-            Real xr, yr, zr;
+            double xr, yr, zr;
             // go back to RAS to see whether the point is close enough
             voxToRAS(mriIn, x, y, z, &xr, &yr, &zr);
             // if the difference is 1/2 voxel size mm then equal
@@ -454,7 +454,7 @@ int main(int argc, char *argv[]) {
     int addedcount=0;
     int totcount = 0;
     int percentage = 0;
-    Real xl, yl, zl;
+    double xl, yl, zl;
     for (int z = 0; z < mriOut->depth; z++) {
       for (int y = 0; y < mriOut->height; y++) {
         for (int x = 0; x < mriOut->width; x++) {

--- a/mri_register/mri_register.c
+++ b/mri_register/mri_register.c
@@ -1953,7 +1953,7 @@ remove_bright_stuff(MRI *mri, GCA *gca, TRANSFORM *transform) {
   int              peak, num, end, x, y, z, xi, yi, zi,
   xk, yk, zk, i, n, erase, five_mm ;
   float            thresh ;
-  Real             val, new_val ;
+  double           val, new_val ;
   MRI              *mri_tmp, *mri_nonbrain, *mri_tmp2 ;
   GCA_PRIOR        *gcap ;
   MRI_SEGMENTATION *mriseg ;

--- a/mri_relabel_hypointensities/mri_relabel_hypointensities.c
+++ b/mri_relabel_hypointensities/mri_relabel_hypointensities.c
@@ -219,7 +219,7 @@ relabel_hypointensities(MRI *mri, MRI_SURFACE *mris, int right)
   MRIS_HASH_TABLE *mht ;
   VERTEX           *v ;
   float            dx, dy, dz, dot, dist ;
-  Real             xw, yw, zw ;
+  double           xw, yw, zw ;
   MRI              *mri_dist ;
 
   mri_dist = MRIcloneDifferentType(mri, MRI_FLOAT) ;

--- a/mri_rf_long_train/mri_rf_long_train.c
+++ b/mri_rf_long_train/mri_rf_long_train.c
@@ -1030,8 +1030,8 @@ lateralize_hypointensities(MRI *mri_seg)
 static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
 {
   int x, y, z, label, errors=0;
-  Real xw=0.0, yw=0.0, zw=0.0; // RAS coords
-  Real xmt=0.0, ymt=0.0, zmt=0.0; // MNI tal coords
+  double xw=0.0, yw=0.0, zw=0.0; // RAS coords
+  double xmt=0.0, ymt=0.0, zmt=0.0; // MNI tal coords
   float xt=0.0, yt=0.0, zt=0.0; // 'real' tal coords
   MRI *mri_fixed = NULL;
 
@@ -1053,6 +1053,12 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
     mri_fixed = MRIcopy(mri_seg,NULL);
   }
 
+#if defined(BEVIN_EXCLUDE_MINC)
+    ErrorExit(ERROR_BADFILE,
+              "ERROR: mri_ca_train: talairach not supported,  processing %s!\n"
+              "Run mri_add_xform_to_header to add to volume.\n",
+              seg_dir);
+#else
   if (NULL == mri_seg->linear_transform)
   {
     ErrorExit(ERROR_BADFILE,
@@ -1255,6 +1261,7 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
   printf("min_xtal_r_amygdala = %4.1f\n",min_xtal_r_amygdala);
   printf("min_xtal_r_putamen  = %4.1f\n",min_xtal_r_putamen);
   printf("min_xtal_r_pallidum = %4.1f\n",min_xtal_r_pallidum);
+#endif
   
   if ( do_fix_badsubjs && errors)
   {

--- a/mri_rf_train/mri_rf_train.c
+++ b/mri_rf_train/mri_rf_train.c
@@ -1133,8 +1133,8 @@ lateralize_hypointensities(MRI *mri_seg)
 static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
 {
   int x, y, z, label, errors=0;
-  Real xw=0.0, yw=0.0, zw=0.0; // RAS coords
-  Real xmt=0.0, ymt=0.0, zmt=0.0; // MNI tal coords
+  double xw=0.0, yw=0.0, zw=0.0; // RAS coords
+  double xmt=0.0, ymt=0.0, zmt=0.0; // MNI tal coords
   float xt=0.0, yt=0.0, zt=0.0; // 'real' tal coords
   MRI *mri_fixed = NULL;
 
@@ -1156,6 +1156,11 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
     mri_fixed = MRIcopy(mri_seg,NULL);
   }
 
+#if defined(BEVIN_EXCLUDE_MINC)
+    ErrorExit(ERROR_BADFILE,
+              "ERROR: mri_ca_train: talairach not supported in %s!\n",
+              seg_dir);
+#else
   if (NULL == mri_seg->linear_transform)
   {
     ErrorExit(ERROR_BADFILE,
@@ -1358,6 +1363,7 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
   printf("min_xtal_r_amygdala = %4.1f\n",min_xtal_r_amygdala);
   printf("min_xtal_r_putamen  = %4.1f\n",min_xtal_r_putamen);
   printf("min_xtal_r_pallidum = %4.1f\n",min_xtal_r_pallidum);
+#endif
   
   if ( do_fix_badsubjs && errors)
   {

--- a/mri_ribbon/mri_ribbon.c
+++ b/mri_ribbon/mri_ribbon.c
@@ -157,7 +157,7 @@ MRIcropVolumeToLabel(MRI *mri_src,
   MHT    *mht_white, *mht_pial ;
   int    x, y, z ;
   VERTEX *v_white, *v_pial ;
-  Real   xs, ys, zs ;
+  double xs, ys, zs ;
 
   mht_white = MHTfillVertexTableRes(mris_white, NULL, CURRENT_VERTICES, 5.0) ;
   mht_pial = MHTfillVertexTableRes(mris_pial, NULL, CURRENT_VERTICES, 5.0) ;

--- a/mri_rigid_register/mri_rigid_register.c
+++ b/mri_rigid_register/mri_rigid_register.c
@@ -1900,7 +1900,7 @@ MRIsynthesizeWeightedVolume(MRI *mri_T1, MRI *mri_PD, float w5, float TR5,
   int        mri_peak, n, min_real_bin, x, y, z, width, height, depth ;
   MRI       *mri30, *mri5 ;
   double    mean_PD ;
-  Real      val30, val5, val ;
+  double    val30, val5, val ;
 
   mean_PD = MRImeanFrame(mri_PD, 0) ;
   /*  MRIscalarMul(mri_PD, mri_PD, 1000.0f/mean_PD) ;*/

--- a/mri_rigid_register/mri_rigid_register.c
+++ b/mri_rigid_register/mri_rigid_register.c
@@ -841,7 +841,7 @@ estimate_rigid_regmatrix(MRI *mri_source, MRI *mri_target, MATRIX *M_reg, MRI *m
 
                       /* ignore background voxels when doing fine alignment */
                       if (noskull) {
-                        Real b1, b2, xf1, yf1, zf1 ;
+                        double b1, b2, xf1, yf1, zf1 ;
 
                         MRIsampleVolume(mri_target_edge, xf, yf, zf, &b2) ;
                         xf1 = voxmat1->rptr[1][indx];
@@ -1647,7 +1647,7 @@ apply_transform(MRI *mri_in, MRI *mri_target, MATRIX *M_reg, MRI *mri_xformed) {
   MATRIX   *m, *m_tmp;
   VECTOR   *v_in, *v_target ;
   int      x, y, z, width, height, depth ;
-  Real     xs, ys, zs, val ;
+  double   xs, ys, zs, val ;
 
   vox2ras_source = MRIgetVoxelToRasXform(mri_in) ;
   vox2ras_target = MRIgetVoxelToRasXform(mri_target) ;

--- a/mri_robust_register/MultiRegistration.cpp
+++ b/mri_robust_register/MultiRegistration.cpp
@@ -36,6 +36,7 @@
 #include "CostFunctions.h"
 #include "MyMatrix.h"
 #include "MyMRI.h"
+#include "mriBSpline.h"
 
 #include <cassert>
 #include <iostream>

--- a/mri_robust_register/MultiRegistration.cpp
+++ b/mri_robust_register/MultiRegistration.cpp
@@ -436,7 +436,13 @@ bool MultiRegistration::mapAndAverageMov(int itdebug)
       // use geometry from ltas
       // (if initXforms was called, this is the center of mass of all tps)
       if (sampletype == SAMPLE_CUBIC_BSPLINE)
+#if !defined(BEVIN_EXCLUDE_MINC)
         mri_warps[i] = LTAtransformBSpline(mri_bsplines[i], NULL, ltas[i]);
+#else
+	{ fprintf(stderr, "%s:%d SAMPLE_CUBIC_BSPLINE not supported without minc", __FILE__, __LINE__); 
+	  exit(1); 
+	}
+#endif
       else
         mri_warps[i] = LTAtransformInterp(mri_mov[i], NULL, ltas[i], sampletype);
       MRIcopyPulseParameters(mri_mov[i], mri_warps[i]);
@@ -726,8 +732,13 @@ bool MultiRegistration::computeTemplate(int itmax, double eps, int iterate,
 #endif  
         cout << " - mapping tp " << i + 1 << " to template (cubic bspline) ..."
             << endl;
+#if !defined(BEVIN_EXCLUDE_MINC)
         mri_warps[i] = LTAtransformBSpline(mri_bsplines[i], mri_warps[i],
             ltas[i]);
+#else
+	fprintf(stderr, "%s:%d LTAtransformBSpline not supported without minc\n", __FILE__, __LINE__);
+	exit(1);
+#endif
       }
       else
       {
@@ -1454,7 +1465,12 @@ bool MultiRegistration::initialXforms(int tpi, bool fixtp, int maxres,
       LTAwriteEx(ltas[j], (oss.str() + ".lta").c_str());
       MRI * warped = NULL;
       if (sampletype == SAMPLE_CUBIC_BSPLINE)
+#if !defined(BEVIN_EXCLUDE_MINC)
         warped = LTAtransformBSpline(mri_bsplines[j], NULL, ltas[j]);
+#else
+	fprintf(stderr, "%s:%d LTAtransformBSpline not supported without minc\n", __FILE__, __LINE__);
+	exit(1);
+#endif
       else
         warped = LTAtransformInterp(mri_mov[j], NULL, ltas[j], sampletype);
 
@@ -1715,7 +1731,12 @@ bool MultiRegistration::initialXforms(int tpi, bool fixtp, int maxres,
       LTAwriteEx(ltas[j], (oss.str() + ".lta").c_str());
       MRI * warped = NULL;
       if (sampletype == SAMPLE_CUBIC_BSPLINE)
+#if !defined(BEVIN_EXCLUDE_MINC)
         warped = LTAtransformBSpline(mri_bsplines[j], NULL, ltas[j]);
+#else
+	fprintf(stderr, "%s:%d LTAtransformBSpline not supported without minc\n", __FILE__, __LINE__);
+	exit(1);
+#endif
       else
         warped = LTAtransformInterp(mri_mov[j], NULL, ltas[j], sampletype);
       if (iscale)

--- a/mri_robust_register/MultiRegistration.cpp
+++ b/mri_robust_register/MultiRegistration.cpp
@@ -1468,8 +1468,10 @@ bool MultiRegistration::initialXforms(int tpi, bool fixtp, int maxres,
 #if !defined(BEVIN_EXCLUDE_MINC)
         warped = LTAtransformBSpline(mri_bsplines[j], NULL, ltas[j]);
 #else
-	fprintf(stderr, "%s:%d LTAtransformBSpline not supported without minc\n", __FILE__, __LINE__);
-	exit(1);
+	{
+	  fprintf(stderr, "%s:%d LTAtransformBSpline not supported without minc\n", __FILE__, __LINE__);
+	  exit(1);
+	}
 #endif
       else
         warped = LTAtransformInterp(mri_mov[j], NULL, ltas[j], sampletype);
@@ -1734,8 +1736,10 @@ bool MultiRegistration::initialXforms(int tpi, bool fixtp, int maxres,
 #if !defined(BEVIN_EXCLUDE_MINC)
         warped = LTAtransformBSpline(mri_bsplines[j], NULL, ltas[j]);
 #else
-	fprintf(stderr, "%s:%d LTAtransformBSpline not supported without minc\n", __FILE__, __LINE__);
-	exit(1);
+	{
+	  fprintf(stderr, "%s:%d LTAtransformBSpline not supported without minc\n", __FILE__, __LINE__);
+	  exit(1);
+	}
 #endif
       else
         warped = LTAtransformInterp(mri_mov[j], NULL, ltas[j], sampletype);

--- a/mri_sbbr/mri_sbbr.c
+++ b/mri_sbbr/mri_sbbr.c
@@ -53,7 +53,7 @@
 #include "mri.h"
 #include "macros.h"
 #include "diag.h"
-#include "volume_io.h"
+#include "minc_volume_io.h"
 #include "fio.h"
 #include "mrisurf.h"
 #include "fsenv.h"

--- a/mri_segment/mri_segment.c
+++ b/mri_segment/mri_segment.c
@@ -654,7 +654,7 @@ MRIfillBasalGanglia(MRI *mri_src, MRI *mri_dst)
   int    total_filled, depth, height, width, x, y, z,
          xi, yi, zi, xk, yk, zk, fill, val0, val, i ;
   MRI    *mri_bg ;
-  Real   tx, ty, tz ;
+  double tx, ty, tz ;
   MRI_SEGMENTATION  *mriseg ;
   MRI_SEGMENT       *mseg ;
   float  dx_left, dx_right, dy, dz, dist_left, dist_right ;
@@ -1069,7 +1069,7 @@ MRIfillVentricles(MRI *mri_src, MRI *mri_dst)
   MRI     *mri_filled, *mri_ventricles = NULL ;
   MRI_SEGMENTATION *mriseg ;
   MRI_SEGMENT      *mseg ;
-  Real    xt, yt, zt ;
+  double  xt, yt, zt ;
 
   if (!mri_dst)
   {

--- a/mri_segment_wm_damage/mri_segment_wm_damage.c
+++ b/mri_segment_wm_damage/mri_segment_wm_damage.c
@@ -242,7 +242,7 @@ compute_damaged_wm_statistics(MRI *mri_T1, MRI *mri_PD, MRI *mri_T2, LABEL *l_da
                               MATRIX **pm_cov) {
   MATRIX *m_cov, *m_T1_ras2vox, *m_T2_ras2vox, *m_tmp ;
   VECTOR *v_mean, *v_T1, *v_T2, *v_ras, *v_X, *v_XT ;
-  Real    xv, yv, zv, val_T1, val_T2, val_PD ;
+  double  xv, yv, zv, val_T1, val_T2, val_PD ;
   int     i, dofs_T1, dofs_T2 ;
 
   m_cov = MatrixAlloc(3, 3, MATRIX_REAL) ;
@@ -346,7 +346,7 @@ compute_label_statistics(MRI *mri_T1, MRI *mri_PD, MRI *mri_T2, MRI *mri_aseg, i
                          MATRIX **pm_inv_cov, int erode) {
   MATRIX *m_cov, *m_T1_to_T2, *m_tmp ;
   VECTOR *v_mean, *v_T1, *v_T2, *v_X, *v_XT ;
-  Real    xv, yv, zv, val_T1, val_T2, val_PD ;
+  double  xv, yv, zv, val_T1, val_T2, val_PD ;
   int     dofs_T1, dofs_T2, x, y, z ;
   MRI     *mri_label ;
 
@@ -464,7 +464,7 @@ label_damaged_wm(MRI *mri_T1, MRI *mri_PD, MRI *mri_T2, MRI *mri_aseg,
   MATRIX    *m_T2_to_T1 ;
   VECTOR    *v_T1, *v_T2, *v_vals, *v_vals_minus_means, *v_tmp ;
   GCA_PRIOR *gcap ;
-  Real      val ;
+  double    val ;
 
   for (l = 0 ; l < MAX_CMA_LABELS ; l++) {
     if (m_inv_covariances[l]  != NULL) {

--- a/mri_segment_wm_damage/mri_segment_wm_damage.c
+++ b/mri_segment_wm_damage/mri_segment_wm_damage.c
@@ -193,7 +193,7 @@ main(int argc, char *argv[]) {
                            &v_means[Right_Lateral_Ventricle], &m_inv_covariances[Right_Lateral_Ventricle],2) ;
 
   mri_damaged_wm = label_damaged_wm(mri_T1, mri_PD, mri_T2, mri_aseg, v_means, m_inv_covariances, transform, gca) ;
-  print("writing output to %s...\n", out_fname) ;
+  printf("writing output to %s...\n", out_fname) ;
   MRIwrite(mri_damaged_wm, out_fname) ;
 
   msec = TimerStop(&start) ;

--- a/mri_segstats/mri_segstats.c
+++ b/mri_segstats/mri_segstats.c
@@ -61,6 +61,7 @@
 #include <math.h>
 #include <sys/utsname.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include "macros.h"
 #include "mrisurf.h"

--- a/mri_synthesize/mri_synthesize.c
+++ b/mri_synthesize/mri_synthesize.c
@@ -434,7 +434,7 @@ FLASHforwardModel(double flip_angle, double TR, double PD, double T1) {
 static MRI *
 MRIsynthesize(MRI *mri_T1, MRI *mri_PD, MRI *mri_T2star, MRI *mri_dst, double TR, double alpha, double TE) {
   int   x, y, z, width, height, depth ;
-  Real flash, T1, PD ;
+  double flash, T1, PD ;
 
 
   if (!mri_dst)
@@ -459,7 +459,7 @@ MRIsynthesize(MRI *mri_T1, MRI *mri_PD, MRI *mri_T2star, MRI *mri_dst, double TR
           DiagBreak() ;
         MRIsampleVolume(mri_PD, x, y, z, &PD) ;
         if (mri_T2star) {
-          Real T2star ;
+          double T2star ;
           MRIsampleVolume(mri_T2star, x, y, z, &T2star) ;
           flash = FLASHforwardModelT2star(T1, PD, T2star, TR, alpha, TE) ;
         } else
@@ -546,7 +546,7 @@ MRIsynthesizeWeightedVolume(MRI *mri_T1, MRI *mri_PD, float w5, float TR5,
   MRI        *mri_dst ;
   int        x, y, z, width, height, depth ;
   MRI        *mri30, *mri5 ;
-  Real       val30, val5, val, min_val ;
+  double     val30, val5, val, min_val ;
 #if 0
   int        mri_peak, n, min_real_bin ;
   double    mean_PD ;
@@ -643,7 +643,7 @@ MRIsynthesizeWeightedVolume(MRI *mri_T1, MRI *mri_PD, float w5, float TR5,
 static int
 transform_T1_values_using_joint_pdf(MRI *mri_T1, char *jpdf_name, int invert) {
   int   x, y, z, nbins, i, j, **jpdf, max_j, max_count ;
-  Real  T1 ;
+  double  T1 ;
   FILE  *fp ;
   float fstep, fmin, fmax, val ;
   char  line[STRLEN], *cp, var_name[STRLEN] ;
@@ -770,7 +770,7 @@ static MRI *
 MRIsynthesizeWithFAF(MRI *mri_T1, MRI *mri_PD, MRI *mri_dst, double TR, double alpha, double TE, int nfaf,
                      float *faf_coefs[3][2]) {
   int   x, y, z, width, height, depth, n ;
-  Real flash, T1, PD ;
+  double flash, T1, PD ;
   double xb, yb, zb, x0, y0, z0, w0x, w0y, w0z ;
 
   x0 = mri_T1->width/2 ;

--- a/mri_transform/mri_transform.c
+++ b/mri_transform/mri_transform.c
@@ -606,7 +606,7 @@ double
 MRIcomputeLinearTransformLabelDist(MRI *mri_src, MATRIX *mA, int label) {
   int    x1, x2, x3, width, height, depth, nvox ;
   VECTOR *v_X, *v_Y ;   /* original and transformed coordinate systems */
-  Real   y1, y2, y3, total_dist, dist ;
+  double y1, y2, y3, total_dist, dist ;
 
   width = mri_src->width ;
   height = mri_src->height ;

--- a/mri_twoclass/mri_twoclass.c
+++ b/mri_twoclass/mri_twoclass.c
@@ -898,7 +898,7 @@ compute_white_matter_density(MRI *mri, MRI *mri_atlas_wm, float resolution,
   MRI          *mri_filled ;
   float        xvf, yvf, zvf ;
   int          xm, xp, ym, yp, zm, zp, xv, yv, zv ;
-  Real         xmd, ymd, zmd, xpd, ypd, zpd,label ;  /* d's are distances */
+  double       xmd, ymd, zmd, xpd, ypd, zpd,label ;  /* d's are distances */
 
   mri_filled = MRIalloc(mri_atlas_wm->width, mri_atlas_wm->height,
                         mri_atlas_wm->depth, MRI_UCHAR) ;

--- a/mri_vol2surf/mri_vol2surf.c
+++ b/mri_vol2surf/mri_vol2surf.c
@@ -1608,7 +1608,7 @@ MRI *MRIvol2surf(MRI *SrcVol, MATRIX *Rtk, MRI_SURFACE *TrgSurf,
   float frow, fcol, fslc; /* float row, col, slc in source */
   float srcval, *valvect, rshift;
   int frm, vtx,nhits, err;
-  Real rval;
+  double rval;
   float Tx, Ty, Tz;
 
   if(vsm){
@@ -1749,7 +1749,7 @@ estimate_gm_values(MRI *mri_wm, MRI *mri_gm, MRI *mri_csf,
   int frm, FreeQsrc=0;
   int vtx,nhits;
   float *valvect;
-  Real rval;
+  double rval;
   int  ProjDistFlag = 1, nskip = 1 ;
   float ProjFrac = 0.5 ;
 

--- a/mri_vol2vol/mri_vol2vol.c
+++ b/mri_vol2vol/mri_vol2vol.c
@@ -430,6 +430,7 @@ ENDHELP --------------------------------------------------------------
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <ctype.h>
+#include <errno.h>
 
 #include "macros.h"
 #include "error.h"

--- a/mri_watershed/brain_volume/mri_brain_volume.cpp
+++ b/mri_watershed/brain_volume/mri_brain_volume.cpp
@@ -288,10 +288,10 @@ void MRISchangeCoordinates(MRI_SURFACE *mris,MRI_SURFACE *mris_orig);
 /*mri->type correction*/
 
 // declare function pointer
-int  (*MyvoxelToWorld)(MRI *mri, Real xv, Real yv, Real zv,
-                       Real *xw, Real *yw, Real *zw) ;
-int  (*MyworldToVoxel)(MRI *mri, Real xw, Real yw, Real zw,
-                       Real *pxv, Real *pyv, Real *pzv) ;
+int  (*MyvoxelToWorld)(MRI *mri, double xv, double yv, double zv,
+                       double *xw, double *yw, double *zw) ;
+int  (*MyworldToVoxel)(MRI *mri, double xw, double yw, double zw,
+                       double *pxv, double *pyv, double *pzv) ;
 
 void getTimeString(char *buf) {
   time_t t;

--- a/mri_watershed/mri_validate_skull_stripped.cpp
+++ b/mri_watershed/mri_validate_skull_stripped.cpp
@@ -14,7 +14,7 @@ extern "C" {
 #include "mri.h"
 #include "macros.h"
 #include "diag.h"
-#include "volume_io.h"
+#include "minc_volume_io.h"
 #include "region.h"
 #include "machine.h"
 #include "fio.h"

--- a/mri_watershed/mri_watershed.cpp
+++ b/mri_watershed/mri_watershed.cpp
@@ -443,11 +443,11 @@ void MRIScomputeCloserLabel(STRIP_PARMS *parms,MRI_variables *MRI_var);
 // declare global function pointers
 // initialized at init_parms(). reset when -useSRAS is set
 int (*myWorldToVoxel)(MRI *mri,
-                      Real xw, Real yw, Real zw,
-                      Real *xv, Real *yv, Real *zv);
+                      double xw, double yw, double zw,
+                      double *xv, double *yv, double *zv);
 int (*myVoxelToWorld)(MRI *mri,
-                      Real xv, Real yv, Real zv,
-                      Real *xw, Real *yw, Real *zw);
+                      double xv, double yv, double zv,
+                      double *xw, double *yw, double *zw);
 ///////////////////////////////////////////////////////////////////
 
 #include "mri_watershed.help.xml.h"

--- a/mri_wbc/mri_wbc.c
+++ b/mri_wbc/mri_wbc.c
@@ -36,6 +36,7 @@
 #include <sys/utsname.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <errno.h>
 
 #include "macros.h"
 #include "utils.h"

--- a/mris2rgb/mris2rgb.c
+++ b/mris2rgb/mris2rgb.c
@@ -193,7 +193,7 @@ static int soap_bubble_iterations = 0 ;
 static char *output_name = NULL ;
 
 #define MAX_POINTS 100
-static Real x_tpoint[MAX_POINTS], y_tpoint[MAX_POINTS], z_tpoint[MAX_POINTS] ;
+static double x_tpoint[MAX_POINTS], y_tpoint[MAX_POINTS], z_tpoint[MAX_POINTS] ;
 static int num_tpoints = 0 ;
 
 static float phi_spoint[MAX_POINTS], theta_spoint[MAX_POINTS] ;
@@ -798,9 +798,9 @@ get_option(int argc, char *argv[]) {
     if (num_tpoints >= MAX_POINTS)
       ErrorExit(ERROR_NOMEMORY, "%s: too many points defined (%d)\n",
                 Progname, MAX_POINTS+1) ;
-    x_tpoint[num_tpoints] = (Real)atof(argv[2]) ;
-    y_tpoint[num_tpoints] = (Real)atof(argv[3]) ;
-    z_tpoint[num_tpoints] = (Real)atof(argv[4]) ;
+    x_tpoint[num_tpoints] = atof(argv[2]) ;
+    y_tpoint[num_tpoints] = atof(argv[3]) ;
+    z_tpoint[num_tpoints] = atof(argv[4]) ;
     fprintf(stderr, "marking Talairach point (%2.1f, %2.1f, %2.1f)\n",
             (float)x_tpoint[num_tpoints], (float)y_tpoint[num_tpoints],
             (float)z_tpoint[num_tpoints]) ;

--- a/mris_annot_to_segmentation/mris_annot_to_segmentation.c
+++ b/mris_annot_to_segmentation/mris_annot_to_segmentation.c
@@ -65,7 +65,7 @@ main(int argc, char *argv[]) {
   VERTEX* v;
   int structure;
   float dx, dy, dz, len, d;
-  Real idxx, idxy, idxz;
+  double idxx, idxy, idxz;
 
 
   /* rkt: check for and handle version tag */

--- a/mris_annot_to_segmentation/mris_annot_to_segmentation.c
+++ b/mris_annot_to_segmentation/mris_annot_to_segmentation.c
@@ -31,7 +31,7 @@
 
 #include "mri.h"
 #include "macros.h"
-#include "volume_io.h"
+#include "minc_volume_io.h"
 #include "error.h"
 #include "diag.h"
 #include "proto.h"

--- a/mris_convert/mris_convert.c
+++ b/mris_convert/mris_convert.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <math.h>
 #include <ctype.h>
+#include <errno.h>
 
 #include "macros.h"
 #include "error.h"

--- a/mris_deform/mris_ca_deform.c
+++ b/mris_deform/mris_ca_deform.c
@@ -541,7 +541,7 @@ compute_target_intensities(MRI_SURFACE *mris, MRI *mri_labels, MRI *mri_intensit
                            HISTOGRAM **histograms, VERTEX_INFO *vi,float sigma, 
                            TRANSFORM *transform, GCA *gca, int target_label, float resolution) {
   int      nin, nout ;
-  Real     val, nx, ny, nz, xi, yi, zi, d, e1x, e2x, e1y, e2y, e1z, e2z, d1, d2, mag ;
+  double   val, nx, ny, nz, xi, yi, zi, d, e1x, e2x, e1y, e2y, e1z, e2z, d1, d2, mag ;
   MRI      *mri_ll ;
   MRI      *mri_grad, *mri_dx, *mri_dy, *mri_dz, *mri_mask, 
            *mri_tmp, *mri_dist, *mri_pin, *mri_pout, *mri_pmap ;
@@ -715,7 +715,7 @@ compute_target_intensities_with_gcab(MRI_SURFACE *mris, MRI *mri_labels, MRI *mr
                                      TRANSFORM *transform, GCA *gca, int target_label, float resolution,
                                      GCAB *gcab) {
   int      nin, nout ;
-  Real     val, nx, ny, nz, xi, yi, zi, d, e1x, e2x, e1y, e2y, e1z, e2z, d1, d2, mag ;
+  double   val, nx, ny, nz, xi, yi, zi, d, e1x, e2x, e1y, e2y, e1z, e2z, d1, d2, mag ;
   MRI      *mri_ll ;
   MRI      *mri_grad, *mri_dx, *mri_dy, *mri_dz, *mri_mask, 
            *mri_tmp, *mri_dist, *mri_pin, *mri_pout, *mri_pmap ;
@@ -888,7 +888,7 @@ static int
 compute_target_labels(MRI_SURFACE *mris, MRI *mri_labels, MRI *mri_intensities, HISTOGRAM **histograms, VERTEX_INFO *vi) {
   VERTEX   *v ;
   int      vno, l_out, l_in ;
-  Real     xv, yv, zv, val, nx, ny, nz ;
+  double   xv, yv, zv, val, nx, ny, nz ;
   HISTOGRAM *h_in, *h_out ;
 
   for (vno = 0 ; vno < mris->nvertices ; vno++) {
@@ -937,7 +937,7 @@ externalLLSSE(MRI_SURFACE *mris, INTEGRATION_PARMS *parms)
   int         vno ;
   VERTEX      *v ;
   double      sse/*, error*/, d ;
-  Real        val, xv, yv, zv, nx, ny, nz, max_d, max_ll, x2, y2, z2, dist, 
+  double      val, xv, yv, zv, nx, ny, nz, max_d, max_ll, x2, y2, z2, dist, 
               prev_dist, xvd, yvd, zvd, nxd, nyd, nzd, mag, sigma=4.0 ;
   MRI         *mri_ll = parms->mri_ll, *mri_dist ;
 
@@ -1036,7 +1036,7 @@ externalLLGradient(MRI_SURFACE *mris, INTEGRATION_PARMS *parms)
   int         vno ;
   VERTEX      *v ;
   double      sse, error, d ;
-  Real        val, xv, yv, zv, nx, ny, nz, max_d, max_ll, x2, y2, z2, dist, 
+  double      val, xv, yv, zv, nx, ny, nz, max_d, max_ll, x2, y2, z2, dist, 
               prev_dist, xvd, yvd, zvd, nxd, nyd, nzd, mag, sigma = 4.0 ;
   MRI         *mri_ll = parms->mri_ll, *mri_dist ;
 

--- a/mris_deform/mris_deform.c
+++ b/mris_deform/mris_deform.c
@@ -1107,7 +1107,7 @@ compute_intensity_offsets(MRI_SURFACE *mris, MRI *mri, MRI *mri_dist, DP *dp)
   VERTEX_PARMS *vp = NULL ;
   int       vno, nfound, nmissed, peak, wsize ;
   HISTOGRAM *h, *hs ;
-  Real      xv, yv, zv, mean_white_border, inward_dist, outward_dist ;
+  double    xv, yv, zv, mean_white_border, inward_dist, outward_dist ;
 
 #define WSIZE_MM  5 // diameter of region to histogram within
   wsize = WSIZE_MM / mri->xsize ;  
@@ -1182,7 +1182,7 @@ compute_targets(MRI_SURFACE *mris, MRI *mri, double sigma, DP *dp, int skip)
   MRI     *mri_white = MRIclone(mri, NULL) ;
   MRI     *mri_pial = MRIclone(mri, NULL) ;
   MRI     *mri_l4 = MRIclone(mri, NULL) ;
-  Real    xv, yv, zv, d, target_val, xr, yr, zr, grad, max_grad, 
+  double  xv, yv, zv, d, target_val, xr, yr, zr, grad, max_grad, 
     target_dist,mean_white_border, mean_pial_border, mean_l4_border,
     mean_dist, inward_dist, outward_dist, mean_abs_dist ;
 
@@ -1262,7 +1262,7 @@ compute_targets(MRI_SURFACE *mris, MRI *mri, double sigma, DP *dp, int skip)
           grad = 0 ;
         if (grad > max_grad)
         {
-          Real val_inside, val_outside, xs, ys, zs ;
+          double val_inside, val_outside, xs, ys, zs ;
           xs = xr-0.5*vp->nx ; ys = yr-0.5*vp->ny ; zs = zr-0.5*vp->nz ;
           MRISsurfaceRASToVoxelCached(mris, mri, xs, ys, zs, &xv, &yv, &zv);
           MRIsampleVolume(mri, xv, yv, zv, &val_inside) ;
@@ -1325,7 +1325,7 @@ compute_targets(MRI_SURFACE *mris, MRI *mri, double sigma, DP *dp, int skip)
             grad = 0 ;
           if (grad > max_grad)
           {
-            Real val_inside, val_outside, xs, ys, zs ;
+            double val_inside, val_outside, xs, ys, zs ;
             xs = xr-0.5*vp->nx ; ys = yr-0.5*vp->ny ; zs = zr-0.5*vp->nz ;
             MRISsurfaceRASToVoxelCached(mris, mri, xs, ys, zs, &xv, &yv, &zv);
             MRIsampleVolume(mri, xv, yv, zv, &val_inside) ;
@@ -4646,7 +4646,7 @@ static int
 rip_dark_vertices(MRI_SURFACE *mris, MRI *mri, float threshold)
 {
   int    vno, ripped ;
-  Real   xv, yv, zv ;
+  double xv, yv, zv ;
   VERTEX *v ;
   float  val ;
 

--- a/mris_distance_to_label/mris_distance_to_label.cpp
+++ b/mris_distance_to_label/mris_distance_to_label.cpp
@@ -93,7 +93,7 @@ static void mrisExtractMRIvalues(MRIS * mris,
                                  float distance,
                                  int mode) {
   int n;
-  Real xw,yw,zw,xv,yv,zv,val;
+  double xw,yw,zw,xv,yv,zv,val;
   VERTEX *v;
 
   MRISclearCurvature(mris);
@@ -132,7 +132,7 @@ static void mrisExtractMidGrayValues(MRIS *mris, MRI *mri) {
 
   int n;
   float th;
-  Real xw,yw,zw,xv,yv,zv,val;
+  double xw,yw,zw,xv,yv,zv,val;
   VERTEX *v;
 
   for (n=0;n<mris->nvertices;n++) {

--- a/mris_info/mris_info.cpp
+++ b/mris_info/mris_info.cpp
@@ -173,7 +173,7 @@ int main(int argc, char *argv[]) {
       printf("\n");
       exit(1);
     }
-    print((char*)"%s has the same number of vertices as %s\n",
+    printf((char*)"%s has the same number of vertices as %s\n",
           curvfile,surffile);
   }
 
@@ -198,7 +198,7 @@ int main(int argc, char *argv[]) {
              annotfile, numVertices, surffile, mris->nvertices);
       exit(1);
     }
-    print((char*)"%s has the same number of vertices as %s\n",
+    printf((char*)"%s has the same number of vertices as %s\n",
           annotfile,surffile);
 
     // also dump the colortable

--- a/mris_longitudinal_surfaces/mris_longitudinal_surfaces.c
+++ b/mris_longitudinal_surfaces/mris_longitudinal_surfaces.c
@@ -1874,7 +1874,7 @@ check_contrast_direction(MRI_SURFACE *mris,MRI *mri_T1)
 {
   int     vno, n ;
   VERTEX  *v ;
-  Real    x, y, z, xw, yw, zw, val, mean_inside, mean_outside ;
+  double  x, y, z, xw, yw, zw, val, mean_inside, mean_outside ;
 
   mean_inside = mean_outside = 0.0 ;
   for (n = vno = 0 ; vno < mris->nvertices ; vno++)

--- a/mris_make_surfaces/mris_exvivo_surfaces.c
+++ b/mris_make_surfaces/mris_exvivo_surfaces.c
@@ -1247,14 +1247,14 @@ MRIScomputeBorderValues_MEF_WHITE(MRI_SURFACE *mris,
                                   float gm_mean[2], float gm_std[2],
                                   double sigma,
                                   float max_thickness, FILE *log_fp) {
-  Real    val30, val5, x, y, z, max_mag_val30, 
+  double  val30, val5, x, y, z, max_mag_val30, 
     max_mag_val5, xw, yw, zw,mag,max_mag, max_mag_dist=0.0f,
     min_val30, min_val5, inward_dist,outward_dist,xw1,yw1,zw1,
     min_val_dist, orig_dist, dx, dy, dz;
-  Real low30, high30, low5, high5;
-  Real previous_mag, next_mag, previous_mag30, 
+  double low30, high30, low5, high5;
+  double previous_mag, next_mag, previous_mag30, 
     previous_mag5, next_mag30, next_mag5;
-  Real mag30, mag5, previous_val30, previous_val5, next_val30;
+  double mag30, mag5, previous_val30, previous_val5, next_val30;
   int     total_vertices, vno, nmissing = 0, 
     nout = 0, nin = 0, nfound = 0,
     nalways_missing = 0, local_max_found, 
@@ -1652,11 +1652,11 @@ MRIScomputeBorderValues_PD_WHITE(MRI_SURFACE *mris,
                                  float PD_gm_mean, float PD_gm_std,
                                  double sigma,
                                  float max_thickness, FILE *log_fp) {
-  Real    val, x, y, z, 
+  double  val, x, y, z, 
     max_mag_val, xw, yw, zw,mag,max_mag, max_mag_dist=0.0f,
     min_val, inward_dist,outward_dist,xw1,yw1,zw1,
     min_val_dist, orig_dist, dx, dy, dz;
-  Real low, high, previous_mag, next_mag, next_val, previous_val;
+  double low, high, previous_mag, next_mag, next_val, previous_val;
   int     total_vertices, vno, nmissing = 0, 
     nout = 0, nin = 0, nfound = 0,
     nalways_missing = 0, local_max_found, 
@@ -2010,13 +2010,13 @@ MRIScomputeBorderValues_MEF_PIAL(MRI_SURFACE *mris,
   //original images, really need to use the membership functions
   //or equivalently, the EM_combined
   //dura may be still low at both flash30 and flash5, but not that low
-  Real  val,  val30, val5, x, y, z, 
+  double  val,  val30, val5, x, y, z, 
     max_mag_val30, max_mag_val5, xw, yw, zw,mag,max_mag, max_mag_dist=0.0f,
     min_val30, min_val5, inward_dist,outward_dist,xw1,yw1,zw1,
     min_val_dist, orig_dist, dx, dy, dz;
-  Real previous_mag, next_mag, 
+  double previous_mag, next_mag, 
     previous_mag30, previous_mag5, next_mag30, next_mag5;
-  Real mag30, mag5, previous_val30, next_val30;
+  double mag30, mag5, previous_val30, next_val30;
   int     total_vertices, vno, 
     nmissing = 0, nout = 0, nin = 0, nfound = 0,
     nalways_missing = 0, local_max_found, 
@@ -2656,11 +2656,11 @@ MRIScomputeBorderValues_PD_PIAL(MRI_SURFACE *mris,
   //original images, really need to use the membership functions
   //or equivalently, the EM_combined
   //dura may be still low at both flash30 and flash5, but not that low
-   Real  val, x, y, z, next_val,
+   double  val, x, y, z, next_val,
      max_mag_val, xw, yw, zw, mag, max_mag, max_mag_dist=0.0f,
     max_PD, inward_dist,outward_dist,xw1,yw1,zw1,
     max_val_dist, orig_dist, dx, dy, dz;
-  Real previous_mag, next_mag, previous_val;
+  double previous_mag, next_mag, previous_val;
   int     total_vertices, vno, was_negative, 
     nmissing = 0, nout = 0, nin = 0, nfound = 0,
     nalways_missing = 0, local_max_found, 
@@ -3038,11 +3038,11 @@ MRIScomputeBorderValues_T1_PIAL(MRI_SURFACE *mris,
   //original images, really need to use the membership functions
   //or equivalently, the EM_combined
   //dura may be still low at both flash30 and flash5, but not that low
-   Real  val, x, y, z, next_val,
+   double  val, x, y, z, next_val,
      max_mag_val, xw, yw, zw, mag, max_mag, max_mag_dist=0.0f,
     max_T1, inward_dist,outward_dist,xw1,yw1,zw1,
     max_val_dist, orig_dist, dx, dy, dz;
-  Real previous_mag, next_mag, previous_val;
+  double previous_mag, next_mag, previous_val;
   int     total_vertices, vno, was_negative, 
     nmissing = 0, nout = 0, nin = 0, nfound = 0,
     nalways_missing = 0, local_max_found, 

--- a/mris_make_surfaces/mris_make_surfaces.c
+++ b/mris_make_surfaces/mris_make_surfaces.c
@@ -3640,7 +3640,7 @@ check_contrast_direction(MRI_SURFACE *mris,MRI *mri_T1)
 {
   int     vno, n ;
   VERTEX  *v ;
-  Real    x, y, z, xw, yw, zw, val, mean_inside, mean_outside ;
+  double  x, y, z, xw, yw, zw, val, mean_inside, mean_outside ;
 
   mean_inside = mean_outside = 0.0 ;
   for (n = vno = 0 ; vno < mris->nvertices ; vno++)
@@ -4230,7 +4230,7 @@ static double
 mark_dura(MRI_SURFACE *mris, MRI *mri_ratio, MRI *mri_brain, double sigma)
 {
   HISTOGRAM *h, *hsmooth ;
-  Real      val, xs, ys, zs, xv, yv, zv, d, mean, std ;
+  double    val, xs, ys, zs, xv, yv, zv, d, mean, std ;
   int       vno, bin, num, found ;
   float     mn, mx ;
   VERTEX    *v ;
@@ -4376,7 +4376,7 @@ compute_T2star_map(MRI **mri_echos, int nvolumes)
   int    x, y, z, e, width, height, depth ;
   MRI    *mri_T2star ;
   float  T2star, cond ;
-  Real   val ;
+  double val ;
 
   mD = MatrixAlloc(nvolumes, 1, MATRIX_REAL) ;
   mT = MatrixAlloc(nvolumes, 2, MATRIX_REAL) ;
@@ -4456,7 +4456,7 @@ compute_T2star_map(MRI **mri_echos, int nvolumes)
 static double
 compute_brain_thresh(MRI_SURFACE *mris, MRI *mri_ratio, float nstd)
 {
-  Real      val, xs, ys, zs, xv, yv, zv, d, mean, std ;
+  double    val, xs, ys, zs, xv, yv, zv, d, mean, std ;
   int       vno, num ;
   VERTEX    *v ;
   double    thresh ;
@@ -4528,7 +4528,7 @@ compute_pial_target_locations(MRI_SURFACE *mris,
 			      double wm_weight,
                               MRI *mri_T1)
 {
-  Real      val, xs, ys, zs, xv, yv, zv, d, xvf, yvf, zvf, xp, yp, zp ;
+  double    val, xs, ys, zs, xv, yv, zv, d, xvf, yvf, zvf, xp, yp, zp ;
   int       vno, num_in, num_out, found_bad_intensity, found ;
   int       outside_of_white, n, outside_of_pial, near_cerebellum ;
   VERTEX    *v ;
@@ -4818,7 +4818,7 @@ compute_pial_target_locations(MRI_SURFACE *mris,
       if (mri_aseg != NULL)
       {
 	int label, xv, yv, zv ;
-	Real xvf, yvf, zvf ;
+	double xvf, yvf, zvf ;
 	
 	MRISsurfaceRASToVoxelCached(mris, mri_aseg, xs, ys, zs, &xvf, &yvf, &zvf);
 	xv = nint(xvf) ; yv = nint(yvf) ; zv = nint(zvf) ;
@@ -4958,7 +4958,7 @@ compute_pial_target_locations(MRI_SURFACE *mris,
 	if (mri_aseg != NULL)
 	{
 	  int label, xv, yv, zv ;
-	  Real xvf, yvf, zvf ;
+	  double xvf, yvf, zvf ;
 	  
 	  MRISsurfaceRASToVoxelCached(mris, mri_aseg, xs, ys, zs, &xvf, &yvf, &zvf);
 	  xv = nint(xvf) ; yv = nint(yvf) ; zv = nint(zvf) ;
@@ -5832,7 +5832,7 @@ compute_white_target_locations(MRI_SURFACE *mris,
 			       int contrast_type, float T2_min_inside, float T2_max_inside, 
 			       int below_set, int above_set, double wsigma)
 {
-  Real      val, xs, ys, zs, xv, yv, zv, d, mean, std, xvf, yvf, zvf ;
+  double    val, xs, ys, zs, xv, yv, zv, d, mean, std, xvf, yvf, zvf ;
   int       vno, num_in, num_out, label ;
   int       done, bin, niter, histo_nbins, in_white ;
   VERTEX    *v ;
@@ -6063,7 +6063,7 @@ compute_white_matter_intensities(MRI_SURFACE *mris,
 				 float nstd_below,
 				 MRI *mri_dst)
 {
-  Real      val, xs, ys, zs, xv, yv, zv, d, mean, std, xvf, yvf, zvf, sum, dist,means[2][2],
+  double    val, xs, ys, zs, xv, yv, zv, d, mean, std, xvf, yvf, zvf, sum, dist,means[2][2],
     stds[2][2], counts[2];
   int       vno, num, label, xk, yk, zk, xi, yi, zi, whalf ;
   int       done, bin, niter, histo_nbins, in_white, count, filled_wm, filled_pial ;
@@ -6371,7 +6371,7 @@ find_and_mark_pinched_regions(MRI_SURFACE *mris,
                               float nstd_below,
                               float nstd_above)
 {
-  Real      val, xs, ys, zs, xv, yv, zv, d, mean, std ;
+  double    val, xs, ys, zs, xv, yv, zv, d, mean, std ;
   int       vno, num_in, num_out, found_bad_intensity, done, bin, niter ;
   VERTEX    *v ;
   double    min_gray, max_gray, thickness, nx, ny, nz, mn, mx, sig, sample_dist ;
@@ -6703,7 +6703,7 @@ find_and_mark_pinched_regions(MRI_SURFACE *mris,
     v->val = mn-sig ;   // a mildly CSF intensity in a flair image to seek
     if (vno == Gdiag_no)
     {
-      Real xv, yv, zv, xv0, yv0, zv0 ;
+      double xv, yv, zv, xv0, yv0, zv0 ;
       MRISsurfaceRASToVoxelCached(mris, mri_T2,
                                   v->x, v->y, v->z,
                                   &xv0, &yv0, &zv0);

--- a/mris_make_surfaces/mris_mef_surfaces.c
+++ b/mris_make_surfaces/mris_mef_surfaces.c
@@ -1238,13 +1238,13 @@ MRIScomputeBorderValues_MEF_WHITE(MRI_SURFACE *mris,
                                   float gm_mean[2], float gm_std[2],
                                   double sigma,
                                   float max_thickness, FILE *log_fp) {
-  Real    val30, val5, x, y, z, max_mag_val30, 
+  double  val30, val5, x, y, z, max_mag_val30, 
     max_mag_val5, xw, yw, zw,mag,max_mag, max_mag_dist=0.0f,
     min_val30, min_val5, inward_dist,outward_dist,xw1,yw1,zw1,
     min_val_dist, orig_dist, dx, dy, dz;
-  Real previous_mag, next_mag, previous_mag30, 
+  double previous_mag, next_mag, previous_mag30, 
     previous_mag5, next_mag30, next_mag5;
-  Real mag30, mag5, previous_val30, next_val30;
+  double mag30, mag5, previous_val30, next_val30;
   int     total_vertices, vno, nmissing = 0, nout = 0, nin = 0, nfound = 0,
     nalways_missing = 0, local_max_found, 
     ngrad_max, ngrad, nmin, num_changed=0 ;
@@ -1617,13 +1617,13 @@ MRIScomputeBorderValues_MEF_PIAL(MRI_SURFACE *mris,
   // original images, really need to use the membership functions
   //or equivalently, the EM_combined
   //dura may be still low at both flash30 and flash5, but not that low
-  Real  val,  val30, val5, x, y, z, max_mag_val30, 
+  double  val,  val30, val5, x, y, z, max_mag_val30, 
     max_mag_val5, xw, yw, zw,mag,max_mag, max_mag_dist=0.0f,
     min_val30, min_val5, inward_dist,outward_dist,xw1,yw1,zw1,
       min_val_dist, orig_dist, dx, dy, dz;
-  Real previous_mag, next_mag, previous_mag30, 
+  double previous_mag, next_mag, previous_mag30, 
     previous_mag5, next_mag30, next_mag5;
-  Real mag30, mag5, previous_val30, previous_val5, next_val30, next_val5;
+  double mag30, mag5, previous_val30, previous_val5, next_val30, next_val5;
   int     total_vertices, vno, 
     nmissing = 0, nout = 0, nin = 0, nfound = 0,
     nalways_missing = 0, local_max_found, 
@@ -2224,7 +2224,7 @@ static double
 mrisRmsValError_mef(MRI_SURFACE *mris,
                     MRI *mri_30, MRI *mri_5, float weight30, float weight5) {
   int     vno, n; //, xv, yv, zv ;
-  Real    val30, val5, total, delta, x, y, z ;
+  double  val30, val5, total, delta, x, y, z ;
   VERTEX  *v ;
 
   for (total = 0.0, n = vno = 0 ; vno < mris->nvertices ; vno++) {
@@ -2257,7 +2257,7 @@ mrisComputeIntensityTerm_mef(MRI_SURFACE *mris,
   int     vno ;
   VERTEX  *v ;
   float   x, y, z, nx, ny, nz, dx, dy, dz ;
-  Real    val0, xw, yw, zw, del, val_outside, val_inside, delI, delV, k,
+  double  val0, xw, yw, zw, del, val_outside, val_inside, delI, delV, k,
   ktotal ;
   double  sigma ;
 
@@ -2288,7 +2288,7 @@ mrisComputeIntensityTerm_mef(MRI_SURFACE *mris,
     /* compute intensity gradient using smoothed volume */
 
     {
-      Real dist, val, step_size ;
+      double dist, val, step_size ;
       int  n ;
 
       step_size = MIN(sigma/2, 
@@ -2347,7 +2347,7 @@ mrisComputeIntensityTerm_mef(MRI_SURFACE *mris,
     MRISsurfaceRASToVoxel(mris, mri_5, x, y, z, &xw, &yw, &zw);
     MRIsampleVolume(mri_5, xw, yw, zw, &val0) ;
     {
-      Real dist, val, step_size ;
+      double dist, val, step_size ;
       int  n ;
 
       step_size = MIN(sigma/2, 

--- a/mris_make_surfaces/mris_refine_surfaces.c
+++ b/mris_make_surfaces/mris_refine_surfaces.c
@@ -1244,7 +1244,7 @@ static float
 check_contrast_direction(MRI_SURFACE *mris,MRI *mri_hires) {
   int     vno, n ;
   VERTEX  *v ;
-  Real    x, y, z, xw, yw, zw, val, mean_inside, mean_outside ;
+  double  x, y, z, xw, yw, zw, val, mean_inside, mean_outside ;
 
   mean_inside = mean_outside = 0.0 ;
   for (n = vno = 0 ; vno < mris->nvertices ; vno++) {
@@ -1299,10 +1299,10 @@ MRIScomputeClassStatistics(MRI_SURFACE *mris,
                            float *pgray_mean, 
                            float *pgray_std) 
 {
-  Real    val, x, y, z, xw, yw, zw ;
+  double  val, x, y, z, xw, yw, zw ;
   int     total_vertices, vno ;
   VERTEX  *v ;
-  Real    mean_white, mean_gray, std_white, std_gray, nsigma, gw_thresh  ;
+  double  mean_white, mean_gray, std_white, std_gray, nsigma, gw_thresh  ;
   FILE    *fpwm, *fpgm ;
 
   if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON) {
@@ -1402,7 +1402,7 @@ find_wm(MRI_SURFACE *mris, MRI *mri, MRI *mri_wm)
   MRI       *mri_interior, *mri_ctrl, *mri_kernel ;
   int       vno, x, y, z ;
   VERTEX    *v ;
-  Real      xv, yv, zv, val ;
+  double    xv, yv, zv, val ;
   
   return(NULL) ;
 #define SDIST 0.5

--- a/mris_ms_refine/mris_ms_refine.c
+++ b/mris_ms_refine/mris_ms_refine.c
@@ -128,10 +128,10 @@ static int  build_lookup_table(double tr, double flip_angle,
 
 static double    scale_all_images(MRI **mri_flash, int nvolumes, MRI_SURFACE *mris,
                                   float target_pd_wm, EXTRA_PARMS *ep) ;
-static int    compute_T1_PD(Real *image_vals, MRI **mri_flash, int nvolumes,
+static int    compute_T1_PD(double *image_vals, MRI **mri_flash, int nvolumes,
                             double *pT1, double *pPD);
 #if 0
-static int    compute_T1_PD_slow(Real *image_vals, MRI **mri_flash, int nvolumes,
+static int    compute_T1_PD_slow(double *image_vals, MRI **mri_flash, int nvolumes,
                                  double *pT1, double *pPD);
 #endif
 static double lookup_flash_value(double TR, double flip_angle, double PD, double T1) ;
@@ -248,11 +248,11 @@ static double FLASHforwardModel(double flip_angle, double TR, double PD,
 static double FLASHforwardModelLookup(double flip_angle, double TR, double PD,
                                       double T1) ;
 
-static double compute_vertex_sse(EXTRA_PARMS *ep, Real image_vals[MAX_FLASH_VOLUMES][MAX_SAMPLES],
+static double compute_vertex_sse(EXTRA_PARMS *ep, double image_vals[MAX_FLASH_VOLUMES][MAX_SAMPLES],
                                  int max_j,
                                  double white_dist, double cortical_dist, double T1_wm, double PD_wm,
                                  double T1_gm, double PD_gm, double T1_csf, double PD_csf, int debug,
-                                 Real *T1_vals, Real *PD_vals, int vno) ;
+                                 double *T1_vals, double *PD_vals, int vno) ;
 char *Progname ;
 static char *gSdir = NULL ;
 
@@ -1372,7 +1372,7 @@ vertex_error(MRI_SURFACE *mris, int vno, EXTRA_PARMS *ep, double *prms) {
   VERTEX  *v_white, *v_pial ;
   double  dist, dx, dy, dz, cortical_dist, sigma,
   T1_wm, T1_gm, T1_csf, PD_wm, PD_gm, PD_csf, sse, inward_dist, outward_dist ;
-  Real    xp, yp, zp, xw, yw, zw, x, y, z,
+  double  xp, yp, zp, xw, yw, zw, x, y, z,
   image_vals[MAX_FLASH_VOLUMES][MAX_SAMPLES] ;
   MRI     *mri ;
   int     i, j, max_j ;
@@ -1623,9 +1623,9 @@ compute_maximal_distances(MRI_SURFACE *mris, float sigma, MRI **mri_flash, int n
   MRI    *mri ;
   float  nx, ny, nz, min_inward_dist, min_outward_dist, dist,
   min_parm_dist, parm_dist ;
-  Real   xw, yw, zw, xp, yp, zp, xo, yo, zo, cortical_dist,
+  double xw, yw, zw, xp, yp, zp, xo, yo, zo, cortical_dist,
   image_vals[MAX_FLASH_VOLUMES][MAX_SAMPLES] ;
-  Real   T1_vals[MAX_SAMPLES], PD_vals[MAX_SAMPLES] ;
+  double T1_vals[MAX_SAMPLES], PD_vals[MAX_SAMPLES] ;
   /*  double dIdN_start[MAX_FLASH_VOLUMES], dIdN ;*/
 
 
@@ -1774,7 +1774,7 @@ compute_maximal_distances(MRI_SURFACE *mris, float sigma, MRI **mri_flash, int n
       nz = zp - zw ;
       cortical_dist = dist = sqrt(nx*nx + ny*ny + nz*nz) ;
       if (TOO_SMALL(dist)) {
-        Real xpn, ypn, zpn ;
+        double xpn, ypn, zpn ;
 
         // MRIworldToVoxel(mri,
         //                 v_pial->pialx+v_white->nx,
@@ -2561,7 +2561,7 @@ compute_optimal_parameters(MRI_SURFACE *mris, int vno,
   best_pial_index, pial_index, white_index, max_white_index, best_csf_len;
   VERTEX       *v_white, *v_pial ;
   MRI          *mri, *mri_T1, *mri_PD ;
-  Real         image_vals[MAX_FLASH_VOLUMES][MAX_SAMPLES], xw, yw, zw, xp, yp, zp,
+  double       image_vals[MAX_FLASH_VOLUMES][MAX_SAMPLES], xw, yw, zw, xp, yp, zp,
   x, y, z, T1_vals[MAX_SAMPLES], PD_vals[MAX_SAMPLES],
   best_image_vals[MAX_FLASH_VOLUMES][MAX_SAMPLES] ;
 
@@ -2958,7 +2958,7 @@ compute_optimal_parameters(MRI_SURFACE *mris, int vno,
 
 
 static double
-compute_vertex_sse(EXTRA_PARMS *ep, Real image_vals[MAX_FLASH_VOLUMES][MAX_SAMPLES], int max_j,
+compute_vertex_sse(EXTRA_PARMS *ep, double image_vals[MAX_FLASH_VOLUMES][MAX_SAMPLES], int max_j,
                    double white_dist, double cortical_dist, double T1_wm, double PD_wm,
                    double T1_gm, double PD_gm, double T1_csf, double PD_csf, int debug,
                    double *T1_vals, double *PD_vals, int vno) {
@@ -3033,7 +3033,7 @@ sample_parameter_map(MRI_SURFACE *mris, MRI *mri, MRI *mri_res,
   VERTEX    *v ;
   int       vno, bpeak, bsmooth_peak, bno ;
   float     dist, max_dist, len, dist1, dist2 ;
-  Real      dx, dy, dz, res, parm_sample, total_wt, wt, x0, y0, z0, x1, y1, z1,
+  double    dx, dy, dz, res, parm_sample, total_wt, wt, x0, y0, z0, x1, y1, z1,
   parm, xs, ys, zs, xe, ye, ze, tx1, ty1, tz1, tx2, ty2, tz2 ;
   HISTOGRAM *histo, *hsmooth ;
 
@@ -3328,7 +3328,7 @@ compute_optimal_vertex_positions(MRI_SURFACE *mris, int vno, EXTRA_PARMS *ep,
   best_pial_index, pial_index, white_index, max_white_index, nwm, npial  ;
   VERTEX       *v_white, *v_pial ;
   MRI          *mri ;
-  Real         image_vals[MAX_FLASH_VOLUMES][MAX_SAMPLES], xw, yw, zw, xp, yp, zp, x, y, z ;
+  double       image_vals[MAX_FLASH_VOLUMES][MAX_SAMPLES], xw, yw, zw, xp, yp, zp, x, y, z ;
   double       pwhite[MAX_FLASH_VOLUMES], pgray[MAX_FLASH_VOLUMES], pcsf[MAX_FLASH_VOLUMES],
   T1_vals[MAX_SAMPLES], PD_vals[MAX_SAMPLES] ;
 
@@ -3668,7 +3668,7 @@ compute_optimal_vertex_positions(MRI_SURFACE *mris, int vno, EXTRA_PARMS *ep,
 
 #if 0
 static int
-compute_T1_PD_slow(Real *image_vals, MRI **mri_flash, int nvolumes,
+compute_T1_PD_slow(double *image_vals, MRI **mri_flash, int nvolumes,
                    double *pT1, double *pPD) {
   double    sse, best_sse, best_T1, best_PD, pred, PD, T1, error ;
   int       i ;
@@ -3702,7 +3702,7 @@ compute_T1_PD_slow(Real *image_vals, MRI **mri_flash, int nvolumes,
 }
 #endif
 static int
-compute_T1_PD(Real *image_vals, MRI **mri_flash, int nvolumes,
+compute_T1_PD(double *image_vals, MRI **mri_flash, int nvolumes,
               double *pT1, double *pPD) {
   double    best_T1, best_PD, norm_im, norm_pred, sse, best_sse, T1,
   pred_vals[MAX_FLASH_VOLUMES], error, upper_T1, lower_T1, mid_T1,
@@ -3847,8 +3847,8 @@ scale_all_images(MRI **mri_flash, int nvolumes, MRI_SURFACE *mris, float target_
                  EXTRA_PARMS *ep) {
   int    vno, i ;
   VERTEX *v ;
-  Real   xw, yw, zw, T1, PD, T1_wm_total, PD_wm_total, T1_gm_total, PD_gm_total ;
-  Real   mean_wm[MAX_FLASH_VOLUMES], scale ;
+  double xw, yw, zw, T1, PD, T1_wm_total, PD_wm_total, T1_gm_total, PD_gm_total ;
+  double mean_wm[MAX_FLASH_VOLUMES], scale ;
 
   MRISsaveVertexPositions(mris, TMP_VERTICES) ;
   MRISrestoreVertexPositions(mris, ORIGINAL_VERTICES) ;
@@ -4079,7 +4079,7 @@ static int
 compute_parameter_maps(MRI **mri_flash, int nvolumes, MRI **pmri_T1,
                        MRI **pmri_PD) {
   int   i, x, y, z, width, height, depth ;
-  Real  image_vals[MAX_FLASH_VOLUMES] ;
+  double image_vals[MAX_FLASH_VOLUMES] ;
   MRI   *mri_T1, *mri_PD ;
   double T1, PD ;
 
@@ -4190,7 +4190,7 @@ static int
 compute_PD_T1_limits(MRI_SURFACE *mris, EXTRA_PARMS *ep, int navgs) {
   int    vno, found ;
   VERTEX *v, *v_white,  *v_pial ;
-  Real   x, y, z, T1, PD, PD_min, PD_max, T1_min, T1_max,  n, cortical_dist,
+  double x, y, z, T1, PD, PD_min, PD_max, T1_min, T1_max,  n, cortical_dist,
   xp, yp, zp, xw, yw, zw, dx, dy,  dz ;
 
   MRISsaveVertexPositions(mris, TMP_VERTICES) ;

--- a/mris_ms_surface_CNR/mris_ms_surface_CNR.c
+++ b/mris_ms_surface_CNR/mris_ms_surface_CNR.c
@@ -108,8 +108,8 @@ main(int argc, char *argv[]) {
   VERTEX *vertex;
   int index, i, j, vno;
   double cx, cy, cz;
-  Real  vx, vy, vz;
-  Real value_in, value_out;
+  double vx, vy, vz;
+  double value_in, value_out;
   double cnr;
   MATRIX *SW1, *SW2, *SW, *InvSW;
   float *weight, weight_norm;

--- a/mris_sample_parc/mris_sample_parc.c
+++ b/mris_sample_parc/mris_sample_parc.c
@@ -98,7 +98,7 @@ main(int argc, char *argv[]) {
   MRI           *mri_parc ;
   VERTEX        *v ;
   double        d ;
-  Real          x, y, z, xw, yw, zw ;
+  double        x, y, z, xw, yw, zw ;
 
   /* rkt: check for and handle version tag */
   nargs = handle_version_option (argc, argv,
@@ -857,7 +857,7 @@ MRIsampleParcellationToSurface(MRI_SURFACE *mris, MRI *mri_parc) {
   float           fmin, fmax, max_count, d ;
   MRIS_HASH_TABLE *mht ;
   VERTEX          *v ;
-  Real            xs, ys, zs, xv, yv, zv, val ;
+  double          xs, ys, zs, xv, yv, zv, val ;
   MRI             *mri_parc_unused ;
 
   mri_parc_unused = MRIcopy(mri_parc, NULL) ;

--- a/mris_show/mris_show.c
+++ b/mris_show/mris_show.c
@@ -1170,7 +1170,7 @@ MRISfillSurface(MRI_SURFACE *mris) {
 
 static int
 mrisFillFace(MRI_SURFACE *mris, int fno) {
-  Real   x, y, z, xa, ya, za, xc, yc, zc, t0, t1, adx, ady, adz, dx, dy, dz,
+  double   x, y, z, xa, ya, za, xc, yc, zc, t0, t1, adx, ady, adz, dx, dy, dz,
   cdx, cdy, cdz, alen, clen, delta_t0, delta_t1, len ;
   VERTEX *v0, *v1, *v2 ;
   FACE   *face ;

--- a/mris_shrinkwrap/mris_AA_shrinkwrap.c
+++ b/mris_shrinkwrap/mris_AA_shrinkwrap.c
@@ -448,7 +448,7 @@ initialize_surface_position(MRI_SURFACE *mris, MRI *mri_masked, int outside, INT
   MRI    *mri_dilated ;
   int    x, y, z, vno ;
   double x0, y0, z0, radius = 0, dist, num ;
-  Real   xs, ys, zs ;
+  double xs, ys, zs ;
   VERTEX *v ;
 
   if (outside) {
@@ -675,7 +675,7 @@ compute_surface_sse(MRI_SURFACE *mris, MRI *mri, float sample_dist) {
   int       vno, nsamples ;
   VERTEX    *v ;
   float     sse, dist ;
-  Real      val, xw, yw, zw, x, y, z, nx, ny, nz, error ;
+  double    val, xw, yw, zw, x, y, z, nx, ny, nz, error ;
 
   for (nsamples = 0, sse = 0.0, vno = 0 ; vno < mris->nvertices ; vno++) {
     v = &mris->vertices[vno] ;
@@ -916,7 +916,7 @@ compute_surface_dist_sse(MRI_SURFACE *mris, MRI *mri) {
   double sse = 0.0 ;
   int    vno ;
   VERTEX *v ;
-  Real   val, error, xw, yw, zw ;
+  double val, error, xw, yw, zw ;
 
   for (vno = 0, sse = 0.0 ; vno < mris->nvertices ; vno++) {
     v = &mris->vertices[vno] ;
@@ -938,7 +938,7 @@ static int
 compute_rigid_gradient(MRI_SURFACE *mris, MRI *mri, double *pdx, double *pdy, double *pdz) {
   int    vno ;
   VERTEX *v ;
-  Real   val, xw, yw, zw, dx, dy, dz, delV, x, y, z, Ix, Iy, Iz, xv, yv, zv ;
+  double val, xw, yw, zw, dx, dy, dz, delV, x, y, z, Ix, Iy, Iz, xv, yv, zv ;
 
   dx = dy = dz = 0.0 ;
   for (vno = 0 ; vno < mris->nvertices ; vno++) {

--- a/mris_shrinkwrap/mris_shrinkwrap.c
+++ b/mris_shrinkwrap/mris_shrinkwrap.c
@@ -652,7 +652,7 @@ initialize_surface_position(MRI_SURFACE *mris, MRI *mri_masked, int outside)
   MRI    *mri_dilated ;
   int    x, y, z, vno ;
   double x0, y0, z0, radius, dist, num, max_r ;
-  Real   xs, ys, zs ;
+  double xs, ys, zs ;
   VERTEX *v ;
 
   if (outside)

--- a/mris_thickness/mris_intensity_profile.c
+++ b/mris_thickness/mris_intensity_profile.c
@@ -1134,7 +1134,7 @@ MRISfindNearestVerticesAndMeasureCorticalIntensityProfiles(MRI_SURFACE *mris, MR
   VERTEX  *v, *vn, *vn2 ;
   float   d, dx, dy, dz, dist, min_dist, nx, ny, nz, dot, sample_dist, thick,
   white_mode, gray_mode, min_gray, max_gray, csf_mode, min_gray_at_wm ;
-  Real    x, y, z, xv, yv, zv, val ;
+  double  x, y, z, xv, yv, zv, val ;
   MRI     *mri_profiles ;
   float   scale = 1 ;
 
@@ -1522,7 +1522,7 @@ static int
 remove_bad_profiles(MRI_SURFACE *mris, MRI *mri_profiles, MRI *mri, float border_mm) {
   int     nvox, vno, i, good, unknown_index, med_index  ;
   VERTEX  *v ;
-  Real    xv, yv, zv ;
+  double  xv, yv, zv ;
   int     annot_index;
 
   if (MRISreadAnnotation(mris, "ad_aparc") != NO_ERROR) {
@@ -1576,7 +1576,7 @@ mrisComputeWhiteMatterIntensities(MRI_SURFACE *mris, MRI *mri, float wsize_mm, f
   VECTOR  *v1, *v2 ;
   MATRIX  *m_vox2vox_aseg, *m_vox2vox ;
   float   avg_wm, res ;
-  Real    xv, yv, zv, xi, yi, zi, val ;
+  double  xv, yv, zv, xi, yi, zi, val ;
 
   MRISsaveVertexPositions(mris, TMP_VERTICES) ;
   MRISrestoreVertexPositions(mris, WHITE_VERTICES) ;

--- a/mris_thickness_diff/mris_thickness_diff.c
+++ b/mris_thickness_diff/mris_thickness_diff.c
@@ -158,7 +158,7 @@ int main(int argc, char *argv[])
   FACE *face;
   VERTEX *vertex;
   double cx, cy, cz;
-  Real  vx, vy, vz;
+  double vx, vy, vz;
 
   MRI *mri_map = NULL;
   int fno, vno0, vno1, vno2;

--- a/mris_volmask/mris_volmask_old.cpp
+++ b/mris_volmask/mris_volmask_old.cpp
@@ -880,7 +880,7 @@ ConvertSurfaceVertexCoordinates(MRI_SURFACE* mris,
                                 MRI* vol)
 {
   double cx, cy, cz;
-  Real vx, vy, vz;
+  double vx, vy, vz;
 
   VERTEX* pvtx = &( mris->vertices[0] );
   unsigned int nvertices = (unsigned int)mris->nvertices;

--- a/tkmedit/tkmDisplayArea.c
+++ b/tkmedit/tkmDisplayArea.c
@@ -1326,10 +1326,12 @@ DspA_tErr DspA_ConvertAndSetCursor ( tkmDisplayAreaRef this,
     eVolume = Volm_ConvertRASToIdx( this->mpVolume[tkm_tVolumeType_Main],
                                     ipCoord, &anaIdx );
     break;
+#if !defined(BEVIN_EXCLUDE_MINC)
   case mri_tCoordSpace_Talairach:
     eVolume = Volm_ConvertTalToIdx( this->mpVolume[tkm_tVolumeType_Main],
                                     ipCoord, &anaIdx );
     break;
+#endif
   default:
     eResult = DspA_tErr_InvalidParameter;
     goto error;
@@ -7530,6 +7532,7 @@ DspA_tErr DspA_SendPointInformationToTcl_ ( tkmDisplayAreaRef this,
   tkm_SendTclCommand( tkm_tTclCommand_UpdateRASCursor, sTclArguments );
 
   /* also convert to mni and send those coords along. */
+#if !defined(BEVIN_EXCLUDE_MINC)
   if (NULL != 
       this->mpVolume[tkm_tVolumeType_Main]->mpMriValues->linear_transform) {
     Volm_ConvertIdxToMNITal( this->mpVolume[tkm_tVolumeType_Main],
@@ -7546,7 +7549,7 @@ DspA_tErr DspA_SendPointInformationToTcl_ ( tkmDisplayAreaRef this,
              DspA_ksaDisplaySet[iSet], xVoxl_ExpandFloat( &voxel ) );
     tkm_SendTclCommand( tkm_tTclCommand_UpdateTalCursor, sTclArguments );
   }
-
+#endif
 
   /* and the scanner coords. */
   Volm_ConvertIdxToScanner( this->mpVolume[tkm_tVolumeType_Main],

--- a/tkmedit/tkmedit.c
+++ b/tkmedit/tkmedit.c
@@ -107,7 +107,7 @@ int Tix_SafeInit ( Tcl_Interp* interp );
 #include <string.h>
 #include <sys/time.h>
 #include "MRIio_old.h"
-#include "volume_io.h"
+#include "minc_volume_io.h"
 #include "rgb_image.h"
 #include "fio.h"
 #include "mri_conform.h"
@@ -3545,8 +3545,6 @@ void WriteVoxelToEditFile ( xVoxelRef iAnaIdx ) {
   FILE*     file            = NULL;
   xVoxel    MRIIdx;
   xVoxel    ras;
-  xVoxel    tal;
-  tBoolean  bHasTransform;
 
   DebugEnterFunction( ("WriteVoxelToEditFile ( iAnaIdx=%d,%d,%d )",
                        xVoxl_ExpandInt( iAnaIdx )) );
@@ -3584,6 +3582,9 @@ void WriteVoxelToEditFile ( xVoxelRef iAnaIdx ) {
   fprintf( file,"%f %f %f\n", xVoxl_ExpandFloat( &ras ) );
 
   /* convert to tal and write that. */
+#if !defined(BEVIN_EXCLUDE_MINC)
+  xVoxel    tal;
+  tBoolean  bHasTransform;
   Volm_HasTalTransform( gAnatomicalVolume[tkm_tVolumeType_Main],
                         &bHasTransform );
   if ( bHasTransform ) {
@@ -3596,6 +3597,7 @@ void WriteVoxelToEditFile ( xVoxelRef iAnaIdx ) {
                 xVoxl_ExpandFloat( &tal ) ));
     fprintf( file,"%f %f %f\n", xVoxl_ExpandFloat( &tal ) );
   }
+#endif
 
   DebugCatch;
   DebugCatchError( eResult, tkm_tErr_NoErr, tkm_GetErrorString );
@@ -8457,12 +8459,15 @@ tkm_tErr LoadVolume ( tkm_tVolumeType iType,
   gAnatomicalVolume[iType] = newVolume;
 
   /* show the tal coords and hide the ras coords */
+#if !defined(BEVIN_EXCLUDE_MINC)
   if (NULL != gAnatomicalVolume[iType]->mpMriValues->linear_transform) {
     DebugNote( ("Showing Tal coords") );
     tkm_SendTclCommand( tkm_tTclCommand_ShowTalCoords, "1" );
     DebugNote( ("Hiding RAS coords") );
     tkm_SendTclCommand( tkm_tTclCommand_ShowRASCoords, "0" );
-  } else {
+  } else 
+#endif
+  {
     DebugNote( ("Hiding Tal coords") );
     tkm_SendTclCommand( tkm_tTclCommand_ShowTalCoords, "0" );
     DebugNote( ("Showing RAS coords") );

--- a/tkregister2/tkregister2.c
+++ b/tkregister2/tkregister2.c
@@ -2357,7 +2357,7 @@ void draw_image2(int imc,int ic,int jc) {
   unsigned char* lvidbuf;
   float f=0;
   int NcFunc, NrFunc, NsFunc;
-  Real rVoxVal;
+  double rVoxVal;
   double dVoxVal;
   float targimgmax, movimgmax;
   float targimgmin, movimgmin;

--- a/tksurfer/tksurfer.c
+++ b/tksurfer/tksurfer.c
@@ -7239,7 +7239,7 @@ void read_image_info(char *fpref)
      Also, the fovs of standard brains like bert and fsaverage are 256 */
   if (fabs(fov) < 0.00001)
   {
-    print ("surfer: WARNING: fov was ~0, setting to 256\n");
+    printf("surfer: WARNING: fov was ~0, setting to 256\n");
     fov = 256;
   }
 
@@ -23124,7 +23124,7 @@ read_and_smooth_parcellation(char *parc_name, char *lut_name,
   FILE   *fp ;
   char   r[256], g[256], b[256], line[STRLEN] ;
   VERTEX *v ;
-  Real   x, y, z ;
+  double x, y, z ;
 
   MRISclearMarks(mris) ;
   cp = strchr(parc_name, '/') ;
@@ -24792,7 +24792,7 @@ int conv_initialize()
 int conv_ras_to_mnital(float srasx, float srasy, float srasz,
                        float* mnix, float* mniy, float* mniz)
 {
-  Real rasx, rasy, rasz;
+  double rasx, rasy, rasz;
 
   /* If we have the original MRI volume and this surface doesn't have
      the useRealRAS flag, use it to go from surface RAS coords to
@@ -24853,7 +24853,7 @@ int conv_mnital_to_ras(float mnix, float mniy, float mniz,
 {
 
   float rasx, rasy, rasz;
-  Real srasx, srasy, srasz;
+  double srasx, srasy, srasz;
 
   /* Run the talairach transformation. */
   if (transform_loaded &&

--- a/unix/xvmri.c
+++ b/unix/xvmri.c
@@ -120,7 +120,7 @@ mri_event_handler(XV_FRAME *xvf, Event *event,DIMAGE *dimage,
                   int *px, int *py, int *pz)
 {
   int       x, y, z, which, depth, frame, xi, yi, zi, xk, yk, zk ;
-  Real      xr, yr, zr, xt, yt, zt, xv, yv, zv, xtv, ytv, ztv ;
+  double    xr, yr, zr, xt, yt, zt, xv, yv, zv, xtv, ytv, ztv ;
   float     xf, yf, zf, xft, yft, zft ;
   MRI       *mri ;
   char      fname[100] ;
@@ -195,12 +195,14 @@ mri_event_handler(XV_FRAME *xvf, Event *event,DIMAGE *dimage,
     repaint_needed = 0 ;
     XVMRIredisplayFrame(xvf, mri, which, mri_depths[which], mri_frames[which]);
   }
+#if !defined(BEVIN_EXCLUDE_MINC)
   if (talairach)
   {
-    MRIvoxelToTalairach(mri, (Real)x, (Real)y, (Real)z, &xt, &yt, &zt) ;
-    MRIvoxelToTalairachVoxel(mri, (Real)x, (Real)y, (Real)z, &xtv,&ytv,&ztv);
+    MRIvoxelToTalairach(mri, (double)x, (double)y, (double)z, &xt, &yt, &zt) ;
+    MRIvoxelToTalairachVoxel(mri, (double)x, (double)y, (double)z, &xtv,&ytv,&ztv);
   }
-  MRIvoxelToWorld(mri, (Real)x, (Real)y, (Real)z, &xr, &yr, &zr) ;
+#endif
+  MRIvoxelToWorld(mri, (double)x, (double)y, (double)z, &xr, &yr, &zr) ;
 
   if (px)
     *px = x ;
@@ -352,10 +354,12 @@ mri_event_handler(XV_FRAME *xvf, Event *event,DIMAGE *dimage,
             return(ERROR_BAD_FILE) ;
           }
           fclose(fp) ;
+#if !defined(BEVIN_EXCLUDE_MINC)
           if (talairach)
-            MRItalairachToVoxel(mri, (Real)xft,(Real)yft,(Real)zft,&xv,&yv,&zv);
+            MRItalairachToVoxel(mri, (double)xft,(double)yft,(double)zft,&xv,&yv,&zv);
           else
-            MRIworldToVoxel(mri, (Real)xf, (Real)yf, (Real)zf, &xv, &yv, &zv) ;
+#endif
+            MRIworldToVoxel(mri, (double)xf, (double)yf, (double)zf, &xv, &yv, &zv) ;
           XVMRIsetPoint(xvf, which, nint(xv), nint(yv), nint(zv)) ;
           XVprintf(xvf, 0, "current point: (%d, %d, %d) --> (%d, %d, %d)",
                    nint(xf), nint(yf), nint(zf), nint(xv), nint(yv), nint(zv)) ;
@@ -389,12 +393,14 @@ mri_event_handler(XV_FRAME *xvf, Event *event,DIMAGE *dimage,
             }
           }
           fp = fopen(fname, "w") ;
-          MRIvoxelToWorld(mri, (Real)x_click, (Real)y_click, (Real)z_click,
+          MRIvoxelToWorld(mri, (double)x_click, (double)y_click, (double)z_click,
                           &xr, &yr, &zr) ;
-          MRIvoxelToTalairach(mri, (Real)x_click, (Real)y_click, (Real)z_click,
-                              &xt, &yt, &zt) ;
           fprintf(fp, "%f %f %f\n", (float)xr, (float)yr, (float)zr) ;
+#if !defined(BEVIN_EXCLUDE_MINC)
+          MRIvoxelToTalairach(mri, (double)x_click, (double)y_click, (double)z_click,
+                              &xt, &yt, &zt) ;
           fprintf(fp, "%f %f %f\n", (float)xt, (float)yt, (float)zt) ;
+#endif
           fclose(fp) ;
 #if 0
           fprintf(stderr, "wrote (%2.3f, %2.3f, %2.3f) and (%2.3f, %2.3f, %2.3f)\n",
@@ -949,7 +955,7 @@ repaint_handler(XV_FRAME *xvf, DIMAGE *dimage)
   {
     VERTEX  *v, *vn ;
     int     vno, n ;
-    Real    xv, yv, zv, slice, xv2, yv2, zv2, dx, dy ;
+    double  xv, yv, zv, slice, xv2, yv2, zv2, dx, dy ;
 
     for (vno = 0 ; vno < mri_surface->nvertices ; vno++)
     {
@@ -1209,7 +1215,7 @@ XVMRIsetPoint(XV_FRAME *xvf, int which, int x, int y, int z)
   int      which2, x2, y2, z2, slice, old_redraw = dont_redraw ;
   MRI      *mri, *mri2 ;
   char     fmt[150], title[50], buf[100] ;
-  Real     xr, yr, zr ;
+  double   xr, yr, zr ;
 
   if (which != which_click)   /* erase old point */
   {
@@ -1256,7 +1262,7 @@ XVMRIsetPoint(XV_FRAME *xvf, int which, int x, int y, int z)
       mri2 = mris[which2] ;
       if (dimage2 /* && (which2 != which) */ && mri2)
       {
-        MRIvoxelToVoxel(mri, mri2, (Real)x, (Real)y, (Real)z, &xr, &yr, &zr);
+        MRIvoxelToVoxel(mri, mri2, (double)x, (double)y, (double)z, &xr, &yr, &zr);
         x2 = nint(xr) ;
         y2 = nint(yr) ;
         z2 = nint(zr) ;

--- a/utils/gca.c
+++ b/utils/gca.c
@@ -1276,7 +1276,7 @@ int GCAsourceVoxelToPrior(
 */
 #if USE_ROUND
   {
-    Real xpf, ypf, zpf;
+    double xpf, ypf, zpf;
     GCAvoxelToPriorReal(gca, gca->mri_tal__, xt, yt, zt, &xpf, &ypf, &zpf);
     *pxp = nint(xpf);
     *pyp = nint(ypf);
@@ -24328,7 +24328,7 @@ static int gcaScale(GCA *gca, int *labels, int *contra_labels, float *scales, in
 int GCAgetMaxPriorLabelAtVoxel(GCA *gca, MRI *mri, int x, int y, int z, TRANSFORM *transform, double *p_prior)
 {
   int xp, yp, zp;
-  Real xpf, ypf, zpf;
+  double xpf, ypf, zpf;
 
   if (!GCAsourceVoxelToPrior(gca, mri, transform, x, y, z, &xp, &yp, &zp)) {
     xpf = xp;
@@ -26713,7 +26713,7 @@ int MRIwmsaHalo2(WMSA *wmsa)
 
   // For each ref tissue, compute the means for each modality and covariance matrix across all modalities
   // 0 = dont use any neighbors
-  print("size %d\n", (int)sizeof(llabel));
+  printf("size %d\n", (int)sizeof(llabel));
   for (i = 0; i < nreftissues; i++) {
     llabel[0] = wmsa->reftissues[i];
     MRIcomputeLabelMeansandCovariances2(

--- a/utils/gcamorphtestutils.cpp
+++ b/utils/gcamorphtestutils.cpp
@@ -1,3 +1,4 @@
+#if !defined(BEVIN_EXCLUDE_MINC)
 /**
  * @file  gcamorphtestutils.cpp
  * @brief Utilities to help with testing GCAmorph routines
@@ -486,3 +487,4 @@ static GCAMorphUtils myGCAMutils;
 // ======================================================================
 
 void WriteGCAMoneInput(const GCAM *src, const char *fName) { myGCAMutils.Write(src, fName); }
+#endif

--- a/utils/gcarray.c
+++ b/utils/gcarray.c
@@ -575,6 +575,7 @@ int GCarrayVoxelToClass(GCARRAY *gcarray, int xv, int yv, int zv, int *pxc, int 
   *pzc = nint((float)(zv - scale / 2) / (float)scale + .99f);
   return (NO_ERROR);
 }
+#if !defined(BEVIN_EXCLUDE_MINC)
 /*-----------------------------------------------------
         Parameters:
 
@@ -589,6 +590,7 @@ int GCarraySetTransform(GCARRAY *gcarray, Transform *transform, Transform *inver
   gcarray->inverse_transform = inverse_transform;
   return (NO_ERROR);
 }
+#endif
 /*-----------------------------------------------------
         Parameters:
 

--- a/utils/gtm.c
+++ b/utils/gtm.c
@@ -26,6 +26,7 @@
 #include "gtm.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/utsname.h>

--- a/utils/label.c
+++ b/utils/label.c
@@ -51,8 +51,9 @@ static int labelGetSurfaceRasCoords(LABEL *area, LABEL_VERTEX *lv, float *px, fl
 static int update_vertex_indices(LABEL *area);
 ;
 static LABEL_VERTEX *labelFindVertexNumber(LABEL *area, int vno);
+#if !defined(BEVIN_EXCLUDE_MINC)
 static Transform *labelLoadTransform(const char *subject_name, const char *sdir, General_transform *transform);
-
+#endif
 #define MAX_VERTICES 500000
 /*-----------------------------------------------------
 ------------------------------------------------------*/
@@ -116,8 +117,10 @@ LABEL *LabelReadFrom(const char *subject_name, FILE *fp)
                 Progname);
     strncpy(subjects_dir, cp, STRLEN - 1);
     strncpy(area->subject_name, subject_name, STRLEN - 1);
+#if !defined(BEVIN_EXCLUDE_MINC)
     area->linear_transform = labelLoadTransform(subject_name, subjects_dir, &area->transform);
     area->inverse_linear_transform = get_inverse_linear_transform_ptr(&area->transform);
+#endif
   }
   return (area);
 }
@@ -1081,6 +1084,7 @@ int LabelFillAll(LABEL *area, int *vertex_list, int nvertices, int max_vertices,
   fprintf(stderr, "%d vertices in label %s\n", area->n_points, area->name);
   return (NO_ERROR);
 }
+#if !defined(BEVIN_EXCLUDE_MINC)
 /*-----------------------------------------------------
         Parameters:
 
@@ -1126,6 +1130,7 @@ int LabelTalairachTransform(LABEL *area, MRI_SURFACE *mris)
   }
   return (NO_ERROR);
 }
+#endif
 /*-----------------------------------------------------
         Parameters:
 

--- a/utils/mincutils.c
+++ b/utils/mincutils.c
@@ -208,6 +208,11 @@ int NameMINCAxes(MINCAXES *MA)
   if (err) return (1);
 
   /* Make final assignments */
+#if defined(BEVIN_EXCLUDE_MINC)
+  char* const MIxspace = "xspace";
+  char* const MIyspace = "yspace";
+  char* const MIzspace = "zspace";
+#endif
   space[xspaceid] = MIxspace;
   space[yspaceid] = MIyspace;
   space[zspaceid] = MIzspace;

--- a/utils/mri.c
+++ b/utils/mri.c
@@ -2475,6 +2475,7 @@ int MRIcheckSize(MRI *mri_src, MRI *mri_check, int width, int height, int depth)
 }
 /*-----------------------------------------------------
   ------------------------------------------------------*/
+#if !defined(BEVIN_EXCLUDE_MINC)
 int MRItransformRegion(MRI *mri_src, MRI *mri_dst, MRI_REGION *src_region, MRI_REGION *dst_region)
 {
   double xw, yw, zw, xt, yt, zt, xv, yv, zv;
@@ -2527,11 +2528,12 @@ int MRItransformRegion(MRI *mri_src, MRI *mri_dst, MRI_REGION *src_region, MRI_R
 
   return (NO_ERROR);
 }
+#endif
 /*-----------------------------------------------------
   ------------------------------------------------------*/
 int MRIvoxelToVoxel(MRI *mri_src, MRI *mri_dst, double xv, double yv, double zv, double *pxt, double *pyt, double *pzt)
 {
-  double xw, yw, zw, xt, yt, zt;
+  double xw, yw, zw;
 
 #if 0
   if (!mri_src->linear_transform)
@@ -2559,7 +2561,10 @@ int MRIvoxelToVoxel(MRI *mri_src, MRI *mri_dst, double xv, double yv, double zv,
                  getSliceDirection(mri_src))) ;
   }
 #endif
-  if (!mri_src->linear_transform || !mri_dst->inverse_linear_transform) {
+#if !defined(BEVIN_EXCLUDE_MINC)
+  if (!mri_src->linear_transform || !mri_dst->inverse_linear_transform) 
+#endif
+  {
     /*
       if either doesn't have a transform defined, assume they are in
       the same coordinate system.
@@ -2574,7 +2579,9 @@ int MRIvoxelToVoxel(MRI *mri_src, MRI *mri_dst, double xv, double yv, double zv,
       *pzt = zv;
     }
   }
+#if !defined(BEVIN_EXCLUDE_MINC)
   else {
+    double xt, yt, zt;
     MRIvoxelToWorld(mri_src, xv, yv, zv, &xw, &yw, &zw);
     if (mri_src->linear_transform)
       transform_point(mri_src->linear_transform, xw, yw, zw, &xt, &yt, &zt);
@@ -2592,6 +2599,7 @@ int MRIvoxelToVoxel(MRI *mri_src, MRI *mri_dst, double xv, double yv, double zv,
     }
     MRIworldToVoxel(mri_dst, xw, yw, zw, pxt, pyt, pzt);
   }
+#endif
 
   return (NO_ERROR);
 }
@@ -2624,9 +2632,12 @@ int MRIvoxelToTalairachVoxel(MRI *mri, double xv, double yv, double zv, double *
   }
 
   MRIvoxelToWorld(mri, xv, yv, zv, &xw, &yw, &zw);
+#if !defined(BEVIN_EXCLUDE_MINC)
   if (mri->linear_transform)
     transform_point(mri->linear_transform, xw, yw, zw, &xt, &yt, &zt);
-  else {
+  else 
+#endif
+  {
     xt = xw;
     yt = yw;
     zt = zw;
@@ -2665,9 +2676,12 @@ int MRIvoxelToTalairach(MRI *mri, double xv, double yv, double zv, double *pxt, 
   }
 
   MRIvoxelToWorld(mri, xv, yv, zv, &xw, &yw, &zw);
+#if !defined(BEVIN_EXCLUDE_MINC)
   if (mri->linear_transform)
     transform_point(mri->linear_transform, xw, yw, zw, pxt, pyt, pzt);
-  else {
+  else 
+#endif
+  {
     *pxt = xw;
     *pyt = yw;
     *pzt = zw;
@@ -2704,9 +2718,12 @@ int MRItalairachToVoxel(MRI *mri, double xt, double yt, double zt, double *pxv, 
           (ERROR_UNSUPPORTED, "MRIvoxelToTalairachVoxel: unsupported slice direction %d", getSliceDirection(mri)));
   }
 
+#if !defined(BEVIN_EXCLUDE_MINC)
   if (mri->inverse_linear_transform)
     transform_point(mri->inverse_linear_transform, xt, yt, zt, &xw, &yw, &zw);
-  else {
+  else 
+#endif
+  {
     xw = xt;
     yw = yt;
     zw = zt;
@@ -2745,9 +2762,12 @@ int MRItalairachVoxelToVoxel(MRI *mri, double xtv, double ytv, double ztv, doubl
   }
 
   MRIvoxelToWorld(mri, xtv, ytv, ztv, &xt, &yt, &zt);
+#if !defined(BEVIN_EXCLUDE_MINC)
   if (mri->inverse_linear_transform)
     transform_point(mri->inverse_linear_transform, xt, yt, zt, &xw, &yw, &zw);
-  else {
+  else 
+#endif
+  {
     xw = xt;
     yw = yt;
     zw = zt;
@@ -2786,9 +2806,12 @@ int MRItalairachVoxelToWorld(MRI *mri, double xtv, double ytv, double ztv, doubl
   }
 
   MRIvoxelToWorld(mri, xtv, ytv, ztv, &xt, &yt, &zt);
+#if !defined(BEVIN_EXCLUDE_MINC)
   if (mri->inverse_linear_transform)
     transform_point(mri->inverse_linear_transform, xt, yt, zt, &xw, &yw, &zw);
-  else {
+  else 
+#endif
+  {
     xw = xt;
     yw = yt;
     zw = zt;
@@ -2833,6 +2856,7 @@ int MRIvoxelToWorld(MRI *mri, double xv, double yv, double zv, double *pxw, doub
 
   return (NO_ERROR);
 }
+#if !defined(BEVIN_EXCLUDE_MINC)
 /*-----------------------------------------------------
   ------------------------------------------------------*/
 int MRIworldToTalairachVoxel(MRI *mri, double xw, double yw, double zw, double *pxv, double *pyv, double *pzv)
@@ -2850,6 +2874,7 @@ int MRIworldToTalairachVoxel(MRI *mri, double xw, double yw, double zw, double *
   MRIworldToVoxel(mri, xt, yt, zt, pxv, pyv, pzv);
   return (NO_ERROR);
 }
+#endif
 /*-----------------------------------------------------
   ------------------------------------------------------*/
 int MRIworldToVoxelIndex(MRI *mri, double xw, double yw, double zw, int *pxv, int *pyv, int *pzv)
@@ -5756,7 +5781,9 @@ int MRIfree(MRI **pmri)
     free(mri->slices);
   }
 
+#if !defined(BEVIN_EXCLUDE_MINC)
   if (mri->free_transform) delete_general_transform(&mri->transform);
+#endif
 
   if (mri->register_mat != NULL) MatrixFree(&(mri->register_mat));
 
@@ -6021,6 +6048,7 @@ MRI *MRIcopyHeader(const MRI *mri_src, MRI *mri_dst)
   mri_dst->ysize = mri_src->ysize;
   mri_dst->zsize = mri_src->zsize;
 
+#if !defined(BEVIN_EXCLUDE_MINC)
   if (mri_dst->free_transform) delete_general_transform(&mri_dst->transform);
   if (mri_src->linear_transform) {
     copy_general_transform(&(((MRI *)mri_src)->transform), &mri_dst->transform);
@@ -6030,6 +6058,7 @@ MRI *MRIcopyHeader(const MRI *mri_src, MRI *mri_dst)
     mri_dst->inverse_linear_transform = get_inverse_linear_transform_ptr(&mri_dst->transform);
     mri_dst->free_transform = 1;
   }
+#endif
   strcpy(mri_dst->transform_fname, mri_src->transform_fname);
   if (mri_dst->depth == mri_src->depth) {
     mri_dst->imnr0 = mri_src->imnr0;
@@ -8104,6 +8133,7 @@ int MRIsetResolution(MRI *mri, float xres, float yres, float zres)
   MRIreInitCache(mri);
   return (NO_ERROR);
 }
+#if !defined(BEVIN_EXCLUDE_MINC)
 /*-----------------------------------------------------
   Parameters:
 
@@ -8119,6 +8149,7 @@ int MRIsetTransform(MRI *mri, General_transform *transform)
 
   return (NO_ERROR);
 }
+#endif
 /*-----------------------------------------------------
   Parameters:
 
@@ -16400,8 +16431,8 @@ int MRIcomputeNbhdMeansandCovariances(
           xi = mri_labeled->xi[x + xk];
           if (nint(MRIgetVoxVal(mri_labeled, xi, yi, zi, 0)) == label) {
             if (a >= size) {
-              printf("ERROR: a %d is greater than the number of neighbors: %d\n", a, size);
-              return (ERROR);
+              printf("ERROR_OUT_OF_BOUNDS: a %d is greater than the number of neighbors: %d\n", a, size);
+              return (ERROR_OUT_OF_BOUNDS);
             }
             m_data->rptr[a + 1][n + 1] = MRIgetVoxVal(mri_inputs, xi, yi, zi, n);
             mean += m_data->rptr[a + 1][n + 1];
@@ -16412,8 +16443,8 @@ int MRIcomputeNbhdMeansandCovariances(
     }
 
     if (a != size) {
-      printf("ERROR: a %d is not equal to the number of neighbors: %d\n", a, size);
-      return (ERROR);
+      printf("ERROR_OUT_OF_BOUNDS: a %d is not equal to the number of neighbors: %d\n", a, size);
+      return (ERROR_OUT_OF_BOUNDS);
     }
     mean = mean / a;
     VECTOR_ELT(v_means, n + 1) = (float)mean;

--- a/utils/mri2.c
+++ b/utils/mri2.c
@@ -864,7 +864,7 @@ int MRIvol2VolR(MRI *src, MRI *targ, MATRIX *Vt2s, int InterpCode, float param, 
   float fcs, frs, fss;
   float *valvect;
   int sinchw;
-  Real rval;
+  double rval;
   MATRIX *V2Rsrc = NULL, *invV2Rsrc = NULL, *V2Rtarg = NULL;
   int FreeMats = 0;
 
@@ -2064,14 +2064,14 @@ int MRImakeVox2VoxReg(MRI *targ, MRI *mov, int regtype, char *regname, mriTransf
   /* Create the targ A->RAS matrix. */
   targ_idx_to_tkregras = MRIxfmCRS2XYZtkreg(targ);
   if (NULL == targ_idx_to_tkregras) {
-    print("ERROR: MRImakeVox2VoxReg: Couldn't create targ_idx_to_tkregras\n");
+    printf("ERROR: MRImakeVox2VoxReg: Couldn't create targ_idx_to_tkregras\n");
     goto error;
   }
 
   /* Create the mov B->RAS matrix. */
   mov_idx_to_tkregras = MRIxfmCRS2XYZtkreg(mov);
   if (NULL == mov_idx_to_tkregras) {
-    print("ERROR: MRImakeVox2VoxReg: Couldn't create mov_idx_to_tkregras\n");
+    printf("ERROR: MRImakeVox2VoxReg: Couldn't create mov_idx_to_tkregras\n");
     goto error;
   }
 

--- a/utils/mriBSpline.c
+++ b/utils/mriBSpline.c
@@ -2230,6 +2230,7 @@ MRI *MRIapplyRASlinearTransformBSpline(const MRI_BSPLINE *bspline, MRI *mri_dst,
   return (mri_dst);
 }
 
+#ifdef BEVIN_MRI_BSPLINE_LTA
 MRI *LTAtransformBSpline(const MRI_BSPLINE *bspline, MRI *mri_dst, LTA *lta)
 // mainly copied from transform.c
 {
@@ -2420,6 +2421,7 @@ MRI *LTAtransformBSpline(const MRI_BSPLINE *bspline, MRI *mri_dst, LTA *lta)
 
   return (mri_dst);
 }
+#endif
 
 // -------------------------------------------------------------------------------
 //

--- a/utils/mriBSpline.c
+++ b/utils/mriBSpline.c
@@ -2230,7 +2230,7 @@ MRI *MRIapplyRASlinearTransformBSpline(const MRI_BSPLINE *bspline, MRI *mri_dst,
   return (mri_dst);
 }
 
-#ifdef BEVIN_MRI_BSPLINE_LTA
+#if !defined(BEVIN_EXCLUDE_MINC)
 MRI *LTAtransformBSpline(const MRI_BSPLINE *bspline, MRI *mri_dst, LTA *lta)
 // mainly copied from transform.c
 {

--- a/utils/mriVolume.c
+++ b/utils/mriVolume.c
@@ -1447,10 +1447,13 @@ Volm_tErr Volm_HasTalTransform(mriVolumeRef this, tBoolean *obHasTransform)
   DebugAssertThrowX((obHasTransform != NULL), eResult, Volm_tErr_InvalidParamater);
 
   /* Return true if we have a tal transform, false if not. */
+#if !defined(BEVIN_EXCLUDE_MINC)
   if (NULL != this->mpMriValues->linear_transform) {
     *obHasTransform = TRUE;
   }
-  else {
+  else 
+#endif
+  {
     *obHasTransform = FALSE;
   }
 
@@ -1541,6 +1544,7 @@ Volm_tErr Volm_ConvertRASToIdx(mriVolumeRef this, xVoxelRef iRAS, xVoxelRef oIdx
   return eResult;
 }
 
+#if !defined(BEVIN_EXCLUDE_MINC)
 Volm_tErr Volm_ConvertIdxToMNITal(mriVolumeRef this, xVoxelRef iIdx, xVoxelRef oMNITal)
 {
   Volm_tErr eResult = Volm_tErr_NoErr;
@@ -1694,6 +1698,7 @@ Volm_tErr Volm_ConvertTalToIdx(mriVolumeRef this, xVoxelRef iTal, xVoxelRef oIdx
 
   return eResult;
 }
+#endif
 
 Volm_tErr Volm_ConvertIdxToScanner(mriVolumeRef this, xVoxelRef iIdx, xVoxelRef oScanner)
 {

--- a/utils/mriclass.c
+++ b/utils/mriclass.c
@@ -953,7 +953,9 @@ MRI *MRICupdatePriors(MRI *mri_target, MRI *mri_priors, int scale)
     mri_priors->xsize *= scale;
     mri_priors->ysize *= scale;
     mri_priors->zsize *= scale;
+#if !defined(BEVIN_EXCLUDE_MINC)
     mri_priors->linear_transform = mri_priors->inverse_linear_transform = NULL;
+#endif
   }
 
   for (z = 0; z < depth; z++) {

--- a/utils/mrinorm.c
+++ b/utils/mrinorm.c
@@ -245,6 +245,7 @@ static MRI *mriSplineNormalizeShort(
   }
   return (mri_dst);
 }
+#if !defined(BEVIN_EXCLUDE_MINC)
 /*-----------------------------------------------------
   Parameters:
 
@@ -317,6 +318,7 @@ MRI *MRIadaptiveHistoNormalize(MRI *mri_src, MRI *mri_norm, MRI *mri_template, i
 
   return (mri_norm);
 }
+#endif
 /*-----------------------------------------------------
   Parameters:
 
@@ -431,6 +433,7 @@ int MRInormInit(
     mni->smooth_sigma = smooth_sigma;
   }
   // look for talairach.xfm
+#if !defined(BEVIN_EXCLUDE_MINC)
   if (mri->inverse_linear_transform) {
     // create lta
     lta = LTAalloc(1, NULL);
@@ -488,6 +491,7 @@ int MRInormInit(
     LTAfree(&lta);
   }
   else /* no Talairach information available */
+#endif
   {
     MRI_REGION bbox;
 

--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -21,9 +21,8 @@
  *
  */
 
-#define BEVIN_MRISURF
-
 #include <ctype.h>
+#include <errno.h>
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
@@ -9372,14 +9371,13 @@ int MRISupdateEllipsoidSurface(MRI_SURFACE *mris)
   using num_avgs nearest-neighbor averages. See also
   MRISaverageGradientsFast()
   ------------------------------------------------------*/
-#ifdef BEVIN_MRISURF
 static int closeEnough(float a, float b) {
   float mag = fabs(a) > fabs(b) ? fabs(a) : fabs(b);
   if (mag < 1.0e-6) return 1;
   if (fabs(a-b) < mag*1.0e-2) return 1;
   return 0; 
 }
-#endif
+
 
 int MRISaverageGradients(MRI_SURFACE *mris, int num_avgs)
 {
@@ -9424,7 +9422,6 @@ int MRISaverageGradients(MRI_SURFACE *mris, int num_avgs)
     MRISPfree(&mrisp_blur);
   }
   else
-#ifdef BEVIN_MRISURF
   {
     // This code shows the num_avgs typically is repeated 1-4 times as 1024, 256, 64, 16, 4, and then 1
     if (0) {
@@ -9455,8 +9452,8 @@ int MRISaverageGradients(MRI_SURFACE *mris, int num_avgs)
     // - only the new algorithm
     // - both algorithms, and compare them
     
-    static const int BEVIN_SERIAL_doNew = 1;
-    static const int BEVIN_SERIAL_doOld = 0;
+    static const int doNew = 1;
+    static const int doOld = 0;
     
     // This is the new algorithm
     int *vno_to_index = NULL;
@@ -9479,7 +9476,7 @@ int MRISaverageGradients(MRI_SURFACE *mris, int num_avgs)
     int  neighbors_size     = 0;
     int *neighbors          = NULL;
     
-    if (BEVIN_SERIAL_doNew) {
+    if (doNew) {
     
       // Malloc the needed storage
       vno_to_index = (int*)    malloc(sizeof(int)     * mris->nvertices) ;
@@ -9587,65 +9584,62 @@ int MRISaverageGradients(MRI_SURFACE *mris, int num_avgs)
     }
 
     // Only perform the old algorithm when needed
-    if (BEVIN_SERIAL_doOld) {
-
-#endif
+    if (doOld) {
     
-    // This is the old algorithm
-    for (i = 0 ; i < num_avgs ; i++) {
-
+      // This is the old algorithm
+      for (i = 0 ; i < num_avgs ; i++) {
+  
 #ifdef HAVE_OPENMP
-      #pragma omp parallel for
+        #pragma omp parallel for
 #endif
-
-      for (vno = 0; vno < mris->nvertices; vno++) {
-        VERTEX *v, *vn;
-        float dx, dy, dz, num;
-        int vnb, *pnb, vnum;
-
-        v = &mris->vertices[vno];
-        if (v->ripflag) continue;
-
-        dx  = v->dx;
-        dy  = v->dy;
-        dz  = v->dz;
-        pnb = v->v;
-        // vnum = v->v2num ? v->v2num : v->vnum;
-        vnum = v->vnum;
-        for (num = 0.0f, vnb = 0; vnb < vnum; vnb++) {
-          vn = &mris->vertices[*pnb++]; // neighboring vertex pointer
-          if (vn->ripflag) continue;
-
+  
+        for (vno = 0; vno < mris->nvertices; vno++) {
+          VERTEX *v, *vn;
+          float dx, dy, dz, num;
+          int vnb, *pnb, vnum;
+  
+          v = &mris->vertices[vno];
+          if (v->ripflag) continue;
+  
+          dx  = v->dx;
+          dy  = v->dy;
+          dz  = v->dz;
+          pnb = v->v;
+          // vnum = v->v2num ? v->v2num : v->vnum;
+          vnum = v->vnum;
+          for (num = 0.0f, vnb = 0; vnb < vnum; vnb++) {
+            vn = &mris->vertices[*pnb++]; // neighboring vertex pointer
+            if (vn->ripflag) continue;
+  
+            num++;
+            dx += vn->dx;
+            dy += vn->dy;
+            dz += vn->dz;
+          }
           num++;
-          dx += vn->dx;
-          dy += vn->dy;
-          dz += vn->dz;
+          v->tdx = dx / num;
+          v->tdy = dy / num;
+          v->tdz = dz / num;
         }
-        num++;
-        v->tdx = dx / num;
-        v->tdy = dy / num;
-        v->tdz = dz / num;
-      }
 #ifdef HAVE_OPENMP
 #pragma omp parallel for schedule(static, 1)
 #endif
-      for (vno = 0; vno < mris->nvertices; vno++) {
-        VERTEX *v;
+        for (vno = 0; vno < mris->nvertices; vno++) {
+          VERTEX *v;
+  
+          v = &mris->vertices[vno];
+          if (v->ripflag) continue;
+  
+          v->dx = v->tdx;
+          v->dy = v->tdy;
+          v->dz = v->tdz;
+        }
+      }  // end of one of the num_avgs iterations
 
-        v = &mris->vertices[vno];
-        if (v->ripflag) continue;
-
-        v->dx = v->tdx;
-        v->dy = v->tdy;
-        v->dz = v->tdz;
-      }
-    }  // end of one of the num_avgs iterations
-
-#ifdef BEVIN_MRISURF
-    }  // if (BEVIN_SERIAL_doOld) 
+    }  // if (doOld) 
     
     // Compare the new algorithm and old algorithm answers
-    if (BEVIN_SERIAL_doOld && BEVIN_SERIAL_doNew) {
+    if (doOld && doNew) {
       int errors = 0;
       for (vno = 0 ; vno < mris->nvertices ; vno++) {
         VERTEX *v = &mris->vertices[vno];
@@ -9670,7 +9664,7 @@ int MRISaverageGradients(MRI_SURFACE *mris, int num_avgs)
 
     // Put the results where they belong
     // Note: this code does not set tdx, etc. - I believe they are temporaries   
-    if (BEVIN_SERIAL_doNew) {
+    if (doNew) {
       int index;
       for (index = 0 ; index < index_to_vno_size; index++) {
         VERTEX *v = &mris->vertices[index_to_vno[index]];
@@ -9688,7 +9682,6 @@ int MRISaverageGradients(MRI_SURFACE *mris, int num_avgs)
       free(vno_to_index);
     }
   }
-#endif
 
   if (Gdiag_no >= 0) {
     float dot;
@@ -31400,7 +31393,7 @@ int MRISpositionSurface(MRI_SURFACE *mris, MRI *mri_brain, MRI *mri_smooth, INTE
       MRISprintTessellationStats(mris, stderr);
     }
     if (Gdiag_no >= 0) {
-      Real xv, yv, zv;
+      double xv, yv, zv;
       VERTEX *v;
       v = &mris->vertices[Gdiag_no];
       MRISvertexToVoxel(mris, v, mri_brain, &xv, &yv, &zv);

--- a/utils/stats.c
+++ b/utils/stats.c
@@ -683,7 +683,9 @@ int StatFree(SV **psv)
     if (sv->mri_std_dofs[event]) MRIfree(&sv->mri_std_dofs[event]);
   }
 
+#if !defined(BEVIN_EXCLUDE_MINC)
   delete_general_transform(&sv->transform);
+#endif
   StatFreeRegistration(&sv->reg);
   free(sv);
 
@@ -1078,8 +1080,10 @@ int StatAccumulateTalairachVolume(SV *sv_tal, SV *sv)
     sv_tal->std_dofs[event] += sv->std_dofs[event];
     mri_avg = sv_tal->mri_avgs[event];
     mri_std = sv_tal->mri_stds[event];
+#if !defined(BEVIN_EXCLUDE_MINC)
     mri_avg->linear_transform = sv->mri_avgs[event]->linear_transform;
     mri_avg->inverse_linear_transform = sv->mri_avgs[event]->inverse_linear_transform;
+#endif
 
     /* Go through each col, row, and slice in the tal volume */
     for (z = 0; z < depth; z++) {
@@ -1356,6 +1360,7 @@ int StatWriteRegistration(fMRI_REG *reg, const char *fname)
 }
 /*-------------------------------------------------------------------
   -------------------------------------------------------------------*/
+#if !defined(BEVIN_EXCLUDE_MINC)
 int StatReadTransform(STAT_VOLUME *sv, const char *name)
 {
   char *sd, subjects[STRLEN], fname[STRLEN];
@@ -1381,6 +1386,7 @@ int StatReadTransform(STAT_VOLUME *sv, const char *name)
   }
   return (NO_ERROR);
 }
+#endif
 /*------------------------------------------------------------------------
   ------------------------------------------------------------------------*/
 int StatVolumeExists(const char *prefix)

--- a/utils/stats.c
+++ b/utils/stats.c
@@ -420,7 +420,12 @@ SV *StatReadVolume(const char *prefix)
   StatAllocVolume(sv, sv->nevents, width, height, nslices, sv->time_per_event, which_alloc);
 
   /* read it after nevents */
-  if (stricmp(sv->reg->name, "talairach") && stricmp(sv->reg->name, "spherical")) StatReadTransform(sv, sv->reg->name);
+  if (stricmp(sv->reg->name, "talairach") && stricmp(sv->reg->name, "spherical")) 
+#if !defined(BEVIN_EXCLUDE_MINC)
+    StatReadTransform(sv, sv->reg->name);
+#else
+    ErrorReturn(NULL, (ERROR_NOFILE, "StatReadVolume: does not support %s", sv->reg->name));
+#endif
 
   /* read in the actual data */
   nitems = width * height;
@@ -622,7 +627,14 @@ SV *StatReadVolume2(const char *prefix)
   StatAllocVolume(sv, sv->nevents, h->width, h->height, h->depth, sv->time_per_event, which_alloc);
 
   /* read it after nevents */
-  if (stricmp(sv->reg->name, "talairach") && stricmp(sv->reg->name, "spherical")) StatReadTransform(sv, sv->reg->name);
+  if (stricmp(sv->reg->name, "talairach") && stricmp(sv->reg->name, "spherical")) {
+#if !defined(BEVIN_EXCLUDE_MINC)
+    StatReadTransform(sv, sv->reg->name);
+#else
+    fprintf(stderr, "ERROR: %s, StatReadVolume(): does not support talairach\n", Progname);
+    exit(1);
+#endif
+  }
 
   f = 0;
   for (event = 0; event < sv->nevents; event++) {

--- a/utils/test/mri_concatenate_lta.c
+++ b/utils/test/mri_concatenate_lta.c
@@ -477,7 +477,7 @@ get_transform:
 }
 
 
-#include "volume_io.h"
+#include "minc_volume_io.h"
 
 int  ltaMNIwrite(LTA *lta, char *fname)
 {

--- a/utils/test/mrishash/mrishash_demo_100_find_coverage.c
+++ b/utils/test/mrishash/mrishash_demo_100_find_coverage.c
@@ -101,7 +101,7 @@ void CoverageTest() {
   int rslt;
   int  xsi, ysi, zsi, xvi, yvi, zvi;
   int intens, halfscansize, closest_vertnum, vno;
-  Real xs,  ys,  zs,  xv,  yv,  zv;  // WTF is Real?
+  double xs,  ys,  zs,  xv,  yv,  zv;
   VERTEX vtx, *v;
   double ddist;
 

--- a/utilscpp/mris_fastmarching.cpp
+++ b/utilscpp/mris_fastmarching.cpp
@@ -39,8 +39,8 @@
 static MRI_REGION*mriFindLabel(MRI *mri,int label,int offset) {
   MRI_REGION *region;
   int i,j,k,nlabels;
-  Real xmin,ymax,zmin,xmax,ymin,zmax;
-  Real xw,yw,zw;
+  double xmin,ymax,zmin,xmax,ymin,zmax;
+  double xw,yw,zw;
 
   region=(MRI_REGION*)calloc(1,sizeof(MRI_REGION));
 

--- a/vtkfsio/vtkFSVolumeSource.cxx
+++ b/vtkfsio/vtkFSVolumeSource.cxx
@@ -149,7 +149,7 @@ vtkFSVolumeSource::SetVoxelToRASMatrix ( vtkMatrix4x4& iMatrix ) {
   MATRIX* m = MatrixIdentity( 4, NULL );
   for ( int r = 0; r < 4; r++ )
     for ( int c = 0; c < 4; c++ )
-      *MATRIX_RELT((m),r+1,c+1) = (Real) iMatrix[r][c];
+      *MATRIX_RELT((m),r+1,c+1) = (float) iMatrix[r][c];
 
   MRIsetVoxelToRasXform( mMRI, m );
 
@@ -168,7 +168,7 @@ vtkFSVolumeSource::ConvertIndexToRAS ( float iIdxX, float iIdxY, float iIdxZ,
     return -1;
   }
 
-  Real ix, iy, iz, wx, wy, wz;
+  double ix, iy, iz, wx, wy, wz;
   int r;
 
   ix = iIdxX;
@@ -191,7 +191,7 @@ vtkFSVolumeSource::ConvertRASToIndex( float iRASX, float iRASY, float iRASZ,
     return -1;
   }
 
-  Real ix, iy, iz, wx, wy, wz;
+  double ix, iy, iz, wx, wy, wz;
   int r;
 
   wx = iRASX;
@@ -214,7 +214,7 @@ vtkFSVolumeSource::ConvertRASToIndex( float iRASX, float iRASY, float iRASZ,
     return -1;
   }
 
-  Real wx, wy, wz;
+  double wx, wy, wz;
   int ix, iy, iz;
   int r;
 


### PR DESCRIPTION
This change allows a build that does not need the MINC component at all.  This is desirable to Corticometrics because it allows the use of the code they need without this component being included, which means it doesn't have to be ported to some build configurations (other compilers, for instance).

This edit consists of several kinds of minor but wide ranging changes

(1) "Real" is replaced by "double" almost everywhere.   There are currently 3 typedefs of Real in the various header files, all defining it as "double", and unrelated to each other.  Furthermore a variety of the uses were not "typesafe" - Real was used when double was meant and vice versa

(2) "print" was being used instead of "printf" in several places, just because it is interchangeable

(3) "errno.h" was being included indirectly via volume_io.h, and needed to be made explicit

(4) Lastly the talairach transforms were being used but are almost always one of several options.  These were conditionalized out.

This edit does not add any new code or change any functionality when the conditionalization is not triggered