### PR TITLE
Create LTA for Talairach XFM from mritotal.

### DIFF
--- a/scripts/talairach
+++ b/scripts/talairach
@@ -103,6 +103,14 @@ if($st) then
   exit 1;
 endif
 
+# Create an LTA version of the XFM.
+set target = ${MINC_BIN_DIR}/../share/mni_autoreg/average_305.mnc
+set cmd = (lta_convert --src $InVol --trg $target)
+set cmd = ($cmd --inxfm $XFM --outlta $XFM.lta --subject fsaverage)
+echo $cmd |& tee -a $LF
+$cmd >> $LF
+if($status) exit 1;
+
 echo " " |& tee -a $LF
 echo " " |& tee -a $LF
 date | tee -a $LF


### PR DESCRIPTION
Create LTA when talairach script is run instead of talairach_avi. The talairach_avi script does this already. Creating the LTA later can be tricky as the target/atlas geometry needs to be known.