### PR TITLE
Nf faster distance map update 8

### DIFF
--- a/include/base.h
+++ b/include/base.h
@@ -89,8 +89,8 @@ extern "C" {
 
 // assertions
 //
-#define cheapAssert(TST)  { if (!(TST)) *(int*)-1 = 0; }
-#define costlyAssert(TST) { if (!(TST)) *(int*)-1 = 0; }
+#define cheapAssert(TST)        { if (!(TST)) *(int*)-1 = 0; }
+#define costlyAssert(TST) //    { if (!(TST)) *(int*)-1 = 0; }
 
 // Regardless of whether the __real_malloc etc. or the __wrap_ ones, it is still desirable
 // to know where in the program the allocations are happening.  This mechanism allows that to happen.

--- a/mris_fix_topology/test_mris_fix_topology_p_timing
+++ b/mris_fix_topology/test_mris_fix_topology_p_timing
@@ -5,10 +5,10 @@ umask 002
 printenv | grep FREESURFER
 
 # 1 2 4 8
-foreach threads ( 1 )
+foreach threads ( 2 )
 
   # 2 -1
-  foreach niters ( 2 )
+  foreach niters ( -1 )
     if ($niters != -1) then
       set NITERS_OPTION = "-niters $niters"
       set NITERS_EXTENSION =
@@ -23,7 +23,7 @@ foreach threads ( 1 )
     # Don't forget to...
     #   cp mris_fix_topology{,.nf_faster_distance_map_update_5}
     #
-    foreach branch ( .nf_faster_distance_map_update_5 )
+    foreach branch ( .nf_faster_distance_map_update_8 )
 
       set feature=0
 
@@ -42,8 +42,8 @@ foreach threads ( 1 )
       echo "#\!/bin/tcsh -f" > tmp_cmd
       echo "( \" >> tmp_cmd
       
-      set p=3
-      foreach i ( 1 2 3)
+      set p=2
+      foreach i ( 1 2 )
 	  rm -rf testdata
 	  gunzip -c testdata.tar.gz | tar xf -
 	  cp testdata/subjects/bert/surf/lh.orig{.before,}
@@ -51,15 +51,14 @@ foreach threads ( 1 )
 	  rm -rf testdata${extension}_p${p}_${i}
     	  mv     testdata{,${extension}_p${p}_${i}}
 	  
-	  echo "( cd testdata${extension}_p${p}_${i}; \"    >> tmp_cmd
-	  echo "  $cmd ) >& \"      	    	    	    >> tmp_cmd
-	  echo "  cout_cerr_p${p}_${i}.txt &; \"     	    >> tmp_cmd
+	  echo "( cd testdata${extension}_p${p}_${i}; \"        >> tmp_cmd
+          echo "setenv FREESURFER_HOME ../../distribution; \"   >> tmp_cmd
+          echo "setenv SUBJECTS_DIR ./subjects; \"              >> tmp_cmd
+          echo "setenv OMP_NUM_THREADS $threads; \"             >> tmp_cmd
+	  echo "  $cmd ) >& \"      	    	    	        >> tmp_cmd
+	  echo "  cout_cerr_p${p}_${i}.txt &; \"     	        >> tmp_cmd
       end
 
-      setenv FREESURFER_HOME ../../distribution
-      setenv SUBJECTS_DIR ./subjects
-      setenv OMP_NUM_THREADS $threads
-      echo "testing with $threads thread(s)"
 
       setenv FREESURFER_REPLACEMENT_FOR_CREATION_TIME_STRING "Sun Jan 11 11:11:11 ZONE 2011"
 

--- a/mris_fix_topology/test_mris_fix_topology_timing
+++ b/mris_fix_topology/test_mris_fix_topology_timing
@@ -26,7 +26,7 @@ foreach threads ( 4 )
     # Don't forget to...
     #   cp mris_fix_topology{,.nf_faster_distance_map_update_5}
     #
-    foreach branch ( .bf_wrongBufferSize  .nf_faster_distance_map_update_6 )
+    foreach branch ( .nf_faster_distance_map_update_8 )
 
       foreach feature ( 0 )
     

--- a/mris_fix_topology/test_mris_fix_topology_timing
+++ b/mris_fix_topology/test_mris_fix_topology_timing
@@ -8,7 +8,7 @@ unsetenv FREESURFER_mrisComputeDefectMRILogUnlikelihood_test_avoidable_predictio
 printenv | grep FREESURFER
 
 # 1 2 4 8
-foreach threads ( 4 )
+foreach threads ( 1 2 4 8 )
 
   # 2 -1
   foreach niters ( -1 )
@@ -26,7 +26,7 @@ foreach threads ( 4 )
     # Don't forget to...
     #   cp mris_fix_topology{,.nf_faster_distance_map_update_5}
     #
-    foreach branch ( .bf_wrongBufferSize  .nf_faster_distance_map_update_6 )
+    foreach branch ( .nf_faster_distance_map_update_8 )
 
       foreach feature ( 0 )
     
@@ -71,6 +71,8 @@ foreach threads ( 4 )
               $cmd >& ../mris_fix_topology${extension}.log
         #opreport --callgraph > ../mris_fix_topology_oprofile_callgraph${extension}.txt
 
+        grep -H RUNTIME ../mris_fix_topology${extension}.log
+        
 	# cleanup
 
 	cd ..

--- a/utils/realm.c
+++ b/utils/realm.c
@@ -41,7 +41,7 @@
 
 #include "fnv_hash.h"
 
-static int chkBnd(int lo, int b, int hi) {
+static inline __attribute__((always_inline)) int chkBnd(int lo, int b, int hi) {
     costlyAssert(lo <= b);
     costlyAssert(b < hi);
     return b;
@@ -1750,8 +1750,13 @@ struct GreatArcSet {
     int*    loVnos;                             // beginning vno of the great arc
     int*    hiVnos;                             // ending vno of the great arc
 
+    int     passedClock;
     int*    passed;                             // used during one callback to note those passed to de-duplicate the multiple cells
-    
+                //
+                // When the passed[i] == passedClock, the index is in the set
+                // When the passed[i] <  passedClock, the index is NOT in the set
+                // This makes it possible to remove all elements from the set by simply incrementing the passedClock
+                
     IntersectionSupport* intersectionSupport;   
         
     int     pairHeadsPlus1[PAIRS_HEADS_SIZE];   // a hash table, indexs into pairs
@@ -1862,7 +1867,8 @@ void freeGreatArcSet(GreatArcSet** setPtr) {
 
 GreatArcSet* makeGreatArcSet(MRIS* mris) {
     GreatArcSet* set = (GreatArcSet*)calloc(1, sizeof(GreatArcSet));
-    set->mris = mris;
+    set->mris        = mris;
+    set->passedClock = 1;
     return set;
 }
 
@@ -2080,7 +2086,6 @@ static bool possiblyIntersectingCell(GreatArcSet* set,
         bool* isHit),               // returns true if should keep going, false if no more needed
     Cell* cell,
     bool  tracing,
-    int*  pFirstPassedPlus1,
     int*  pCallBackCount,
     int*  pCallBackFirstFound,
     bool  doFastIntersectionTest,
@@ -2093,9 +2098,8 @@ static bool possiblyIntersectingCell(GreatArcSet* set,
 
         // eliminate duplicates
         //
-        if (set->passed[index]) continue;           // in list, hence this is a duplicate
-        set->passed[index] = *pFirstPassedPlus1;    // prepend to list
-        *pFirstPassedPlus1 = index + 1;
+        if (set->passed[index] == set->passedClock) continue;   // in the set, hence this is a duplicate
+        set->passed[index] = set->passedClock;                  // add to the set
 
         // If shared vertex, don't intersect
         //
@@ -2450,8 +2454,6 @@ void possiblyIntersectingGreatArcs(GreatArcSet* set,
     //
     int callBackCount = 0, callBackFirstFound = -1;
 
-    int firstPassedPlus1 = -1;  // 0 means not passed, -1 means end of list
-    
     static long localCount;
 
     int wI,hI;
@@ -2460,7 +2462,7 @@ void possiblyIntersectingGreatArcs(GreatArcSet* set,
         Cell* cell = getCell(set,wI,hI);
         localCount += cell->size;           
         if (possiblyIntersectingCell(set, callbackCtx, callback, cell, 
-                tracing, &firstPassedPlus1, &callBackCount, &callBackFirstFound,
+                tracing, &callBackCount, &callBackFirstFound,
                 !(universal_cell0 || universal_cell1),
                 vno0, vno1,
                 w0, h0, w1, h1)) goto Found;
@@ -2478,7 +2480,7 @@ void possiblyIntersectingGreatArcs(GreatArcSet* set,
     }
 
     if (possiblyIntersectingCell(set, callbackCtx, callback, &set->cells[UNIVERSAL_CELL], 
-                tracing, &firstPassedPlus1, &callBackCount, &callBackFirstFound,
+                tracing, &callBackCount, &callBackFirstFound,
                 false,
                 vno0, vno1,
                 w0, h0, w1, h1)) goto Found;
@@ -2486,11 +2488,12 @@ void possiblyIntersectingGreatArcs(GreatArcSet* set,
 Found:
     // Reset the passed list
     //
-    {   int index;
-        while ((index = firstPassedPlus1 - 1) >= 0) {
-            firstPassedPlus1 = set->passed[index];
-            set->passed[index] = 0;
-        }
+    set->passedClock++;
+    if (set->passedClock > 1000000000) {
+        // It is HIGHLY unlikely this code will ever execute
+        int index;
+        for (index = 0; index < set->capacity; index++) set->passed[index] = 0;
+        set->passedClock = 1;
     }
     
     // Done


### PR DESCRIPTION
Various small tweaks along the hottest paths to reduce topology fixing from 2.6 mins to 2.3 mins

1 - change some sqrt to sqrtf 
2 - eliminate some bounds checking that was on the hot path
3 - use memset to reset the deferred face norm flags
4 - add a cache to computeDefectFaceNormals to speed up finding the unique faces
5 - reorganized defectMaximizeLikelihood as ..._new
6 - added updateDistanceEltFromSignArgAndSquareNoLockNeeded, which simplifies the hottest path and which starts the sqrtf well before it is needed, even if it is not needed, because the h/w can throw it away and the DIV unit is not busy doing anything else
7 - replaced some / 3.0 with *0.33333f in places where the precise accuracy of the double precision divide was not needed
8 - changed the way the 'passed' set is implemented in realm.c to speed up the emptying of the set.  Documented the approach in the Wiki.  Basically the set is a vector of ints, and a counter.  Elements are added to the set by setting set[element] = counter;  If set[element] == counter, the element is in the set.  The set is emptied by counter++.
9 - reorganized the finding of the ignorable k values to avoid branch mispredicts.

Note: There are other places where  A /= N, B /= N, ... could be changed into   A *= 1.0f/N, ...  but I did not do so because it changed the results.  The new results are probably equally valid but different, and the win was not, in my opinion, worth pursuing at this time