### PR TITLE
Nf faster distance map update 9

### DIFF
--- a/include/base.h
+++ b/include/base.h
@@ -95,7 +95,9 @@ extern "C" {
 // Regardless of whether the __real_malloc etc. or the __wrap_ ones, it is still desirable
 // to know where in the program the allocations are happening.  This mechanism allows that to happen.
 //
-#if 0
+//#define DEBUG_MEMLEAK
+
+#if defined(DEBUG_MEMLEAK)
 
 void *mallocHere (              size_t size,                        const char* file, const char* function, int line);
 void  freeHere   (void *ptr,                                        const char* file, const char* function, int line);

--- a/include/mrishash_internals.h
+++ b/include/mrishash_internals.h
@@ -45,10 +45,10 @@ typedef struct
 #ifdef HAVE_OPENMP
   omp_lock_t     bucket_lock;
 #endif
-  MRIS_HASH_BIN  *bins ;
-  int            max_bins ;
-  int            nused ;
-  int            xsize, ysize, zsize ;
+  MRIS_HASH_BIN  * const bins ;
+  int              const max_bins ;
+  int                    nused ;
+  int                    size, ysize, zsize ;
 } MRIS_HASH_BUCKET, MHBT ;
 
 

--- a/utils/realm.c
+++ b/utils/realm.c
@@ -1858,6 +1858,7 @@ void freeGreatArcSet(GreatArcSet** setPtr) {
     freeAndNULL(set->hiVnos);
     freeAndNULL(set->loVnos);
     freeAndNULL(set->keys);
+    freeAndNULL(set);
 }
 
 GreatArcSet* makeGreatArcSet(MRIS* mris) {

--- a/utils/realm.c
+++ b/utils/realm.c
@@ -896,13 +896,18 @@ static RealmTreeNode* insertVnoIntoNode(
 }
 
 static void removeVnoFromRealmTree(RealmTree* realmTree, int vno) {
-
     RealmTreeNode* n = realmTree->vnoToRealmTreeNode[chkBnd(0, vno, realmTree->saved_nvertices)];
     realmTree->vnoToRealmTreeNode[vno] = NULL;
     {
+        // find it, backwards since the active ones are at end
+	//
         int vi;
-        for (vi = n->vnosSize - 1; n->vnos[vi] != vno; vi--);                   // find it, backwards since the active ones are at end
-        do { n->vnos[vi] = n->vnos[vi+1]; } while (++vi < n->vnosSize - 1);     // remove it
+        for (vi = n->vnosSize - 1; n->vnos[vi] != vno; vi--) { }
+	                   
+	// found at vi, shrink the list
+	//
+        for (; vi+1 < n->vnosSize; vi++)  { n->vnos[vi] = n->vnos[vi+1]; }  // remove it
+	n->vnosSize--;
     }
 }
 


### PR DESCRIPTION
Add support for finding memory leaks - https://surfer.nmr.mgh.harvard.edu/fswiki/MorphoOptimizationProject_debuggingSupport

Apply it to find and remove two major leaks introduced by the faster distance map update changes - our test system apparently does not detect this

Fix a minor problem in realm.c - items not being correctly removed from a list of possibles, causing unnecessary extra work to eliminate them.  Also rarely (never seen as a real problem) accessing one beyond the end of list. (Intel Inspector found this, which led to my finding the first problem)

Further decrease of 5-10% in mris_fix_topology

No change in results