### PR TITLE
Initialized GCAM to voxel space to avoid undefined value.

### DIFF
--- a/utils/gcamorph.c
+++ b/utils/gcamorph.c
@@ -1363,7 +1363,8 @@ GCA_MORPH *GCAMalloc(const int width, const int height, const int depth)
   gcam->width = width;
   gcam->height = height;
   gcam->depth = depth;
-  gcam->spacing = 1;  // may be changed by the user later
+  gcam->spacing = 1; // may be changed by the user later
+  gcam->type = GCAM_VOX;
 
   gcam->nodes = (GCA_MORPH_NODE ***)calloc(width, sizeof(GCA_MORPH_NODE **));
   if (!gcam->nodes) {


### PR DESCRIPTION
GCA_MORPHs can be of type GCAM_RAS (value 1) or GCAM_VOX (value 2). Avoid problems in case the value was not initialised (e.g. equal to 0). Can be changed by the user later, although most of our GCAMs seem to be defined in voxel space.