### PR TITLE
The list was not marked empty, 

### DIFF
--- a/utils/realm.c
+++ b/utils/realm.c
@@ -1001,6 +1001,7 @@ void updateRealmTree(RealmTree* realmTree, MRIS const * mris, GetXYZ_FunctionTyp
         realmTree->nextVnoToUpdatePlus1[vno] = 0;                       // clear the link for next time
         vno = next_vno;
     }
+    realmTree->firstVnoToUpdatePlus1 = -1;				// mark the list as empty
 
     // process all the pending fno, resetting the links to zero
     //    


### PR DESCRIPTION
amazing this did not cause a visible problem

make check has no surprising fails - only 3 which I think are long-standing - a TCL issue, a fortran library issue, and talairach one that will not be caused by this