### PR TITLE
Fixed ITK_DIR on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,11 @@ find_package(PETSC)
 
 # -------- itk --------
 if(NOT ITK_DIR)
-  set(ITK_DIR ${FS_PACKAGES_DIR}/itk/5.0.0)
+  if(APPLE)
+    set(ITK_DIR ${FS_PACKAGES_DIR}/itk/4.13.0)
+  else()
+    set(ITK_DIR ${FS_PACKAGES_DIR}/itk/5.0.0)
+  endif()
 endif()
 find_package(ITK HINTS ${ITK_DIR} REQUIRED)
 add_definitions(-DHAVE_ITK_LIBS)


### PR DESCRIPTION
When compiling FS on macOS, prebuild 3rd-party libraries available from "http://surfer.nmr.mgh.harvard.edu/pub/data/fspackages/prebuilt/osx10.11-packages.tar.gz" are needed.

Currently, this package contains ITK 4.13.0, whereas version 5.0.0 is expected within CMakeLists.txt. Until someone makes a newer version of the package (and updates the URL in CMakeLists.txt), the correct ITK_DIR should be set if on macOS. See attached configuration attempts with CMake.
[problem.txt](https://github.com/freesurfer/freesurfer/files/2336980/problem.txt)
[solution.txt](https://github.com/freesurfer/freesurfer/files/2336981/solution.txt)

