### PR TITLE
Fixes freesurfer/freesurfer#308

### DIFF
--- a/tkmedit/tkmedit.c
+++ b/tkmedit/tkmedit.c
@@ -64,6 +64,7 @@ char *VERSION = "$Revision: 1.348 $";
 #include "fsgdf.h"
 #include "mri2.h"
 #include "registerio.h"
+#include "timer.h"
 
 #include <tcl.h>
 //#include <tclDecls.h>


### PR DESCRIPTION
fixes  implicit declaration of function 'current_date_time' on centos 6