### PR TITLE
bf: added check for Darwin v17 (Mac OS High Sierra)

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -642,7 +642,7 @@ case "${target}" in
  TEEM_32BIT=0
  ;;
  *-apple-darwin*)
- # Mac OS X
+ # Mac OS X - include detection of Darwin v17.*
  OS=Darwin
  OS_CPPFLAGS=
  OS_LDFLAGS="$DEADCODE_STRIP_MAC"
@@ -651,6 +651,11 @@ case "${target}" in
  SHARED_LDFLAGS="-dynamiclib"
  CPPFLAGS="$DBGFLAG -O3 -msse2 -mfpmath=sse $WALL $WERROR $LFS_CFLAGS"
  FFLAGS="$DBGFLAG -O3 -msse2 -mfpmath=sse"
+ uname -r | grep "17" >& /dev/null
+ if test "$?" = "0"; then
+  AC_MSG_NOTICE(Have Darwin v17.*)
+ CPPFLAGS="$CPPFLAGS -DDarwin17"
+ fi
  ;;
  i*86-*-solaris*)
  OS=SunOS

--- a/include/timer.h
+++ b/include/timer.h
@@ -44,8 +44,10 @@ Nanosecs TimerElapsedNanosecs(NanosecsTimer * then) ;	// returns delta in nanose
 
 // mach_gettime is a replacement for clock_gettime (not available on osx < 10.12)
 #ifdef __APPLE__
-  //typedef int clockid_t;
-  //int mach_gettime(clockid_t clk_id, struct timespec *tp);
+#ifndef Darwin17
+  typedef int clockid_t;
+  int mach_gettime(clockid_t clk_id, struct timespec *tp);
+#endif
 #endif
 
 #ifdef Linux


### PR DESCRIPTION
bf: added check for Darwin v17 (Mac OS High Sierra) because include/timer.h includes a clockid_t def that doesnt need to be defined in the (new) Darwin v17