### PR TITLE
bf: read in python dependencies from file

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,3 @@
-nibabel==2.2.1
+nibabel==2.3.0
 numpy==1.13.3
 scipy==1.0.0

--- a/python/setup.py
+++ b/python/setup.py
@@ -14,12 +14,11 @@ packages = [
     'freesurfer.samseg'
 ]
 
-# required dependencies
-requirements = [
-    'nibabel == 2.3.0',
-    'numpy == 1.13.3',
-    'scipy == 1.0.0'
-]
+# get required dependencies from requirements.txt
+base_dir = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(base_dir, 'requirements.txt')) as requirements_file:
+    requirements = [line for line in requirements_file.read().splitlines()
+                    if not line.startswith('#')]
 
 
 # ---- run the setup ----


### PR DESCRIPTION
The `requirements.txt` and `setup.py` files within the freesurfer python package don't match. 

This PR bumps up `nibabel` to 2.3.0 in `requirements.txt` (seems to be necessary for code to work), and ensures that only 1 place needs to be updated in the future for managing python dependencies.