### PR TITLE
Nf faster distance map update 5

### DIFF
--- a/mris_fix_topology/test_mris_fix_topology_p_timing
+++ b/mris_fix_topology/test_mris_fix_topology_p_timing
@@ -1,0 +1,80 @@
+#!/bin/tcsh -f
+
+umask 002
+
+printenv | grep FREESURFER
+
+# 1 2 4 8
+foreach threads ( 1 )
+
+  # 2 -1
+  foreach niters ( 2 )
+    if ($niters != -1) then
+      set NITERS_OPTION = "-niters $niters"
+      set NITERS_EXTENSION =
+    else
+      set NITERS_OPTION = 
+      set NITERS_EXTENSION = _unlimited
+    endif
+  
+    #  currently available:
+    # 	.dev .nf_faster_distance_map_update_4 .nf_faster_distance_map_update_5
+    #
+    # Don't forget to...
+    #   cp mris_fix_topology{,.nf_faster_distance_map_update_5}
+    #
+    foreach branch ( .nf_faster_distance_map_update_5 )
+
+      set feature=0
+
+      set extension = -B${branch}-F${feature}-N${niters}-T${threads}
+
+      # the simple cmd
+      #
+      set cmd=(../mris_fix_topology${branch} \
+              $NITERS_OPTION \
+              -mgz \
+              -sphere qsphere.nofix \
+              -ga -seed 1234 bert lh)
+
+      # extract testing data
+      #
+      echo "#\!/bin/tcsh -f" > tmp_cmd
+      echo "( \" >> tmp_cmd
+      
+      set p=3
+      foreach i ( 1 2 3)
+	  rm -rf testdata
+	  gunzip -c testdata.tar.gz | tar xf -
+	  cp testdata/subjects/bert/surf/lh.orig{.before,}
+
+	  rm -rf testdata${extension}_p${p}_${i}
+    	  mv     testdata{,${extension}_p${p}_${i}}
+	  
+	  echo "( cd testdata${extension}_p${p}_${i}; \"    >> tmp_cmd
+	  echo "  $cmd ) >& \"      	    	    	    >> tmp_cmd
+	  echo "  cout_cerr_p${p}_${i}.txt &; \"     	    >> tmp_cmd
+      end
+
+      setenv FREESURFER_HOME ../../distribution
+      setenv SUBJECTS_DIR ./subjects
+      setenv OMP_NUM_THREADS $threads
+      echo "testing with $threads thread(s)"
+
+      setenv FREESURFER_REPLACEMENT_FOR_CREATION_TIME_STRING "Sun Jan 11 11:11:11 ZONE 2011"
+
+      # ---- TEST 1 ----
+
+      # run mris_make_surfaces using typical input
+
+      echo "wait )" >> tmp_cmd
+      chmod u+x tmp_cmd
+      
+      cat tmp_cmd
+      ./tmp_cmd
+      
+      grep RUN cout_cerr_p${p}_*.txt
+      
+    end
+  end
+end

--- a/mris_fix_topology/test_mris_fix_topology_timing
+++ b/mris_fix_topology/test_mris_fix_topology_timing
@@ -7,7 +7,7 @@ unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_test_avoidable_predictio
 
 
 # 1 2 4 8
-foreach threads ( 4 )
+foreach threads ( 1 2 4 8)
 
   # 2 -1
   foreach niters ( -1 )
@@ -23,11 +23,11 @@ foreach threads ( 4 )
     # 	.nf_faster_distance_map_update_4 
     #
     # Don't forget to...
-    #   cp mris_fix_topology{,.nf_faster_distance_map_update_4}
+    #   cp mris_fix_topology{,.nf_faster_distance_map_update_5}
     #
-    foreach branch ( .nf_faster_distance_map_update_4 )
+    foreach branch ( .nf_faster_distance_map_update_5 )
 
-      foreach feature ( 1 )
+      foreach feature ( 1 7 )
     
         # This is the supposedly worst state
 	#

--- a/mris_fix_topology/test_mris_fix_topology_timing
+++ b/mris_fix_topology/test_mris_fix_topology_timing
@@ -5,12 +5,13 @@ umask 002
 unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_ComputeVertexPseudoNormalCache_test
 unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_test_avoidable_prediction
 
+printenv | grep FREESURFER
 
 # 1 2 4 8
-foreach threads ( 1 2 4 8)
+foreach threads ( 4 )
 
   # 2 -1
-  foreach niters ( -1 )
+  foreach niters ( 2 )
     if ($niters != -1) then
       set NITERS_OPTION = "-niters $niters"
       set NITERS_EXTENSION =
@@ -20,53 +21,42 @@ foreach threads ( 1 2 4 8)
     endif
   
     #  currently available:
-    # 	.nf_faster_distance_map_update_4 
+    # 	.dev .nf_faster_distance_map_update_4 .nf_faster_distance_map_update_5
     #
     # Don't forget to...
     #   cp mris_fix_topology{,.nf_faster_distance_map_update_5}
     #
     foreach branch ( .nf_faster_distance_map_update_5 )
 
-      foreach feature ( 1 7 )
+      foreach feature ( 6 )
     
         # This is the supposedly worst state
 	#
-    	unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_fix_sign_bug
-
         setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_loop3_old	    	    	    	1
-        unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_loop3_new
-
     	setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_MRIDistance_old	    	    	    	1
-    	unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_MRIDistance_new
-	
-	setenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_avoidable_prediction 	    	1
-	setenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_fast_avoidable_prediction    	1
-	setenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_ComputeVertexPseudoNormalCache_suppress 	1
-        setenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_sharedVertexPseudoNormalCache    1
+	setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_avoidable_prediction 	    	1
+	setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_fast_avoidable_prediction    	1
+	setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_ComputeVertexPseudoNormalCache_suppress 1
+        setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_sharedVertexPseudoNormalCache  1
 	
 	# Enabling the new features one at a time
 	#
         if ($feature >= 1) then
-            unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_loop3_old   	    	    	1
-            setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_loop3_new
+            unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_loop3_old
         endif
         if ($feature >= 2) then
-	    setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_MRIDistance_new 	    	    	1
-        endif
-        if ($feature >= 3) then
 	    unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_MRIDistance_old
         endif
-        if ($feature >= 4) then
+        if ($feature >= 3) then
 	    unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_avoidable_prediction
         endif
-        if ($feature >= 5) then
+        if ($feature >= 4) then
 	    unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_fast_avoidable_prediction
         endif
-        if ($feature >= 6) then
+        if ($feature >= 5) then
 	    unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_ComputeVertexPseudoNormalCache_suppress
         endif
-        if ($feature >= 7) then
-            # setenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_test_sharedVertexPseudoNormalCache
+        if ($feature >= 6) then
 	    unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_sharedVertexPseudoNormalCache
         endif
 	

--- a/mris_fix_topology/test_mris_fix_topology_timing
+++ b/mris_fix_topology/test_mris_fix_topology_timing
@@ -2,8 +2,12 @@
 
 umask 002
 
+unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_ComputeVertexPseudoNormalCache_test
+unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_test_avoidable_prediction
+
+
 # 1 2 4 8
-foreach threads ( 8 )
+foreach threads ( 4 )
 
   # 2 -1
   foreach niters ( -1 )
@@ -16,55 +20,61 @@ foreach threads ( 8 )
     endif
   
     #  currently available:
-    # 	.nf_fewer_free_locks_1 
-    # 	.nf_faster_distance_map_update_1 
+    # 	.nf_faster_distance_map_update_4 
     #
-    foreach branch ( .nf_fewer_free_locks_1 )
+    # Don't forget to...
+    #   cp mris_fix_topology{,.nf_faster_distance_map_update_4}
+    #
+    foreach branch ( .nf_faster_distance_map_update_4 )
 
-      # 0 = old code with sign bug
-      # 1 = old code without sign bug
-      # 2 = new code with sign bug
-      # 3 = new code without sign bug
-      # 4 = 3 with other improvements also
-      #
-      foreach feature ( 1 4 )
+      foreach feature ( 1 )
     
-        if ($feature == 0) then
-          setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_old 1
-    	  unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_new
-    	  setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_fix_sign_bug 1
-          setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_oldMriDistance 1
+        # This is the supposedly worst state
+	#
+    	unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_fix_sign_bug
+
+        setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_loop3_old	    	    	    	1
+        unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_loop3_new
+
+    	setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_MRIDistance_old	    	    	    	1
+    	unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_MRIDistance_new
+	
+	setenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_avoidable_prediction 	    	1
+	setenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_fast_avoidable_prediction    	1
+	setenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_ComputeVertexPseudoNormalCache_suppress 	1
+        setenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_sharedVertexPseudoNormalCache    1
+	
+	# Enabling the new features one at a time
+	#
+        if ($feature >= 1) then
+            unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_loop3_old   	    	    	1
+            setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_loop3_new
         endif
-        if ($feature == 1) then
-          setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_old 1
-    	  unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_new
-    	  unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_fix_sign_bug
-          setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_oldMriDistance 1
+        if ($feature >= 2) then
+	    setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_MRIDistance_new 	    	    	1
         endif
-        if ($feature == 2) then
-          unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_old
-    	  setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_new 1
-    	  setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_fix_sign_bug 1
-          setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_oldMriDistance 1
+        if ($feature >= 3) then
+	    unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_MRIDistance_old
         endif
-        if ($feature == 3) then
-          unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_old
-    	  setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_new 1
-    	  unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_fix_sign_bug
-          setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_oldMriDistance 1
+        if ($feature >= 4) then
+	    unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_avoidable_prediction
         endif
-        if ($feature == 4) then
-          unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_old
-    	  setenv   FREESURFER_mrisComputeDefectMRILogUnlikelihood_new 1
-    	  unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_fix_sign_bug
-          unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_oldMriDistance
+        if ($feature >= 5) then
+	    unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_fast_avoidable_prediction
+        endif
+        if ($feature >= 6) then
+	    unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_ComputeVertexPseudoNormalCache_suppress
+        endif
+        if ($feature >= 7) then
+            # setenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_test_sharedVertexPseudoNormalCache
+	    unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_sharedVertexPseudoNormalCache
         endif
 	
 	set extension = -B${branch}-F${feature}-N${niters}-T${threads}
 
 	# extract testing data
 	rm -rf testdata
-	gunzip -c testdata.tar.gz | tar xvf -
+	gunzip -c testdata.tar.gz | tar xf -
 
 	cd testdata
 	cp subjects/bert/surf/lh.orig{.before,}

--- a/mris_fix_topology/test_mris_fix_topology_timing
+++ b/mris_fix_topology/test_mris_fix_topology_timing
@@ -26,7 +26,7 @@ foreach threads ( 4 )
     # Don't forget to...
     #   cp mris_fix_topology{,.nf_faster_distance_map_update_5}
     #
-    foreach branch ( .nf_faster_distance_map_update_5 )
+    foreach branch ( .nf_faster_distance_map_update_5  )
 
       foreach feature ( 6 )
     

--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -57070,6 +57070,21 @@ static double mrisComputeDefectMRILogUnlikelihood_wkr(
     DEFECT_PATCH * const dp_nonconst, 
     HISTOGRAM    * const h_border_nonconst)
 {
+#if 1
+  // The tests themselves are expensive, so eliminate them except when developing
+  //
+  static const bool 
+    keep_sign_bug = false,  	    	    	    	    	    	    	    	// no test
+    do_new_MRIDistance = true,     	    	    	    	    	    	    	// if both set, that tests the new
+    do_old_MRIDistance = false,
+    do_new_loop3 = true,   	    	    	    	    	    	    	    	// if both set, that tests the new
+    do_old_loop3 = false, 
+    	    	    	            	        use_fast_avoidable_prediction = true,	// no test
+    test_avoidable_prediction = false, 	        use_avoidable_prediction = true,
+    test_sharedVertexPseudoNormalCache = false, use_sharedVertexPseudoNormalCache = true;
+#else
+  // Allow comparing different options quickly, but the times are affected compared to unconditional
+  //
   static bool 
     keep_sign_bug,  	    	    	    	    	    	    	    	// no test
     do_new_MRIDistance,     	    	    	    	    	    	    	// if both set, that tests the new
@@ -57096,7 +57111,7 @@ static double mrisComputeDefectMRILogUnlikelihood_wkr(
     test_sharedVertexPseudoNormalCache	= !!getenv("FREESURFER_mrisComputeDefectMRILogUnlikelihood_test_sharedVertexPseudoNormalCache"),
     use_sharedVertexPseudoNormalCache	=  !getenv("FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_sharedVertexPseudoNormalCache")
     	    	    	    	    	    || test_sharedVertexPseudoNormalCache;
-    
+
     if (do_old_loop3) {
       fprintf(stdout, "mrisComputeDefectMRILogUnlikelihood using old loop3 algorithm with the %s\n",keep_sign_bug?"sign bug still there":"sign bug fixed");
       if (do_new_loop3) 
@@ -57119,6 +57134,7 @@ static double mrisComputeDefectMRILogUnlikelihood_wkr(
         test_sharedVertexPseudoNormalCache?" only, but testing it":"");
     }
   }
+#endif
 
   MRI_SURFACE  const * const mris     = mris_nonconst;			// find where the modifiers are
   DEFECT_PATCH const * const dp       = dp_nonconst;


### PR DESCRIPTION
Same results on recon-all as dev branch
Next significant decrease in the times to do mris_fix_topology

before:FSRUNTIME@ mris_fix_topology lh  0.0674 hours 4 threads
after   :FSRUNTIME@ mris_fix_topology lh  0.0519 hours 4 threads
before:FSRUNTIME@ mris_fix_topology rh  0.0871 hours 4 threads
after   :FSRUNTIME@ mris_fix_topology rh  0.0667 hours 4 threads

Achieved by (next step is to write these up in the Wiki)
1) Reducing the number of nodes in the realm tree by not making children until needed
2) Removing excess locking of the realm tree
3) Cached the psuedo norms rather than recomputing
4) Created per-thread distance temporary rather than locking a shared one
5) loop invariant'ed the k->z calculation
6) Added a fast test - described below - that eliminates many of the points from consideration

The k->z loop invariant:
Consider

    for i in 0..maxI
       for j in 0..maxJ
            v = f(j)

The f(j) returns the same value when i is 0, 1, 2, ...   but the compiler does not loop-invariant it from the inner loop because it depends on j.   The solution is to rewrite this as
   
    for j in 0..maxJ
            cache[j] = f(j)

    for i in ...
       for j in ...
            v = cache[j]

Now the expensive function f(j) is called maxJ times  rather than maxI*maxJ times


The fast test path:

The code is calculating the min distance from a point to any point on a triangle.  It now determines a fast crude lower bound on this distance, and ignores the point if the current min is less than this lower bound.   The lower bound is based on some math, namely

  //	    	let IJK be any point in the box, and FP be any point on the face
  //	    	    distance(IJK, Center) <= distance(IJK,FP) + distance(FP,Center) 	hence
  //	    	    distance(IJK, Center) - distance(FP,Center) <= distance(IJK,FP)

so when the LHS is larger than the current mininum distance for IJK, it is not worth further consideration of this face

distance(FP, Center) is itself less than the distance from center to furtherest vertex, which is loop invariant of the i,j,k loops

distance(IJK, Center)  is sqrt( square(x-cx) + ... )    The code exploits     sqrt(a) < sqrt(b)  if and only if   a<b   to eliminate the need to calculate this sqrt

The code gets a pointer to the (i,j,kmin..kmax) vector to avoid having to re-index every time around the fast test path loop
