### PR TITLE
nf: added --enable-Werror-lax configure flag to ignore three known compiler errors

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -543,11 +543,11 @@ WERROR="-Werror"
 AC_ARG_ENABLE(Wall,
  [  --disable-Wall          do not add -Wall to compiler flags],
  [ WALL="" ],
- [ ])
+ [ WALL="-Wall"])
 AC_ARG_ENABLE(Werror,
  [  --disable-Werror        do not add -Werror to compiler flags],
  [ WERROR="" ],
- [ ])
+ [ WERROR="-Werror"])
 # temporary: so that --disable-Werror is no longer needed
 if test "$ac_have_gcc_48_or_higher" = "yes"; then
   [ WERROR="" ]

--- a/configure.in
+++ b/configure.in
@@ -548,6 +548,11 @@ AC_ARG_ENABLE(Werror,
  [  --disable-Werror        do not add -Werror to compiler flags],
  [ WERROR="" ],
  [ WERROR="-Werror"])
+AC_ARG_ENABLE(Werror-lax,
+ [  --enable-Werror-lax     add -Werror -Wno-unused-but-set-variable -Wno-unused-result -Wno-unused-local-typedefs to compiler flags],
+ [ WERROR="-Werror -Wno-unused-but-set-variable -Wno-unused-result -Wno-unused-local-typedefs" ],
+ [ ])
+
 # temporary: so that --disable-Werror is no longer needed
 if test "$ac_have_gcc_48_or_higher" = "yes"; then
   [ WERROR="" ]
@@ -575,20 +580,6 @@ WERROR="$WERROR -Wno-unused-but-set-variable"
   # header files, hence not possible to fix, and harmless.
   # WERROR="$WERROR -Wno-unused-local-typedefs"
 # fi
-
-# allow override, enabling warning and error stoppage
-AC_ARG_ENABLE(Wall,
- [  --enable-Wall           add -Wall to compiler flags],
- [ WALL="-Wall" ],
- [ ])
-AC_ARG_ENABLE(Werror,
- [  --enable-Werror         add -Werror to compiler flags],
- [ WERROR="-Werror" ],
- [ ])
-AC_ARG_ENABLE(Werror-lax,
- [  --enable-Werror-lax     add -Werror -Wno-unused-but-set-variable -Wno-unused-result -Wno-unused-local-typedefs to compiler flags],
- [ WERROR="-Werror -Wno-unused-but-set-variable -Wno-unused-result -Wno-unused-local-typedefs" ],
- [ ])
 
 # to strip unused code when using Linux gcc.
 # but not on cent4 because for some reason it fails

--- a/configure.in
+++ b/configure.in
@@ -568,18 +568,18 @@ if test "x$CC" = "xicc"; then
   # error #279: controlling expression is constant
   #   assert(!"Cannot invert 2x2 matrix with zero determinant");
 fi
-# There are approximately 1000 of this 'error', most caused by
-# the presence of code intending for debugging, so don't report it
-WERROR="$WERROR -Wno-unused-but-set-variable"
 
-# if (test "${CC}" = "gcc"); then
+if (test "${CC}" = "gcc"); then
+  # There are approximately 1000 of this 'error', most caused by
+  # the presence of code intending for debugging, so don't report it
+  WERROR="$WERROR -Wno-unused-but-set-variable"
   # There are approximately 600 of this 'error', most caused by
   # the presence of code ignoring status from write, fgets and similar functions
-  # WERROR="$WERROR -Wno-unused-result"
+  WERROR="$WERROR -Wno-unused-result"
   # There are approximately 40 of this 'error', but in external packages
   # header files, hence not possible to fix, and harmless.
-  # WERROR="$WERROR -Wno-unused-local-typedefs"
-# fi
+  WERROR="$WERROR -Wno-unused-local-typedefs"
+fi
 
 # to strip unused code when using Linux gcc.
 # but not on cent4 because for some reason it fails

--- a/configure.in
+++ b/configure.in
@@ -543,11 +543,11 @@ WERROR="-Werror"
 AC_ARG_ENABLE(Wall,
  [  --disable-Wall          do not add -Wall to compiler flags],
  [ WALL="" ],
- [ WALL="-Wall" ])
+ [ ])
 AC_ARG_ENABLE(Werror,
  [  --disable-Werror        do not add -Werror to compiler flags],
  [ WERROR="" ],
- [ WERROR="-Werror" ])
+ [ ])
 # temporary: so that --disable-Werror is no longer needed
 if test "$ac_have_gcc_48_or_higher" = "yes"; then
   [ WERROR="" ]
@@ -575,6 +575,20 @@ WERROR="$WERROR -Wno-unused-but-set-variable"
   # header files, hence not possible to fix, and harmless.
   # WERROR="$WERROR -Wno-unused-local-typedefs"
 # fi
+
+# allow override, enabling warning and error stoppage
+AC_ARG_ENABLE(Wall,
+ [  --enable-Wall           add -Wall to compiler flags],
+ [ WALL="-Wall" ],
+ [ ])
+AC_ARG_ENABLE(Werror,
+ [  --enable-Werror         add -Werror to compiler flags],
+ [ WERROR="-Werror" ],
+ [ ])
+AC_ARG_ENABLE(Werror-lax,
+ [  --enable-Werror-lax     add -Werror -Wno-unused-but-set-variable -Wno-unused-result -Wno-unused-local-typedefs to compiler flags],
+ [ WERROR="-Werror -Wno-unused-but-set-variable -Wno-unused-result -Wno-unused-local-typedefs" ],
+ [ ])
 
 # to strip unused code when using Linux gcc.
 # but not on cent4 because for some reason it fails


### PR DESCRIPTION
added configure flag --enable-Werror-lax, which add this to CFLAGS:

-Werror -Wno-unused-but-set-variable -Wno-unused-result -Wno-unused-local-typedefs

These three warnings appear throughout the code, but for mostly benign reasons (debugging).  Having this configure flag allows chasing down all the other warnings, at least in gcc 4.9 where there are not too many, so the build can return to the days when it would stop the build for the bulk of the compiler warnings, which in some instances, catch buggy code.  The intent is that this --enable-Werror-lax flag should be included with the default nmr center build for public releases.