### PR TITLE
fix Qt platform plugin xcb missing in freeview 

### DIFF
--- a/scripts/qt_setup
+++ b/scripts/qt_setup
@@ -49,6 +49,8 @@ if ( $?FS_QT_HOME ) then
     if ( -e $FS_QT_HOME/lib/qt ) then
       setenv QTLIBPATH $FS_QT_HOME/lib/
     endif
+    
+    setenv QT_QPA_PLATFORM_PLUGIN_PATH $FS_QT_HOME/plugins
 
     if(! $?LD_LIBRARY_PATH ) then
       setenv LD_LIBRARY_PATH $QTLIBPATH


### PR DESCRIPTION
assuming plugin directory is in package tar ball (please put it there, with all plugins needed by freeview). Once plugins are also distributed, this should solve the issue #264. 
