### PR TITLE
Clean up netcdf, fix for external ITK50, add fix for C++11

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1016,7 +1016,7 @@ AC_ARG_ENABLE(fermi-gpu,
 AM_CONDITIONAL(HAVE_FERMI_GPU, test "x$ac_have_fermi_gpu" = "xyes")
 
 # setup nvcc flags (default is for tesla-class, --enable-fermi-gpu overrides)
-NVIDIA_ARCH="sm_11"
+NVIDIA_ARCH="sm_52"
 if test x$ac_have_fermi_gpu = xyes
 then
   NVIDIA_ARCH="sm_20"
@@ -2941,7 +2941,9 @@ if test "$itk_apps" = "yes"; then
     $ac_itk_libraries/libitkv3p_netlib-5.0.a \
     $ac_itk_libraries/libitkzlib-5.0.a \
     $ac_itk_libraries/libitkopenjpeg-5.0.a \
-    $ac_itk_libraries/libITKDICOMParser-5.0.a"
+    $ac_itk_libraries/libITKDICOMParser-5.0.a\
+    $ac_itk_libraries/libITKTransform-5.0.a"
+    ITK_CFLAGS+=" -DHAVE_ITK50"
   fi
 
   # ITK 4.5 uses these:

--- a/include/minc_volume_io.h
+++ b/include/minc_volume_io.h
@@ -34,7 +34,7 @@
 // instead of using the libminc included with an external MNI package build,
 // use the local one found in minc_1_5_1
 
-#include "netcdf_3_6_0_p1/netcdf.h"
+#include "netcdf.h"
 #include "minc_multidim_arrays.h"
 
 typedef bool BOOLEAN;

--- a/include/utils.h
+++ b/include/utils.h
@@ -59,8 +59,10 @@ void   fComplementCode(double *pdIn, double *pdOut, int iLen) ;
 #ifndef _HOME_
 char *fgetl(char *s, int n, FILE *fp) ;
 #endif
+#ifndef HAVE_ITK50
 #ifndef isfinite 
 #define isfinite(x) (finite(x))
+#endif
 #endif
 
 int  IntSqrt(int n) ;

--- a/lineprof/Preprocessor.cpp
+++ b/lineprof/Preprocessor.cpp
@@ -155,7 +155,7 @@ Preprocessor::convertPointSetToBinaryImage(PointSetPointer pointSet)
   FilterType::Pointer filter = FilterType::New();
 
   // compute the bounding box of the pointSet
-#ifdef HAVE_ITK45
+#if defined(HAVE_ITK45) || defined(HAVE_ITK50)
   typedef itk::BoundingBox<itk::IdentifierType, Dimension, float> BoundingBoxType;
   BoundingBoxType::Pointer boundingBox = BoundingBoxType::New();
   boundingBox->SetPoints(pointSet->GetPoints());

--- a/vtkutils/vtkFDTensorGlyph.h
+++ b/vtkutils/vtkFDTensorGlyph.h
@@ -75,7 +75,12 @@ protected:
     EVA = 10,
   };
 
+  #if __cplusplus <= 199711L
   static const double SMALL_EIGENVALUE = 1e-8;
+  #else
+  static constexpr double SMALL_EIGENVALUE = 1e-8;
+  #endif
+
 
 private:
   vtkFDTensorGlyph(const vtkFDTensorGlyph&);  // Not implemented.


### PR DESCRIPTION
Added a few fixes for external ITK 50; cleaned up the netcdf path (-I../netcdf_3_6_0_p1 is already set) and replaced sm_11 with sm_52 for more modern GPUs.  I can make a change for later models later.  

Some changes were made to build with C++11.

