### PR TITLE
How did this not get found before?

### DIFF
--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -45245,7 +45245,7 @@ struct ComputeDefectContext {
 };
 
 static void constructComputeDefectContext(ComputeDefectContext* computeDefectContext) {
-    computeDefectContext->realmTree = NULL;
+    bzero(computeDefectContext, sizeof(*computeDefectContext));
 }
 
 


### PR DESCRIPTION
Uninitialized member caused a crash when compiled with icc but,weirdly, not with GCC but it should have...

recon-all runs with identical results