### PR TITLE
T2/FLAIR edits fix

### DIFF
--- a/scripts/recon-all
+++ b/scripts/recon-all
@@ -4313,18 +4313,18 @@ if($DoT2pial || $DoFLAIRpial) then
     if($RunIt) $fs_time $normcmd |& tee -a $LF
     if($status) goto error_exit;
     
-    # then mask the T2/FLAIR 
-    # note: post-normalized file remains for debug, with .norm in name
-    # this creates ${t2flair}.mgz
-    set maskcmd = (mri_mask \
-        $mdir/${t2flair}.norm.mgz \
-        $mdir/brain.finalsurfs.mgz \
-        $mdir/${t2flair}.mgz)
-    echo "\n $maskcmd \n"|& tee -a $LF |& tee -a $CF
-    if($RunIt) $fs_time $maskcmd |& tee -a $LF
-    if($status) goto error_exit;
-    
   endif
+
+  # then mask the T2/FLAIR 
+  # note: post-normalized file remains for debug, with .norm in name
+  # this creates ${t2flair}.mgz
+  set maskcmd = (mri_mask \
+  $mdir/${t2flair}.norm.mgz \
+  $mdir/brain.finalsurfs.mgz \
+  $mdir/${t2flair}.mgz)
+  echo "\n $maskcmd \n"|& tee -a $LF |& tee -a $CF
+  if($RunIt) $fs_time $maskcmd |& tee -a $LF
+  if($status) goto error_exit;
 
   set CMDFS = () # see earlier notes on -parallel implementation
   foreach hemi ($hemilist)


### PR DESCRIPTION
New edits to the brainmask weren't getting applied to the `T2.mgz` if the T2 volume already exists