### PR TITLE
Fixed hostname check in long_submit_jobs.

### DIFF
--- a/scripts/long_submit_jobs
+++ b/scripts/long_submit_jobs
@@ -78,9 +78,9 @@ def submit(fname,nodes,mem,queue):
     hostname = os.getenv('HOSTNAME')
         
     # assemble the command (maybe modify to your needs):
-    if hostname == "launchpad":
+    if hostname.split('.')[0] == "launchpad":
         pbcmd = launchpad % {'command':fname,'username':user,'nodes':nodes,'mem':mem}
-    elif hostname == "seychelles":
+    elif hostname.split('.')[0] == "seychelles":
         pbcmd = seychelles % {'command':fname,'username':user}
     else:
         pbcmd = mycluster % {'command':fname,'username':user}


### PR DESCRIPTION
Apparently the $HOSTNAME environment variable on launchpad changed from 'launchpad' to 'launchpad.nmr.mgh.harvard.edu', which stopped this script from working.