### PR TITLE
NF travis mac build : find brew gnu toolchain easily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,24 +4,27 @@ language: cpp
 
 compiler: gcc
 
-os: linux
-
 cache:
   - apt
   - ccache
 
-env:
-  matrix:
-  # Compile Only:
-  - TESTS=""
-  # Autorecon1:
-  - TESTS="mri_convert mri_add_xform_to_header talairach_avi talairach_afd mri_normalize mri_watershed"
-  # Autorecon2:
-  - TESTS="mri_cc mri_mask mri_segment mri_edit_wm_with_aseg mri_pretess mri_fill mri_tesellate mris_inflate"
-  # Autorecon3:
-  - TESTS="mris_ca_label"
+matrix:
+  include:
+  # Compile only on osx and linux:
+  - os: osx
+    env: TESTS=""
+  - os: linux
+    env: TESTS=""
+  # tests currently work only on linux due to neurodebian-travis.sh script below
+  # Autorecon1:  
+  - os: linux
+    env: TESTS="mri_convert mri_add_xform_to_header talairach_avi talairach_afd mri_normalize mri_watershed"
+  # Autorecon2 and 3:
+  - os: linux
+    env: TESTS="mri_cc mri_mask mri_segment mri_edit_wm_with_aseg mri_pretess mri_fill mri_tesellate mris_inflate mris_ca_label"
   # Misc
-  - TESTS="utils"
+  - os: linux
+    env: TESTS="utils"
 
 addons:
   apt:
@@ -46,7 +49,16 @@ addons:
      - libxml2-utils
 
 before_install:
-  # Needs recent git-annex to be able to get -J3 --metadata ; fi
+  # on osx use brew to install autotools and compiler
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libtool ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install automake ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew postinstall automake ; fi
+     # workaround to make install gcc work (first uninstall conflicting oclint)
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall oclint ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc49 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew postinstall gcc49 ; fi
+  # Needs recent git-annex to be able to get -J3 --metadata
   - if [[ "$TESTS" != "" ]]; then bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh) ; fi
   - if [[ "$TESTS" != "" ]]; then travis_retry sudo apt-get update -qq ; fi
   - if [[ "$TESTS" != "" ]]; then travis_retry sudo apt-get install git-annex-standalone ; fi
@@ -57,17 +69,25 @@ before_install:
 
 install:
   # Install library packages needed to compile FreeSurfer
-  - curl -O ftp://surfer.nmr.mgh.harvard.edu/pub/dist/fs_supportlibs/prebuilt/centos6_x86_64/centos6-x86_64-packages.tar.gz
-  - tar -xzf centos6-x86_64-packages.tar.gz 
-  - rm centos6-x86_64-packages.tar.gz 
-  - cd centos6-x86_64-packages 
-  - ./setup.sh
-  - cd ..
-
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then curl -O ftp://surfer.nmr.mgh.harvard.edu/pub/dist/fs_supportlibs/prebuilt/centos6_x86_64/centos6-x86_64-packages.tar.gz ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tar -xzf centos6-x86_64-packages.tar.gz  ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then rm centos6-x86_64-packages.tar.gz  ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd centos6-x86_64-packages  ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./setup.sh ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd .. ; fi
+  # different package on osx
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then mkdir osx-lion-packages ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then cd osx-lion-packages ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then curl -O ftp://surfer.nmr.mgh.harvard.edu/pub/dist/fs_supportlibs/prebuilt/OSX/osx-lion-packages.tar.gz ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then tar -xzf osx-lion-packages.tar.gz ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then rm osx-lion-packages.tar.gz ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then cd .. ; fi
+ 
 script:
   # configure and build freesurfer
   - ./setup_configure
-  - ./configure --prefix=/usr/local/freesurfer/dev --with-pkgs-dir=${PWD}/centos6-x86_64-packages --disable-Werror --disable-GUI-build
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./configure --prefix=/usr/local/freesurfer/dev --with-pkgs-dir=${PWD}/centos6-x86_64-packages --disable-Werror --disable-GUI-build ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then ./configure --prefix=/usr/local/freesurfer/dev --with-pkgs-dir=${PWD}/osx-lion-packages       --disable-Werror --disable-GUI-build  F77=/usr/local/bin/gfortran-4.9 CC=/usr/local/bin/gcc-4.9 CXX=/usr/local/bin/g++-4.9 ; fi
   - travis_wait 40 ./travis_make.sh || travis_terminate 1
   # run tests
   - if [[ "$TESTS" != "" ]]; then travis_wait 60 ./run_selected_tests ; fi

--- a/configure.in
+++ b/configure.in
@@ -274,21 +274,17 @@ if test ! `uname -s` = "Darwin"; then
 fi
 
 if test `uname -s` = "Darwin"; then
+  if test -e "/usr/local/bin/glibtool" ; then
+    # brew installs here
+    AC_MSG_NOTICE(Copying /usr/local/bin/glibtool overtop the PROG_LIBTOOL)
+    cp /usr/local/bin/glibtool ./libtool
+  elif test -e "/opt/local/bin/glibtool" ; then
+    # port installs here
     AC_MSG_NOTICE(Copying /opt/local/bin/glibtool overtop the PROG_LIBTOOL)
     cp /opt/local/bin/glibtool ./libtool
+  fi
 fi
 
-# Temporary fix until I can get all version of OSX building
-#if (test `uname -n` = "gust.nmr.mgh.harvard.edu"); then
-#    AC_MSG_NOTICE(Copying /usr/pubsw/packages/autotools/bin/libtool overtop the PROG_LIBTOOL)
-#    cp /usr/pubsw/packages/autotools/bin/libtool .
-#fi
-
-# Temporary fix until I can get all version of OSX building
-# if (test `uname -n` = "aspasia.nmr.mgh.harvard.edu"); then
-#    AC_MSG_NOTICE(Copying /usr/pubsw/packages/autotools/bin/libtool overtop the PROG_LIBTOOL)
-#    cp /usr/pubsw/packages/autotools/bin/libtool .
-# fi
 
 ################################################################
 # Checks for header files.
@@ -457,7 +453,11 @@ AC_CHECK_FILE(/bin/tcsh,[],
   [AC_MSG_ERROR([FATAL: /bin/tcsh is required!])])
 
 # links with g++ rather than gcc (and check for Intel and AMD Compilers)
-CCLD=g++
+# first use $CXX if passed 
+CCLD=$CXX
+if test "x$CCLD" = "x"; then
+  CCLD=g++
+fi
 if test "x$CC" = "xicc"; then
   CCLD=icpc
 fi
@@ -766,11 +766,11 @@ if test ! "$OS" = "Darwin"; then
 fi
 
 if test "x$MAC_64" = "xYES"; then
-  if test ! "x$F77" = "xgfortran"; then
-    AC_MSG_ERROR([FATAL: gfortran (not $F77) required for 64-bit Mac OSX systems.])
-  else
+  #if test ! "x$F77" = "xgfortran"; then
+  #  AC_MSG_ERROR([FATAL: gfortran (not $F77) required for 64-bit Mac OSX systems.])
+  #else
     FFLAGS="$FFLAGS -m64"
-  fi
+  #fi
 fi
 
 # many linux systems, namedly Ubuntu, dont have libgfortran.so installed

--- a/setup_configure
+++ b/setup_configure
@@ -7,6 +7,9 @@
 
 set cmd1=(rm -rf autom4te.cache)
 set cmd2=(libtoolize --force)
+if ( `uname` == "Darwin" ) then
+  set cmd2=(glibtoolize --force)
+endif
 set cmd3=(aclocal)
 #automake --add-missing is necessary because config.sub
 # and config.guess are links, and make not be present,

--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -3939,7 +3939,9 @@ static int MRIScomputeNormals_new(MRI_SURFACE *mris)
     if (f->ripflag) {
       int n;
       for (n = 0; n < VERTICES_PER_FACE; n++) {
+#ifdef HAVE_OPENMP
         #pragma omp critical
+#endif
         {
           mris->vertices[f->v[n]].border = TRUE;
         }
@@ -4051,8 +4053,9 @@ static int MRIScomputeNormals_new(MRI_SURFACE *mris)
         
         ROMP_PFLB_continue;
       }
-      
+#ifdef HAVE_OPENMP
       #pragma omp critical                              // Retry after various adjustments below
+#endif
       {
         nextPending[nextPendingSize++] = k;
       }
@@ -11466,8 +11469,8 @@ static int MRIScomputeTriangleProperties_new(MRI_SURFACE *mris, bool old_done)
 
 /* calculate the "area" of the vertices */
   int vno;
-#ifdef HAVE_OPENMP
   ROMP_PF_begin		// mris_fix_topology
+#ifdef HAVE_OPENMP
   #pragma omp parallel for if_ROMP(shown_reproducible)
 #endif
   for (vno = 0; vno < mris->nvertices; vno++) {


### PR DESCRIPTION
This fixes the mac build and makes building easier:

- adds mac travis build (working , but without any tests)
- allows setup_configure to find glibtoolize on mac
- allows configure to take F77 GCC and GXX flags to point to brew installed tools
- fixes mrisurf.c to compile even if we don't have openmp

After merge, the wiki instructions for mac:
https://surfer.nmr.mgh.harvard.edu/fswiki/freesurfer_mac_developers_page 
can be simplified quite a bit (only brew installs and modified configure to point it to
F77=/usr/local/bin/gfortran-4.9   CC=/usr/local/bin/gcc-4.9  CXX=/usr/local/bin/g++-4.9 )
