### PR TITLE
Adds --no-relabel to the call to mri_aparc2aseg when calling recon-al…

### DIFF
--- a/scripts/make_average_subject
+++ b/scripts/make_average_subject
@@ -107,10 +107,14 @@ if($DoVolumes) then
 endif
 
 if($DoSurfaces && $DoVolumes) then
+  set xopts = /tmp/make_average_subject.$$.xopts
   set cmd = (recon-all -s $average_subject -cortribbon -aparc2aseg)
+  echo "mri_aparc2aseg --no-relabel" > $xopts
+  set cmd = ($cmd -expert $xopts -xopts-overwrite)
   echo $cmd
   $cmd
   if($status) exit 1;
+  rm $xopts
 endif
 
 date | tee -a $LF


### PR DESCRIPTION
…l. This is a patch that is needed to make v6 make_average_subject work