### PR TITLE
fixed var declarations to eliminate unused var warnings introduced in…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -432,13 +432,13 @@ fastbuild:
 	done
 	@list='$(OTHERDIRS)'; \
 	for d in $$list; do \
-		cd "$$d"; (make -j --max-load $(FS_FASTBUILD_THREADS) &) ; sleep 0.1; cd - ; \
+		cd "$$d"; (make -j --max-load $(FS_FASTBUILD_THREADS) &) ; sleep 0.2; cd - ; \
 	done
 	@list='$(BIGDIRS)'; \
 	for d in $$list; do \
 		cd "$$d"; (make -j --max-load $(FS_FASTBUILD_THREADS) ); cd - ; \
 	done
-	sleep 10
+	sleep 30
 	make
 
 # build stamp and symlinks to necessary 3rd-party packages.

--- a/configure.in
+++ b/configure.in
@@ -1316,7 +1316,7 @@ if test "x$MNI_DIR" = "xno"; then
   # which indicates that no MNI libs should be used in the build
   ac_mni_includes=no
   ac_mni_libraries=no
-  MNI_CFLAGS=""
+  MNI_CFLAGS="-DBEVIN_EXCLUDE_MINC"
   MNI_LIBS=""
   MNI_DIR="no" # indicates --without-mni-dir was used
   LIBS_MNI=""

--- a/mri_ca_train/mri_ca_train.c
+++ b/mri_ca_train/mri_ca_train.c
@@ -14,7 +14,7 @@
  *    $Date: 2015/07/27 20:52:08 $
  *    $Revision: 1.70 $
  *
- * Copyright © 2011 The General Hospital Corporation (Boston, MA) "MGH"
+ * Copyright © 2011-2017 The General Hospital Corporation (Boston, MA) "MGH"
  *
  * Terms and conditions for use, reproduction, distribution and contribution
  * are found in the 'FreeSurfer Software License Agreement' contained
@@ -1618,11 +1618,16 @@ lateralize_hypointensities(MRI *mri_seg)
  */
 static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
 {
-  int x, y, z, label, errors=0;
+  MRI *mri_fixed = NULL;
+  int errors=0;
+#if defined(BEVIN_EXCLUDE_MINC)
+    ErrorExit(ERROR_BADFILE,
+              "ERROR: mri_ca_train: talairach not supported!\n");
+#else
+  int x, y, z, label=0;
   double xw=0.0, yw=0.0, zw=0.0; // RAS coords
   double xmt=0.0, ymt=0.0, zmt=0.0; // MNI tal coords
   float xt=0.0, yt=0.0, zt=0.0; // 'real' tal coords
-  MRI *mri_fixed = NULL;
 
   float max_xtal_l_hippo    = -1000;
   float max_xtal_l_caudate  = -1000;
@@ -1642,10 +1647,6 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
     mri_fixed = MRIcopy(mri_seg,NULL);
   }
 
-#if defined(BEVIN_EXCLUDE_MINC)
-    ErrorExit(ERROR_BADFILE,
-              "ERROR: mri_ca_train: talairach not supported!\n");
-#else
   if (NULL == mri_seg->linear_transform)
   {
     ErrorExit(ERROR_BADFILE,

--- a/mri_fill/mri_fill.c
+++ b/mri_fill/mri_fill.c
@@ -13,7 +13,7 @@
  *    $Date: 2011/10/25 14:09:58 $
  *    $Revision: 1.119 $
  *
- * Copyright © 2011 The General Hospital Corporation (Boston, MA) "MGH"
+ * Copyright © 2011-2017 The General Hospital Corporation (Boston, MA) "MGH"
  *
  * Terms and conditions for use, reproduction, distribution and contribution
  * are found in the 'FreeSurfer Software License Agreement' contained
@@ -2017,7 +2017,6 @@ main(int argc, char *argv[])
   MRI *mri_talheader;
   LT *lt;
   MATRIX *m_L;
-  int row;
   VOL_GEOM *dst=0;
   VOL_GEOM *src=0;
   char cmdline[CMD_LINE_LEN] ;
@@ -2228,6 +2227,7 @@ main(int argc, char *argv[])
 #if !defined(BEVIN_EXCLUDE_MINC)
     if (mri_im->linear_transform)
     {
+      int row;
       // linear_transform is zero based column-major array
       for (row = 1 ; row <= 3 ; row++)
       {

--- a/mri_histo_eq/mri_histo_eq.c
+++ b/mri_histo_eq/mri_histo_eq.c
@@ -11,7 +11,7 @@
  *    $Date: 2011/03/02 00:04:18 $
  *    $Revision: 1.6 $
  *
- * Copyright © 2011 The General Hospital Corporation (Boston, MA) "MGH"
+ * Copyright © 2011-2017 The General Hospital Corporation (Boston, MA) "MGH"
  *
  * Terms and conditions for use, reproduction, distribution and contribution
  * are found in the 'FreeSurfer Software License Agreement' contained
@@ -57,7 +57,7 @@ main(int argc, char *argv[]) {
   int    ac, nargs ;
   int          msec, minutes, seconds ;
   struct timeb start ;
-  MRI    *mri_src, *mri_template, *mri_eq ;
+  MRI    *mri_src, *mri_template ;
 
   /* rkt: check for and handle version tag */
   nargs = handle_version_option (argc, argv, "$Id: mri_histo_eq.c,v 1.6 2011/03/02 00:04:18 nicks Exp $", "$Name:  $");
@@ -131,6 +131,7 @@ main(int argc, char *argv[]) {
     MatrixFree(&m_L);
   }
 
+  MRI *mri_eq=NULL;
   if (adaptive_normalize)
 #if !defined(BEVIN_EXCLUDE_MINC)
     mri_eq = MRIadaptiveHistoNormalize(mri_src, NULL, mri_template,

--- a/mri_rf_long_train/mri_rf_long_train.c
+++ b/mri_rf_long_train/mri_rf_long_train.c
@@ -12,7 +12,7 @@
  *    $Date: 2012/06/15 12:22:28 $
  *    $Revision: 1.5 $
  *
- * Copyright © 2011 The General Hospital Corporation (Boston, MA) "MGH"
+ * Copyright © 2011-2017 The General Hospital Corporation (Boston, MA) "MGH"
  *
  * Terms and conditions for use, reproduction, distribution and contribution
  * are found in the 'FreeSurfer Software License Agreement' contained
@@ -1029,11 +1029,16 @@ lateralize_hypointensities(MRI *mri_seg)
  */
 static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
 {
-  int x, y, z, label, errors=0;
+  MRI *mri_fixed = NULL;
+  int errors=0;
+#if defined(BEVIN_EXCLUDE_MINC)
+    ErrorExit(ERROR_BADFILE,
+              "ERROR: mri_rf_long_train: talairach not supported.\n");
+#else
+  int x, y, z, label=0;
   double xw=0.0, yw=0.0, zw=0.0; // RAS coords
   double xmt=0.0, ymt=0.0, zmt=0.0; // MNI tal coords
   float xt=0.0, yt=0.0, zt=0.0; // 'real' tal coords
-  MRI *mri_fixed = NULL;
 
   float max_xtal_l_hippo    = -1000;
   float max_xtal_l_caudate  = -1000;
@@ -1053,12 +1058,6 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
     mri_fixed = MRIcopy(mri_seg,NULL);
   }
 
-#if defined(BEVIN_EXCLUDE_MINC)
-    ErrorExit(ERROR_BADFILE,
-              "ERROR: mri_ca_train: talairach not supported,  processing %s!\n"
-              "Run mri_add_xform_to_header to add to volume.\n",
-              seg_dir);
-#else
   if (NULL == mri_seg->linear_transform)
   {
     ErrorExit(ERROR_BADFILE,

--- a/mri_rf_train/mri_rf_train.c
+++ b/mri_rf_train/mri_rf_train.c
@@ -12,7 +12,7 @@
  *    $Date: 2012/05/24 00:04:15 $
  *    $Revision: 1.2 $
  *
- * Copyright © 2011 The General Hospital Corporation (Boston, MA) "MGH"
+ * Copyright © 2011-2017 The General Hospital Corporation (Boston, MA) "MGH"
  *
  * Terms and conditions for use, reproduction, distribution and contribution
  * are found in the 'FreeSurfer Software License Agreement' contained
@@ -1132,11 +1132,17 @@ lateralize_hypointensities(MRI *mri_seg)
  */
 static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
 {
-  int x, y, z, label, errors=0;
+  MRI *mri_fixed = NULL;
+  int errors = 0;
+#if defined(BEVIN_EXCLUDE_MINC)
+    ErrorExit(ERROR_BADFILE,
+              "ERROR: mri_rf_train: talairach not supported in %s!\n",
+              seg_dir);
+#else
+  int x, y, z, label=0;
   double xw=0.0, yw=0.0, zw=0.0; // RAS coords
   double xmt=0.0, ymt=0.0, zmt=0.0; // MNI tal coords
   float xt=0.0, yt=0.0, zt=0.0; // 'real' tal coords
-  MRI *mri_fixed = NULL;
 
   float max_xtal_l_hippo    = -1000;
   float max_xtal_l_caudate  = -1000;
@@ -1156,11 +1162,6 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
     mri_fixed = MRIcopy(mri_seg,NULL);
   }
 
-#if defined(BEVIN_EXCLUDE_MINC)
-    ErrorExit(ERROR_BADFILE,
-              "ERROR: mri_ca_train: talairach not supported in %s!\n",
-              seg_dir);
-#else
   if (NULL == mri_seg->linear_transform)
   {
     ErrorExit(ERROR_BADFILE,

--- a/mris_make_surfaces/mris_refine_surfaces.c
+++ b/mris_make_surfaces/mris_refine_surfaces.c
@@ -16,7 +16,7 @@
  *    $Date: 2016/12/10 22:57:53 $
  *    $Revision: 1.23 $
  *
- * Copyright © 2011 The General Hospital Corporation (Boston, MA) "MGH"
+ * Copyright © 2011-2017 The General Hospital Corporation (Boston, MA) "MGH"
  *
  * Terms and conditions for use, reproduction, distribution and contribution
  * are found in the 'FreeSurfer Software License Agreement' contained
@@ -1433,16 +1433,16 @@ find_wm(MRI_SURFACE *mris, MRI *mri, MRI *mri_wm)
         }
   }
 
-  print("writing 1...\n") ;
+  printf("writing 1...\n") ;
   MRIwrite(mri_interior, "i1.mgz") ;
   MRIbuildVoronoiDiagram(mri, mri_ctrl, mri_interior) ;
-  print("writing 2...\n") ;
+  printf("writing 2...\n") ;
   MRIwrite(mri_interior, "i2.mgz") ;
   MRIwrite(mri_ctrl, "c.mgz") ;
   mri_kernel = MRIgaussian1d(.25/mri->xsize, 0) ;
   mri_wm = MRIconvolveGaussian(mri_interior, NULL, mri_kernel) ;
   //  MRIsoapBubble(mri_interior, mri_ctrl, mri_interior, 5) ;
-  print("writing 3...\n") ;
+  printf("writing 3...\n") ;
   MRIwrite(mri_wm, "i3.mgz") ;
 
   MRIfree(&mri_interior) ; MRIfree(&mri_ctrl) ; MRIfree(&mri_kernel) ;

--- a/unix/xvmri.c
+++ b/unix/xvmri.c
@@ -120,7 +120,7 @@ mri_event_handler(XV_FRAME *xvf, Event *event,DIMAGE *dimage,
                   int *px, int *py, int *pz)
 {
   int       x, y, z, which, depth, frame, xi, yi, zi, xk, yk, zk ;
-  double    xr, yr, zr, xt, yt, zt, xv, yv, zv, xtv, ytv, ztv ;
+  double    xr, yr, zr, xt=0.0, yt=0.0, zt=0.0, xv, yv, zv, xtv=0.0, ytv=0.0, ztv=0.0 ;
   float     xf, yf, zf, xft, yft, zft ;
   MRI       *mri ;
   char      fname[100] ;

--- a/utils/mriio.c
+++ b/utils/mriio.c
@@ -12,7 +12,7 @@
  *    $Date: 2016/10/14 19:13:08 $
  *    $Revision: 1.425 $
  *
- * Copyright © 2011 The General Hospital Corporation (Boston, MA) "MGH"
+ * Copyright © 2011-2017 The General Hospital Corporation (Boston, MA) "MGH"
  *
  * Terms and conditions for use, reproduction, distribution and contribution
  * are found in the 'FreeSurfer Software License Agreement' contained
@@ -11251,8 +11251,6 @@ static MRI *mghRead(const char *fname, int read_volume, int frame)
   // tag reading
   if (getenv("FS_SKIP_TAGS") == NULL) {
     long long len;
-    char *fnamedir;
-    char tmpstr[1000];
 
     while (1) {
       tag = znzTAGreadStart(fp, &len);
@@ -11275,10 +11273,13 @@ static MRI *mghRead(const char *fname, int read_volume, int frame)
           break;
 
         case TAG_OLD_MGH_XFORM:
-        case TAG_MGH_XFORM:
+        case TAG_MGH_XFORM: {
 #if defined(BEVIN_EXCLUDE_MINC)
 	  ErrorPrintf(ERROR_BAD_FILE, "talairach xform files not supported\n");
 #else
+          char *fnamedir;
+          char tmpstr[1000];
+
           // First, try a path relative to fname (not the abs path)
           fnamedir = fio_dirname(fname);
           sprintf(tmpstr, "%s/transforms/talairach.xfm", fnamedir);
@@ -11306,7 +11307,7 @@ static MRI *mghRead(const char *fname, int read_volume, int frame)
           }
 #endif
           break;
-
+        }
         case TAG_CMDLINE:
           if (mri->ncmds >= MAX_CMDS)
             ErrorExit(ERROR_NOMEMORY, "mghRead(%s): too many commands (%d) in file", fname, mri->ncmds);

--- a/utils/mrinorm.c
+++ b/utils/mrinorm.c
@@ -13,7 +13,7 @@
  *    $Date: 2016/11/30 15:46:42 $
  *    $Revision: 1.120 $
  *
- * Copyright © 2011-2012 The General Hospital Corporation (Boston, MA) "MGH"
+ * Copyright © 2011-2017 The General Hospital Corporation (Boston, MA) "MGH"
  *
  * Terms and conditions for use, reproduction, distribution and contribution
  * are found in the 'FreeSurfer Software License Agreement' contained
@@ -408,14 +408,6 @@ int MRInormInit(
   int i, x, y, z, dx, dy, dz, nup, z_offset, nwindows;
   int x0_tal, y0_tal, z0_tal;
   float size_mod;
-  double x0, y0, z0;
-
-  LTA *lta = 0;       // need to be freeed
-  LT *lt;             // just a reference pointer (no need to free)
-  MATRIX *m_L;        // just a reference pointer (no need to free)
-  VOL_GEOM *dst = 0;  // just a reference pointer (no need to free)
-  VOL_GEOM *src = 0;  // just a reference pointer (no need to free)
-  int row;
 
   if (wsize <= 0) {
     wsize = nint(DEFAULT_WINDOW_SIZE / mri->ysize);
@@ -435,6 +427,14 @@ int MRInormInit(
   // look for talairach.xfm
 #if !defined(BEVIN_EXCLUDE_MINC)
   if (mri->inverse_linear_transform) {
+    double x0, y0, z0;
+    LTA *lta = 0;       // need to be freeed
+    LT *lt;             // just a reference pointer (no need to free)
+    MATRIX *m_L;        // just a reference pointer (no need to free)
+    VOL_GEOM *dst = 0;  // just a reference pointer (no need to free)
+    VOL_GEOM *src = 0;  // just a reference pointer (no need to free)
+    int row;
+
     // create lta
     lta = LTAalloc(1, NULL);
     // this will allocate lta->xforms[0].m_L = MatrixIdentity(4, NULL)


### PR DESCRIPTION
… new bevin_exclude_minc code which would break the build (unless --disable-Wall and --disable-Werror were used); slowed make fastbuild a bit, as it was creating too many make threads too quickly for an eight core machine to keep-up