### PR TITLE
don't build fsgd_wrap.c with non-GUI build (includes tcl.h)

### DIFF
--- a/fsgdf/Makefile.am
+++ b/fsgdf/Makefile.am
@@ -21,7 +21,7 @@ noinst_LIBRARIES= libfsgdf.a
 if ENABLE_TCLTK_APPS
 libfsgdf_a_SOURCES = fsgdf.c fsgdf_wrap.c FsgdfPlot.cxx
 else
-libfsgdf_a_SOURCES = fsgdf.c fsgdf_wrap.c
+libfsgdf_a_SOURCES = fsgdf.c
 endif
 
 if ENABLE_TCLTK_APPS

--- a/minc_1_5_1/minc_image_conversion.c
+++ b/minc_1_5_1/minc_image_conversion.c
@@ -1442,7 +1442,7 @@ PRIVATE int MI_icv_zero_buffer(mi_icv_type *icvp, long count[], void *values)
 	signed int     si;
 	float          f;
 	double         d;
-   } volatile zerobuf;
+   } volatile zerobuf = { 0 };
    volatile char *zerostart;
    int zerolen, idim, ndims;
    char *bufptr, *bufend, *zeroptr, *zeroend;

--- a/packages/vxl/makefile
+++ b/packages/vxl/makefile
@@ -5,6 +5,7 @@ build_dir:=./build
 lib_dir:=./lib
 install_dir:=..
 include_dir:=./include
+share_dir:=./share
 
 GIT:=$(shell which git)
 MAKE:=$(shell which make)
@@ -72,7 +73,7 @@ all: checkout config build test install
 .PHONY: nuke checkout config build test install
 
 nuke:
-	rm -rf $(dist_name) $(src_dir) $(build_dir) $(bin_dir) $(lib_dir) $(include_dir)
+	rm -rf $(dist_name) $(src_dir) $(build_dir) $(bin_dir) $(lib_dir) $(include_dir) $(share_dir)
 
 checkout:
 	$(checkout_cmd)

--- a/xml2/xmlschemas.c
+++ b/xml2/xmlschemas.c
@@ -15327,8 +15327,8 @@ xmlSchemaCheckCOSNSSubset(xmlSchemaWildcardPtr sub,
   * 2.2 super must be a pair of not and the same value.
   */
   if ((sub->negNsSet != NULL) &&
-      (super->negNsSet != NULL) &&
-      (sub->negNsSet->value == sub->negNsSet->value))
+      (super->negNsSet != NULL)) // &&
+    //gcc 7 hates this!      (sub->negNsSet->value == sub->negNsSet->value))
     return (0);
   /*
   * 3.1 sub must be a set whose members are either namespace names or �absent�.


### PR DESCRIPTION
- removed fsgd_wrap.c from non-GUI build because it includes tcl.h
- other minor improvements