### PR TITLE
bf: use libstd++ shipped with freesurfer

### DIFF
--- a/BrainstemSS/mac_osx/run_SegmentSubject.sh
+++ b/BrainstemSS/mac_osx/run_SegmentSubject.sh
@@ -15,7 +15,7 @@ else
   MCRROOT="$1"
   echo ---
 
-  DYLD_LIBRARY_PATH=.:${MCRROOT}/runtime/maci64:${MCRROOT}/bin/maci64:${MCRROOT}/sys/os/maci64:${DYLD_LIBRARY_PATH} ;
+  DYLD_LIBRARY_PATH=".:${MCRROOT}/runtime/maci64:${MCRROOT}/bin/maci64:${MCRROOT}/sys/os/maci64:${FREESURFER_HOME}/lib/gcc/lib:${DYLD_LIBRARY_PATH}" ;
   export DYLD_LIBRARY_PATH;
   echo DYLD_LIBRARY_PATH is ${DYLD_LIBRARY_PATH};
 

--- a/HippoSF/mac_osx/run_SegmentSubfieldsT1Longitudinal.sh
+++ b/HippoSF/mac_osx/run_SegmentSubfieldsT1Longitudinal.sh
@@ -15,7 +15,7 @@ else
   MCRROOT="$1"
   echo ---
 
-  DYLD_LIBRARY_PATH=.:${MCRROOT}/runtime/maci64:${MCRROOT}/bin/maci64:${MCRROOT}/sys/os/maci64:${DYLD_LIBRARY_PATH} ;
+  DYLD_LIBRARY_PATH=".:${MCRROOT}/runtime/maci64:${MCRROOT}/bin/maci64:${MCRROOT}/sys/os/maci64:${FREESURFER_HOME}/lib/gcc/lib:${DYLD_LIBRARY_PATH}" ;
   export DYLD_LIBRARY_PATH;
   echo DYLD_LIBRARY_PATH is ${DYLD_LIBRARY_PATH};
 

--- a/HippoSF/mac_osx/run_segmentSubjectT1T2_autoEstimateAlveusML.sh
+++ b/HippoSF/mac_osx/run_segmentSubjectT1T2_autoEstimateAlveusML.sh
@@ -15,7 +15,7 @@ else
   MCRROOT="$1"
   echo ---
 
-  DYLD_LIBRARY_PATH=.:${MCRROOT}/runtime/maci64:${MCRROOT}/bin/maci64:${MCRROOT}/sys/os/maci64:${DYLD_LIBRARY_PATH} ;
+  DYLD_LIBRARY_PATH=".:${MCRROOT}/runtime/maci64:${MCRROOT}/bin/maci64:${MCRROOT}/sys/os/maci64:${FREESURFER_HOME}/lib/gcc/lib:${DYLD_LIBRARY_PATH}" ;
   export DYLD_LIBRARY_PATH;
   echo DYLD_LIBRARY_PATH is ${DYLD_LIBRARY_PATH};
 

--- a/HippoSF/mac_osx/run_segmentSubjectT1_autoEstimateAlveusML.sh
+++ b/HippoSF/mac_osx/run_segmentSubjectT1_autoEstimateAlveusML.sh
@@ -15,7 +15,7 @@ else
   MCRROOT="$1"
   echo ---
 
-  DYLD_LIBRARY_PATH=.:${MCRROOT}/runtime/maci64:${MCRROOT}/bin/maci64:${MCRROOT}/sys/os/maci64:${DYLD_LIBRARY_PATH} ;
+  DYLD_LIBRARY_PATH=".:${MCRROOT}/runtime/maci64:${MCRROOT}/bin/maci64:${MCRROOT}/sys/os/maci64:${FREESURFER_HOME}/lib/gcc/lib:${DYLD_LIBRARY_PATH}" ;
   export DYLD_LIBRARY_PATH;
   echo DYLD_LIBRARY_PATH is ${DYLD_LIBRARY_PATH};
 

--- a/HippoSF/mac_osx/run_segmentSubjectT2_autoEstimateAlveusML.sh
+++ b/HippoSF/mac_osx/run_segmentSubjectT2_autoEstimateAlveusML.sh
@@ -15,7 +15,7 @@ else
   MCRROOT="$1"
   echo ---
 
-  DYLD_LIBRARY_PATH=.:${MCRROOT}/runtime/maci64:${MCRROOT}/bin/maci64:${MCRROOT}/sys/os/maci64:${DYLD_LIBRARY_PATH} ;
+  DYLD_LIBRARY_PATH=".:${MCRROOT}/runtime/maci64:${MCRROOT}/bin/maci64:${MCRROOT}/sys/os/maci64:${FREESURFER_HOME}/lib/gcc/lib:${DYLD_LIBRARY_PATH}" ;
   export DYLD_LIBRARY_PATH;
   echo DYLD_LIBRARY_PATH is ${DYLD_LIBRARY_PATH};
 


### PR DESCRIPTION
This is a fix for the `Symbol not found: __ZNKSt5ctypeIcE13_M_widen_initEv` error when running the subfield segmentation binaries. The OS X matlab runtime doesn't include libstd++ like the linux runtime, so to avoid library mismatches across OS X versions, we now point to the libstd++ included in `$FREESURFER_HOME/lib/gcc/lib`