### PR TITLE
Add release flag to GEMS2 build

### DIFF
--- a/GEMS2/make_gems2Python_wheel
+++ b/GEMS2/make_gems2Python_wheel
@@ -5,6 +5,7 @@ cmake  -D CMAKE_CXX_FLAGS="-msse2 -mfpmath=sse -fPIC -fpermissive" \
           -D BUILD_GUI=OFF \
           -D BUILD_MATLAB=OFF \
           -D BUILD_PYTHON=ON \
+          -D CMAKE_BUILD_TYPE=RELEASE \
           -D BUILD_SHARED_LIBS=OFF \
           -D BUILD_TESTING=OFF \
           . && \


### PR DESCRIPTION
Change in build script forces release build, which is at least twice as fast as debug build.