### PR TITLE
Nf mapmovhdr

### DIFF
--- a/mri_robust_register/MultiRegistration.cpp
+++ b/mri_robust_register/MultiRegistration.cpp
@@ -1832,6 +1832,34 @@ bool MultiRegistration::writeLTAs(const std::vector<std::string> & nltas,
   return (error == 0);
 }
 
+bool MultiRegistration::writeMapMovHdr(
+  const std::vector<std::string>& mapmovhdr)
+{
+  assert(mapmovhdr.size() == mri_mov.size());
+  for (unsigned int i = 0; i < mapmovhdr.size(); i++)
+  {
+    if (!ltas[i])
+    {
+      std::cout << " ERROR: No LTAs exist! Skipping output.\n";
+      return false;
+    }
+    vnl_matrix<double> fMr2r = MyMatrix::LTA2RASmatrix(ltas[i]);
+    MATRIX * ras2ras = MyMatrix::convertVNL2MATRIX(fMr2r, NULL);
+    MATRIX * vox2ras = MRIgetVoxelToRasXform(mri_mov[i]);
+    vox2ras = MatrixMultiply(ras2ras, vox2ras, vox2ras);
+    MRI *mri_aligned = MRIcopy(mri_mov[i], NULL);
+    MRIsetVoxelToRasXform(mri_aligned, vox2ras);
+    const int error = MRIwrite(mri_aligned, mapmovhdr[i].c_str());
+    MRIfree(&mri_aligned);
+    if (error)
+    {
+      std::cout << "ERROR: Can't write " << mapmovhdr[i].c_str() << '\n';
+      return false;
+    }
+  }
+  return true;
+}
+
 bool MultiRegistration::writeWarps(const std::vector<std::string>& nwarps)
 {
   assert(nwarps.size() == mri_warps.size() || nwarps.size() == 1);

--- a/mri_robust_register/MultiRegistration.h
+++ b/mri_robust_register/MultiRegistration.h
@@ -129,6 +129,8 @@ public:
       const std::string & mean);
   //! Write all mapped movables
   bool writeWarps(const std::vector<std::string>& nwarps);
+  //! Write header-adjusted movables.
+  bool writeMapMovHdr(const std::vector<std::string>& mapmovhdr);
   //! Write all intensity scales
   bool writeIntensities(const std::vector<std::string>& nintens);
   //! Write all weights

--- a/mri_robust_register/mri_robust_register.cpp
+++ b/mri_robust_register/mri_robust_register.cpp
@@ -1835,24 +1835,24 @@ static int parseNextCommand(int argc, char *argv[], Parameters & P)
   else if (!strcmp(option, "AFFINE") || !strcmp(option, "A"))
   {
     P.affine = true;
-    cout << "--affine: Enableing affine transform!" << endl;
+    cout << "--affine: Enabling affine transform!" << endl;
   }
   else if (!strcmp(option, "ISOSCALE"))
   {
     P.isoscale = true;
-    cout << "--isoscale: Enableing isotropic scaling!" << endl;
+    cout << "--isoscale: Enabling isotropic scaling!" << endl;
   }
   else if (!strcmp(option, "INITSCALING"))
   {
     P.initscaling = true;
     cout
-        << "--initscaling: Enableing initial scale adjustment based on image dimensions!"
+        << "--initscaling: Enabling initial scale adjustment based on image dimensions!"
         << endl;
   }
   else if (!strcmp(option, "ISCALE") || !strcmp(option, "I"))
   {
     P.iscale = true;
-    cout << "--iscale: Enableing intensity scaling!" << endl;
+    cout << "--iscale: Enabling intensity scaling!" << endl;
   }
   else if (!strcmp(option, "ISCALEONLY") )
   {

--- a/mri_robust_register/mri_robust_template.cpp
+++ b/mri_robust_register/mri_robust_template.cpp
@@ -560,12 +560,12 @@ static int parseNextCommand(int argc, char *argv[], Parameters & P)
   else if (!strcmp(option, "AFFINE") || !strcmp(option, "A"))
   {
     P.affine = true;
-    cout << "--affine: Enableing affine transform!" << endl;
+    cout << "--affine: Enabling affine transform!" << endl;
   }
   else if (!strcmp(option, "ISCALE") || !strcmp(option, "I"))
   {
     P.iscale = true;
-    cout << "--iscale: Enableing intensity scaling!" << endl;
+    cout << "--iscale: Enabling intensity scaling!" << endl;
   }
   else if (!strcmp(option, "TRANSONLY"))
   {

--- a/mri_robust_register/mri_robust_template.cpp
+++ b/mri_robust_register/mri_robust_template.cpp
@@ -99,6 +99,7 @@ struct Parameters
   vector<string> iltas;
   vector<string> nltas;
   vector<string> nweights;
+  vector<string> mapmovhdr;
   bool fixvoxel;
   bool floattype;
   bool lta_vox2vox;
@@ -136,9 +137,9 @@ struct Parameters
 // Initializations:
 static struct Parameters P =
 { vector<string>(0), vector<string>(0), "", vector<string>(0), vector<string>(0), vector<string>(
-    0), false, false, false, false, false, false, false, false, false, 5, -1.0, SAT, vector<
-    string>(0), 0, 1, -1, false, false, SSAMPLE, false, false, "", false, true,
-    vector<string>(0), vector<string>(0), SAMPLE_CUBIC_BSPLINE, -1, 0 , false, 5, 0.01};
+    0), vector<string>(0), false, false, false, false, false, false, false, false, false,
+    5, -1.0, SAT, vector<string>(0), 0, 1, -1, false, false, SSAMPLE, false, false, "", false,
+    true, vector<string>(0), vector<string>(0), SAMPLE_CUBIC_BSPLINE, -1, 0 , false, 5, 0.01};
 
 static void printUsage(void);
 static bool parseCommandLine(int argc, char *argv[], Parameters & P);
@@ -361,6 +362,10 @@ int main(int argc, char *argv[])
     if (P.nwarps.size() > 0)
     {
       MR.writeWarps(P.nwarps);
+    }
+    if (P.mapmovhdr.size() > 0)
+    {
+      MR.writeMapMovHdr(P.mapmovhdr);
     }
     if (P.iscaleout.size() > 0)
     {
@@ -703,7 +708,22 @@ static int parseNextCommand(int argc, char *argv[], Parameters & P)
       }
     } while (nargs + 1 < argc && option[0] != '-');
     assert(nargs > 0);
-    cout << "--mapmov: Will save mapped movables/sources !" << endl;
+    cout << "--mapmov: Will save mapped movables/sources!" << endl;
+  }
+  else if (!strcmp(option, "MAPMOVHDR"))
+  {
+    nargs = 0;
+    do
+    {
+      option = argv[nargs + 1];
+      if (option[0] != '-')
+      {
+        nargs++;
+        P.mapmovhdr.push_back(string(argv[nargs]));
+      }
+    } while (nargs + 1 < argc && option[0] != '-');
+    assert(nargs > 0);
+    cout << "--mapmovhdr: Will save header-adjusted movables!" << endl;
   }
   else if (!strcmp(option, "TEST"))
   {
@@ -841,15 +861,23 @@ static bool parseCommandLine(int argc, char *argv[], Parameters & P)
   {
     ntest = false;
     cerr
-        << "ERROR: Number of filnames for --warp should agree with number of inputs!"
+        << "ERROR: Number of filenames for --warp should equal number of inputs!"
         << endl;
+    exit(1);
+  }
+  if (P.mapmovhdr.size()>0 && P.mov.size()!=P.mapmovhdr.size())
+  {
+    ntest = false;
+      std::cerr
+      << "ERROR: Number of filenames for --mapmovhdr should equal number of inputs!"
+      << std::endl;
     exit(1);
   }
   if (P.nltas.size() > 0 && P.mov.size() != P.nltas.size())
   {
     ntest = false;
     cerr
-        << "ERROR: Number of filnames for --lta should agree with number of inputs!"
+        << "ERROR: Number of filenames for --lta should equal number of inputs!"
         << endl;
     exit(1);
   }
@@ -857,7 +885,7 @@ static bool parseCommandLine(int argc, char *argv[], Parameters & P)
   {
     ntest = false;
     cerr
-        << "ERROR: Number of filnames for --ixforms should agree with number of inputs!"
+        << "ERROR: Number of filenames for --ixforms should equal number of inputs!"
         << endl;
     exit(1);
   }
@@ -865,7 +893,7 @@ static bool parseCommandLine(int argc, char *argv[], Parameters & P)
   {
     ntest = false;
     cerr
-        << "ERROR: Number of filnames for --weights should agree with number of inputs!"
+        << "ERROR: Number of filenames for --weights should equal number of inputs!"
         << endl;
     exit(1);
   }
@@ -881,7 +909,7 @@ static bool parseCommandLine(int argc, char *argv[], Parameters & P)
   {
     ntest = false;
     cerr
-        << "ERROR: Number of filnames for --iscaleout should agree with number of inputs!"
+        << "ERROR: Number of filenames for --iscaleout should equal number of inputs!"
         << endl;
     exit(1);
   }

--- a/mri_robust_register/mri_robust_template.help.xml
+++ b/mri_robust_register/mri_robust_template.help.xml
@@ -71,6 +71,10 @@ Important Note: For best performance the input images should all have the same i
       <explanation>use initial intensity scales</explanation>
       <argument>--iscaleout &lt;is1.txt&gt; &lt;is2.txt&gt; ...</argument>
       <explanation>output final intensity scales (will activate --iscale)</explanation>
+      <argument>--transonly</argument>
+      <explanation>find 3 parameter translation only</explanation>
+      <argument>--affine</argument>
+      <explanation>find 12 parameter affine transform</explanation>
       <argument>--ixforms &lt;t1.lta&gt; &lt;t2.lta&gt; ...</argument>
       <explanation>use initial transforms (lta) on source  ('id'=identity)</explanation>
       <argument>--masks &lt;mask1.mgz&gt; ...</argument>

--- a/mri_robust_register/mri_robust_template.help.xml
+++ b/mri_robust_register/mri_robust_template.help.xml
@@ -51,6 +51,8 @@ Important Note: For best performance the input images should all have the same i
       <explanation>output xforms to template (for each input)</explanation>
       <argument>--mapmov &lt;aligned1.mgz&gt; ...</argument>
       <explanation>output images: map and resample each input to template</explanation>
+      <argument>--mapmovhdr &lt;aligned1.mgz&gt; ...</argument>
+      <explanation>output images: header-adjusted movables (no resampling) </explanation>
       <argument>--weights &lt;weights1.mgz&gt; ...</argument>
       <explanation>output weights (outliers) in target space</explanation>
       <argument>--oneminusw</argument>


### PR DESCRIPTION
Implemented --mapmovhdr option from mri_robust_register for mri_robust_template. The flag allows to save the aligned time points in template space without resampling - only the world matrix is changed. Updated bits of the help text.