### PR TITLE
Add a thread safe version of MRISsurfaceRASToVoxelCached

### DIFF
--- a/include/mri.h
+++ b/include/mri.h
@@ -396,7 +396,7 @@ long  MRIcorrelate(MRI *mri_ref, MRI *mri_in, int xoff, int yoff, int zoff) ;
 
 
 int   MRIpeak(MRI *mri, int *px, int *py, int *pz) ;
-int   MRIcompareHeaders(MRI *mri1, MRI *mri2) ;
+int   MRIcompareHeaders(MRI const *mri1, MRI const *mri2) ;
 MRI   *MRIcopyHeader( const MRI *mri_src, MRI *mri_dst) ;
 int   MRIcopyPulseParameters(MRI *mri_src, MRI *mri_dst) ;
 MRI   *MRIcopy(MRI *mri_src, MRI *mri_dst) ;
@@ -877,8 +877,8 @@ MRI   *MRIresize(MRI *mri, double xsize, double ysize, double zsize, int nframes
 /* surfaceRAS and voxel routines */
 MATRIX *surfaceRASFromVoxel_(MRI *mri);
 MATRIX *voxelFromSurfaceRAS_(MRI *mri);
-MATRIX *surfaceRASFromRAS_(MRI *mri);
-MATRIX *RASFromSurfaceRAS_(MRI *mri);
+MATRIX *surfaceRASFromRAS_(MRI const *mri);
+MATRIX *RASFromSurfaceRAS_(MRI const *mri);
 
   int MRIscannerRASToVoxel(MRI *mri, double xr, double yr, double zr, double *xv, double *yv, double *zv);
 int MRIvoxelToSurfaceRAS(MRI *mri, double xv, double yv, double zv,

--- a/include/mrisurf.h
+++ b/include/mrisurf.h
@@ -1098,13 +1098,36 @@ int          MRISworldToTalairachVoxel(MRI_SURFACE *mris, MRI *mri,
                                        double xw, double yw, double zw,
                                        double *pxv, double *pyv, double *pzv) ;
 #endif
+
 int          MRISsurfaceRASToVoxel(MRI_SURFACE *mris, MRI *mri, double r, 
                                    double a, double s, 
                                    double *px, double *py, double *pz) ;
+                                   
+// THE FOLLOWING IS NOT THREAD SAFE!
 int          MRISsurfaceRASToVoxelCached(MRI_SURFACE *mris,
                                          MRI *mri,
                                          double r, double a, double s, 
                                          double *px, double *py, double *pz) ;
+
+
+typedef struct MRIS_SurfRAS2VoxelCache {
+    MRI*    mri;                            // was held in mris->mri_sras2vox
+    MATRIX* sras2vox;                       // was held in mris->m_sras2vox
+    VECTOR * volatile v1[_MAX_FS_THREADS];  // used to avoid repeated allocations
+    VECTOR * volatile v2[_MAX_FS_THREADS];  // used to avoid repeated allocations
+} MRIS_SurfRAS2VoxelCache;
+
+void MRIS_useRAS2VoxelCache(MRIS_SurfRAS2VoxelCache * cache_nonconst,   // accesses cache thread safely
+        MRI const * const mri,
+        double r, double a, double s, double *px, double *py, double *pz);
+    
+void MRIS_loadRAS2VoxelCache(MRIS_SurfRAS2VoxelCache* cache,            // not thread safe
+        MRI const * const mri, MRI_SURFACE const * const mris);
+void MRIS_unloadRAS2VoxelCache(MRIS_SurfRAS2VoxelCache* cache);         // not thread safe
+
+MRIS_SurfRAS2VoxelCache* MRIS_makeRAS2VoxelCache(                       // not thread safe
+        MRI const * const mri, MRI_SURFACE const * const mris);
+void MRIS_freeRAS2VoxelCache(MRIS_SurfRAS2VoxelCache** const cachePtr); // not thread safe
 
 // these are the inverse of the previous two
 int          MRISsurfaceRASFromVoxel(MRI_SURFACE *mris, MRI *mri, 

--- a/utils/mri.c
+++ b/utils/mri.c
@@ -2975,7 +2975,7 @@ MATRIX *voxelFromSurfaceRAS_(MRI *mri)
   intermediate matrices are alloced, inverted, and dealloced, so
   it might not be a good thing to have inside a loop.
   --------------------------------------------------------------*/
-MATRIX *surfaceRASFromRAS_(MRI *mri)
+MATRIX *surfaceRASFromRAS_(MRI const *mri)
 {
   MATRIX *sRASFromRAS;
   MATRIX *Vox2TkRAS, *Vox2RAS;
@@ -3005,13 +3005,13 @@ MATRIX *surfaceRASFromRAS_(MRI *mri)
   intermediate matrices are alloced, inverted, and dealloced, so
   it might not be a good thing to have inside a loop.
   --------------------------------------------------------------*/
-MATRIX *RASFromSurfaceRAS_(MRI *mri)
+MATRIX *RASFromSurfaceRAS_(MRI const *mri)
 {
   MATRIX *RASFromSRAS;
 
   MATRIX *Vox2TkRAS, *Vox2RAS;
 
-  Vox2RAS = MRIxfmCRS2XYZ(mri, 0);      // scanner vox2ras
+  Vox2RAS   = MRIxfmCRS2XYZ(mri, 0);      // scanner vox2ras
   Vox2TkRAS = MRIxfmCRS2XYZtkreg(mri);  // tkreg vox2ras
   // RASFromSRAS = Vox2RAS * inv(Vox2TkRAS)
   RASFromSRAS = MatrixInverse(Vox2TkRAS, NULL);
@@ -6009,7 +6009,7 @@ int MRIpeak(MRI *mri, int *px, int *py, int *pz)
 /*
   compare two headers to see if they are the same voxel and ras coords
 */
-int MRIcompareHeaders(MRI *mri1, MRI *mri2)
+int MRIcompareHeaders(MRI const *mri1, MRI const *mri2)
 {
   if (mri1 == NULL || mri2 == NULL) return (1);  // not the same
   if (!FEQUAL(mri1->xsize, mri2->xsize)) return (1);


### PR DESCRIPTION
The cache management was not thread safe, and was expensive

For most purposes the cache can be inited outside the threaded loop and used inside with almost no locking.  This new code makes it possible to do this.

Gets same results
Passes mris_make_surfaces check