### PR TITLE
5-10% speedup in MRIS_FIX_TOPOLOGY by better mriSurfaceRASToVoxel

### DIFF
--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -54989,26 +54989,84 @@ static int edgeExists(MRI_SURFACE *mris, int vno1, int vno2)
 }
 
 #if MATRIX_ALLOCATION
+
 #ifndef V4_LOAD
 #define V4_LOAD(v, x, y, z, r) (VECTOR_ELT(v, 1) = x, VECTOR_ELT(v, 2) = y, VECTOR_ELT(v, 3) = z, VECTOR_ELT(v, 4) = r);
 #endif
 
-int mriSurfaceRASToVoxel(double xr, double yr, double zr, double *xv, double *yv, double *zv)
+int mriSurfaceRASToVoxel(
+    double xr, double yr, double zr, 
+    double *xv, double *yv, double *zv)
 {
-  VECTOR *sr, *vv;
+  static int once;
+  static bool const try_both_way = true;
+  static bool const try_new_way  = true;
+  static bool       try_old_way  = false;
+  if (!once) {
+    once++; 
+    try_both_way = getenv("FREESURFER_mriSurfaceRASToVoxel_both");
+    try_old_way  = getenv("FREESURFER_mriSurfaceRASToVoxel_old");
+    if (try_both_way) try_new_way = try_old_way = true;
+  }
 
-  sr = VectorAlloc(4, MATRIX_REAL);
+  bool const new_way = 
+    try_new_way &&
+      VoxelFromSRASmatrix->type == MATRIX_REAL &&
+      VoxelFromSRASmatrix->rows == 4 &&
+      VoxelFromSRASmatrix->cols == 4;
 
+  bool const old_way = 
+    try_old_way ||
+    !new_way;
+
+  float nx = 0, ny = 0, nz = 0;
+  if (new_way) {
+    nx = 
+      *MATRIX_RELT(VoxelFromSRASmatrix, 1,1)*xr +
+      *MATRIX_RELT(VoxelFromSRASmatrix, 1,2)*yr +
+      *MATRIX_RELT(VoxelFromSRASmatrix, 1,3)*zr +
+      *MATRIX_RELT(VoxelFromSRASmatrix, 1,4) ;
+    ny = 
+      *MATRIX_RELT(VoxelFromSRASmatrix, 2,1)*xr +
+      *MATRIX_RELT(VoxelFromSRASmatrix, 2,2)*yr +
+      *MATRIX_RELT(VoxelFromSRASmatrix, 2,3)*zr +
+      *MATRIX_RELT(VoxelFromSRASmatrix, 2,4) ;
+    nz = 
+      *MATRIX_RELT(VoxelFromSRASmatrix, 3,1)*xr +
+      *MATRIX_RELT(VoxelFromSRASmatrix, 3,2)*yr +
+      *MATRIX_RELT(VoxelFromSRASmatrix, 3,3)*zr +
+      *MATRIX_RELT(VoxelFromSRASmatrix, 3,4) ;
+  }
+  
+  if (!old_way) {
+    *xv = nx;
+    *yv = ny;
+    *zv = nz;
+    return (NO_ERROR);
+  }
+
+  VECTOR* sr = VectorAlloc(4, MATRIX_REAL);
   V4_LOAD(sr, xr, yr, zr, 1.);
 
-  vv = MatrixMultiply(VoxelFromSRASmatrix, sr, NULL);
+  VECTOR* vv = MatrixMultiply(VoxelFromSRASmatrix, sr, NULL);
 
-  *xv = V3_X(vv);
-  *yv = V3_Y(vv);
-  *zv = V3_Z(vv);
+  float ox = V3_X(vv);
+  float oy = V3_Y(vv);
+  float oz = V3_Z(vv);
 
   VectorFree(&sr);
   VectorFree(&vv);
+
+  if (new_way) {
+    if (closeEnough(ox,nx) || closeEnough(oy,ny) || closeEnough(oz, nz)) {
+      fprintf(stderr, "%s:%d not same answer\n", __FILE__, __LINE__);
+      *(int*)-1 = 0;
+    }
+  }
+
+  *xv = ox;
+  *yv = oy;
+  *zv = oz;
 
   return (NO_ERROR);
 }

--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -54999,14 +54999,16 @@ int mriSurfaceRASToVoxel(
     double *xv, double *yv, double *zv)
 {
   static int once;
-  static bool const try_both_way = true;
-  static bool const try_new_way  = true;
-  static bool       try_old_way  = false;
+  static bool try_both_way = false;
+  static bool try_new_way  = true;
+  static bool try_old_way  = false;
   if (!once) {
     once++; 
     try_both_way = getenv("FREESURFER_mriSurfaceRASToVoxel_both");
-    try_old_way  = getenv("FREESURFER_mriSurfaceRASToVoxel_old");
-    if (try_both_way) try_new_way = try_old_way = true;
+    if  (try_both_way) 
+        try_new_way = try_old_way = true;
+    else if (getenv("FREESURFER_mriSurfaceRASToVoxel_old"))
+        try_new_way = false, try_old_way = true;
   }
 
   bool const new_way = 
@@ -55021,21 +55023,22 @@ int mriSurfaceRASToVoxel(
 
   float nx = 0, ny = 0, nz = 0;
   if (new_way) {
+    float fxr = xr, fyr = yr, fzr = zr;     // cvt to float to match old way
     nx = 
-      *MATRIX_RELT(VoxelFromSRASmatrix, 1,1)*xr +
-      *MATRIX_RELT(VoxelFromSRASmatrix, 1,2)*yr +
-      *MATRIX_RELT(VoxelFromSRASmatrix, 1,3)*zr +
-      *MATRIX_RELT(VoxelFromSRASmatrix, 1,4) ;
+      (double)*MATRIX_RELT(VoxelFromSRASmatrix, 1,1)*fxr +
+      (double)*MATRIX_RELT(VoxelFromSRASmatrix, 1,2)*fyr +
+      (double)*MATRIX_RELT(VoxelFromSRASmatrix, 1,3)*fzr +
+      (double)*MATRIX_RELT(VoxelFromSRASmatrix, 1,4) ;
     ny = 
-      *MATRIX_RELT(VoxelFromSRASmatrix, 2,1)*xr +
-      *MATRIX_RELT(VoxelFromSRASmatrix, 2,2)*yr +
-      *MATRIX_RELT(VoxelFromSRASmatrix, 2,3)*zr +
-      *MATRIX_RELT(VoxelFromSRASmatrix, 2,4) ;
+      (double)*MATRIX_RELT(VoxelFromSRASmatrix, 2,1)*fxr +
+      (double)*MATRIX_RELT(VoxelFromSRASmatrix, 2,2)*fyr +
+      (double)*MATRIX_RELT(VoxelFromSRASmatrix, 2,3)*fzr +
+      (double)*MATRIX_RELT(VoxelFromSRASmatrix, 2,4) ;
     nz = 
-      *MATRIX_RELT(VoxelFromSRASmatrix, 3,1)*xr +
-      *MATRIX_RELT(VoxelFromSRASmatrix, 3,2)*yr +
-      *MATRIX_RELT(VoxelFromSRASmatrix, 3,3)*zr +
-      *MATRIX_RELT(VoxelFromSRASmatrix, 3,4) ;
+      (double)*MATRIX_RELT(VoxelFromSRASmatrix, 3,1)*fxr +
+      (double)*MATRIX_RELT(VoxelFromSRASmatrix, 3,2)*fyr +
+      (double)*MATRIX_RELT(VoxelFromSRASmatrix, 3,3)*fzr +
+      (double)*MATRIX_RELT(VoxelFromSRASmatrix, 3,4) ;
   }
   
   if (!old_way) {


### PR DESCRIPTION
It is significantly faster to hand code this partial matrix multiply than too compute too much the hard way

< topology fixing took 0.9 minutes
> topology fixing took 0.8 minutes

< mris_fix_topology utimesec    119.596000
> mris_fix_topology utimesec    115.500000

< FSRUNTIME@ mris_fix_topology lh  0.0145 hours 4 threads
> FSRUNTIME@ mris_fix_topology lh  0.0135 hours 4 threads
