### PR TITLE
mri_ca_register is disabling all threading, but I don't know why... so I am turning it on again to see!

### DIFF
--- a/mri_ca_register/mri_ca_register.c
+++ b/mri_ca_register/mri_ca_register.c
@@ -1531,30 +1531,18 @@ main(int argc, char *argv[])
     }
     if (parms.noneg < 2)
     {
-      int nthreads ;
-#if 1
       parms.tol /= 5 ;  // reset parameters to previous level
       parms.l_smoothness /= 20 ;
-#ifdef HAVE_OPENMP
-      if (getenv("FS_FAST_CAREG") == NULL)
-	omp_set_num_threads(1);
-#endif 
+
       GCAMregister(gcam, mri_inputs, &parms) ;
-#ifdef HAVE_OPENMP
-      if (getenv("FS_FAST_CAREG") == NULL)
-      {
-	nthreads = omp_get_max_threads();
-	omp_set_num_threads(nthreads);
-      }
-#endif 
-#endif
+
       printf("********************* ALLOWING NEGATIVE NODES IN DEFORMATION"
              "********************************\n") ;
       parms.noneg = 0 ;
       parms.tol = 0.25 ;
       parms.orig_dt = 1e-6 ;
       parms.navgs = 256 ;
-//      omp_set_num_threads(1);  this doesn't fix it
+
       GCAMregister(gcam, mri_inputs, &parms) ;
     }
   }


### PR DESCRIPTION
mri_ca_register is a huge fraction of recon-all's time, but a coding error in this file left threading turned off even beyond when it tried to turn it back on.

The two tests for this test passes without this, and other users of GCAM_register don't have a problem, so I am turning threading on here to run through the whole test system to see if any failures appear.

If not, then maybe we should leave this threading on.