### PR TITLE
Hcp v6

### DIFF
--- a/scripts/recon-all.v6.hires
+++ b/scripts/recon-all.v6.hires
@@ -2039,7 +2039,6 @@ if($DoNormalization) then
       echo "Recompute intensity norm to create $longbaseid ctrl_vol.mgz" \
         |& tee -a $LF
       set cmd = (mri_normalize)
-      if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
       if($#Norm3dIters)  set cmd = ($cmd -n $Norm3dIters)
       if($#Norm1_b)      set cmd = ($cmd -b $Norm1_b)
       if($#Norm1_n)      set cmd = ($cmd -n $Norm1_n)
@@ -2061,9 +2060,7 @@ if($DoNormalization) then
       rm -f $longbasedir/mri/T1_tmp.mgz
     endif
     # use ctrl_vol.mgz from base for normalization:
-    set cmd = (mri_normalize)
-    if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
-    set cmd = ($cmd \
+    set cmd = (mri_normalize \
       -w $subjdir/mri/ctrl_vol.mgz $subjdir/mri/bias_vol.mgz \
       -l $longbasedir/mri/ctrl_vol.mgz $longbasedir/mri/bias_vol.mgz \
       $subjdir/mri/nu.mgz \
@@ -2096,7 +2093,6 @@ if($DoNormalization) then
     endif
     # for cross, base (and long if not useLongBaseCtrlVol) processing streams:
     set cmd = (mri_normalize -g $NormMaxGrad);
-    if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
     if($UseControlPoints) set cmd = ($cmd -f $ControlPointsFile)
     if($#Norm3dIters)     set cmd = ($cmd -n $Norm3dIters)
     if($#Norm1_b)         set cmd = ($cmd -b $Norm1_b)
@@ -2906,7 +2902,6 @@ if($DoNormalization2) then
   cd $subjdir/mri > /dev/null
   set xopts = `fsr-getxopts mri_normalize $XOptsFile`;
   set cmd = (mri_normalize);
-  if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
   if($UseControlPoints)   set cmd = ($cmd -f $ControlPointsFile)
   if($#Norm3dIters)       set cmd = ($cmd -n $Norm3dIters)
   if($#Norm2_b)           set cmd = ($cmd -b $Norm2_b)
@@ -3670,9 +3665,7 @@ if($DoCurvHK) then
     $PWD |& tee -a $LF
     # create curvature files ?h.white.H and ?h.white.K
     set xopts = `fsr-getxopts mris_curatvure $XOptsFile`;
-    set cmd = (mris_curvature -w)
-    if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
-    set cmd = ($cmd $xopts $hemi.white.preaparc)
+    set cmd = (mris_curvature -w $xopts $hemi.white.preaparc)
     echo "\n $cmd \n"|& tee -a $LF |& tee -a $CF
     if($DoParallel) then
       set CMDF = mris_curvature_white_${hemi}.cmd
@@ -3710,9 +3703,7 @@ if($DoCurvHK) then
 
     # create curvature files ?h.inflated.H and ?h.inflated.K
     set xopts = `fsr-getxopts mris_curatvure $XOptsFile`;
-    set cmd = (mris_curvature)
-    if ($NoRandomness) set cmd = ($cmd -seed $RngSeed)
-    set cmd = ($cmd -thresh .999 -n -a 5 -w -distances 10 10)
+    set cmd = (mris_curvature -thresh .999 -n -a 5 -w -distances 10 10)
     set cmd = ($cmd $xopts $hemi.inflated)
     echo "\n $cmd \n"|& tee -a $LF |& tee -a $CF
     if($DoParallel) then
@@ -4330,9 +4321,7 @@ if($DoT2pial || $DoFLAIRpial) then
       # this creates ${t2flair}.norm.mgz
       # MOD: removed -sigma 0.5 -nonmax_suppress 0 -min_dist 1 so now just
       # uses default parameters. But this does not seem to work very well, so if(0)
-      set normcmd = (mri_normalize)
-      if ($NoRandomness) set normcmd = ($normcmd -seed $RngSeed)
-      set normcmd = ($normcmd \
+      set normcmd = (mri_normalize \
           -aseg $mdir/aseg.presurf.mgz \
           -surface $sdir/rh.white identity.nofile \
           -surface $sdir/lh.white identity.nofile \
@@ -4349,9 +4338,7 @@ if($DoT2pial || $DoFLAIRpial) then
       # WM is defined as voxels in wm.mgz = 100
       set T2prenorm = $mdir/${t2flair}.prenorm.mgz \
       set T2meanfile = $mdir/${t2flair}.prenorm.mean.dat
-      set cmd = (mri_segstats)
-      if ($NoRandomness) set cmd = ($cmd --seed $RngSeed)
-      set cmd = ($cmd --seg $mdir/wm.mgz --id 110 --i $T2prenorm --avgwf $T2meanfile)
+      set cmd = (mri_segstats --seg $mdir/wm.mgz --id 110 --i $T2prenorm --avgwf $T2meanfile)
       echo $cmd | tee -a $LF |& tee -a $CF
       if($RunIt) $fs_time $cmd | tee -a $LF
       if($status) goto error_exit;
@@ -4850,9 +4837,7 @@ if($DoSegStats) then
   cd $subjdir > /dev/null
   $PWD |& tee -a $LF
   set xopts = `fsr-getxopts mri_segstats $XOptsFile`;
-  set cmd = (mri_segstats)
-  if ($NoRandomness) set cmd = ($cmd --seed $RngSeed)
-  set cmd = ($cmd --seg mri/aseg.mgz --sum stats/aseg.stats)
+  set cmd = (mri_segstats --seg mri/aseg.mgz --sum stats/aseg.stats)
   set cmd = ($cmd --pv mri/norm.mgz --empty)
   set cmd = ($cmd --brainmask mri/brainmask.mgz --brain-vol-from-seg)
   set cmd = ($cmd --excludeid 0 --excl-ctxgmwm)
@@ -4914,7 +4899,6 @@ if($DoWMParc) then
   echo $cmd > $touchdir/wmaparc.touch
   # Do wm segstats while we're here
   set cmd = (mri_segstats)
-  if ($NoRandomness) set cmd = ($cmd --seed $RngSeed)
   set cmd = ($cmd --seg mri/wmparc.mgz --sum stats/wmparc.stats \
     --pv mri/norm.mgz --excludeid 0 \
     --brainmask mri/brainmask.mgz --in mri/norm.mgz --in-intensity-name norm \
@@ -4946,7 +4930,6 @@ if($DoAParcASegStats) then
   cd $subjdir > /dev/null
   set xopts = `fsr-getxopts mri_segstats $XOptsFile`;
   set cmd = (mri_segstats)
-  if ($NoRandomness) set cmd = ($cmd --seed $RngSeed)
   set cmd = ($cmd --seg mri/aparc+aseg.mgz --sum stats/aparc+aseg.stats)
   set cmd = ($cmd --pv mri/norm.mgz )
   set cmd = ($cmd --excludeid 0 --ctab-default --empty)

--- a/scripts/tess1mm
+++ b/scripts/tess1mm
@@ -8,6 +8,7 @@ set VERSION = '$Id$';
 
 set hrsubject = ();
 set hemilist = (lh rh);
+set tess1mmname = tess1mm
 
 set tmpdir = ();
 set cleanup = 1;
@@ -41,7 +42,7 @@ set min    = `date +%M`
 
 setenv HR_SUBJECTS_DIR $SUBJECTS_DIR
 set hrmdir = $HR_SUBJECTS_DIR/$hrsubject/mri
-set subject = tess1mm # folder inside hires-subject
+set subject = $tess1mmname # folder inside hires-subject
 set outdir = $SUBJECTS_DIR/$hrsubject/$subject
 
 setenv SUBJECTS_DIR $SUBJECTS_DIR/$hrsubject
@@ -123,17 +124,19 @@ echo $cmd | tee -a $LF
 $cmd | tee -a $LF
 if($status) goto error_exit;
 
-set cmd = (mri_pretess filled.mgz 255 norm.mgz filled-pretess.mgz)
-echo $cmd | tee -a $LF
-$cmd | tee -a $LF
-if($status) goto error_exit;
-
 cd $outdir
 foreach hemi ($hemilist)
   if($hemi == lh) set vhemi = 255
   if($hemi == rh) set vhemi = 127
 
-  set cmd = (mri_tessellate mri/filled-pretess.mgz $vhemi surf/$hemi.orig.nofix)
+  # Pretess removes micro defects. In previous versions of this script, this command
+  # was only run for 255 (left hemi), leaving the right hemi unchanged. 
+  set cmd = (mri_pretess mri/filled.mgz $vhemi mri/norm.mgz mri/filled-pretess$vhemi.mgz)
+  echo $cmd | tee -a $LF
+  $cmd | tee -a $LF
+  if($status) goto error_exit;
+
+  set cmd = (mri_tessellate mri/filled-pretess$vhemi.mgz $vhemi surf/$hemi.orig.nofix)
   echo $cmd | tee -a $LF
   $cmd | tee -a $LF
   if($status) goto error_exit;
@@ -221,6 +224,11 @@ while( $#argv != 0 )
       set hrsubject = $argv[1]; shift;
       breaksw
 
+    case "--name":
+      if($#argv < 1) goto arg1err;
+      set tess1mmname = $argv[1]; shift;
+      breaksw
+
     case "--lh":
       set hemilist = (lh)
       breaksw
@@ -301,6 +309,7 @@ usage_exit:
   echo ""
   echo "tess1mm --s subject"
   echo "  --lh, --rh : do only lh or rh (default is both)"
+  echo "  --name tess1mmfolder : default is tess1mm"
   echo ""
   echo ""
 


### PR DESCRIPTION
These two changes only affect the recon-all.v6.hires result through recon-all.v6.hires directly and indirectly through tess1mm. The change to recon-all.v6.hires is only to back out of the changes made by Bevin. The tess1mm script had a bug in which mri_pretess was only being run for lh and rh.