### PR TITLE
 !a == b  is not the same as  a != b

### DIFF
--- a/mri_robust_register/RegRobust.cpp
+++ b/mri_robust_register/RegRobust.cpp
@@ -82,7 +82,7 @@ void RegRobust::findSatMultiRes(const vnl_matrix<double> &mi, double scaleinit)
 
   // allow 2d case (depth == 1)
   if (gpS[0]->width < 16 || gpS[0]->height < 16
-      || (gpS[0]->depth < 16 && !gpS[0]->depth == 1))
+      || (gpS[0]->depth < 16 && gpS[0]->depth != 1))
   {
     ErrorExit(ERROR_BADFILE, "Input images must be larger than 16^3.\n");
   }


### PR DESCRIPTION
I strongly suspect this is a typo that has not been detected by testing, since the new code 

#include <stdio.h>
int main() {
    int a = 4;
    printf("a %d\n!a == 1 %s \n a != 1 %s\n",
        a,
        (!a == 1) ? "true" : "false",
        ( a != 1) ? "true" : "false"
	);
    return 0;
}
a 4
!a == 1 false 
 a != 1 true
