### PR TITLE
re-added mri_segcentroids

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -3937,6 +3937,7 @@ AC_OUTPUT([Makefile
            mri_rigid_register/Makefile
            mri_robust_register/Makefile
            mri_seg_diff/Makefile
+           mri_segcentroids/Makefile
            mri_seghead/Makefile
            mri_segment/Makefile
            mri_segment_tumor/Makefile


### PR DESCRIPTION
For some reason this got removed from `configure.in`