### PR TITLE
Fixed assert heisenbug.

### DIFF
--- a/mri_robust_register/mri_robust_template.cpp
+++ b/mri_robust_register/mri_robust_template.cpp
@@ -247,14 +247,16 @@ int main(int argc, char *argv[])
         P.iltas.size () == 0 || P.iltas.size() == P.mov.size() || (int)P.iltas.size() == nin);
     if (P.iltas.size() > 0)
     {
-      assert(MR.loadLTAs(P.iltas)==nin);
+      const int numLoaded = MR.loadLTAs(P.iltas);
+      assert(numLoaded==nin);
     }
 
     // load initial iscales if set:
     assert(P.iscalein.size () == 0 || (int)P.iscalein.size() == nin);
     if (P.iscalein.size() > 0)
     {
-      assert(MR.loadIntensities(P.iscalein)==nin);
+      const int numLoaded = MR.loadIntensities(P.iscalein);
+      assert(numLoaded==nin);
     }
 
     // Randomly pick target (default):


### PR DESCRIPTION
Fixed segmentation fault occurring in mri_robust_template when compiled on macOS with CMake (see attached files).

The problem consisted in function calls that were placed inside assert statements - assertions are not evaluated when the macro NDEBUG is defined. It's therefore wise not to rely too much on them, and I moved the above mentioned calls out of these statements.

In addition, it may be useful to check if we can prevent CMake from defining NDEBUG when compiling in release mode so we know what's wrong if something fails.

[problem.txt](https://github.com/freesurfer/freesurfer/files/2353731/problem.txt)
[solved.txt](https://github.com/freesurfer/freesurfer/files/2353732/solved.txt)
