### PR TITLE
Extra ] causes warning during ./configure

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -733,7 +733,7 @@ AC_ARG_ENABLE(gl-apps,
   yes)  build_gl_apps=yes ;;
   no)   build_gl_apps=no  ;;
   *) AC_MSG_ERROR([bad value ${enableval} for --enable-gl-apps]) ;;
-  esac]
+  esac
  ])
 ################################################################
 # Mac 64-bit 32-bit concerns


### PR DESCRIPTION
Fix this message,,,

./configure: line 26570: ]: command not found