### PR TITLE
Nf mris register speedup 2

### DIFF
--- a/include/MRISrigidBodyAlignGlobal.h
+++ b/include/MRISrigidBodyAlignGlobal.h
@@ -1,0 +1,36 @@
+/**
+ * @file  MRISrigidBodyAlignGlobal.h
+ * @brief functions for finding the best rotation for aligning a MRIS with a target
+ *
+ */
+/*
+ * Original Author: Bevin Brett
+ * CVS Revision Info:
+ *    $Author: bbrett $
+ *    $Date: 2018/05/04 07:52:00 $
+ *    $Revision: 1.0 $
+ *
+ * Copyright © 2018 The General Hospital Corporation (Boston, MA) "MGH"
+ *
+ * Terms and conditions for use, reproduction, distribution and contribution
+ * are found in the 'FreeSurfer Software License Agreement' contained
+ * in the file 'LICENSE' found in the FreeSurfer distribution, and here:
+ *
+ * https://surfer.nmr.mgh.harvard.edu/fswiki/FreeSurferSoftwareLicense
+ *
+ * Reporting: freesurfer@nmr.mgh.harvard.edu
+ *
+ */
+
+#pragma once
+
+#include "mrisurf.h"
+
+void MRISrigidBodyAlignGlobal_findMinSSE(
+    double* mina, double* new_minb, double* new_ming, double* new_sse,  // outputs
+    MRI_SURFACE*        mris,
+    INTEGRATION_PARMS*  parms,
+    float               min_radians,
+    float               max_radians,
+    double              ext_sse,
+    int                 nangles);

--- a/include/base.h
+++ b/include/base.h
@@ -116,6 +116,14 @@ int posix_memalignHere(void **memptr, size_t alignment, size_t size,const char* 
 
 #define freeAndNULL(PTR) { free((PTR)); (PTR) = NULL; }
 
+
+// Some trivial math functions needed lots
+//
+#pragma GCC diagnostic ignored "-Wunused-function"
+static float squaref(float x) { return x*x; }
+
+
+
 #if defined(__cplusplus)
 };
 #endif

--- a/include/mrisp.h
+++ b/include/mrisp.h
@@ -1,0 +1,30 @@
+#pragma once
+/**
+ * @file  mrisp.h
+ * @brief utilities for spherical parameterization of an MRI_SURFACE
+ *
+ * mrisp = MRI_SURFACE parameterization contains utilities for writing various
+ * fields over the surface (e.g. curvature, coordinate functions) into a
+ * spherical (longitude/colatitude) parameterization in the form of a 2D
+ * image. Also for Gaussian blurring and other utilities.
+ */
+/*
+ * Original Author: Bruce Fischl
+ * CVS Revision Info:
+ *    $Author: nicks $
+ *    $Date: 2011/03/02 00:04:47 $
+ *    $Revision: 1.23 $
+ *
+ * Copyright © 2011 The General Hospital Corporation (Boston, MA) "MGH"
+ *
+ * Terms and conditions for use, reproduction, distribution and contribution
+ * are found in the 'FreeSurfer Software License Agreement' contained
+ * in the file 'LICENSE' found in the FreeSurfer distribution, and here:
+ *
+ * https://surfer.nmr.mgh.harvard.edu/fswiki/FreeSurferSoftwareLicense
+ *
+ * Reporting: freesurfer@nmr.mgh.harvard.edu
+ *
+ */
+
+#include "mrisurf.h"

--- a/include/mrisurf.h
+++ b/include/mrisurf.h
@@ -1324,9 +1324,28 @@ MRI_SP       *MRISPcombine(MRI_SP *mrisp, MRI_SP *mrisp_template, int fno);
 MRI_SP       *MRISPaccumulate(MRI_SP *mrisp, MRI_SP *mrisp_template, int fno);
 int          MRISPcoordinate(MRI_SP *mrisp, float x, float y, float z,
                              int *pu, int *pv) ;
+
+typedef struct MRISPfunctionValResultForAlpha {
+    double curr;
+    double next;
+} MRISPfunctionValResultForAlpha;
+
+void MRISPfunctionVal_radiusR(                                                      // returns the value that would be stored in resultsForEachFno[0] for fnoLo
+                              MRI_SURFACE_PARAMETERIZATION *mrisp,  
+                              MRISPfunctionValResultForAlpha* resultsForEachAlpha,  // must be numAlphas elements
+                              MRI_SURFACE *mris,
+                              float r, float x, float y, float z, 
+                              int fno, bool getNextAlso,                            // always fills in resultsForEachAlpha.curr for fno, optionally fills in .next for fno+1
+                              const float* alphas, float numAlphas,                 // rotate x,y,z by these alphas (radians) and get the values
+                              bool trace) ;                                         // note: this rotation is around the z axis, hence z does not change
+                             
+double       MRISPfunctionValTraceable(MRI_SURFACE_PARAMETERIZATION *mrisp,
+                              MRI_SURFACE *mris,
+                              float x, float y, float z, int fno, bool trace) ;
 double       MRISPfunctionVal(MRI_SURFACE_PARAMETERIZATION *mrisp,
                               MRI_SURFACE *mris,
                               float x, float y, float z, int fno) ;
+                              
 MRI_SP       *MRIStoParameterization(MRI_SURFACE *mris, MRI_SP *mrisp,
                                      float scale, int fno) ;
 MRI_SURFACE  *MRISfromParameterization(MRI_SP *mrisp, MRI_SURFACE *mris,

--- a/include/vertexRotator.h
+++ b/include/vertexRotator.h
@@ -1,0 +1,35 @@
+/**
+ * @file  vertexRotator.h
+ * @brief rapidly rotate vertexs around the x=0 y=0 z=0 axes
+ *
+ */
+/*
+ * Original Author: Bevin Brett
+ * CVS Revision Info:
+ *    $Author: bbrett $
+ *    $Date: 2018/05/04 07:52:00 $
+ *    $Revision: 1.0 $
+ *
+ * Copyright © 2018 The General Hospital Corporation (Boston, MA) "MGH"
+ *
+ * Terms and conditions for use, reproduction, distribution and contribution
+ * are found in the 'FreeSurfer Software License Agreement' contained
+ * in the file 'LICENSE' found in the FreeSurfer distribution, and here:
+ *
+ * https://surfer.nmr.mgh.harvard.edu/fswiki/FreeSurferSoftwareLicense
+ *
+ * Reporting: freesurfer@nmr.mgh.harvard.edu
+ *
+ */
+
+#pragma once
+
+#include "base.h"
+
+void rotateVertices(
+  float*         xv_out, float*       yv_out, float      * zv_out,
+  float const *  xv_inp, float const* yv_inp, float const* zv_inp,
+  size_t         nvertices,
+  float          alpha,       // rotate around z axis - last rotation
+  float          beta,        // rotate around y axis - middle rotation
+  float          gamma);      // rotate around x axis - first rotation

--- a/mris_register/test_mris_register
+++ b/mris_register/test_mris_register
@@ -53,10 +53,8 @@ endif
 set REF_VOL = ref_lh.sphere.reg
 set TST_VOL = lh.sphere.reg
 
-hd -s 96 -n 550000 < $REF_VOL > ${REF_VOL}.hd.txt
-hd -s 96 -n 550000 < $TST_VOL > ${TST_VOL}.hd.txt
+set cmd=(../../mris_diff/mris_diff --debug $REF_VOL $TST_VOL );
 
-set cmd=(diff -q ${REF_VOL}.hd.txt ${TST_VOL}.hd.txt );
 echo ""
 echo $cmd
 $cmd
@@ -66,8 +64,6 @@ if ($diff_status != 0) then
   exit 1
 endif
 
-echo ""
-echo ""
 echo ""
 
 #

--- a/utils/MRISrigidBodyAlignGlobal.c
+++ b/utils/MRISrigidBodyAlignGlobal.c
@@ -1,0 +1,501 @@
+/**
+ * @file  MRISrigidBodyAlignGlobal.c
+ * @brief functions for finding the best rotation for aligning a MRIS with a target
+ *
+ */
+/*
+ * Original Author: Bevin Brett
+ * CVS Revision Info:
+ *    $Author: bbrett $
+ *    $Date: 2018/05/04 07:52:00 $
+ *    $Revision: 1.0 $
+ *
+ * Copyright © 2018 The General Hospital Corporation (Boston, MA) "MGH"
+ *
+ * Terms and conditions for use, reproduction, distribution and contribution
+ * are found in the 'FreeSurfer Software License Agreement' contained
+ * in the file 'LICENSE' found in the FreeSurfer distribution, and here:
+ *
+ * https://surfer.nmr.mgh.harvard.edu/fswiki/FreeSurferSoftwareLicense
+ *
+ * Reporting: freesurfer@nmr.mgh.harvard.edu
+ *
+ */
+#include "MRISrigidBodyAlignGlobal.h"
+#include "romp_support.h"
+#include "vertexRotator.h"
+
+static float* getFloats(size_t capacity) {
+  void* ptr = NULL;
+  int status = posix_memalign(&ptr, 64, capacity*sizeof(float));
+  if (status) {
+    fprintf(stderr, "%s:%d could not posix_memalign %ld aligned floats, status:%d\n", __FILE__, __LINE__, capacity, status);
+    ptr = (float*)malloc(capacity*sizeof(float));
+    if (!ptr) exit(1);
+    fprintf(stderr, "%s:%d but malloc could\n", __FILE__, __LINE__);
+  }
+  return (float*)ptr;
+}
+
+void MRISrigidBodyAlignGlobal_findMinSSE(
+  double* new_mina, double* new_minb, double* new_ming, double* new_sse,  // outputs
+  MRI_SURFACE*       mris,
+  INTEGRATION_PARMS* parms,
+  float              min_radians,
+  float              max_radians,
+  double             ext_sse,
+  int                nangles) {
+
+  bool const tracing     = false;
+  bool const spreadsheet = false;
+  
+  // Get all the non-ripped vertices
+  // This yields cache-aligned dense coordinates to work with.
+  //
+  size_t verticesCapacity = mris->nvertices;
+
+  float* const curv                = getFloats(verticesCapacity);
+
+  float* const xv                  = getFloats(verticesCapacity);
+  float* const yv                  = getFloats(verticesCapacity);
+  float* const zv                  = getFloats(verticesCapacity);
+
+  float* const gammaRotated_xv     = getFloats(verticesCapacity);
+  float* const gammaRotated_yv     = getFloats(verticesCapacity);
+  float* const gammaRotated_zv     = getFloats(verticesCapacity);
+
+  float* const betaGammaRotated_xv = getFloats(verticesCapacity);
+  float* const betaGammaRotated_yv = getFloats(verticesCapacity);
+  float* const betaGammaRotated_zv = getFloats(verticesCapacity);
+
+  size_t verticesSize = 0;
+  int vno;
+  for (vno = 0; vno < mris->nvertices; vno++) {
+    VERTEX const * v = &mris->vertices[vno];
+    if (v->ripflag) continue;
+    xv[verticesSize] = v->x;
+    yv[verticesSize] = v->y;
+    zv[verticesSize] = v->z;
+    curv[verticesSize] = v->curv;
+    verticesSize++;
+  }
+
+  // Project these coordinates to the surface of a sphere of radius mris->radius
+  // This assumes that the vertices are already well away from (0,0,0)
+  //
+  { int i;
+    for (i = 0; i < verticesSize; i++) {
+      float invLength = mris->radius/sqrtf(squaref(xv[i])+squaref(yv[i])+squaref(zv[i]));
+      xv[i] *= invLength;
+      yv[i] *= invLength;
+      zv[i] *= invLength;
+    }
+  }
+
+  // TODO sort on z
+  // to maximize cache hit rate in the MRISPfunctionVal_radiusR function
+  
+  // Decide on the number of points along each edge of the grid
+  // and what that is in radians
+  //
+  int gridSize_init = 1;
+  while (max_radians / gridSize_init > min_radians) gridSize_init *= 2;
+  int const gridSize = gridSize_init;
+  int const gridCenterI = gridSize/2;
+  float const radiansPerGridCell = max_radians / gridSize;
+  
+  #define iToRadians(I) (((I) - gridCenterI)*radiansPerGridCell)
+  
+  // Allocate enough done flags for a cube of this many points
+  // Zero'ed since none visited yet
+  //
+  size_t const doneFlagsSize_inBits = gridSize*gridSize*gridSize;
+  size_t const doneFlagsPerElt      = sizeof(long)*8;
+  size_t const doneFlagsMask        = doneFlagsPerElt-1;
+  size_t const doneFlagsSize        = (doneFlagsSize_inBits + doneFlagsPerElt - 1) / doneFlagsPerElt;
+  long*  const doneFlags = (long*)calloc(doneFlagsSize, sizeof(long));
+  
+  // Support inverting the alpha and the vertices loops
+  // The vertices are broken into partitions
+  // so the inner loops can be threaded
+  //
+  int const numberOfVerticesPartitions     = 16;
+  int const forAlphasCapacity              = nangles + 1;
+
+  int*      ajsForAlphas                   = (int*)
+                                             malloc(forAlphasCapacity*sizeof(int));
+  float*    alphasForAlphas                = (float*)
+                                             malloc(forAlphasCapacity*sizeof(float));
+
+  int const forAlphasForPartitionsCapacity = forAlphasCapacity * numberOfVerticesPartitions;
+  
+  double*   ssesForAlphasForPartitions     = (double*)
+                                             malloc(forAlphasForPartitionsCapacity*sizeof(double));
+  MRISPfunctionValResultForAlpha* 
+            fvsForAlphasForPartitions      = (MRISPfunctionValResultForAlpha*)
+                                             malloc(forAlphasForPartitionsCapacity*sizeof(MRISPfunctionValResultForAlpha));
+
+  // The old code rotates this sphere is rotated around the x- y- and z- axis and compares this resulting rotated vertices with 
+  // the corresponding points in an image, first mapping the points into the image.  The mapping is very expensive.
+  // .
+  // Rather than do that, this code rotates the vertices around the x and y axes, and then rotates the image around the z axes
+  // which avoids a lot of the rotation work
+  //
+  // The old code converged on a single min, which meant it was very fragile.
+  // This code converges on several mins, provided they are far enough apart.
+  //
+  struct Center { 
+    double center_sse;
+    int    center_ai, center_bi, center_gi;
+    bool   center_sse_known;
+  };
+  
+  // Initialize the centers
+  //
+  #define centersCapacity 1
+  typedef struct Center Centers[centersCapacity];
+
+  Centers outCenters;
+  outCenters[0].center_ai = gridSize/2;
+  outCenters[0].center_bi = gridSize/2;
+  outCenters[0].center_gi = gridSize/2;
+  outCenters[0].center_sse = -1.0;  // not known
+  outCenters[0].center_sse_known = false;
+  int outCentersSize = 1;
+
+  // Walk near the centers, stepping gridSize rather than 1, and going 
+  //        center_i + for (j=0 ; j < nangles+1 ; j++) gridStride*(j - nangles/2)       // nangles+1 == forAlphaCapacity because of this
+  // 
+  int gridStride = (gridSize + nangles - 1)/nangles - 1;
+  if (spreadsheet) {
+    // format suitable for spreadsheet
+    fprintf(stdout, "gridStride %d\n", gridStride); 
+  }
+
+  bool changed = true;
+  for (;;) {
+
+    // Change to a finer stride when nothing changes
+    //  
+    if (!changed) {
+      if (gridStride == 1) break;
+      gridStride /= 2;
+      if (spreadsheet) {
+        // format suitable for spreadsheet
+        fprintf(stdout, "gridStride %d\n", gridStride); 
+      }
+    }
+    changed = false;
+    
+    // Use the outputs from the previous iteration as the best known centers so far
+    //
+    Centers inpCenters;
+    memcpy(inpCenters, outCenters, outCentersSize*sizeof(struct Center));
+    int const inpCentersSize = outCentersSize;
+    
+    // Search near each to improve them
+    //
+    int ici;
+    for (ici = 0; ici < inpCentersSize; ici++) {
+    
+      // search around each of the current centers
+      //
+      struct Center* icp = &inpCenters[ici];
+      
+      int    const center_ai        = icp->center_ai; 
+      int    const center_bi        = icp->center_bi; 
+      int    const center_gi        = icp->center_gi;
+      double const center_sse       = icp->center_sse;
+      bool   const center_sse_known = icp->center_sse_known;
+
+      bool trace = tracing;
+
+      if (tracing) {
+        fprintf(stdout, 
+          "%s:%d scanning %2.2f degree nbhd of centers[%d] (%2.2f, %2.2f, %2.2f), min sse = %2.2f\n", __FILE__, __LINE__,
+          (float)DEGREES(nangles   * radiansPerGridCell), 
+          ici,
+          (float)DEGREES(iToRadians(center_ai)),  
+          (float)DEGREES(iToRadians(center_bi)), 
+          (float)DEGREES(iToRadians(center_gi)),
+          center_sse_known ? (float)(center_sse + ext_sse) : -666.0);
+      }
+
+      int gj;
+      for (gj=0; gj < nangles + 1 ; gj++) {
+        int   const gi    = center_gi + gridStride*(gj - nangles/2);
+        float const gamma = iToRadians(gi);
+        
+        rotateVertices(gammaRotated_xv, gammaRotated_yv, gammaRotated_zv, xv, yv, zv, verticesSize,
+          0.0,      // rotate around z axis - last rotation
+          0.0,      // rotate around y axis - middle rotation
+          gamma);   // rotate around x axis - first rotation
+
+        int bj;
+        for (bj=0; bj < nangles + 1 ; bj++) {
+          int   const bi   = center_bi + gridStride*(bj - nangles/2);
+          float const beta = iToRadians(bi);
+          
+          rotateVertices(betaGammaRotated_xv, betaGammaRotated_yv, betaGammaRotated_zv, gammaRotated_xv, gammaRotated_yv, gammaRotated_zv, verticesSize,
+            0.0,    // rotate around z axis - last rotation
+            beta,   // rotate around y axis - middle rotation
+            0.0);   // rotate around x axis - first rotation
+
+          // select those not already done
+          //
+          size_t ajsSize = 0;
+
+          int aj;
+          for (aj = 0; aj < nangles + 1 ; aj++) {
+            int   ai    = center_ai + gridStride*(aj - nangles/2);
+            float alpha = iToRadians(ai);
+
+            int    doneIndex = gi*gridSize*gridSize + bi*gridSize + ai;
+            int    doneElt   = doneIndex / doneFlagsPerElt;
+            size_t doneFlag  = 1L << (doneIndex&doneFlagsMask);
+
+            bool done = doneFlags[doneElt] & doneFlag;
+            if (!done) {
+              doneFlags[doneElt] |= doneFlag;
+              ajsForAlphas   [ajsSize  ] = aj;
+              alphasForAlphas[ajsSize++] = alpha;
+            }
+          }
+              
+          // Partition the vertices so can spread across any threads in a deterministic manner
+          //
+          int const verticesPerPartition = (verticesSize + numberOfVerticesPartitions - 1)/numberOfVerticesPartitions;
+
+          ROMP_PF_begin        
+          int partition;
+  #ifdef HAVE_OPENMP
+          #pragma omp parallel for if_ROMP(assume_reproducible)
+  #endif
+          for (partition = 0; partition < numberOfVerticesPartitions; partition++) {
+            ROMP_PFLB_begin
+
+            int const viLo = partition*verticesPerPartition;
+            int const viHi = MIN(verticesSize, viLo + verticesPerPartition);
+
+            double*                         const ssesForAlphas   = &  ssesForAlphasForPartitions[partition*forAlphasCapacity];
+            MRISPfunctionValResultForAlpha* const fvsForAlphas    = &   fvsForAlphasForPartitions[partition*forAlphasCapacity];
+
+            { int aj;
+              for (aj = 0; aj < forAlphasCapacity; aj++) {
+                ssesForAlphas[aj] = 0.0;
+              }
+            }
+
+            int vi;
+            for (vi = viLo; vi < viHi; vi++) {
+
+              // alpha rotates around the z axis
+              //      which keeps the z coordinate constant
+              //      which can be used to speed up the MRISPfunctionVal_radiusR calls for each vertex
+              // hence the movement of this loop inside the vertices loop
+              //
+              bool const vertexTrace = trace && (vi == 0);
+
+              // process those selected
+              //
+              MRISPfunctionVal_radiusR(
+                  parms->mrisp_template, 
+                  fvsForAlphas,             // output values
+                  mris,
+                  mris->radius, betaGammaRotated_xv[vi], betaGammaRotated_yv[vi], betaGammaRotated_zv[vi], 
+                  parms->frame_no, true,
+                  alphasForAlphas, ajsSize, // input requests
+                  vertexTrace);
+
+              int ajsI;
+              for (ajsI = 0; ajsI < ajsSize ; ajsI++) {
+                int    const aj     = ajsForAlphas[ajsI];
+                double const target = fvsForAlphas[ajsI].curr;
+                double const std    = fvsForAlphas[ajsI].next;
+                
+                int    const ai     = center_ai + gridStride*(aj - nangles/2);
+                float  const alpha  = iToRadians(ai);
+
+                if (0) {
+
+                  // This is temporary, until it is built into MRISPfunctionVal_radiusR
+                  //
+                  float x = 0, y = 0, z = 0;
+
+                  rotateVertices(&x, &y, &z, &betaGammaRotated_xv[vi], &betaGammaRotated_yv[vi], &betaGammaRotated_zv[vi], 1,
+                    alpha,    // rotate around z axis - last rotation
+                    0.0,      // rotate around y axis - middle rotation
+                    0.0);     // rotate around x axis - first rotation
+
+                  bool const vertexAlphaTrace = trace && (vi == 0) && (aj == 0);
+                  if (vertexAlphaTrace) {
+                    fprintf(stdout, "%s:%d rotated (%g,%g,%g) by (a:%g, b:%g, g:%g) to (%g,%g,%g)\n", __FILE__, __LINE__, 
+                      xv[vi],yv[vi],zv[vi],
+                      alpha, beta, gamma,
+                      x,y,z); 
+                  }
+
+                  MRISPfunctionValResultForAlpha targetAndStd;
+                  MRISPfunctionVal_radiusR(
+                      parms->mrisp_template, &targetAndStd, mris, 
+                      mris->radius, x, y, z, 
+                      parms->frame_no, true,
+                      &alpha, 1,
+                      vertexAlphaTrace);
+
+                  if (vertexTrace && (aj < 2 || forAlphasCapacity-2 <= aj)) {
+                      fprintf(stdout, "%s:%d predicted target:%g target:%g   std:%g v %g\n", __FILE__, __LINE__, 
+                        target, targetAndStd.curr,
+                        std,    targetAndStd.next);
+                  }
+                }
+
+                double sqrt_std = sqrt(std);
+                if (FZERO(sqrt_std)) {
+                  #define DEFAULT_STD 4.0f
+                  sqrt_std = DEFAULT_STD /*FSMALL*/;
+                }
+
+                float const src = curv[vi];
+
+                double const delta = (src - target) / sqrt_std;
+                if (parms->geometry_error) {
+                  parms->geometry_error[vno] = (delta * delta);
+                }
+                if (parms->abs_norm) {
+                  ssesForAlphas[aj] += fabs(delta);
+                } else {
+                  ssesForAlphas[aj] += delta * delta;
+                }
+
+              }     // alpha
+            }       // vertices
+
+            ROMP_PFLB_end
+          }         // partitions
+          ROMP_PF_end
+
+          // Combine all the partitions into the 0'th
+          //
+          {
+            int partition;
+            for (partition = 1; partition < numberOfVerticesPartitions; partition++) {
+
+              double* const ssesForAlphas = &ssesForAlphasForPartitions[partition*forAlphasCapacity];
+
+              int aj;
+              for (aj = 0; aj < forAlphasCapacity; aj++) {
+                  ssesForAlphasForPartitions[aj] += ssesForAlphas[aj];
+              }
+            }
+          }
+
+          // Add to the output centers
+          //
+          int ajsI;
+          for (ajsI = 0; ajsI < ajsSize ; ajsI++) {
+            int const aj = ajsForAlphas[ajsI];
+            int const ai = center_ai + gridStride*(aj - nangles/2);
+
+            double const sse = ssesForAlphasForPartitions[aj];
+
+            if (spreadsheet) {
+              int    const ai    = center_ai + gridStride*(aj - nangles/2);
+              float  const alpha = iToRadians(ai);
+              // format suitable for spreadsheet
+              fprintf(stdout, "abgi, %d,%d,%d,  abg, %g,%g,%g, sse,%g\n", ai,bi,gi, alpha,beta,gamma, sse); 
+            }
+
+            if (trace) fprintf(stdout, "%s:%d sse:%g after vno:%d\n", __FILE__, __LINE__, sse, vno); 
+            trace = false;
+
+            // Consider adding this center to the outCenters, either as a new or as a replacement for an old
+            //
+            float const radius = (gridStride*nangles) / 3.0f;
+                // Anything within this grid index is consider to be 'nearby' and hence replaces the center
+            
+            int oci;
+            for (oci = 0; oci < outCentersSize; oci++) {
+              struct Center* oc = &outCenters[oci];
+              bool nearBy = 
+                  fabsf(oc->center_ai - ai) <= radius
+               && fabsf(oc->center_bi - bi) <= radius
+               && fabsf(oc->center_gi - gi) <= radius;
+              if (nearBy) {
+                if (oc->center_sse_known && oc->center_sse < sse) {
+                  oci = -1;                                 // Don't replace any
+                }
+                break;                                      // Was nearBy one,so don't look further
+              }
+            }
+            if (oci == centersCapacity) {                   // A distant local minimum, and centers is full
+              oci = 0;                                      // Select the largest existing minimum to be replaced
+              int i;
+              for (i = 1; i < outCentersSize; i++) {
+                if (outCenters[oci].center_sse < outCenters[i].center_sse) oci = i;
+              }
+              if (outCenters[oci].center_sse <= sse) oci = -1;  // The largest existing min is better than this
+            }
+            
+            // Keep this one
+            //
+            if (0 <= oci) {
+              changed = true;
+              struct Center* oc = &outCenters[oci];
+              oc->center_ai = ai;
+              oc->center_bi = bi;
+              oc->center_gi = gi;
+              oc->center_sse = sse;
+              oc->center_sse_known = true;
+              if (oci == outCentersSize) outCentersSize++;
+            }
+            
+          }     // alpha
+        }       // beta
+      }         // gamma
+    }           // centers
+    
+    if (false || tracing) {
+      int oci;
+      for (oci = 0; oci < outCentersSize; oci++) {
+        struct Center* oc = &outCenters[oci];
+        fprintf(stdout, 
+          "%s:%d best fit %d at (%2.2f, %2.2f, %2.2f), min sse = %2.2f\n", __FILE__, __LINE__,
+          oci, 
+          (float)DEGREES(iToRadians(oc->center_ai)),  
+          (float)DEGREES(iToRadians(oc->center_bi)),
+          (float)DEGREES(iToRadians(oc->center_gi)),
+          oc->center_sse_known ? (float)(oc->center_sse + ext_sse) : -666.0);
+      }
+    }
+  }             // gridStride
+
+
+  // Free the temps
+  //
+  free(fvsForAlphasForPartitions);  free(ssesForAlphasForPartitions);
+  free(alphasForAlphas);            free(ajsForAlphas); 
+  free(doneFlags);
+  free(betaGammaRotated_zv);        free(betaGammaRotated_yv);          free(betaGammaRotated_xv);
+  free(gammaRotated_zv);            free(gammaRotated_yv);              free(gammaRotated_xv);
+  free(zv);                         free(yv);                           free(xv);
+  free(curv);
+
+  // Return the min center
+  //
+  { int oci = 0;
+    int i;
+    for (i = 1; i < outCentersSize; i++) {
+      if (outCenters[oci].center_sse > outCenters[i].center_sse) oci = i;
+    }
+    struct Center* oc = &outCenters[oci];
+    *new_mina = iToRadians(oc->center_ai);
+    *new_minb = iToRadians(oc->center_bi);
+    *new_ming = iToRadians(oc->center_gi);
+    *new_sse  = oc->center_sse + ext_sse;
+  }
+  
+#undef iToRadians
+}
+
+

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -183,6 +183,7 @@ libutils_main_SOURCES=\
 	mrisp.c \
 	mriSurface.c \
 	mrisurf.c \
+        MRISrigidBodyAlignGlobal.c \
 	mrisutils.c \
 	mri_tess.c \
 	mri_topology.c \
@@ -230,6 +231,7 @@ libutils_main_SOURCES=\
 	tukey.c \
 	utils.c \
 	version.c \
+        vertexRotator.c \
 	vlabels.c \
 	volcluster.c \
 	voxlist.c \

--- a/utils/vertexRotator.c
+++ b/utils/vertexRotator.c
@@ -1,0 +1,233 @@
+/**
+ * @file  vertexRotator.c
+ * @brief rapidly rotate vertexs around the x=0 y=0 z=0 axes
+ */
+/*
+ * Original Author: Bevin Brett based on code in mrisurf.c
+ * CVS Revision Info:
+ *    $Author: bbrett $
+ *    $Date: 2018/05/04 07:52:00 $
+ *    $Revision: 1.0 $
+ *
+ * Copyright © 2018 The General Hospital Corporation (Boston, MA) "MGH"
+ *
+ * Terms and conditions for use, reproduction, distribution and contribution
+ * are found in the 'FreeSurfer Software License Agreement' contained
+ * in the file 'LICENSE' found in the FreeSurfer distribution, and here:
+ *
+ * https://surfer.nmr.mgh.harvard.edu/fswiki/FreeSurferSoftwareLicense
+ *
+ * Reporting: freesurfer@nmr.mgh.harvard.edu
+ *
+ */
+#include "vertexRotator.h"
+
+//  The command line for the self-test is
+//
+//      gcc -I../include -DTEST vertexRotator.c -lm
+
+// Note: it is expected that the caller will do any needed parallelism
+// because they can tile along the vertices dimension to optimize for cache behaviour
+
+// This is the special case of two of the angles being zero
+// The invariant dimension is optional
+// 
+// It can be faster when some of the angles are zero
+// The inliner is relied on to make those fixes
+// Only one implementation is needed because the axes are permuted below accordingly
+//
+static void rotateVertices1axis_wkr(
+  float*         xv_out, float*       yv_out, 
+  float const *  xv_inp, float const* yv_inp, 
+  float*         zv_out,
+  float const*   zv_inp,
+  size_t         nvertices,
+  float          alpha)       // rotate around x axis
+{
+  float const sa = sin(alpha);
+  float const ca = cos(alpha);
+
+  int vno;
+  
+  for (vno = 0; vno < nvertices; vno++) {
+    float x  = xv_inp[vno];
+    float y  = yv_inp[vno];
+    float xp =  x * ca + y * sa;
+    float yp = -x * sa + y * ca;
+    xv_out[vno] = xp;
+    yv_out[vno] = yp;
+  }
+
+  if (zv_out) {
+    for (vno = 0; vno < nvertices; vno++) {
+      zv_out[vno] = zv_inp[vno];
+    }
+  }
+}
+
+
+// This is the general case
+// It can be faster when some of the angles are zero
+// The inliner is relied on to make those fixes
+//
+static inline void rotateVertices_wkr(
+  float*         xv_out, float*       yv_out, float      * zv_out,
+  float const *  xv_inp, float const* yv_inp, float const* zv_inp,
+  size_t         nvertices,
+  float          alpha,       // rotate around z axis - last rotation
+  float          beta,        // rotate around y axis - middle rotation
+  float          gamma)       // rotate around x axis - first rotation
+{
+  float const sa = (alpha == 0.0) ? 0.0 : sin(alpha);
+  float const sb = (beta  == 0.0) ? 0.0 : sin(beta);
+  float const sg = (gamma == 0.0) ? 0.0 : sin(gamma);
+  float const ca = (alpha == 0.0) ? 1.0 : cos(alpha);
+  float const cb = (beta  == 0.0) ? 1.0 : cos(beta);
+  float const cg = (gamma == 0.0) ? 1.0 : cos(gamma);
+
+  float const cacb = ca * cb;
+  float const cacgsb = ca * cg * sb;
+  float const sasg = sa * sg;
+  float const cgsa = cg * sa;
+  float const casbsg = ca * sb * sg;
+  float const cbsa = cb * sa;
+  float const cgsasb = cg * sa * sb;
+  float const casg = ca * sg;
+  float const cacg = ca * cg;
+  float const sasbsg = sa * sb * sg;
+  float const cbcg = cb * cg;
+  float const cbsg = cb * sg;
+
+  int vno;
+  
+  for (vno = 0; vno < nvertices; vno++) {
+
+    float x = xv_inp[vno];
+    float y = yv_inp[vno];
+    float z = zv_inp[vno];
+                                                                            // when sa == sb == 0       when sa == sg == 0      when sb == sg == 0
+    float xp =  x * cacb + z * (-cacgsb - sasg) + y * (cgsa - casbsg);      //             x            x cb - z sb             x ca  + y sa
+    float yp = -x * cbsa + z * ( cgsasb - casg) + y * (cacg + sasbsg);      // - z sg + y cg            y                       -x sa + y ca
+    float zp =  z * cbcg + x * sb               + y * cbsg;                 //   z cg + y sg            x sb - z cb             z
+    
+    xv_out[vno] = xp;
+    yv_out[vno] = yp;
+    zv_out[vno] = zp;
+  }
+}
+
+
+
+void rotateVertices(
+    float*         xv_out, float*       yv_out, float      * zv_out,
+    float const *  xv_inp, float const* yv_inp, float const* zv_inp,
+    size_t         nvertices,
+    float          alpha,       // alpha is the last rotation
+    float          beta,        // beta  is the second rotation
+    float          gamma)       // gamma is the first rotation
+{
+    // One axis rotation
+    if (alpha == 0.0 && beta  == 0.0) { rotateVertices1axis_wkr( yv_out, zv_out, yv_inp, zv_inp, xv_out, xv_inp, nvertices, -gamma); return; }
+    if (alpha == 0.0 && gamma == 0.0) { rotateVertices1axis_wkr( xv_out, zv_out, xv_inp, zv_inp, yv_out, yv_inp, nvertices, -beta ); return; }
+    if (beta  == 0.0 && gamma == 0.0) { rotateVertices1axis_wkr( xv_out, yv_out, xv_inp, yv_inp, zv_out, zv_inp, nvertices,  alpha); return; }
+    
+    // Three axis rotation
+    if (alpha != 0.0 && beta != 0.0 && gamma != 0.0) 
+                                      { rotateVertices_wkr( xv_out, yv_out, zv_out, xv_inp, yv_inp, zv_inp, nvertices, alpha, beta, gamma); return; }
+
+    // Two axis rotation
+    if (alpha != 0.0 && beta  != 0.0) { rotateVertices_wkr( xv_out, yv_out, zv_out, xv_inp, yv_inp, zv_inp, nvertices, alpha, beta, 0.0);   return; }
+    if (alpha != 0.0 && gamma != 0.0) { rotateVertices_wkr( xv_out, yv_out, zv_out, xv_inp, yv_inp, zv_inp, nvertices, alpha, 0.0,  gamma); return; }
+    if (beta  != 0.0 && gamma != 0.0) { rotateVertices_wkr( xv_out, yv_out, zv_out, xv_inp, yv_inp, zv_inp, nvertices, 0.0,   beta, gamma); return; }
+}
+
+
+#if defined(TEST) 
+#include <stdio.h>
+
+static const char* final = "PASSED";
+static int errorCount;
+static void check_wkr(float t, float o, float xi, float yi, float zi, const char* msg) {
+    if (fabsf(t - o) < 0.01) return;
+    printf("FAILED %s, t:%g o:%g (x:%g,y:%g,z:%g)\n", msg, t,o,xi,yi,zi);
+    final = "FAILED";
+    errorCount++;
+}
+
+#define check(t,o) check_wkr(t,o,xi,yi,zi,#t "!=" #o)
+
+static void test(float xi, float yi, float zi, float xo, float yo, float zo, float alpha, float beta, float gamma) {
+    float xt,yt,zt;
+    rotateVertices(&xt,&yt,&zt,&xi,&yi,&zi,1,alpha,beta,gamma);
+    int saved_errorCount = errorCount;
+    check(xt,xo); check(yt,yo); check(zt,zo);
+    if (saved_errorCount != errorCount) printf(" when alpha:%g beta:%g gamma:%g\n", alpha,beta,gamma);
+}
+
+int main() {
+    double const pi = 3.141592653589793;
+    printf("vectorRotator test\n");
+
+    test(1,0,0, 1,0,0, 0,0,0);
+    test(0,1,0, 0,1,0, 0,0,0);
+    test(0,0,1, 0,0,1, 0,0,0);
+
+    // Test singles
+    //
+    float tiny = 0.00001;
+    for (tiny = 0.00001; ; tiny = 0) { 
+        printf("around z\n");
+        test(1,0,0,  0,-1,0,  pi/2,tiny,tiny);
+        test(0,1,0, +1, 0,0,  pi/2,tiny,tiny);
+        test(0,0,1,  0, 0,1,  pi/2,tiny,tiny);
+        test(1,0,0,  0,+1,0, -pi/2,tiny,tiny);
+        test(0,1,0, -1, 0,0, -pi/2,tiny,tiny);
+
+        printf("around y\n");
+        test(1,0,0,  0,0, 1, tiny, pi/2,tiny);
+        test(0,1,0,  0,1, 0, tiny, pi/2,tiny);
+        test(0,0,1, -1,0, 0, tiny, pi/2,tiny);
+        test(1,0,0,  0,0,-1, tiny,-pi/2,tiny);
+        test(0,0,1,  1,0, 0, tiny,-pi/2,tiny);
+
+        printf("around x\n");
+        test(1,0,0, 1, 0, 0, tiny,tiny, pi/2);
+        test(0,1,0, 0, 0,+1, tiny,tiny, pi/2);
+        test(0,0,1, 0,-1, 0, tiny,tiny, pi/2);
+        test(0,1,0, 0, 0,-1, tiny,tiny,-pi/2);
+        test(0,0,1, 0, 1, 0, tiny,tiny,-pi/2);
+
+        if (tiny == 0.0f) break;
+    }
+
+    // Test composition
+    //
+    float xi=1,yi=2,zi=3;
+    float x1,y1,z1;
+    float x2a,y2a,z2a;
+    float x2b,y2b,z2b;
+    
+    //  beta then alpha
+    printf("beta then alpha\n");
+    rotateVertices(&x1,&y1,&z1,    &xi,&yi,&zi, 1,    0, pi/2,0);
+    rotateVertices(&x2a,&y2a,&z2a, &x1,&y1,&z1, 1, pi/2,    0,0);
+    rotateVertices(&x2b,&y2b,&z2b, &xi,&yi,&zi, 1, pi/2, pi/2,0);
+    check(x2a, x2b); check(y2a, y2b); check(z2a, z2b);
+            
+    //  gamma then alpha
+    printf("gamma then alpha\n");
+    rotateVertices(&x1,&y1,&z1,    &xi,&yi,&zi, 1,    0,0, pi/2);
+    rotateVertices(&x2a,&y2a,&z2a, &x1,&y1,&z1, 1, pi/2,0,    0);
+    rotateVertices(&x2b,&y2b,&z2b, &xi,&yi,&zi, 1, pi/2,0, pi/2);
+    check(x2a, x2b); check(y2a, y2b); check(z2a, z2b);
+            
+    //  gamma then beta
+    printf("gamma then beta\n");
+    rotateVertices(&x1,&y1,&z1,    &xi,&yi,&zi, 1, 0, 0,   pi/2);
+    rotateVertices(&x2a,&y2a,&z2a, &x1,&y1,&z1, 1, 0, pi/2,   0);
+    rotateVertices(&x2b,&y2b,&z2b, &xi,&yi,&zi, 1, 0, pi/2,pi/2);
+    check(x2a, x2b); check(y2a, y2b); check(z2a, z2b);
+            
+    printf("%s\n",final);
+}
+#endif


### PR DESCRIPTION
Speeds up mris_register by approx. 3.5 mins each for lh and rh.  recon-all gets slightly different but acceptable results.  Checkin includes getting mris_register test to work - uses old input and new ref data from old algorithm, and uses mris_diff to show that the new result is acceptably close to the old result for this shared input

Does so by (a) moving the data into dense tmp vectors,  (b) does the rotations over Gamma and Beta in two steps rather than one, so the Gamma rotation can be shared by all the Beta rotations,  (c) does the Alpha rotation as part of the lookup into the image, (d) does several Alpha lookups at once so that the Gamma Beta part can be shared, (e) uses a grid to search the ABG space so that repeated lookups at the same (a,b,g) can be avoided.

The result finds a better solution in 0.14 mins compared to the old code's 3.6 mins, hence the 3.5 min speedup