### PR TITLE
Use atan2f when the inputs and output are float

### DIFF
--- a/utils/mrisp.c
+++ b/utils/mrisp.c
@@ -1422,7 +1422,7 @@ void MRISPfunctionVal_radiusR(                                                  
   float phi;
   { float d = r * r - z * z;
     if (d < 0.0) d = 0.0;
-    phi = atan2(sqrt(d), z);
+    phi = atan2f(sqrt(d), z);
     if (phi < RADIANS(1)) DiagBreak();
   }
   
@@ -1460,7 +1460,7 @@ void MRISPfunctionVal_radiusR(                                                  
 
   // This is the rotation around the z axis
   //
-  float const baseTheta = atan2(y / r, x / r);
+  float const baseTheta = atan2f(y, x);
 
   int alphaIndex;
   for (alphaIndex = 0; alphaIndex < numAlphas; alphaIndex++) {

--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -11663,7 +11663,7 @@ static int MRIScomputeTriangleProperties_old(MRI_SURFACE *mris, bool old_done)
       VERTEX_EDGE(v_b[tid], vo, vb);
       cross = VectorTripleProduct(v_b[tid], v_a[tid], v_n[tid]);
       dot   = V3_DOT(v_a[tid], v_b[tid]);
-      angle = atan2(cross, dot);
+      angle = atan2f(cross, dot);
       face->angle[ano] = angle;
 
 #if 0
@@ -11880,7 +11880,7 @@ static int MRIScomputeTriangleProperties_new(MRI_SURFACE *mris, bool old_done)
       VERTEX_EDGE(v_b[tid], vo, vb);
       float cross = VectorTripleProduct(v_b[tid], v_a[tid], v_n[tid]);
       float dot   = V3_DOT(v_a[tid], v_b[tid]);
-      float angle = atan2(cross, dot);
+      float angle = atan2f(cross, dot);
       SET_OR_CHECK(face->angle[ano], angle);
     }
 
@@ -27760,7 +27760,7 @@ int MRIScomputeCanonicalCoordinates(MRI_SURFACE *mris)
     x = v->cx;
     y = v->cy;
     z = v->cz;
-    theta = atan2(y / r, x / r);
+    theta = atan2f(y, x);
     if (theta < 0.0f) {
       theta = 2 * M_PI + theta; /* make it 0 --> 2*PI */
     }
@@ -27768,7 +27768,7 @@ int MRIScomputeCanonicalCoordinates(MRI_SURFACE *mris)
     if (d < 0.0) {
       d = 0.0;
     }
-    phi = atan2(sqrt(d), z);
+    phi = atan2f(sqrt(d), z);
     v->theta = theta;
     v->phi = phi;
   }


### PR DESCRIPTION
Even when both the inputs and outputs were only f-precision, the code was using double precision atan.

This function is a lot slower than atanf, and so changing to atanf gives equally valid results and runtimes that, for mris_register and mris_sphere and some others, about 10% less.

The results also change slightly.