### PR TITLE
Fix ROMP-caused build problems on centos 6

### DIFF
--- a/include/romp_support.h
+++ b/include/romp_support.h
@@ -39,11 +39,6 @@ typedef enum ROMP_level {
     } ROMP_level;
 extern ROMP_level romp_level;
 
-#define if_ROMP(LEVEL) \
-    if (ROMP_pf_stack.staticInfo && \
-        (ROMP_if_parallel(ROMP_level_##LEVEL,&ROMP_pf_static))) \
-    // end of macro
-
 // Surround a parallel for
 
 #define ROMP_maxWatchedThreadNum 4
@@ -68,16 +63,6 @@ typedef struct ROMP_pf_stack_struct  {
 
 #define ROMP_main ROMP_main_started(__FILE__, __LINE__);
     
-#define ROMP_PF_begin \
-    { \
-    static ROMP_pf_static_struct ROMP_pf_static = { 0L, __FILE__, __LINE__ }; \
-    ROMP_pf_stack_struct  ROMP_pf_stack;  \
-    ROMP_pf_begin(&ROMP_pf_static, &ROMP_pf_stack);
-
-#define ROMP_PF_end \
-    ROMP_pf_end(&ROMP_pf_stack); \
-    }
-
 void ROMP_main_started(const char* file, int line);
 
 void ROMP_pf_begin(
@@ -99,6 +84,14 @@ typedef struct ROMP_pflb_stack_struct {
 
 #if 1
 
+#define if_ROMP(LEVEL)
+
+#define ROMP_PF_begin \
+    {
+
+#define ROMP_PF_end \
+    }
+
 #define ROMP_PFLB_begin
 #define ROMP_PFLB_end
 #define ROMP_PFLB_continue \
@@ -107,6 +100,21 @@ typedef struct ROMP_pflb_stack_struct {
     ROMP_PFLB_continue
     
 #else
+
+#define if_ROMP(LEVEL) \
+    if (ROMP_pf_stack.staticInfo && \
+        (ROMP_if_parallel(ROMP_level_##LEVEL,&ROMP_pf_static))) \
+    // end of macro
+
+#define ROMP_PF_begin \
+    { \
+    static ROMP_pf_static_struct ROMP_pf_static = { 0L, __FILE__, __LINE__ }; \
+    ROMP_pf_stack_struct  ROMP_pf_stack;  \
+    ROMP_pf_begin(&ROMP_pf_static, &ROMP_pf_stack);
+
+#define ROMP_PF_end \
+    ROMP_pf_end(&ROMP_pf_stack); \
+    }
 
 #define ROMP_PFLB_begin \
     /* ROMP_pflb_stack_struct  ROMP_pflb_stack;  \

--- a/mris_watershed/mris_watershed.c
+++ b/mris_watershed/mris_watershed.c
@@ -367,8 +367,8 @@ MRISfindMostSimilarBasins(MRI_SURFACE *mris, MRI *mri, int *pb2)
     memset(avg_grad, 0, nbasins*sizeof(*avg_grad)) ;
     max_basin = 0 ;
 // reductions for min and max aren't available in earlier openmp
-#if defined(HAVE_OPENMP) && GCC_VERSION > 40408
     ROMP_PF_begin
+#if defined(HAVE_OPENMP) && GCC_VERSION > 40408
     #pragma omp parallel for if_ROMP(experimental) reduction(max:max_basin)
 #endif
     for (vno = 0 ;  vno < mris->nvertices ; vno++)

--- a/utils/mri.c
+++ b/utils/mri.c
@@ -4382,8 +4382,8 @@ MRI *MRIbinarizeNoThreshold(MRI *mri_src, MRI *mri_dst)
   depth = mri_src->depth;
 
   for (f = 0; f < mri_src->nframes; f++) {
-#ifdef HAVE_OPENMP
     ROMP_PF_begin
+#ifdef HAVE_OPENMP
     #pragma omp parallel for if_ROMP(experimental)
 #endif
     for (z = 0; z < depth; z++) {
@@ -4427,8 +4427,8 @@ MRI *MRIbinarize(MRI *mri_src, MRI *mri_dst, float threshold, float low_val, flo
   depth = mri_src->depth;
 
   for (f = 0; f < mri_src->nframes; f++) {
-#ifdef HAVE_OPENMP
     ROMP_PF_begin
+#ifdef HAVE_OPENMP
     #pragma omp parallel for if_ROMP(experimental)
 #endif
     for (z = 0; z < depth; z++) {
@@ -17220,8 +17220,8 @@ MRIsolveLaplaceEquation(MRI *mri_interior, MRI *mri_seg, int source_label, int t
   {
     max_change = 0.0 ;
     mri_tmp = MRIcopy(mri_laplace, mri_tmp) ;
-#if defined(HAVE_OPENMP) && GCC_VERSION > 40408
     ROMP_PF_begin
+#if defined(HAVE_OPENMP) && GCC_VERSION > 40408
     #pragma omp parallel for if_ROMP(experimental) reduction(max: max_change)
 #endif
     for (v = 0 ; v < vl->nvox  ; v++)


### PR DESCRIPTION
Change the ROMP definitions and move their uses so they are not sensitive to the compiler version being used, successful build now on Centos 6 with gcc 4.4.*