### PR TITLE
Fix an error msg

### DIFF
--- a/utils/chklc.c
+++ b/utils/chklc.c
@@ -143,7 +143,7 @@ void chklc(void)
     struct stat path_stat;
     stat(alt, &path_stat);
     if S_ISDIR(path_stat.st_mode) {;
-      printf(isdir_msg);
+      puts(isdir_msg);
       exit(-1);
     }
   }


### PR DESCRIPTION
The printf was causing a 

chklc.c:146:7: error: format not a string literal and no format arguments [-Werror=format-security]
       printf(isdir_msg);

