### PR TITLE
Bf three more commands need -seed and need it to be set in recon-all etc.

### DIFF
--- a/mri_normalize/mri_normalize.c
+++ b/mri_normalize/mri_normalize.c
@@ -1203,6 +1203,13 @@ get_option(int argc, char *argv[])
             control_point_fname) ;
     printf( "only using file control points...\n") ;
   }
+  else if (!stricmp(option, "seed"))
+  {
+    setRandomSeed(atol(argv[2])) ;
+    printf("setting seed for random number genererator to %d\n",
+            atoi(argv[2])) ;
+    nargs = 1 ;
+  }
   else switch (toupper(*option))
     {
     case 'D':

--- a/mri_normalize/mri_normalize.help.xml
+++ b/mri_normalize/mri_normalize.help.xml
@@ -91,6 +91,8 @@
       <explanation>for reading</explanation>
       <argument>-surface &lt;surface&gt; &lt;xform&gt;</argument>
       <explanation>normalize based on the skelton of the interior of the transformed surface</explanation>
+      <argument>-seed N</argument>
+      <explanation>set random number generator to seed N</explanation>
       <argument>-u or -h</argument>
       <explanation>print usage</explanation>
  </optional-flagged>

--- a/mri_segstats/mri_segstats.c
+++ b/mri_segstats/mri_segstats.c
@@ -1451,6 +1451,11 @@ static int parse_commandline(int argc, char **argv)
     usage_exit();
   }
 
+  setRandomSeed(4321) ;
+    // It was previously using a different random sequence every time
+    // it was run, and did not have a --seed option to stop this
+    // and it appears in many scripts!
+
   nargc   = argc;
   pargv = argv;
   while (nargc > 0)

--- a/mri_segstats/mri_segstats.c
+++ b/mri_segstats/mri_segstats.c
@@ -1970,7 +1970,7 @@ static int parse_commandline(int argc, char **argv)
       GTMdefaultSegReplacmentList(&nReplace,&(SrcReplace[0]),&(TrgReplace[0]));
     else if(!strcasecmp(option, "--gtm-default-seg-merge-choroid")){
       GTMdefaultSegReplacmentList(&nReplace,&(SrcReplace[0]),&(TrgReplace[0]));
-      nReplace -= 2;       // Last two itmes are choroid.
+      nReplace -= 2;       // Last two items are choroid.
     }
     else if(!strcmp(option, "--replace-file")){
       if(nargc < 1) CMDargNErr(option,1);
@@ -1985,6 +1985,13 @@ static int parse_commandline(int argc, char **argv)
       nReplace++;
       nargsused = 2;
     } 
+    else if(!strcasecmp(option, "--seed")) {
+      if(nargc < 1) CMDargNErr(option,1);
+      setRandomSeed(atol(pargv[0])) ;
+      printf("setting seed for random number genererator to %d\n",
+            atoi(pargv[0])) ;
+      nargsused = 1;
+    }
     else
     {
       fprintf(stderr,"ERROR: Option %s unknown\n",option);

--- a/mri_segstats/mri_segstats.help.xml
+++ b/mri_segstats/mri_segstats.help.xml
@@ -183,6 +183,8 @@ For each segmentation, computes the average waveform across all the voxels in th
       </explanation>
       <argument>--sd SUBJECTS_DIR</argument>
       <explanation>Set SUBJECTS_DIR env var</explanation>
+      <argument>-seed N</argument>
+      <explanation>set random number generator to seed N</explanation>
     </optional-flagged>
   </arguments>
 	<example>mri_segstats --seg $SUBJECTS_DIR/bert/mri/aseg --ctab $FREESURFER_HOME/FreeSurferColorLUT.txt --excludeid 0 --sum bert.aseg.sum

--- a/mri_segstats/mri_segstats.help.xml
+++ b/mri_segstats/mri_segstats.help.xml
@@ -183,7 +183,7 @@ For each segmentation, computes the average waveform across all the voxels in th
       </explanation>
       <argument>--sd SUBJECTS_DIR</argument>
       <explanation>Set SUBJECTS_DIR env var</explanation>
-      <argument>-seed N</argument>
+      <argument>--seed N</argument>
       <explanation>set random number generator to seed N</explanation>
     </optional-flagged>
   </arguments>

--- a/mris_curvature/mris_curvature.c
+++ b/mris_curvature/mris_curvature.c
@@ -494,6 +494,13 @@ get_option(int argc, char *argv[])
     nargs = 1 ;
     fprintf(stderr, "using neighborhood size=%d\n", nbrs) ;
   }
+  else if (!stricmp(option, "seed"))
+  {
+    setRandomSeed(atol(argv[2])) ;
+    fprintf(stderr,"setting seed for random number generator to %d\n",
+            atoi(argv[2])) ;
+    nargs = 1 ;
+  }
   else switch (toupper(*option))
     {
     case 'N':

--- a/mris_curvature/mris_curvature.help.xml
+++ b/mris_curvature/mris_curvature.help.xml
@@ -47,6 +47,8 @@
       <explanation>perform &lt;avgs&gt; iterative averages of curvature measure before saving</explanation>
       <argument>-nbrs &lt;nbrs&gt;</argument>
       <explanation>set neighborhood size to nbrs </explanation>
+      <argument>-seed N</argument>
+      <explanation>set random number generator to seed N</explanation>
     </optional-flagged>
   </arguments>
   <outputs>

--- a/scripts/recon-all
+++ b/scripts/recon-all
@@ -4821,7 +4821,7 @@ if($DoSegStats) then
   $PWD |& tee -a $LF
   set xopts = `fsr-getxopts mri_segstats $XOptsFile $GlobXOptsFile`;
   set cmd = (mri_segstats)
-  if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
+  if ($NoRandomness) set cmd = ($cmd --seed $RngSeed)
   set cmd = ($cmd --seg mri/aseg.mgz --sum stats/aseg.stats)
   set cmd = ($cmd --pv mri/norm.mgz --empty)
   set cmd = ($cmd --brainmask mri/brainmask.mgz --brain-vol-from-seg)
@@ -4888,7 +4888,7 @@ if($DoWMParc) then
   # Do wm segstats while we're here
   set xopts = `fsr-getxopts mri_segstats $XOptsFile $GlobXOptsFile`;
   set cmd = (mri_segstats)
-  if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
+  if ($NoRandomness) set cmd = ($cmd --seed $RngSeed)
   set cmd = ($cmd --seg mri/wmparc.mgz --sum stats/wmparc.stats \
     --pv mri/norm.mgz --excludeid 0 \
     --brainmask mri/brainmask.mgz --in mri/norm.mgz --in-intensity-name norm \
@@ -4922,7 +4922,7 @@ if($DoAParcASegStats) then
   cd $subjdir > /dev/null
   set xopts = `fsr-getxopts mri_segstats $XOptsFile $GlobXOptsFile`;
   set cmd = (mri_segstats)
-  if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
+  if ($NoRandomness) set cmd = ($cmd --seed $RngSeed)
   set cmd = ($cmd --seg mri/aparc+aseg.mgz --sum stats/aparc+aseg.stats)
   set cmd = ($cmd --pv mri/norm.mgz )
   set cmd = ($cmd --excludeid 0 --ctab-default --empty)

--- a/scripts/recon-all
+++ b/scripts/recon-all
@@ -2026,6 +2026,7 @@ if($DoNormalization) then
       echo "Recompute intensity norm to create $longbaseid ctrl_vol.mgz" \
         |& tee -a $LF
       set cmd = (mri_normalize)
+      if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
       if($#Norm3dIters)  set cmd = ($cmd -n $Norm3dIters)
       if($#Norm1_b)      set cmd = ($cmd -b $Norm1_b)
       if($#Norm1_n)      set cmd = ($cmd -n $Norm1_n)
@@ -2047,7 +2048,9 @@ if($DoNormalization) then
       rm -f $longbasedir/mri/T1_tmp.mgz
     endif
     # use ctrl_vol.mgz from base for normalization:
-    set cmd = (mri_normalize \
+    set cmd = (mri_normalize)
+    if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
+    set cmd = ($cmd \
       -w $subjdir/mri/ctrl_vol.mgz $subjdir/mri/bias_vol.mgz \
       -l $longbasedir/mri/ctrl_vol.mgz $longbasedir/mri/bias_vol.mgz \
       $subjdir/mri/nu.mgz \
@@ -2080,6 +2083,7 @@ if($DoNormalization) then
     endif
     # for cross, base (and long if not useLongBaseCtrlVol) processing streams:
     set cmd = (mri_normalize -g $NormMaxGrad);
+    if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
     if($UseControlPoints) set cmd = ($cmd -f $ControlPointsFile)
     if($#Norm3dIters)     set cmd = ($cmd -n $Norm3dIters)
     if($#Norm1_b)         set cmd = ($cmd -b $Norm1_b)
@@ -2911,6 +2915,7 @@ if($DoNormalization2) then
   cd $subjdir/mri > /dev/null
   set xopts = `fsr-getxopts mri_normalize $XOptsFile $GlobXOptsFile`;
   set cmd = (mri_normalize);
+  if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
   if($UseControlPoints)   set cmd = ($cmd -f $ControlPointsFile)
   if($#Norm3dIters)       set cmd = ($cmd -n $Norm3dIters)
   if($#Norm2_b)           set cmd = ($cmd -b $Norm2_b)
@@ -3638,7 +3643,9 @@ if($DoCurvHK) then
     $PWD |& tee -a $LF
     # create curvature files ?h.white.H and ?h.white.K
     set xopts = `fsr-getxopts mris_curatvure $XOptsFile $GlobXOptsFile`;
-    set cmd = (mris_curvature -w $xopts $hemi.white.preaparc)
+    set cmd = (mris_curvature -w)
+    if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
+    set cmd = ($cmd $xopts $hemi.white.preaparc)
     echo "\n $cmd \n"|& tee -a $LF |& tee -a $CF
     if($DoParallel) then
       set CMDF = mris_curvature_white_${hemi}.cmd
@@ -3676,7 +3683,9 @@ if($DoCurvHK) then
 
     # create curvature files ?h.inflated.H and ?h.inflated.K
     set xopts = `fsr-getxopts mris_curatvure $XOptsFile $GlobXOptsFile`;
-    set cmd = (mris_curvature -thresh .999 -n -a 5 -w -distances 10 10)
+    set cmd = (mris_curvature )
+    if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
+    set cmd = ($cmd -thresh .999 -n -a 5 -w -distances 10 10)
     set cmd = ($cmd $xopts $hemi.inflated)
     echo "\n $cmd \n"|& tee -a $LF |& tee -a $CF
     if($DoParallel) then
@@ -4304,7 +4313,9 @@ if($DoT2pial || $DoFLAIRpial) then
     foreach hemi ($hemilist)
         set surfaces = ($surfaces -surface $sdir/$hemi.white identity.nofile)
     end
-    set normcmd = (mri_normalize \
+    set normcmd = (mri_normalize)
+    if ($NoRandomness) set normcmd = ($normcmd -seed $RngSeed)
+    set normcmd = ($normcmd \
         -sigma 0.5 -nonmax_suppress 0 -min_dist 1 \
         -aseg $mdir/aseg.presurf.mgz \
 	$surfaces  \
@@ -4809,7 +4820,9 @@ if($DoSegStats) then
   cd $subjdir > /dev/null
   $PWD |& tee -a $LF
   set xopts = `fsr-getxopts mri_segstats $XOptsFile $GlobXOptsFile`;
-  set cmd = (mri_segstats --seg mri/aseg.mgz --sum stats/aseg.stats)
+  set cmd = (mri_segstats)
+  if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
+  set cmd = ($cmd --seg mri/aseg.mgz --sum stats/aseg.stats)
   set cmd = ($cmd --pv mri/norm.mgz --empty)
   set cmd = ($cmd --brainmask mri/brainmask.mgz --brain-vol-from-seg)
   set cmd = ($cmd --excludeid 0 --excl-ctxgmwm)
@@ -4875,6 +4888,7 @@ if($DoWMParc) then
   # Do wm segstats while we're here
   set xopts = `fsr-getxopts mri_segstats $XOptsFile $GlobXOptsFile`;
   set cmd = (mri_segstats)
+  if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
   set cmd = ($cmd --seg mri/wmparc.mgz --sum stats/wmparc.stats \
     --pv mri/norm.mgz --excludeid 0 \
     --brainmask mri/brainmask.mgz --in mri/norm.mgz --in-intensity-name norm \
@@ -4908,6 +4922,7 @@ if($DoAParcASegStats) then
   cd $subjdir > /dev/null
   set xopts = `fsr-getxopts mri_segstats $XOptsFile $GlobXOptsFile`;
   set cmd = (mri_segstats)
+  if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
   set cmd = ($cmd --seg mri/aparc+aseg.mgz --sum stats/aparc+aseg.stats)
   set cmd = ($cmd --pv mri/norm.mgz )
   set cmd = ($cmd --excludeid 0 --ctab-default --empty)

--- a/scripts/recon-all.v6.hires
+++ b/scripts/recon-all.v6.hires
@@ -2039,6 +2039,7 @@ if($DoNormalization) then
       echo "Recompute intensity norm to create $longbaseid ctrl_vol.mgz" \
         |& tee -a $LF
       set cmd = (mri_normalize)
+      if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
       if($#Norm3dIters)  set cmd = ($cmd -n $Norm3dIters)
       if($#Norm1_b)      set cmd = ($cmd -b $Norm1_b)
       if($#Norm1_n)      set cmd = ($cmd -n $Norm1_n)
@@ -2060,7 +2061,9 @@ if($DoNormalization) then
       rm -f $longbasedir/mri/T1_tmp.mgz
     endif
     # use ctrl_vol.mgz from base for normalization:
-    set cmd = (mri_normalize \
+    set cmd = (mri_normalize)
+    if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
+    set cmd = ($cmd \
       -w $subjdir/mri/ctrl_vol.mgz $subjdir/mri/bias_vol.mgz \
       -l $longbasedir/mri/ctrl_vol.mgz $longbasedir/mri/bias_vol.mgz \
       $subjdir/mri/nu.mgz \
@@ -2093,6 +2096,7 @@ if($DoNormalization) then
     endif
     # for cross, base (and long if not useLongBaseCtrlVol) processing streams:
     set cmd = (mri_normalize -g $NormMaxGrad);
+    if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
     if($UseControlPoints) set cmd = ($cmd -f $ControlPointsFile)
     if($#Norm3dIters)     set cmd = ($cmd -n $Norm3dIters)
     if($#Norm1_b)         set cmd = ($cmd -b $Norm1_b)
@@ -2902,6 +2906,7 @@ if($DoNormalization2) then
   cd $subjdir/mri > /dev/null
   set xopts = `fsr-getxopts mri_normalize $XOptsFile`;
   set cmd = (mri_normalize);
+  if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
   if($UseControlPoints)   set cmd = ($cmd -f $ControlPointsFile)
   if($#Norm3dIters)       set cmd = ($cmd -n $Norm3dIters)
   if($#Norm2_b)           set cmd = ($cmd -b $Norm2_b)
@@ -3665,7 +3670,9 @@ if($DoCurvHK) then
     $PWD |& tee -a $LF
     # create curvature files ?h.white.H and ?h.white.K
     set xopts = `fsr-getxopts mris_curatvure $XOptsFile`;
-    set cmd = (mris_curvature -w $xopts $hemi.white.preaparc)
+    set cmd = (mris_curvature -w)
+    if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
+    set cmd = ($cmd $xopts $hemi.white.preaparc)
     echo "\n $cmd \n"|& tee -a $LF |& tee -a $CF
     if($DoParallel) then
       set CMDF = mris_curvature_white_${hemi}.cmd
@@ -3703,7 +3710,9 @@ if($DoCurvHK) then
 
     # create curvature files ?h.inflated.H and ?h.inflated.K
     set xopts = `fsr-getxopts mris_curatvure $XOptsFile`;
-    set cmd = (mris_curvature -thresh .999 -n -a 5 -w -distances 10 10)
+    set cmd = (mris_curvature)
+    if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
+    set cmd = ($cmd -thresh .999 -n -a 5 -w -distances 10 10)
     set cmd = ($cmd $xopts $hemi.inflated)
     echo "\n $cmd \n"|& tee -a $LF |& tee -a $CF
     if($DoParallel) then
@@ -4321,7 +4330,9 @@ if($DoT2pial || $DoFLAIRpial) then
       # this creates ${t2flair}.norm.mgz
       # MOD: removed -sigma 0.5 -nonmax_suppress 0 -min_dist 1 so now just
       # uses default parameters. But this does not seem to work very well, so if(0)
-      set normcmd = (mri_normalize \
+      set normcmd = (mri_normalize)
+      if ($NoRandomness) set normcmd = ($normcmd -seed $RngSeed)
+      set normcmd = ($normcmd \
           -aseg $mdir/aseg.presurf.mgz \
           -surface $sdir/rh.white identity.nofile \
           -surface $sdir/lh.white identity.nofile \
@@ -4338,7 +4349,9 @@ if($DoT2pial || $DoFLAIRpial) then
       # WM is defined as voxels in wm.mgz = 100
       set T2prenorm = $mdir/${t2flair}.prenorm.mgz \
       set T2meanfile = $mdir/${t2flair}.prenorm.mean.dat
-      set cmd = (mri_segstats --seg $mdir/wm.mgz --id 110 --i $T2prenorm --avgwf $T2meanfile)
+      set cmd = (mri_segstats)
+      if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
+      set cmd = ($cmd --seg $mdir/wm.mgz --id 110 --i $T2prenorm --avgwf $T2meanfile)
       echo $cmd | tee -a $LF |& tee -a $CF
       if($RunIt) $fs_time $cmd | tee -a $LF
       if($status) goto error_exit;
@@ -4837,7 +4850,9 @@ if($DoSegStats) then
   cd $subjdir > /dev/null
   $PWD |& tee -a $LF
   set xopts = `fsr-getxopts mri_segstats $XOptsFile`;
-  set cmd = (mri_segstats --seg mri/aseg.mgz --sum stats/aseg.stats)
+  set cmd = (mri_segstats)
+  if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
+  set cmd = ($cmd --seg mri/aseg.mgz --sum stats/aseg.stats)
   set cmd = ($cmd --pv mri/norm.mgz --empty)
   set cmd = ($cmd --brainmask mri/brainmask.mgz --brain-vol-from-seg)
   set cmd = ($cmd --excludeid 0 --excl-ctxgmwm)
@@ -4899,6 +4914,7 @@ if($DoWMParc) then
   echo $cmd > $touchdir/wmaparc.touch
   # Do wm segstats while we're here
   set cmd = (mri_segstats)
+  if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
   set cmd = ($cmd --seg mri/wmparc.mgz --sum stats/wmparc.stats \
     --pv mri/norm.mgz --excludeid 0 \
     --brainmask mri/brainmask.mgz --in mri/norm.mgz --in-intensity-name norm \
@@ -4930,6 +4946,7 @@ if($DoAParcASegStats) then
   cd $subjdir > /dev/null
   set xopts = `fsr-getxopts mri_segstats $XOptsFile`;
   set cmd = (mri_segstats)
+  if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
   set cmd = ($cmd --seg mri/aparc+aseg.mgz --sum stats/aparc+aseg.stats)
   set cmd = ($cmd --pv mri/norm.mgz )
   set cmd = ($cmd --excludeid 0 --ctab-default --empty)

--- a/scripts/recon-all.v6.hires
+++ b/scripts/recon-all.v6.hires
@@ -4350,7 +4350,7 @@ if($DoT2pial || $DoFLAIRpial) then
       set T2prenorm = $mdir/${t2flair}.prenorm.mgz \
       set T2meanfile = $mdir/${t2flair}.prenorm.mean.dat
       set cmd = (mri_segstats)
-      if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
+      if ($NoRandomness) set cmd = ($cmd --seed $RngSeed)
       set cmd = ($cmd --seg $mdir/wm.mgz --id 110 --i $T2prenorm --avgwf $T2meanfile)
       echo $cmd | tee -a $LF |& tee -a $CF
       if($RunIt) $fs_time $cmd | tee -a $LF
@@ -4851,7 +4851,7 @@ if($DoSegStats) then
   $PWD |& tee -a $LF
   set xopts = `fsr-getxopts mri_segstats $XOptsFile`;
   set cmd = (mri_segstats)
-  if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
+  if ($NoRandomness) set cmd = ($cmd --seed $RngSeed)
   set cmd = ($cmd --seg mri/aseg.mgz --sum stats/aseg.stats)
   set cmd = ($cmd --pv mri/norm.mgz --empty)
   set cmd = ($cmd --brainmask mri/brainmask.mgz --brain-vol-from-seg)
@@ -4914,7 +4914,7 @@ if($DoWMParc) then
   echo $cmd > $touchdir/wmaparc.touch
   # Do wm segstats while we're here
   set cmd = (mri_segstats)
-  if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
+  if ($NoRandomness) set cmd = ($cmd --seed $RngSeed)
   set cmd = ($cmd --seg mri/wmparc.mgz --sum stats/wmparc.stats \
     --pv mri/norm.mgz --excludeid 0 \
     --brainmask mri/brainmask.mgz --in mri/norm.mgz --in-intensity-name norm \
@@ -4946,7 +4946,7 @@ if($DoAParcASegStats) then
   cd $subjdir > /dev/null
   set xopts = `fsr-getxopts mri_segstats $XOptsFile`;
   set cmd = (mri_segstats)
-  if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
+  if ($NoRandomness) set cmd = ($cmd --seed $RngSeed)
   set cmd = ($cmd --seg mri/aparc+aseg.mgz --sum stats/aparc+aseg.stats)
   set cmd = ($cmd --pv mri/norm.mgz )
   set cmd = ($cmd --excludeid 0 --ctab-default --empty)

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -106,8 +106,9 @@ double randomNumber(double low, double hi)
 
   if (idum == 0L) /* change seed from run to run */
   {
-    static int laterTime = 0;
-    if (!laterTime) {
+    if (0) {
+      static int laterTime = 0;
+      if (!laterTime) {
         laterTime = 1; 
         char commBuffer[1024];
         FILE* commFile = fopen("/proc/self/comm", "r");
@@ -124,6 +125,7 @@ double randomNumber(double low, double hi)
         commBuffer[commSize] = 0;
         fprintf(stderr, "%s supposed to be reproducible but seed not set\n",
             commBuffer);
+      }
     }
     idum = -1L * (long)(abs((int)time(NULL)));
   }

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -105,8 +105,29 @@ double randomNumber(double low, double hi)
   }
 
   if (idum == 0L) /* change seed from run to run */
+  {
+    static int laterTime = 0;
+    if (!laterTime) {
+        laterTime = 1; 
+        char commBuffer[1024];
+        FILE* commFile = fopen("/proc/self/comm", "r");
+        int commSize = 0;
+        if (commFile) {
+            commSize = fread(commBuffer, 1, 1023, commFile);
+	    if (commSize > 0) commSize-=1; // drop the \n
+	    int i = 0;
+	    for (i = 0; i < commSize; i++) {
+	        if (commBuffer[i] == '/') commBuffer[i] = '@';
+	    }
+            fclose(commFile);
+        }
+        commBuffer[commSize] = 0;
+        fprintf(stderr, "%s supposed to be reproducible but seed not set\n",
+            commBuffer);
+    }
     idum = -1L * (long)(abs((int)time(NULL)));
-
+  }
+  
   range = hi - low;
   val = OpenRan1(&idum) * range + low;
   // printf("randomcall %3ld %12.10lf\n",nrgcalls,val);


### PR DESCRIPTION
The use of a time-based initial seed to the random number generator is a source of non-determinacy in the recon-all run.

There is a flag for adding -seed some-fixed-number to most of the commands, BUT...

 three utilities - mri_normalize, mris_curvature, and mri_segstats - did not even have a -seed option, and hence it was not being set and these were resulting in run-to-run differences.

This adds -seed or --seed to these three commands, uses it in recon-all and recon-all.v6.hires

Because mri-segstats is used in many scripts, and because it is a surprise that the stats could differ each time you asked for them, I have made that one always set a fixed seed rather than use the time.  You can change it to a different seed, but it won't default to a time-based one any more.