### PR TITLE
fix: OS X configure error

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -3173,7 +3173,10 @@ LDFLAGS="$LDFLAGS $OS_LDFLAGS"
 #####################################################
 # link map
 #####################################################
-LDFLAGS="$LDFLAGS -Wl,-Map,ld_map.txt -Wl,--no-demangle"
+# this produces errors on os x
+if test ! "$OS" = "Darwin"; then
+  LDFLAGS="$LDFLAGS -Wl,-Map,ld_map.txt -Wl,--no-demangle"
+fi
 
 #####################################################
 # Checks for libraries.


### PR DESCRIPTION
This fixes the `FATAL: netcdf lib not found` error on macs. For currently unknown reasons, `-Wl,-Map,ld_map.txt` prevents `AC_CHECK_LIB` from locating the mni libs.