### PR TITLE
Bf configure.in avx2 fix

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -578,19 +578,22 @@ AC_ARG_ENABLE(Werror,
 # so that escalating warnings to errors (which stops the build) is still
 # possible.
 if test "x$CC" = "xicc"; then
-  WERROR="$WERROR -diag-disable 1268"
+  WERROR="$WERROR -diag-disable 1268 -diag-disable 279"
   # warning #1268: support for exported templates is disabled
+  # error #279: controlling expression is constant
+  #   assert(!"Cannot invert 2x2 matrix with zero determinant");
 fi
 # There are approximately 1000 of this 'error', most caused by
 # the presence of code intending for debugging, so don't report it
 WERROR="$WERROR -Wno-unused-but-set-variable"
-# There are approximately 600 of this 'error', most caused by
-# the presence of code ignoring status from write, fgets and similar functions
-WERROR="$WERROR -Wno-unused-result"
-# There are approximately 40 of this 'error', but in external packages
-# header files, hence not possible to fix, and harmless.
-WERROR="$WERROR -Wno-unused-local-typedefs"
-
+if (test "${CC}" = "gcc"); then
+  # There are approximately 600 of this 'error', most caused by
+  # the presence of code ignoring status from write, fgets and similar functions
+  WERROR="$WERROR -Wno-unused-result"
+  # There are approximately 40 of this 'error', but in external packages
+  # header files, hence not possible to fix, and harmless.
+  WERROR="$WERROR -Wno-unused-local-typedefs"
+fi
 # to strip unused code when using Linux gcc.
 # but not on cent4 because for some reason it fails
 # on certain binaries.
@@ -1124,6 +1127,7 @@ AC_SUBST(CPUTYPE)
 case "$CPUTYPE" in
   intel_haswell)
      #CPUFLAGS="-march=core-avx2 -m64"
+     ac_have_avx2=yes
      CPUFLAGS="-m64"
      ;;
   pentium3)
@@ -3626,13 +3630,18 @@ AC_SUBST(LIBS_TCL_OPENGL)
 # this is done here because if added earlier -ipo breaks the OpenGL check
 if test "x$CC" = "xicc"; then
   AC_MSG_NOTICE(Setting Intel Compiler optimizations...)
-  CPPFLAGS="$CPPFLAGS -ip -axCORE-AVX2"
+  CPPFLAGS="$CPPFLAGS -ip"
+  if test "x$ac_have_avx2" = "xyes"; then
+    CPPFLAGS="$CPPFLAGS -axCORE-AVX2"
+  fi
   CPPFLAGS="$CPPFLAGS -parallel"
   CPPFLAGS="$CPPFLAGS -qopt-report=5" # -guide-par
   LDFLAGS="$LDFLAGS -ip"
 fi
 if test "x$F77" = "xifort"; then
-  FFLAGS="$FFLAGS -xCORE-AVX2"
+  if test "x$ac_have_avx2" = "xyes"; then
+    FFLAGS="$FFLAGS -xCORE-AVX2"
+  fi
 fi
 
 ###########################################################


### PR DESCRIPTION
Trying to use icc on a sandybridge system revealed a bug in configure.in 