### PR TITLE
Compare object compatibility using class names for MAC support

### DIFF
--- a/GEMS2/Matlab/kvlChangeK.h
+++ b/GEMS2/Matlab/kvlChangeK.h
@@ -40,7 +40,8 @@ public:
     // Retrieve input arguments
     const int meshHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMesh ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "Not an atlas mesh object" );
       }

--- a/GEMS2/Matlab/kvlEvaluateMeshPosition.h
+++ b/GEMS2/Matlab/kvlEvaluateMeshPosition.h
@@ -64,7 +64,8 @@ public:
     // Retrieve mesh
     const int meshHandle = *( static_cast< int* >( mxGetData( prhs[ 1 ] ) ) );
     object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMesh ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "mesh doesn't refer to the correct ITK object type" );
       }

--- a/GEMS2/Matlab/kvlEvaluateMeshPositionWithEntropy.h
+++ b/GEMS2/Matlab/kvlEvaluateMeshPositionWithEntropy.h
@@ -41,7 +41,8 @@ public:
     // Retrieve input mesh
     const int meshHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMesh ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "mesh doesn't refer to the correct ITK object type" );
       }
@@ -52,7 +53,8 @@ public:
     typedef ConditionalGaussianEntropyCostAndGradientCalculator::ImageType  ImageType;
     const int imageHandle = *( static_cast< int* >( mxGetData( prhs[ 1 ] ) ) );
     object = kvl::MatlabObjectArray::GetInstance()->GetObject( imageHandle );
-    if ( typeid( *(object) ) != typeid( ImageType ) )
+    // if ( typeid( *(object) ) != typeid( ImageType ) )
+    if ( strcmp(typeid( *object ).name(), typeid( ImageType ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "image doesn't refer to the correct ITK object type" );
       }

--- a/GEMS2/Matlab/kvlGetAlphasInMeshNodes.h
+++ b/GEMS2/Matlab/kvlGetAlphasInMeshNodes.h
@@ -40,7 +40,8 @@ public:
     // Retrieve input mesh
     const int meshHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMesh ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "mesh doesn't refer to the correct ITK object type" );
       }

--- a/GEMS2/Matlab/kvlGetAverageAtlasMeshPositionCostAndGradientCalculator.h
+++ b/GEMS2/Matlab/kvlGetAverageAtlasMeshPositionCostAndGradientCalculator.h
@@ -43,7 +43,8 @@ public:
     // Retrieve mesh collection
     const int meshCollectionHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshCollectionHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMeshCollection ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMeshCollection ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMeshCollection ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "Not an atlas mesh collection object" );
       }
@@ -63,7 +64,8 @@ public:
     typedef CroppedImageReader::TransformType  TransformType;
     const int transformHandle = *( static_cast< int* >( mxGetData( prhs[ 3 ] ) ) );
     object = kvl::MatlabObjectArray::GetInstance()->GetObject( transformHandle );
-    if ( typeid( *object ) != typeid( TransformType ) )
+    // if ( typeid( *object ) != typeid( TransformType ) )
+    if ( strcmp(typeid( *object ).name(), typeid( TransformType ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "transform doesn't refer to the correct ITK object type" );
       }

--- a/GEMS2/Matlab/kvlGetCostAndGradientCalculator.h
+++ b/GEMS2/Matlab/kvlGetCostAndGradientCalculator.h
@@ -68,7 +68,8 @@ public:
        const int handle = *(imagesHandle);
        std::cout << "Image: " << handle << std::endl;
        itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( handle );
-       if ( typeid( *(object) ) != typeid( ImageType ) )
+       // if ( typeid( *(object) ) != typeid( ImageType ) )
+       if ( strcmp(typeid( *object ).name(), typeid( ImageType ).name()) )  // Eugenio: MAC compatibility
          {
          mexErrMsgTxt( "image doesn't refer to the correct ITK object type" );
          }
@@ -91,7 +92,8 @@ public:
         
       const int transformHandle = *( static_cast< int* >( mxGetData( prhs[ 3 ] ) ) );
       itk::Object::ConstPointer  object = kvl::MatlabObjectArray::GetInstance()->GetObject( transformHandle );
-      if ( typeid( *object ) != typeid( TransformType ) )
+      // if ( typeid( *object ) != typeid( TransformType ) )
+      if ( strcmp(typeid( *object ).name(), typeid( TransformType ).name()) )  // Eugenio: MAC compatibility
         {
         mexErrMsgTxt( "transform doesn't refer to the correct ITK object type" );
         }

--- a/GEMS2/Matlab/kvlGetLevenbergMarquardtOptimizer.h
+++ b/GEMS2/Matlab/kvlGetLevenbergMarquardtOptimizer.h
@@ -42,7 +42,8 @@ public:
     // Retrieve input mesh
     const int meshHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMesh ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "mesh doesn't refer to the correct ITK object type" );
       }
@@ -75,7 +76,8 @@ public:
 	 const int handle = *(imagesHandle);
 	 std::cout<<"Image: "<<handle<<std::endl;
 	 itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( handle );
-	 if ( typeid(*(object)  ) != typeid( ImageType ) )
+	 // if ( typeid(*(object)  ) != typeid( ImageType ) )
+	 if ( strcmp(typeid( *object ).name(), typeid( ImageType ).name()) )  // Eugenio: MAC compatibility
 	   {
 	     mexErrMsgTxt( "image doesn't refer to the correct ITK object type" );
 	   }
@@ -90,7 +92,8 @@ public:
     typedef CroppedImageReader::TransformType  TransformType;
     const int transformHandle = *( static_cast< int* >( mxGetData( prhs[ 2 ] ) ) );
     object = kvl::MatlabObjectArray::GetInstance()->GetObject( transformHandle );
-    if ( typeid( *object ) != typeid( TransformType ) )
+    // if ( typeid( *object ) != typeid( TransformType ) )
+    if ( strcmp(typeid( *object ).name(), typeid( TransformType ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "transform doesn't refer to the correct ITK object type" );
       }

--- a/GEMS2/Matlab/kvlGetMesh.h
+++ b/GEMS2/Matlab/kvlGetMesh.h
@@ -38,7 +38,8 @@ public:
     // Retrieve input arguments
     const int meshCollectionHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshCollectionHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMeshCollection ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMeshCollection ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMeshCollection ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "Not an atlas mesh collection object" );
       }

--- a/GEMS2/Matlab/kvlGetMeshNodePositions.h
+++ b/GEMS2/Matlab/kvlGetMeshNodePositions.h
@@ -40,7 +40,8 @@ public:
     // Retrieve input mesh
     const int meshHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMesh ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "mesh doesn't refer to the correct ITK object type" );
       }

--- a/GEMS2/Matlab/kvlGetTransformMatrix.h
+++ b/GEMS2/Matlab/kvlGetTransformMatrix.h
@@ -44,7 +44,8 @@ public:
     typedef itk::AffineTransform< double, 3 >  TransformType; //double here!
     const int transformHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( transformHandle );
-    if ( typeid( *object ) != typeid( TransformType ) )
+    // if ( typeid( *object ) != typeid( TransformType ) )
+    if ( strcmp(typeid( *object ).name(), typeid(  TransformType ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "transform doesn't refer to the correct ITK object type" );
       }

--- a/GEMS2/Matlab/kvlImageConverter.h
+++ b/GEMS2/Matlab/kvlImageConverter.h
@@ -69,7 +69,8 @@ public:
   static mxArray*  Convert( const itk::Object*  itkObject )
     {
     // Check if we can handle this object
-    if ( typeid( *itkObject ) != typeid( ImageType ) )
+    // if ( typeid( *itkObject ) != typeid( ImageType ) )
+     if ( strcmp(typeid( *itkObject ).name(), typeid( ImageType ).name()) )  // Eugenio: MAC compatibility
       {
       return 0;
       }

--- a/GEMS2/Matlab/kvlRasterizeAtlasMesh.h
+++ b/GEMS2/Matlab/kvlRasterizeAtlasMesh.h
@@ -49,7 +49,8 @@ public:
     // Retrieve input arguments
     const int meshHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMesh ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "mesh doesn't refer to the correct ITK object type" );
       }

--- a/GEMS2/Matlab/kvlReadMesh.h
+++ b/GEMS2/Matlab/kvlReadMesh.h
@@ -57,7 +57,8 @@ public:
       const int transformHandle = *( static_cast< int* >( mxGetData( prhs[ 1 ] ) ) );
       itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( transformHandle );
  
-      if ( typeid( *object ) != typeid( TransformType ) )
+      // if ( typeid( *object ) != typeid( TransformType ) )
+    if ( strcmp(typeid( *object ).name(), typeid( TransformType ).name()) )  // Eugenio: MAC compatibility
         {
         mexErrMsgTxt( "transform doesn't refer to the correct ITK object type" );
         }

--- a/GEMS2/Matlab/kvlReadMeshCollection.h
+++ b/GEMS2/Matlab/kvlReadMeshCollection.h
@@ -56,7 +56,8 @@ public:
       const int transformHandle = *( static_cast< int* >( mxGetData( prhs[ 1 ] ) ) );
       itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( transformHandle );
  
-      if ( typeid( *object ) != typeid( TransformType ) )
+      // if ( typeid( *object ) != typeid( TransformType ) )
+      if ( strcmp(typeid( *object ).name(), typeid( TransformType ).name()) )  // Eugenio: MAC compatibility
         {
         mexErrMsgTxt( "transform doesn't refer to the correct ITK object type" );
         }

--- a/GEMS2/Matlab/kvlScaleMesh.h
+++ b/GEMS2/Matlab/kvlScaleMesh.h
@@ -38,7 +38,8 @@ public:
     // Retrieve input arguments
     const int meshHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMesh ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "Not an atlas mesh object" );
       }

--- a/GEMS2/Matlab/kvlScaleMeshCollection.h
+++ b/GEMS2/Matlab/kvlScaleMeshCollection.h
@@ -38,7 +38,8 @@ public:
     // Retrieve input arguments
     const int meshCollectionHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshCollectionHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMeshCollection ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMeshCollection ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMeshCollection ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "Not an atlas mesh collection object" );
       }

--- a/GEMS2/Matlab/kvlSetAlphasInMeshNodes.h
+++ b/GEMS2/Matlab/kvlSetAlphasInMeshNodes.h
@@ -41,7 +41,8 @@ public:
     // Retrieve input mesh
     const int meshHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMesh ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "mesh doesn't refer to the correct ITK object type" );
       }

--- a/GEMS2/Matlab/kvlSetKOfMeshCollection.h
+++ b/GEMS2/Matlab/kvlSetKOfMeshCollection.h
@@ -40,7 +40,8 @@ public:
     // Retrieve mesh collection
     const int meshCollectionHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshCollectionHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMeshCollection ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMeshCollection ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMeshCollection ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "Not an atlas mesh collection object" );
       }

--- a/GEMS2/Matlab/kvlSetMeshCollectionPositions.h
+++ b/GEMS2/Matlab/kvlSetMeshCollectionPositions.h
@@ -41,7 +41,8 @@ public:
     // Retrieve mesh collection
     const int meshCollectionHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshCollectionHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMeshCollection ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMeshCollection ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMeshCollection ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "Not an atlas mesh collection object" );
       }

--- a/GEMS2/Matlab/kvlSetMeshNodePositions.h
+++ b/GEMS2/Matlab/kvlSetMeshNodePositions.h
@@ -41,7 +41,8 @@ public:
     // Retrieve input mesh
     const int meshHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMesh ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "mesh doesn't refer to the correct ITK object type" );
       }

--- a/GEMS2/Matlab/kvlSmoothMesh.h
+++ b/GEMS2/Matlab/kvlSmoothMesh.h
@@ -39,7 +39,8 @@ public:
     // Retrieve input arguments
     const int meshHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMesh ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "Not an atlas mesh object" );
       }

--- a/GEMS2/Matlab/kvlSmoothMeshCollection.h
+++ b/GEMS2/Matlab/kvlSmoothMeshCollection.h
@@ -39,7 +39,8 @@ public:
     // Retrieve input arguments
     const int meshCollectionHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshCollectionHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMeshCollection ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMeshCollection ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMeshCollection ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "Not an atlas mesh collection object" );
       }

--- a/GEMS2/Matlab/kvlSmoothMeshPerClass.h
+++ b/GEMS2/Matlab/kvlSmoothMeshPerClass.h
@@ -39,7 +39,8 @@ public:
     // Retrieve input arguments
     const int meshHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMesh ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMesh ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "Not an atlas mesh object" );
       }

--- a/GEMS2/Matlab/kvlTransformMeshCollection.h
+++ b/GEMS2/Matlab/kvlTransformMeshCollection.h
@@ -41,7 +41,8 @@ public:
     // Retrieve the mesh collection
     const int meshCollectionHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshCollectionHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMeshCollection ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMeshCollection ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMeshCollection ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "Not an atlas mesh collection object" );
       }
@@ -54,7 +55,8 @@ public:
     typedef CroppedImageReader::TransformType  TransformType;
     const int transformHandle = *( static_cast< int* >( mxGetData( prhs[ 1 ] ) ) );
     object = kvl::MatlabObjectArray::GetInstance()->GetObject( transformHandle );
-    if ( typeid( *object ) != typeid( TransformType ) )
+    // if ( typeid( *object ) != typeid( TransformType ) )
+    if ( strcmp(typeid( *object ).name(), typeid( TransformType ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "transform doesn't refer to the correct ITK object type" );
       }

--- a/GEMS2/Matlab/kvlWriteImage.h
+++ b/GEMS2/Matlab/kvlWriteImage.h
@@ -46,7 +46,8 @@ public:
     // Retrieve the image
     itk::Object::Pointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( imageHandle );
     typedef itk::Image< float, 3 >   FloatImageType;
-    if ( typeid( *object ) != typeid( FloatImageType ) )
+    // if ( typeid( *object ) != typeid( FloatImageType ) )
+    if ( strcmp(typeid( *object ).name(), typeid( FloatImageType ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "image doesn't refer to the correct ITK object type" );
       }
@@ -65,7 +66,8 @@ public:
       typedef CroppedImageReader::TransformType  TransformType;
       const int transformHandle = *( static_cast< int* >( mxGetData( prhs[ 2 ] ) ) );
       object = kvl::MatlabObjectArray::GetInstance()->GetObject( transformHandle );
-      if ( typeid( *object ) != typeid( TransformType ) )
+      // if ( typeid( *object ) != typeid( TransformType ) )
+      if ( strcmp(typeid( *object ).name(), typeid( TransformType ).name()) )  // Eugenio: MAC compatibility
         {
         mexErrMsgTxt( "transform doesn't refer to the correct ITK object type" );
         }

--- a/GEMS2/Matlab/kvlWriteMeshCollection.h
+++ b/GEMS2/Matlab/kvlWriteMeshCollection.h
@@ -38,7 +38,8 @@ public:
     // Retrieve mesh collection
     const int meshCollectionHandle = *( static_cast< int* >( mxGetData( prhs[ 0 ] ) ) );
     itk::Object::ConstPointer object = kvl::MatlabObjectArray::GetInstance()->GetObject( meshCollectionHandle );
-    if ( typeid( *object ) != typeid( kvl::AtlasMeshCollection ) )
+    // if ( typeid( *object ) != typeid( kvl::AtlasMeshCollection ) )
+    if ( strcmp(typeid( *object ).name(), typeid( kvl::AtlasMeshCollection ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "Not an atlas mesh collection object" );
       }

--- a/GEMS2/Matlab/kvlWriteRGBImage.h
+++ b/GEMS2/Matlab/kvlWriteRGBImage.h
@@ -51,7 +51,8 @@ public:
     typedef itk::Image< RGBAPixelType, 3 >   RGBAImageType;
     std::cout<<"Here! "<<std::endl;
     
-    if ( typeid( *object ) != typeid( RGBAImageType ) )
+    // if ( typeid( *object ) != typeid( RGBAImageType ) )
+    if ( strcmp(typeid( *object ).name(), typeid( RGBAImageType ).name()) )  // Eugenio: MAC compatibility
       {
       mexErrMsgTxt( "image doesn't refer to the correct ITK object type" );
       }
@@ -76,7 +77,8 @@ public:
       typedef CroppedImageReader::TransformType  TransformType;
       const int transformHandle = *( static_cast< int* >( mxGetData( prhs[ 2 ] ) ) );
       object = kvl::MatlabObjectArray::GetInstance()->GetObject( transformHandle );
-      if ( typeid( *object ) != typeid( TransformType ) )
+      // if ( typeid( *object ) != typeid( TransformType ) )
+      if ( strcmp(typeid( *object ).name(), typeid( TransformType ).name()) )  // Eugenio: MAC compatibility
         {
         mexErrMsgTxt( "transform doesn't refer to the correct ITK object type" );
         }


### PR DESCRIPTION
I've gone through all *.h files in GEMS2/Matlab, and replaced comparisons like this:
`if (typeid(*object)!=typeid( WHATEVER_TYPE))`
by
`if (strcmp(typeid(*object).name(),typeid( WHATEVER_TYPE).name()))`

The reason: the former dies when compiled on MAC (I've got no idea why)