### PR TITLE
Bf icc mm malloc bugfix

### DIFF
--- a/include/base.h
+++ b/include/base.h
@@ -26,7 +26,7 @@
 
 #if !defined(DARWIN) && !defined(__APPLE__)
 #include <malloc.h>
-#include <mm_malloc.h>
+// DON'T #include <mm_malloc.h> IT BREAKS icc AND IS NOT NEEDED
 #endif
 
 #include <math.h>

--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -4536,8 +4536,10 @@ static int MRIScomputeNormals_new(MRI_SURFACE *mris)
       __FILE__, __LINE__, trial, pendingSize);
   }
 
+  freeAndNULL(nextPending);
+  freeAndNULL(pending);
+  
   return (NO_ERROR);
-
 }
 
 #undef randomNumber

--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -45245,7 +45245,7 @@ struct ComputeDefectContext {
 };
 
 static void constructComputeDefectContext(ComputeDefectContext* computeDefectContext) {
-    computeDefectContext->realmTree = NULL;
+    bzero(computeDefectContext, sizeof(*computeDefectContext));
 }
 
 


### PR DESCRIPTION
Stops the #include of mm_malloc.h, which apparently is not needed, and which breaks the icc build
It is possible some GUI component may have needed this - in which case a full build may fail

Includes two prior bugfixes that were in a current pull request