### PR TITLE
Nf icc build 1

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -36,12 +36,31 @@ AC_CONFIG_MACRO_DIR([m4])
 # To use the Intel C/C++ compiler, assuming it is installed here:
 #   /somepath/intel
 # do this prior to configuring:
+#
 #   source /somepath/intel/bin/iccvars.csh -arch intel64 -platform linux
 #   setenv CC icc
 #   setenv CXX icpc
 #   setenv LD icpc
 #   setenv LDFLAGS "-L/somepath/intel/lib"
 #   setenv AR xiar
+#
+ac_enable_icc=no
+AC_ARG_ENABLE(icc,
+ [  --enable-icc         enable use of the Intel compiler],
+ [case "${enableval}" in
+  yes)  ac_enable_icc=yes ;;
+  no)   ;;
+  *) AC_MSG_ERROR([bad value ${enableval} for --enable-icc]) ;;
+  esac])
+if test "$ac_enable_icc" = "yes"; then
+  AC_MSG_NOTICE([icc enabled with defaults])
+  CC=icc
+  CXX=icpc
+  LD=icpc
+  LDFLAGS="-L/opt/intel/lib"
+  AR="xiar"
+fi
+
 ########################################################################
 
 ##############################################################
@@ -3795,7 +3814,19 @@ $ITK_LIBS $EXPAT_LIBS"
 # The order is important here. When adding or removing a lib, be sure
 # to test the link line to make sure you don't need to adjust the
 # order.
+ac_use_mkl=no
 if test "x$CC" = "xicc"; then
+  # was yes, but that assumed MKL was installed, which is not guaranteed
+  ac_use_mkl=no
+fi
+AC_ARG_ENABLE(icc,
+ [  --enable-mkl         enable use of the Intel Math Kernel Library],
+ [case "${enableval}" in
+  yes)  ac_enable_icc=yes ;;
+  no)   ;;
+  *) AC_MSG_ERROR([bad value ${enableval} for --enable-mkl]) ;;
+  esac])
+if test "$ac_use_mkl" = "yes"; then
   AC_MSG_NOTICE(Using Intel Math Kernel Library)
   MATH_LIBS="-lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core"
   MATH_LIBS="$MATH_LIBS -liomp5 -lm"

--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -58467,12 +58467,13 @@ static double mrisComputeDefectMRILogUnlikelihood_wkr(
 
   if (do_new_MRIDistance) {
     ROMP_PF_begin
-    int i,j,k;
+    long i;
 #ifdef HAVE_OPENMP
     #pragma omp parallel for if_ROMP(shown_reproducible) 
 #endif
     for (i = 0; i < mri_distance->width; i++) {
       ROMP_PFLB_begin
+      long j,k;
       for (j = 0; j < mri_distance->height; j++) {
         for (k = 0; k < mri_distance->depth; k++) {
 	
@@ -58486,7 +58487,7 @@ static double mrisComputeDefectMRILogUnlikelihood_wkr(
 	  if (do_old_MRIDistance) {
 	    float old_distance = MRIFvox(mri_distance_nonconst, i, j, k);
 	    if (old_distance != distance) {
-	      fprintf(stdout, "%s:%d diff distances at i:%d j:%d k:%d old:%g new:%g\n", __FILE__, __LINE__,
+	      fprintf(stdout, "%s:%d diff distances at i:%ld j:%ld k:%ld old:%g new:%g\n", __FILE__, __LINE__,
 	      	i,j,k,old_distance,distance);
 	      exit(1);
 	    }


### PR DESCRIPTION
Modify the configure script to make it easier to use the Intel compiler, and to make the Intel MKL optional when you are using it

Fix a bug that gcc did not notice but icc did - accidental sharing of variables being used for inner loop control but declared outside the parallel loop