### PR TITLE
Add a missing allocation of the faceNormCacheEntries

### DIFF
--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -27972,7 +27972,8 @@ MRI_SURFACE *MRISreadVTK(MRI_SURFACE *mris, const char *fname)
   if (newMris) {
     mris->nfaces = nfaces;
     mris->faces = (FACE *)calloc(nfaces, sizeof(FACE));
-    if (!mris->faces) {
+    mris->faceNormCacheEntries = (FaceNormCacheEntry*)calloc(nfaces, sizeof(FaceNormCacheEntry));
+    if (!mris->faces || !mris->faceNormCacheEntries) {
       fclose(fp);
       ErrorExit(ERROR_NO_MEMORY, "MRISreadVTK(%d, %d): could not allocate faces", nfaces, sizeof(FACE));
     }


### PR DESCRIPTION
absence was causing a crash in mris_convert check

mris_convert check now passes
