### PR TITLE
bf: solved osx divergence

### DIFF
--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -61522,13 +61522,18 @@ static int compare_edge_length(const void *pe0, const void *pe1)
 
   /*  return(c1 > c2 ? 1 : c1 == c2 ? 0 : -1) ;*/
   if (e0->len > e1->len) {
-    return (1);
+    return(1);
   }
   else if (e0->len < e1->len) {
-    return (-1);
+    return(-1);
   }
-
-  return (0);
+  else if (e0->vno1 > e1->vno1) {
+    // if two lengths are the same, force a consistent order by
+    // comparing the vno1 values for each edge. Otherwise, returning 0
+    // will produce sorting differences on osx
+    return(1);
+  }
+  return(-1)
 }
 #if 0
 static int

--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -61533,7 +61533,7 @@ static int compare_edge_length(const void *pe0, const void *pe1)
     // will produce sorting differences on osx
     return(1);
   }
-  return(-1)
+  return(-1);
 }
 #if 0
 static int


### PR DESCRIPTION
Provided with identical edge arrays,
```c
qsort(et, nedges, sizeof(EDGE), compare_edge_length);
```
produces different results on osx vs linux. `compare_edge_length()` returns 0 when two edges have the same length, leaving the final order reliant on the order in which `qsort` compares elements (which appears to be platform-specific). This fix involves forcing a consistent hierarchy for edges with the same length by comparing their `vno1` values.