### PR TITLE
remove -fno-lto

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1,3 +1,4 @@
+
 ########################################################################
 #
 #                          -*- Autoconf -*-
@@ -3138,14 +3139,6 @@ LDFLAGS="$LDFLAGS $OS_LDFLAGS"
 # link map
 #####################################################
 LDFLAGS="$LDFLAGS -Wl,-Map,ld_map.txt -Wl,--no-demangle"
-
-#####################################################
-# for now, turn off link time optimization
-# at least until we get a clean build
-#####################################################
-CFLAGS="$CFLAGS -fno-lto"
-CPPFLAGS="$CPPFLAGS -fno-lto"
-
 
 #####################################################
 # Checks for libraries.


### PR DESCRIPTION
With this in place, AC_CHECK_LIB fails on centos6 gcc4
It was only necessary during some debugging I was doing

I don't know how it got in passed the testing
