### PR TITLE
Fixes the NULL input to Matrix_invert error recon-all is currently getting with dev stream

### DIFF
--- a/mri_relabel_hypointensities/Makefile.am
+++ b/mri_relabel_hypointensities/Makefile.am
@@ -10,6 +10,11 @@ mri_relabel_hypointensities_SOURCES=mri_relabel_hypointensities.c
 mri_relabel_hypointensities_LDADD= $(addprefix $(top_builddir)/, $(LIBS_MGH))
 mri_relabel_hypointensities_LDFLAGS=$(OS_LDFLAGS)
 
+TESTS=test_mri_relabel_hypointensities
+
+EXTRA_DIST=test_mri_relabel_hypointensities testdata.tar.gz $(foo_DATA) $(BUILT_SOURCES)
+
+
 # Our release target. Include files to be excluded here. They will be
 # found and removed after 'make install' is run during the 'make
 # release' target.

--- a/mri_relabel_hypointensities/test_mri_relabel_hypointensities
+++ b/mri_relabel_hypointensities/test_mri_relabel_hypointensities
@@ -1,0 +1,90 @@
+#!/bin/tcsh -f
+
+umask 002
+
+if ( $?SKIP_MRI_RELABEL_HYPOINTENSITIES_TEST ) then
+  exit 0
+endif
+
+set passed = 1
+
+foreach threads ( 4 )
+
+  # extract testing data
+  
+  rm -rf testdata
+  
+  gunzip -c testdata.tar.gz | tar xvf -
+
+  cd testdata
+
+  setenv FREESURFER_HOME ../../distribution
+  setenv SUBJECTS_DIR `pwd`
+  setenv OMP_NUM_THREADS $threads
+  echo "testing with $threads thread(s)"
+
+
+  # ---- TEST 1 ----
+
+  # run mri_relabel_hypointensities using typical input
+
+  set cmd=(../mri_relabel_hypointensities aseg.presurf.mgz ./surf aseg.presurf.hypos.mgz )
+
+  echo ""
+  echo $cmd
+  $cmd
+  if ($status != 0) then
+    echo "mris_make_surfaces FAILED"
+    set passed = 0
+  else
+    # compare expected results with actual (produced) results
+
+    set TST = aseg.presurf.hypos.mgz
+    rm -rf ${TST}_tmp{,.gz}
+    rm -rf ${TST}.REF_tmp{,.gz}
+    cp     ${TST}{,_tmp.gz}
+    cp     ${TST}.REF{,_tmp.gz}
+    gunzip ${TST}_tmp.gz
+    gunzip ${TST}.REF_tmp.gz
+    
+    #hexdump -c <  ${TST}_tmp     | wc
+    #hexdump -c <  ${TST}.REF_tmp | wc
+    hexdump -c <  ${TST}_tmp     | head -n-125 > ${TST}_hexdump.txt
+    hexdump -c <  ${TST}.REF_tmp | head -n-125 > ${TST}.REF_hexdump.txt
+    #cksum ${TST}_hexdump.txt ${TST}.REF_hexdump.txt
+    
+    set cmd=(diff -q ${TST}_hexdump.txt ${TST}.REF_hexdump.txt );
+
+    echo ""
+    echo $cmd
+    $cmd
+    set diff_status=$status
+    if ($diff_status != 0) then
+      echo "$cmd FAILED (exit status=$diff_status)"
+      set passed = 0
+    endif
+  endif
+
+
+  echo ""
+  echo ""
+  echo ""
+
+
+  # cleanup
+
+  cd ..
+  # leave the files for making a replacement .tar.gz
+  #     rm -rf testdata
+
+end
+
+if ($passed != 0) then
+  echo ""
+  echo "test_mri_relabel_hypointensities passed all tests"
+  exit 0
+else
+  echo ""
+  echo "test_mri_relabel_hypointensities failed some tests"
+  exit 1
+endif

--- a/utils/matrix.c
+++ b/utils/matrix.c
@@ -306,7 +306,7 @@ int MatrixFree(MATRIX **pmat)
   mat = *pmat;
   *pmat = NULL;
 
-  if (!mat) ErrorReturn(ERROR_BADPARM, (ERROR_BADPARM, "MatrixFree: NULL mat POINTER!\n"));
+  if (!mat) return (0);
 
   /* silly numerical recipes in C requires 1-based stuff */
   mat->data -= 2;

--- a/utils/mriflood.c
+++ b/utils/mriflood.c
@@ -1494,6 +1494,9 @@ MRI *MRISfillInterior(MRI_SURFACE *mris, double resolution, MRI *mri_dst)
   }
   MRIcopyHeader(mri_dst, mri_shell);
 
+  MRIS_SurfRAS2VoxelCache* map = MRIS_makeRAS2VoxelCache(mri_dst, mris);
+  MRIS_loadRAS2VoxelCache(map, mri_dst, mris);
+    
   /* Create a "watertight" shell of the surface by filling each face in MRI volume */
   for (fno = 0; fno < mris->nfaces; fno++) {
     f = &mris->faces[fno];
@@ -1534,8 +1537,10 @@ MRI *MRISfillInterior(MRI_SURFACE *mris, double resolution, MRI *mri_dst)
         px = px0 + (px1 - px0) * (double)u / (double)numu;
         py = py0 + (py1 - py0) * (double)u / (double)numu;
         pz = pz0 + (pz1 - pz0) * (double)u / (double)numu;
-        MRISsurfaceRASToVoxelCached(mris, mri_dst, px, py, pz, &fcol, &frow, &fslc);
-        if (vox2sras == NULL) vox2sras = MatrixInverse(mris->m_sras2vox, NULL);
+        
+        MRIS_useRAS2VoxelCache(map, mri_dst, px, py, pz, &fcol, &frow, &fslc);
+        if (vox2sras == NULL) vox2sras = MatrixInverse(map->sras2vox, NULL);
+ 
         col = nint(fcol);
         row = nint(frow);
         slc = nint(fslc);
@@ -1571,6 +1576,7 @@ MRI *MRISfillInterior(MRI_SURFACE *mris, double resolution, MRI *mri_dst)
     }
   }
   // printf("  shell done  t = %g\n",TimerStop(&start)/1000.0) ;
+  MRIS_freeRAS2VoxelCache(&map);
   MatrixFree(&crs);
   MatrixFree(&xyz);
   MRIfree(&mri_vlen);


### PR DESCRIPTION
Added a test to mri_relabel_hypointensities

Fixed the problem

Fixed warning messages about NULL being passed to Matrix_free

Test passes