### PR TITLE
Bf 0x04040 coredump

### DIFF
--- a/hiam_make_template/hiam_make_template.c
+++ b/hiam_make_template/hiam_make_template.c
@@ -206,7 +206,7 @@ main(int argc, char *argv[]) {
       } else
         strcpy(parms.base_name, "template") ;
       sprintf(fname, "%s.%s.out", hemi, parms.base_name);
-      parms.fp = fopen(fname, "w") ;
+      INTEGRATION_PARMS_openFp(&parms, fname, "w") ;
       printf("writing output to '%s'\n", fname) ;
     }
     for (ino = 0 ; ino < argc-1 ; ino++) {

--- a/hiam_register/hiam_register.c
+++ b/hiam_register/hiam_register.c
@@ -481,7 +481,7 @@ mrisRegister(MRI_SURFACE *mris, MRI_SP *mrisp_template,
     sprintf(fname, "%s.%s.out",
             mris->hemisphere == RIGHT_HEMISPHERE ? "rh":"lh",parms->base_name);
     if (!parms->start_t) {
-      parms->fp = fopen(fname, "w") ;
+      INTEGRATION_PARMS_openFp(parms, fname, "w") ;
       if (!parms->fp)
         ErrorExit(ERROR_NOFILE, "%s: could not open log file %s",
                   Progname, fname) ;
@@ -719,9 +719,9 @@ mrisIntegrationEpoch(MRI_SURFACE *mris, INTEGRATION_PARMS *parms,int base_averag
                 mris->hemisphere == RIGHT_HEMISPHERE ? "rh":"lh",
                 parms->base_name);
         if (!parms->start_t)
-          parms->fp = fopen(fname, "w") ;
+          INTEGRATION_PARMS_openFp(parms, fname, "w") ;
         else
-          parms->fp = fopen(fname, "a") ;
+          INTEGRATION_PARMS_openFp(parms, fname, "a") ;
         if (!parms->fp)
           ErrorExit(ERROR_NOFILE, "%s: could not open log file %s",
                     Progname, fname) ;

--- a/include/mrisurf.h
+++ b/include/mrisurf.h
@@ -779,7 +779,7 @@ typedef struct
   int     start_t ;           /* starting time step */
   int     t ;                 /* current time */
   
-  FILE    * const fp ;        /* for logging results, write by calling  */
+  FILE    * const fp ;        /* for logging results, write by calling INTEGRATION_PARMS_<various> functions */
   
   float   Hdesired ;          /* desired (mean) curvature */
   int     integration_type ;  /* line minimation or momentum */

--- a/include/mrisurf.h
+++ b/include/mrisurf.h
@@ -778,7 +778,9 @@ typedef struct
   float   c ;                 /* ellipsoid parameters */
   int     start_t ;           /* starting time step */
   int     t ;                 /* current time */
-  FILE    *fp ;               /* for logging results */
+  
+  FILE    * const fp ;        /* for logging results, write by calling  */
+  
   float   Hdesired ;          /* desired (mean) curvature */
   int     integration_type ;  /* line minimation or momentum */
   double  momentum ;
@@ -892,6 +894,13 @@ typedef struct
   int          explode_flag ;
 }
 INTEGRATION_PARMS ;
+
+void INTEGRATION_PARMS_copy   (INTEGRATION_PARMS* dst, INTEGRATION_PARMS const * src);
+
+void INTEGRATION_PARMS_openFp (INTEGRATION_PARMS* parms, const char* name, const char* mode);
+void INTEGRATION_PARMS_closeFp(INTEGRATION_PARMS* parms);
+void INTEGRATION_PARMS_copyFp (INTEGRATION_PARMS* dst, INTEGRATION_PARMS const * src);
+
 
 extern double (*gMRISexternalGradient)(MRI_SURFACE *mris,
                                          INTEGRATION_PARMS *parms) ;

--- a/include/mrisurf.h
+++ b/include/mrisurf.h
@@ -707,7 +707,7 @@ MRI_SURFACE_PARAMETERIZATION, MRI_SP ;
 /* VECTORIAL_REGISTRATION */
 #include "field_code.h"
 
-typedef struct
+typedef struct INTEGRATION_PARMS
 {
   double  tol ;               /* tolerance for terminating a step */
   float   l_angle ;           /* coefficient of angle term */
@@ -892,11 +892,18 @@ typedef struct
   double       target_intensity ;
   double       stressthresh ;
   int          explode_flag ;
+  
+#ifdef __cplusplus
+  INTEGRATION_PARMS() : fp(NULL) {}
+  INTEGRATION_PARMS(FILE* file) : fp(file) {}
+#endif 
+  
 }
 INTEGRATION_PARMS ;
 
 void INTEGRATION_PARMS_copy   (INTEGRATION_PARMS* dst, INTEGRATION_PARMS const * src);
 
+void INTEGRATION_PARMS_setFp  (INTEGRATION_PARMS* parms, FILE* file);
 void INTEGRATION_PARMS_openFp (INTEGRATION_PARMS* parms, const char* name, const char* mode);
 void INTEGRATION_PARMS_closeFp(INTEGRATION_PARMS* parms);
 void INTEGRATION_PARMS_copyFp (INTEGRATION_PARMS* dst, INTEGRATION_PARMS const * src);

--- a/mris_congeal/mris_congeal.c
+++ b/mris_congeal/mris_congeal.c
@@ -1066,7 +1066,7 @@ MRIScongeal(MRI_SURFACE *mris_ico, MRI_SURFACE **mris_array, int nsubjects,
   {
     char fname[STRLEN] ;
     sprintf(fname, "%s.log", parms->base_name) ;
-    parms->fp = fopen(fname, "a") ;
+    INTEGRATION_PARMS_openFp(parms, fname, "a") ;
   }
 
   MRISscaleBrain(mris_ico, mris_ico, mris_array[0]->radius / mris_ico->radius) ;
@@ -1152,8 +1152,7 @@ MRIScongeal(MRI_SURFACE *mris_ico, MRI_SURFACE **mris_array, int nsubjects,
   MHTfree(&mht_ico) ;
   if (Gdiag & DIAG_WRITE)
   {
-    fclose(parms->fp) ;
-    parms->fp = NULL ;
+    INTEGRATION_PARMS_closeFp(parms);
   }
   return(mrisp) ;
 }

--- a/mris_deform/mris_deform.c
+++ b/mris_deform/mris_deform.c
@@ -524,7 +524,7 @@ main(int argc, char *argv[]) {
     MRISsaveVertexPositions(mris, WHITE_VERTICES) ;
     vp_copy_from_surface(mris, CURRENT_VERTICES, WHITE_VERTICES);
     if (Gdiag & DIAG_WRITE)
-      eparms.fp = stdout ;
+      INTEGRATION_PARMS_setFp(&eparms, stdout) ;
     MRISexpandSurface(mris, MIN(1, 4*mri->xsize), &eparms, 0, 1) ;
     if (Gdiag & DIAG_WRITE)
     {

--- a/mris_expand/mris_expand.c
+++ b/mris_expand/mris_expand.c
@@ -117,7 +117,7 @@ main(int argc, char *argv[])
   {
     char log_fname[STRLEN] ;
     sprintf(log_fname, "%s.log", fname) ;
-    parms.fp = fopen(log_fname, "w") ;
+    INTEGRATION_PARMS_openFp(&parms, log_fname, "w") ;
     if (parms.fp)
       printf("writing log results to %s\n", log_fname) ;
     else

--- a/mris_flatten/mris_flatten.c
+++ b/mris_flatten/mris_flatten.c
@@ -459,7 +459,7 @@ main(int argc, char *argv[])
       }
       else if (!sphere_flag && !one_surf_flag)
         MRISreadOriginalProperties(mris, original_unfold_surf_name) ;
-      *(&p2) = *(&parms) ;
+      INTEGRATION_PARMS_copy(&p2, &parms) ;
       p2.l_dist = 0 ;
       p2.niterations = 100 ;
       p2.nbhd_size = p2.max_nbrs = 1 ;

--- a/mris_make_surfaces/mris_make_surfaces.c
+++ b/mris_make_surfaces/mris_make_surfaces.c
@@ -1284,14 +1284,14 @@ L) ;
       sprintf(fname, "./%s-white%2.2f.mgz", hemi, current_sigma) ;
       MRISwriteValues(mris, fname);
     }
-    *(&old_parms) = *(&parms) ;
+    INTEGRATION_PARMS_copy(&old_parms, &parms) ;
     parms.l_tspring *= spring_scale ; parms.l_nspring *= spring_scale ; parms.l_spring *= spring_scale ;
     parms.l_tspring = MIN(1.0,parms.l_tspring) ;
     parms.l_nspring = MIN(1.0, parms.l_nspring) ;
     parms.l_spring = MIN(1.0, parms.l_spring) ;
     MRISpositionSurface(mris, mri_T1, mri_smooth,&parms);
     old_parms.start_t = parms.start_t ;
-    *(&parms) = *(&old_parms) ;
+    INTEGRATION_PARMS_copy(&parms, &old_parms) ;
 
     if (add)
     {
@@ -1729,7 +1729,7 @@ L) ;
             INTEGRATION_PARMS saved_parms ;
 
             MRISsegmentMarked(mris, &labels, &nlabels, 1) ;
-            *(&saved_parms) = *(&parms) ;
+            INTEGRATION_PARMS_copy(&saved_parms, &parms) ;
 
             printf("%d vertices found in imminent self-intersecting "
                    "regions, deforming to remove...\n",
@@ -1857,7 +1857,7 @@ L) ;
             INTEGRATION_PARMS saved_parms ;
 
             MRISsegmentMarked(mris, &labels, &nlabels, 1) ;
-            *(&saved_parms) = *(&parms) ;
+            INTEGRATION_PARMS_copy(&saved_parms, &parms) ;
 
             printf("%d vertices found in imminent self-intersecting regions, deforming to remove...\n", MRIScountMarked(mris,1));
             MRISinvertMarks(mris) ;
@@ -2100,7 +2100,7 @@ L) ;
 	int k, start_t ;
 
 	printf("perforing initial smooth deformation to move away from white surface\n") ;
-	*(&saved_parms) = *(&parms) ;
+	INTEGRATION_PARMS_copy(&saved_parms, &parms) ;
 //	parms.l_intensity /= 5 ;
 	parms.dt /= 10 ;   // take small steps to unkink pinched areas
 //	parms.l_spring = 1 ;
@@ -2109,14 +2109,14 @@ L) ;
 
 	for (k = 0 ; k < 3 ; k++)
 	{
-	  *(&old_parms) = *(&parms) ;
+	  INTEGRATION_PARMS_copy(&old_parms, &parms) ;
 	  parms.l_tspring *= spring_scale ; parms.l_nspring *= spring_scale ; parms.l_spring *= spring_scale ;
 	  parms.l_tspring = MIN(1.0,parms.l_tspring) ;
 	  parms.l_nspring = MIN(1.0, parms.l_nspring) ;
 	  parms.l_spring = MIN(1.0, parms.l_spring) ;
 	  MRISpositionSurface(mris, mri_T1, mri_smooth,&parms);
 	  old_parms.start_t = parms.start_t ;
-	  *(&parms) = *(&old_parms) ;
+	  INTEGRATION_PARMS_copy(&parms, &old_parms) ;
 	  if (!FZERO(parms.l_intensity))
 	    MRIScomputeBorderValues
 	      (mris, mri_T1, mri_smooth, max_gray,
@@ -2126,7 +2126,7 @@ L) ;
 	       GRAY_CSF, mri_mask, thresh, parms.flags,mri_aseg) ;
 	}
 	start_t = parms.start_t ;
-	*(&parms) = *(&saved_parms) ;
+	INTEGRATION_PARMS_copy(&parms, &saved_parms) ;
 	parms.start_t = start_t ;
 	parms.l_surf_repulse = l_surf_repulse ;
 #else
@@ -2134,14 +2134,14 @@ L) ;
 #endif
       }
 #endif
-      *(&old_parms) = *(&parms) ;
+      INTEGRATION_PARMS_copy(&old_parms, &parms) ;
       parms.l_tspring *= spring_scale ; parms.l_nspring *= spring_scale ; parms.l_spring *= spring_scale ;
       parms.l_tspring = MIN(1.0,parms.l_tspring) ;
       parms.l_nspring = MIN(1.0, parms.l_nspring) ;
       parms.l_spring = MIN(1.0, parms.l_spring) ;
       MRISpositionSurface(mris, mri_T1, mri_smooth,&parms);
       old_parms.start_t = parms.start_t ;
-      *(&parms) = *(&old_parms) ;
+      INTEGRATION_PARMS_copy(&parms, &old_parms) ;
 
       if (parms.l_location > 0)
       {

--- a/mris_make_template/mris_make_template.c
+++ b/mris_make_template/mris_make_template.c
@@ -223,7 +223,7 @@ main(int argc, char *argv[])
       else
         strcpy(parms.base_name, "template") ;
       sprintf(fname, "%s.%s.out", hemi, parms.base_name);
-      parms.fp = fopen(fname, "w") ;
+      INTEGRATION_PARMS_openFp(&parms, fname, "w") ;
       printf("writing output to '%s'\n", fname) ;
     }
 

--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -112,29 +112,29 @@ void INTEGRATION_PARMS_copy   (INTEGRATION_PARMS* dst, INTEGRATION_PARMS const *
     memcpy(dst, src, sizeof(*src)); // note: copies the const fp et. al.!
 }
 
-
-void INTEGRATION_PARMS_openFp (INTEGRATION_PARMS* parms, const char* name, const char* mode) {
+void INTEGRATION_PARMS_setFp  (INTEGRATION_PARMS* parms, FILE* file) {
   FILE* const* fpcp = &parms->fp;
   FILE*      * fpp  = (FILE**)fpcp;
-  *fpp = fopen(name, mode);
-  if (!*fpp) {
+  *fpp = file;
+}
+
+void INTEGRATION_PARMS_openFp (INTEGRATION_PARMS* parms, const char* name, const char* mode) {
+  FILE* file = fopen(name, mode);
+  if (!file) {
     fprintf(stderr, "%s:%d Error opening parms.fp using filename %s mode %s\n", __FILE__, __LINE__, name, mode);
     exit(1);
   }
+  INTEGRATION_PARMS_setFp(parms, file);
 }
 
 void INTEGRATION_PARMS_closeFp(INTEGRATION_PARMS* parms) {
   if (!parms->fp) return;
   fclose(parms->fp);
-  FILE* const* fpcp = &parms->fp;
-  FILE*      * fpp  = (FILE**)fpcp;
-  *fpp = NULL;
+  INTEGRATION_PARMS_setFp(parms, NULL);
 }
 
 void INTEGRATION_PARMS_copyFp (INTEGRATION_PARMS* dst, INTEGRATION_PARMS const * src) {
-  FILE* const* fpcp = &dst->fp;
-  FILE*      * fpp  = (FILE**)fpcp;
-  *fpp = src->fp;
+  INTEGRATION_PARMS_setFp(dst, src->fp);
 }
 
 #define DMALLOC 0


### PR DESCRIPTION
The core dump was caused by a typo that was resulting in parms->fp being used when it had not been set

The fix changes this, but also makes all the setting of ->fp be done by specialist functions rather than in lots of places, so that this and other problems will be easier to find