### PR TITLE
cmake features: FS_INSTALL_DIR, FS_PACKAGES_DIR, /usr/local/freesurfer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,13 @@ if(NOT XXD)
   message(FATAL_ERROR "The xxd program is required to build freesurfer")
 endif()
 
+# allow reading installation dir from environment var, but if not defined,
+# then override default install dir /usr/local (too messy to install there)
+if(NOT "$ENV{FS_INSTALL_DIR}" STREQUAL "")
+  set(CMAKE_INSTALL_PREFIX "$ENV{FS_INSTALL_DIR}" CACHE INTERNAL "Copied from environment variable")
+else()
+  set(CMAKE_INSTALL_PREFIX "/usr/local/freesurfer")
+endif()
 
 # --------------------------------------------------
 #   library dependencies and third-party packages
@@ -45,8 +52,11 @@ endif()
 # can run the packages/build_packages.py script to compile the dependencies locally. If a package
 # is not found under FS_PACKAGES_DIR, cmake will continue to look through the default search paths.
 # Additionally, alternative paths to package installs can be specified with the <PACKAGE>_DIR variables
+# Note: FS_PACKAGES_DIR can be defined in an environment variable
 
-#set(FS_PACKAGES_DIR ${CMAKE_SOURCE_DIR}/packages)
+if(NOT "$ENV{FS_PACKAGES_DIR}" STREQUAL "")
+  set(FS_PACKAGES_DIR "$ENV{FS_PACKAGES_DIR}" CACHE INTERNAL "Copied from environment variable")
+endif()
 
 if(NOT FS_PACKAGES_DIR)
   if(EXISTS /usr/pubsw/packages)
@@ -208,7 +218,11 @@ add_definitions(-D${CMAKE_SYSTEM_NAME})
 test_big_endian(IS_BIG_ENDIAN)
 
 # compiler warnings
-set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wall -Wno-unused-but-set-variable -Wno-unused-result -Wno-unused-local-typedefs")
+if(APPLE) # clang on Mac complains about -Wno-unused-but-set-variable and says to use -Wno-unused-const-variable
+  set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wall -Wno-unused-const-variable -Wno-unused-result -Wno-unused-local-typedefs")
+else()
+  set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wall -Wno-unused-but-set-variable -Wno-unused-result -Wno-unused-local-typedefs")
+endif()
 
 # ANSI
 add_definitions(-DANSI)

--- a/mri_compute_seg_overlap/mri_compute_seg_overlap.c
+++ b/mri_compute_seg_overlap/mri_compute_seg_overlap.c
@@ -14,7 +14,7 @@
  *    $Date: 2015/08/28 18:05:30 $
  *    $Revision: 1.18 $
  *
- * Copyright © 2011-2013 The General Hospital Corporation (Boston, MA) "MGH"
+ * Copyright © 2011-2018 The General Hospital Corporation (Boston, MA) "MGH"
  *
  * Terms and conditions for use, reproduction, distribution and contribution
  * are found in the 'FreeSurfer Software License Agreement' contained
@@ -109,9 +109,12 @@ static int isOverallDiceLabel(int volVal)
   return 0;
 }
 
-/* maximum number of classes */
-#define MAX_CLASSES 256
-#define MAX_CLASS_NUM 255
+/* maximum number of classes: 
+   large enough to handle the maximum label value
+   in FreeSurferColorLUT.txt
+*/
+#define MAX_CLASSES 15000
+#define MAX_CLASS_NUM 14999
 
 int all_labels_flag = FALSE;
 int num_all_labels = 0;
@@ -457,7 +460,6 @@ static int get_option(int argc, char *argv[])
   else if (!stricmp(option, "-all_labels"))
   {
     all_labels_flag = TRUE;
-    nargs = 1;
     fprintf(stderr, "Computing overlap measures for all commonly existing labels. \n") ;
   }
   else if (!stricmp(option, "mlog"))

--- a/mri_compute_seg_overlap/mri_compute_seg_overlap.help.xml
+++ b/mri_compute_seg_overlap/mri_compute_seg_overlap.help.xml
@@ -32,7 +32,7 @@
     L/R Pallidum (13,52)
     L/R Amygdala (18,54)
     L/R Thalamus_Proper (10,49)
-    L/R Lateral_Ventricle (75,76)
+    L/R Lateral_Ventricle (4,43)
     Third and Fourth Ventricles (14,15)
     L/R Inf_Lat_Vent (5,44)
     L/R Cerebral_White_Matter (2,41)
@@ -43,6 +43,9 @@
     'overall Dice' measure (which is a mean), as the surface-based 
     wm/gm measures are more accurate (and accumbens is very 
     difficult to measure).
+
+    Use the --all_labels flag to compute across all labels (not
+    just the structures listed above)
 
 </description>
   <arguments>
@@ -72,6 +75,8 @@
       <argument>-wm (0/1)</argument>
       <explanation>if (0/1) is nonzero, exclude cerebral white matter
 	  labels from all calculation</explanation>
+      <argument>-all_labels</argument>
+      <explanation>check all labels</explanation>
     </optional-flagged>
   </arguments>
   <example>mri_compute_seg_overlap manual_seg.mgz aseg.mgz


### PR DESCRIPTION
cmake features: read enviro vars FS_INSTALL_DIR, FS_PACKAGES_DIR; default install dir is now /usr/local/freesurfer