### PR TITLE
nf: added git-rcs-keywords git filter 

### DIFF
--- a/.git_filters/gcs-rcs-keywords-README
+++ b/.git_filters/gcs-rcs-keywords-README
@@ -1,0 +1,28 @@
+This module provides a means to add keyword expansion of the following
+standard RCS tags to your git projects:
+
+         Id$
+         $Date$
+         $File$
+         $Author$
+         $Revision$
+         $Source$
+
+The mechanism used are filters.  The smudge filter is run on checkout, and the
+clean filter is run on commit.  The tags are only expanded on the local disk,
+not in the repository itself.
+
+To start, you need to add the following to ~/.gitconfig:
+
+[filter "rcs-keywords"]
+        clean  = .git_filters/rcs-keywords.clean
+        smudge = .git_filters/rcs-keywords.smudge %f
+
+Then, to add keyword expansion, simply add these files to your project:
+    <project>/.gitattributes                    - *.c filter=rcs-keywords
+    <project>/.git_filters/rcs-keywords.smudge  - copy this file to project
+    <project>/.git_filters/rcs-keywords.clean   - copy companion to project
+
+Note: This feature is known not to work in git 1.6.2.2 and 1.7.3.*, and
+      verified to work in git 1.7.4.4 and 1.7.4.msysgit.0
+

--- a/.git_filters/rcs-keywords.clean
+++ b/.git_filters/rcs-keywords.clean
@@ -1,0 +1,14 @@
+#!/usr/bin/perl -p
+#
+# @brief  Git filter to implement rcs keyword expansion as seen in cvs and svn.
+# @author Martin Turon
+#
+# Copyright (c) 2009-2011 Turon Technologies, Inc.  All rights reserved.
+
+s/\$Id[^\$]*\$/\$Id\$/; 
+s/\$Date[^\$]*\$/\$Date\$/;
+s/\$Author[^\$]*\$/\$Author\$/; 
+s/\$Source[^\$]*\$/\$Source\$/; 
+s/\$File[^\$]*\$/\$File\$/; 
+s/\$Revision[^\$]*\$/\$Revision\$/;
+

--- a/.git_filters/rcs-keywords.smudge
+++ b/.git_filters/rcs-keywords.smudge
@@ -1,0 +1,50 @@
+#!/usr/bin/perl
+#
+# @brief  Git filter to implement rcs keyword expansion as seen in cvs and svn.
+# @author Martin Turon
+#
+# Usage:
+#    .git_filter/rcs-keywords.smudge file_path < file_contents
+# 
+# To add keyword expansion:
+#    <project>/.gitattributes                    - *.c filter=rcs-keywords
+#    <project>/.git_filters/rcs-keywords.smudge  - copy this file to project
+#    <project>/.git_filters/rcs-keywords.clean   - copy companion to project
+#    ~/.gitconfig                                - add [filter] lines below
+#
+# [filter "rcs-keywords"]
+#	clean  = .git_filters/rcs-keywords.clean
+#	smudge = .git_filters/rcs-keywords.smudge %f
+#
+# Copyright (c) 2009-2011 Turon Technologies, Inc.  All rights reserved.
+
+$path = shift;
+$path =~ /.*\/(.*)/;
+$filename = $1;
+
+if (0 == length($filename)) {
+	$filename = $path;
+}
+
+# Need to grab filename and to use git log for this to be accurate.
+$rev = `git log -- $path | head -n 3`;
+$rev =~ /^Author:\s*(.*)\s*$/m;
+$author = $1;
+$author =~ /\s*(.*)\s*<.*/;
+$name = $1;
+$rev =~ /^Date:\s*(.*)\s*$/m;
+$date = $1;
+$rev =~ /^commit (.*)$/m;
+$ident = $1;
+
+while (<STDIN>) {
+    s/\$Date[^\$]*\$/\$Date:   $date \$/;
+    s/\$Author[^\$]*\$/\$Author: $author \$/;
+    s/\$Id[^\$]*\$/\$Id: $filename | $date | $name \$/;
+    s/\$File[^\$]*\$/\$File:   $filename \$/;
+    s/\$Source[^\$]*\$/\$Source: $path \$/;
+	s/\$Revision[^\$]*\$/\$Revision: $ident \$/;
+} continue {
+    print or die "-p destination: $!\n";
+}
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# see man gitattributes
+
+# ident does the following: When the attribute ident is set for a path, 
+# Git replaces <dollar>Id<dollar> in the blob object with <dollar>Id:, followed by the 40-character 
+# hexadecimal blob object name, followed by a <dollar> sign <dollar> upon checkout. 
+# Any byte sequence that begins with <dollar>Id: and ends with <dollar> in the worktree 
+# file is replaced with <dollar>Id<dollar> upon check-in.
+
+# expand <dollar>Id<dollar> in any of these files, to update git commit info:
+*.c ident
+*.cpp ident
+*.h ident
+*.hpp ident
+*.py ident
+*.am ident

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,8 @@
+# See .git_filters/git-rcs-keywords-README
+# To add keyword expansion:
+# git init
+# cp ~/.gitconfig, <project>/.gitattributes, and <project>/.git_filters
+
+[filter "rcs-keywords"]
+	clean  = .git_filters/rcs-keywords.clean
+	smudge = .git_filters/rcs-keywords.smudge %f

--- a/include/version.h
+++ b/include/version.h
@@ -9,10 +9,10 @@
  */
 /*
  * Original Author: Kevin Teich
- * CVS Revision Info:
+ * Revision Info:
  *    $Author: nicks $
  *    $Date: 2011/03/02 00:04:10 $
- *    $Revision: 1.15 $
+ *    $Id$
  *
  * Copyright © 2011 The General Hospital Corporation (Boston, MA) "MGH"
  *

--- a/mris_convert/mris_convert.c
+++ b/mris_convert/mris_convert.c
@@ -48,7 +48,7 @@
 
 //------------------------------------------------------------------------
 static char vcid[] =
-  "$Id: mris_convert.c,v 1.47 2015/07/24 16:13:39 greve Exp $";
+  "$Id$";
 
 /*-------------------------------- CONSTANTS -----------------------------*/
 // this mini colortable is used when .label file gets converted to gifti
@@ -134,7 +134,7 @@ main(int argc, char *argv[])
   /* rkt: check for and handle version tag */
   nargs = handle_version_option
           (argc, argv,
-           "$Id: mris_convert.c,v 1.47 2015/07/24 16:13:39 greve Exp $",
+           "$Id$",
            "$Name:  $");
   if (nargs && argc - nargs == 1)
   {

--- a/utils/version.c
+++ b/utils/version.c
@@ -9,10 +9,10 @@
  */
 /*
  * Original Author: Kevin Teich
- * CVS Revision Info:
+ * Revision Info:
  *    $Author: nicks $
  *    $Date: 2011/03/02 00:04:55 $
- *    $Revision: 1.36 $
+ *    $Id$
  *
  * Copyright © 2011 The General Hospital Corporation (Boston, MA) "MGH"
  *
@@ -212,7 +212,7 @@ int make_cmd_version_string(
   sprintf(return_string,
           "%s %s "
           "ProgramVersion: %s  TimeStamp: %s  "
-          "BuildTimeStamp: %s  CVS: %s  User: %s  "
+          "BuildTimeStamp: %s  Id: %s  User: %s  "
           "Machine: %s  Platform: %s  PlatformVersion: %s  "
           "CompilerName: %s  CompilerVersion: %d  ",
           program_name,


### PR DESCRIPTION
nf: added git-rcs-keywords git filter to expand the existing CVS-stye tags like dollarIddollar, dollarAuthordollar, dollarDatedollar, as found in most .c/h files