### PR TITLE
Bf mris transform

### DIFF
--- a/mri_warp_convert/mri_warp_convert.cpp
+++ b/mri_warp_convert/mri_warp_convert.cpp
@@ -173,6 +173,7 @@ GCAM* readITK(const string& warp_file, const string& src_geom)
 
   GCA_MORPH* gcam = GCAMalloc(itk->width, itk->height, itk->depth) ;
   GCAMinitVolGeom(gcam, src, itk) ;
+  gcam->type = GCAM_VOX;
 
   MATRIX *ras2lps = MatrixIdentity(4, NULL);
   ras2lps->rptr[1][1] = -1;

--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -42843,7 +42843,6 @@ int MRIStransform(MRI_SURFACE *mris, MRI *mri, TRANSFORM *transform, MRI *mri_ds
     GCA_MORPH *gcam;
     double xs, ys, zs, xv, yv, zv;
     float xv2, yv2, zv2;
-    MATRIX *m_atlas_ras2vox, *m_surf_vox2ras, *m_surf_ras_to_atlas_ras;
     VECTOR *v1, *v2;
 
     /*
@@ -42862,7 +42861,9 @@ int MRIStransform(MRI_SURFACE *mris, MRI *mri, TRANSFORM *transform, MRI *mri_ds
       mri = MRIalloc(gcam->atlas.width, gcam->atlas.height, gcam->atlas.depth, MRI_UCHAR);
       useVolGeomToMRI(&gcam->atlas, mri);
     }
-    GCAMrasToVox(gcam, mri_dst);
+    if (gcam->type == GCAM_RAS) {
+        GCAMrasToVox(gcam, mri_dst);
+    }
 
     v1 = VectorAlloc(4, MATRIX_REAL);
     VECTOR_ELT(v1, 4) = 1.0;
@@ -42870,12 +42871,6 @@ int MRIStransform(MRI_SURFACE *mris, MRI *mri, TRANSFORM *transform, MRI *mri_ds
     VECTOR_ELT(v2, 4) = 1.0;
     voxelFromSurfaceRAS = voxelFromSurfaceRAS_(mri);
     surfaceRASFromVoxel = surfaceRASFromVoxel_(mri_dst);
-    m_surf_vox2ras = MRIgetVoxelToRasXform(mri);  // from "surface" volume to ras
-    m_atlas_ras2vox = VGgetVoxelToRasXform(&gcam->atlas, NULL, 0);
-    // from "surface" volume to ras
-    // from surface ras to atlas ras
-    m_surf_ras_to_atlas_ras = MatrixMultiply(m_surf_vox2ras, voxelFromSurfaceRAS, NULL);
-    MatrixMultiply(m_atlas_ras2vox, m_surf_ras_to_atlas_ras, voxelFromSurfaceRAS);
 
     // now apply the transform
     for (vno = 0; vno < mris->nvertices; vno++) {
@@ -42910,9 +42905,6 @@ int MRIStransform(MRI_SURFACE *mris, MRI *mri, TRANSFORM *transform, MRI *mri_ds
     VectorFree(&v2);
     MatrixFree(&voxelFromSurfaceRAS);
     MatrixFree(&surfaceRASFromVoxel);
-    MatrixFree(&m_surf_vox2ras);
-    MatrixFree(&m_atlas_ras2vox);
-    MatrixFree(&m_surf_ras_to_atlas_ras);
     if (dstNotGiven) {
       MRIfree(&mri_dst);
     }

--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -42862,7 +42862,7 @@ int MRIStransform(MRI_SURFACE *mris, MRI *mri, TRANSFORM *transform, MRI *mri_ds
       useVolGeomToMRI(&gcam->atlas, mri);
     }
     if (gcam->type == GCAM_RAS) {
-        GCAMrasToVox(gcam, mri);
+        GCAMrasToVox(gcam, mri_dst);
     }
 
     v1 = VectorAlloc(4, MATRIX_REAL);

--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -42862,7 +42862,7 @@ int MRIStransform(MRI_SURFACE *mris, MRI *mri, TRANSFORM *transform, MRI *mri_ds
       useVolGeomToMRI(&gcam->atlas, mri);
     }
     if (gcam->type == GCAM_RAS) {
-        GCAMrasToVox(gcam, mri_dst);
+        GCAMrasToVox(gcam, mri);
     }
 
     v1 = VectorAlloc(4, MATRIX_REAL);
@@ -42870,7 +42870,6 @@ int MRIStransform(MRI_SURFACE *mris, MRI *mri, TRANSFORM *transform, MRI *mri_ds
     v2 = VectorAlloc(4, MATRIX_REAL);
     VECTOR_ELT(v2, 4) = 1.0;
     voxelFromSurfaceRAS = voxelFromSurfaceRAS_(mri);
-    surfaceRASFromVoxel = surfaceRASFromVoxel_(mri_dst);
 
     // now apply the transform
     for (vno = 0; vno < mris->nvertices; vno++) {
@@ -42904,7 +42903,6 @@ int MRIStransform(MRI_SURFACE *mris, MRI *mri, TRANSFORM *transform, MRI *mri_ds
     VectorFree(&v1);
     VectorFree(&v2);
     MatrixFree(&voxelFromSurfaceRAS);
-    MatrixFree(&surfaceRASFromVoxel);
     if (dstNotGiven) {
       MRIfree(&mri_dst);
     }


### PR DESCRIPTION
Fixed large offset that would move surfaces out of the brain when applying non-linear warps where source and target image have different world matrices.

The implicit convention (see e.g. mri_convert, line 2949ff) is that orig warp coordinates are given in source image space, the updated x/y/z coordinates in target image space. The function MRIStransform() in mrisurf.c, however, assumed those coordinates were given in source image space and therefore transformed them to target image space.

Checked if that function (and specifically its non-linear part) were called at any point during the CROSS/BASE/LONG run, which was not the case. Unit tests to follow.