### PR TITLE
Fixing possible infinite recursion in trc/blood.cxx.

### DIFF
--- a/trc/blood.cxx
+++ b/trc/blood.cxx
@@ -2426,9 +2426,12 @@ void Blood::FindCenterStreamline(bool CheckOverlap, bool CheckDeviation,
       cout << "WARN: Turning off FA check for center streamline" << endl;
       FindCenterStreamline(CheckOverlap, false, false);
     }
-    else {
+    else if (CheckOverlap) {
       cout << "WARN: Turning off overlap check for center streamline" << endl;
       FindCenterStreamline(false, false, false);
+    else {
+      cout << "WARN: All checks already off. Exiting." << endl;
+      return;
     }
   }
   else {


### PR DESCRIPTION
FindCenterStreamline function (in trc/blood.cxx) calls itself with different checking options set to true or false in certain cases. The base case (else branch on line 2429) potentially calls itself to infinity if it happens that hdmin's value is not changed from numeric_limits<double>::infinity(). I presume this has to do with some characteristic of a streamline being unsatisfactory. In any case, FindCenterStreamline should not call itself again if all the check variables are already set to false.

I haven't looked in detail at what FindCenterStreamline does, so my fix may not be satisfactory, but I suspect this is something that should be fixed and that the fix is similar to my solution.