### PR TITLE
WIP: Infant recon for non-MGH users

### DIFF
--- a/scripts/InfantFS/SetLabelFusionParams.csh
+++ b/scripts/InfantFS/SetLabelFusionParams.csh
@@ -1,8 +1,8 @@
-#!/bin/tcsh -ef    
+#!/bin/tcsh -ef
 
 #setenv CMDDIR `pwd`
-setenv CMDDIR $FREESURFER_HOME/scripts/LabelFusionBetterDist/
-setenv MLAB /autofs/cluster/matlab/8.0/
+setenv CMDDIR $FREESURFER_HOME/scripts/InfantFS/
+setenv MLAB $MATLAB_ROOT
 setenv MRFparams "1 5"
 
 setenv LFOPTIONS1 "2 41 3 42" # new -- cerebral WM hack

--- a/scripts/InfantFS/SetLabelFusionParams.csh
+++ b/scripts/InfantFS/SetLabelFusionParams.csh
@@ -1,7 +1,7 @@
 #!/bin/tcsh -ef
 
 #setenv CMDDIR `pwd`
-setenv CMDDIR $FREESURFER_HOME/scripts/InfantFS/
+setenv CMDDIR $FREESURFER_HOME/bin/
 setenv MLAB $MATLAB_ROOT
 setenv MRFparams "1 5"
 

--- a/scripts/InfantFS/infant_recon_all
+++ b/scripts/InfantFS/infant_recon_all
@@ -37,7 +37,7 @@ set setksize            = 0
 
 set useMI               = 0
 
-source set_infant_recon_params.csh
+source $FREESURFER_HOME/bin/set_infant_recon_params.csh
 set TEMPLATE_SUBJECTS = ($CNYBCH_SUBJECTS) # the full CNYBCH training set
 set TEMPLATE_AGES     = ($CNYBCH_AGES)
 setenv TEMPLATE_SUBJECTS_DIR  $CNYBCH_TEMPLATE_SUBJECTS_DIR 

--- a/scripts/InfantFS/set_babydev_packages.csh
+++ b/scripts/InfantFS/set_babydev_packages.csh
@@ -3,7 +3,7 @@
 ##### scripts location
 
 set FS_HOME = $FREESURFER_HOME
-setenv FSSCRIPTSDIR      $FS_HOME/scripts/InfantFS/
+setenv FSSCRIPTSDIR      $FS_HOME/bin/
 setenv BABYDEVSCRIPTSDIR $FSSCRIPTSDIR
 set BabyDevPath = $BABYDEVSCRIPTSDIR
 

--- a/scripts/InfantFS/set_infant_recon_params.csh
+++ b/scripts/InfantFS/set_infant_recon_params.csh
@@ -1,14 +1,14 @@
 #!/bin/tcsh -ef
 
 #Emma set:
-setenv FSSCRIPTSDIR $FREESURFER_HOME/scripts/InfantFS
+setenv FSSCRIPTSDIR $FREESURFER_HOME/bin
 
 # training subjects
 source $BABYDEVSCRIPTSDIR/atlassubjects.csh
 
 # segmentation postprocessing
 # set version = Num4
-# set withparcellationlabels = 0 
+# set withparcellationlabels = 0
 set parcellationlabels = (9000 9001 9002 9003 9004 9005 9006 9500 9501 9502 9503 9504 9505 9506)
 
 # for the surface extraction step


### PR DESCRIPTION
Trying to run the `infant_recon_all`. WIP because I haven't completed a run, but this is to keep track of the changes that were necessary. @lillazollei let me know if this is helpful or not!

1. Need to add to the Wiki that ~~MATLAB~~ the [MATLAB R2012b Runtime](https://www.mathworks.com/products/compiler/matlab-runtime.html) is required, and the `MATLAB_ROOT` env var needs to be set to point to this.
2. Update wiki that FSL is required.
3. Update wiki that [dramms](https://www.nitrc.org/projects/dramms/) is required.
4. ~~Packaging needs to be fixed to include some or all of `scripts/InfantFS`, or these files need to be moved to `bin` during packaging (if the latter, `InfantFS` instances will need to be replaced in the scripts).~~
5. Use `LabelFusion` from GitHub master rather than the archive.
6. Do not use a relative path for the skull-stripped input or it will break in the `norm.nii.gz` linking step.

We'll see if it runs all the way through now.