### PR TITLE
FIX: Label construction in read_annotation.m 

### DIFF
--- a/matlab/read_annotation.m
+++ b/matlab/read_annotation.m
@@ -37,9 +37,9 @@ function [vertices, label, colortable] = read_annotation(filename, varargin)
 %       o struct_names: cell array of structure names
 %       o table:        n x 5 matrix
 %                       Columns 1,2,3 are RGB values for struct color
-%                       Column 4 is a flag (usually 0)
+%                       Column 4 is the transparency value (i.e. 255 - alpha)
 %                       Column 5 is the structure ID, calculated from
-%                       R + G*2^8 + B*2^16 + flag*2^24
+%                       R + G*2^8 + B*2^16
 %                       
 % LABEL VECTOR
 % 
@@ -132,7 +132,7 @@ if(bool)
             colortable.table(i,2) = fread(fp, 1, 'int');
             colortable.table(i,3) = fread(fp, 1, 'int');
             colortable.table(i,4) = fread(fp, 1, 'int');
-            colortable.table(i,5) = colortable.table(i,1) + colortable.table(i,2)*2^8 + colortable.table(i,3)*2^16 + colortable.table(i,4)*2^24;
+            colortable.table(i,5) = colortable.table(i,1) + colortable.table(i,2)*2^8 + colortable.table(i,3)*2^16;
         end
         if verbosity
             disp(['colortable with ' num2str(colortable.numEntries) ' entries read (originally ' colortable.orig_tab ')']);
@@ -170,7 +170,7 @@ if(bool)
             colortable.table(structure,2) = fread(fp, 1, 'int');
             colortable.table(structure,3) = fread(fp, 1, 'int');
             colortable.table(structure,4) = fread(fp, 1, 'int');
-            colortable.table(structure,5) = colortable.table(structure,1) + colortable.table(structure,2)*2^8 + colortable.table(structure,3)*2^16 + colortable.table(structure,4)*2^24;       
+            colortable.table(structure,5) = colortable.table(structure,1) + colortable.table(structure,2)*2^8 + colortable.table(structure,3)*2^16;
 	end
         if verbosity 
           disp(['colortable with ' num2str(colortable.numEntries) ' entries read (originally ' colortable.orig_tab ')']);

--- a/matlab/write_annotation.m
+++ b/matlab/write_annotation.m
@@ -45,8 +45,8 @@ function write_annotation(filename, vertices, label, ct)
 % ct.orig_tab = name of original ct
 % ct.struct_names = list of structure names (e.g. central sulcus and so on)
 % ct.table = n x 5 matrix. 1st column is r, 2nd column is g, 3rd column
-% is b, 4th column is flag, 5th column is resultant integer values
-% calculated from r + g*2^8 + b*2^16 + flag*2^24. flag expected to be all 0
+% is b, 4th column is transparency (1 - alpha), 5th column is resultant integer
+% values calculated from r + g*2^8 + b*2^16.
 
 fp = fopen(filename, 'w', 'b');
 
@@ -137,7 +137,7 @@ for i = 1:ct.numEntries
     
     count = fwrite(fp, int32(ct.table(i, 4)), 'int');
     if(count~=1)
-       error('write_annotation: Unable to write padded color'); 
+       error('write_annotation: Unable to write transparency');
     end 
     
 end


### PR DESCRIPTION
This brings the MATLAB annotation code and comments in line with the C color table code.

Please see:

* https://mail.nmr.mgh.harvard.edu/pipermail/freesurfer/2018-September/058741.html
* https://github.com/nipy/nibabel/issues/649#issuecomment-424755969