### PR TITLE
Add labels for lobe parcellations to LUT

### DIFF
--- a/distribution/FreeSurferColorLUT.txt
+++ b/distribution/FreeSurferColorLUT.txt
@@ -613,9 +613,29 @@
 4034    wm-rh-transversetemporal            105 105 55  0
 4035    wm-rh-insula                        20  220 160 0
 
+# Below is the color table for a lobar parcellation obtained from running:
+# mri_annotation2label --subject subject --hemi lh --lobesStrict lobes
+# mri_annotation2label --subject subject --hemi rh --lobesStrict lobes
+# mri_aparc2aseg --s subject --rip-unknown --volmask \
+#   --o aparc.lobes.mgz --annot lobes \
+#   --base-offset 300 [--base-offset must be last arg]
 
-# Below is the color table for a lobar white matter parcelation
-#  obtained from running
+1301    ctx-lh-frontal-lobe                  20  220 160 0
+1303    ctx-lh-cingulate-lobe                220 180 220 0
+1304    ctx-lh-occiptal-lobe                 140 220 220 0
+1305    ctx-lh-temporal-lobe                 35  195 35  0
+1306    ctx-lh-parietal-lobe                 220 60  220 0
+1307    ctx-lh-insula-lobe                   255 192 32  0
+
+2301    ctx-rh-frontal-lobe                  20  220 160 0
+2303    ctx-rh-cingulate-lobe                220 180 220 0
+2304    ctx-rh-occiptal-lobe                 140 220 220 0
+2305    ctx-rh-temporal-lobe                 35  195 35  0
+2306    ctx-rh-parietal-lobe                 220 60  220 0
+2307    ctx-rh-insula-lobe                   255 192 32  0
+
+# Below is the color table for a lobar white matter parcellation
+#  obtained from running:
 # mri_annotation2label --subject subject --hemi lh --lobesStrict lobes
 # mri_annotation2label --subject subject --hemi rh --lobesStrict lobes
 # mri_aparc2aseg --s subject --labelwm --hypo-as-wm --rip-unknown \

--- a/distribution/FreeSurferColorLUT.txt
+++ b/distribution/FreeSurferColorLUT.txt
@@ -620,18 +620,18 @@
 #   --o aparc.lobes.mgz --annot lobes \
 #   --base-offset 300 [--base-offset must be last arg]
 
-1301    ctx-lh-frontal-lobe                  20  220 160 0
-1303    ctx-lh-cingulate-lobe                220 180 220 0
-1304    ctx-lh-occiptal-lobe                 140 220 220 0
-1305    ctx-lh-temporal-lobe                 35  195 35  0
-1306    ctx-lh-parietal-lobe                 220 60  220 0
+1301    ctx-lh-frontal-lobe                  25  100 40  0
+1303    ctx-lh-cingulate-lobe                100 25  0   0
+1304    ctx-lh-occiptal-lobe                 120 70  50  0
+1305    ctx-lh-temporal-lobe                 220 20  100 0
+1306    ctx-lh-parietal-lobe                 220 20  10  0
 1307    ctx-lh-insula-lobe                   255 192 32  0
 
-2301    ctx-rh-frontal-lobe                  20  220 160 0
-2303    ctx-rh-cingulate-lobe                220 180 220 0
-2304    ctx-rh-occiptal-lobe                 140 220 220 0
-2305    ctx-rh-temporal-lobe                 35  195 35  0
-2306    ctx-rh-parietal-lobe                 220 60  220 0
+2301    ctx-rh-frontal-lobe                  25  100 40  0
+2303    ctx-rh-cingulate-lobe                100 25  0   0
+2304    ctx-rh-occiptal-lobe                 120 70  50  0
+2305    ctx-rh-temporal-lobe                 220 20  100 0
+2306    ctx-rh-parietal-lobe                 220 20  10  0
 2307    ctx-rh-insula-lobe                   255 192 32  0
 
 # Below is the color table for a lobar white matter parcellation


### PR DESCRIPTION
This adds label values to the LUT for each lobar parcellation obtained from `mri_annotation2label --lobesStrict`, following the color convention used for the `wm-hemi-lobe` lobes in the lines below (eg the frontal-lobe value is the same as superiorfrontal, etc). 