### PR TITLE
Change AC_ARG_WITH macro for CUDA.  This allows for proper detection …

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -977,10 +977,10 @@ fi
 # Nvidia CUDA enabling
 ############################################################
 CUDA_DIR=""
-with_cuda=""
+#with_cuda=""
 AC_ARG_WITH([cuda],
    [  --with-cuda=PATH        prefix where cuda is installed [default=auto]],
-   [  with_cuda="${withval}"],[])
+   [  with_cuda="${withval}"],[with_cuda=""])
 
 if test -n "$with_cuda"; then
     CUDA_DIR="$with_cuda"


### PR DESCRIPTION
Combining behavior of with-cuda="" with the AC_ARG_WITH CUDA detection macro.  This allows CUDA utilities to properly build on my system.  It seems that having with-cuda="" on the previous line cannibalized the actual configure argument.  