### PR TITLE
Update build_packages script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,6 +229,7 @@ mri_robust_register/mri_robust_register
 mri_robust_register/mri_robust_template
 mri_sbbr/mri_sbbr
 mri_seg_diff/mri_seg_diff
+mri_seg_overlap/mri_seg_overlap
 mri_segcentroids/mri_segcentroids
 mri_seghead/mri_seghead
 mri_segment/mri_segment

--- a/packages/build_packages.py
+++ b/packages/build_packages.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This is a utility script to help external developers easily build
 # freesurfer dependencies. The packages, defined below in the 'pkgs' list,
 # are built with the scripts and tarballs stored in the packages/source dir
 # and will get installed to the destination directory specified on the command-line.
-# 
+#
 # usage:
 #    build_packages.py /path/to/install/destination
 #
@@ -17,144 +17,163 @@
 # if this script is rerun, the package is only rebuilt when the source code has been
 # modified/updated.
 
+import argparse
+import hashlib
 import os
-import sys
 import platform
 import shutil
-import argparse
-import tarfile
 import subprocess
-import hashlib
+import sys
 
 # get the absolute path of this build_packages.py script, so we can
 # locate the source tarballs and scripts (and import the log module while we're at it)
 fs_source_dir = os.path.dirname(os.path.abspath(os.path.dirname(sys.argv[0])))
 sys.path.append(os.path.join(fs_source_dir, 'python'))
-from freesurfer.log import *
+from freesurfer.log import term, error, errorExit
+
 
 # simple package class to store package source information
 class Package:
-  def __init__(self, name, version, script, tarball, required=True):
-    self.name = name
-    self.version = version
-    self.required = required
-    self.script = os.path.join(fs_source_dir, 'packages/source', script)
-    if not os.path.exists(self.script):
-      errorExit('%s does not exist' % self.script)
-    self.tarball = os.path.join(fs_source_dir, 'packages/source', tarball)
-    if not os.path.exists(self.tarball):
-      errorExit('%s does not exist' % self.tarball)
+    def __init__(self, name, version, script, tarball, required=True):
+        self.name = name
+        self.version = version
+        self.required = required
+        self.script = os.path.join(fs_source_dir, 'packages/source', script)
+        if not os.path.exists(self.script):
+            errorExit('%s does not exist' % self.script)
+        self.tarball = os.path.join(fs_source_dir, 'packages/source', tarball)
+        if not os.path.exists(self.tarball):
+            errorExit('%s does not exist' % self.tarball)
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #                              ~~ freesurfer dependencies ~~
-
-pkgs = [
-  Package('jpeg',        '6b',     'build_jpeg.sh',      'jpeg-6b.tar.gz'),
-  Package('tiff',        '3.6.1',  'build_tiff.sh',      'tiff-3.6.1.tar.gz'),
-  Package('expat',       '2.0.1',  'build_expat.sh',     'expat-2.0.1.tar.gz'),
-  Package('xml2',        '2.7.7',  'build_xml2.sh',      'xml2-2.7.7.tar.gz'),
-  Package('glut',        '3.7',    'build_glut.sh',      'glut-3.7.tar.gz', required=False), # found in freesurfer/glut
-  Package('netcdf',      '3.6.0',  'build_netcdf.sh',    'netcdf-3.6.0-p1.tar.gz', required=False), # found in freesurfer/netcdf_3_6_0_p1
-  Package('minc',        '1.5',    'build_minc.sh',      'minc-1.5.tar.gz', required=False),  # found in freesurfer/minc_1_5_1 
-  Package('tetgen',      '1.4.1',  'build_tetgen.sh',    'tetgen-1.4.1.tar.gz'),
-  Package('itk',         '4.13.0', 'build_itk.sh',       'itk-4.13.0.tar.gz'),
-  Package('petsc',       '2.3.3',  'build_petsc.sh',     'petsc-2.3.3.tar.gz', required=False),
-  Package('ann',         '1.1.2',  'build_ann.sh',       'ann-1.1.2.tar.gz', required=False),
-  Package('vtk',         '5.10.1', 'build_vtk.sh',       'vtk-5.10.1.tar.gz', required=False),
-  Package('kwwidgets',   'CVS',    'build_kwwidgets.sh', 'kwwidgets-cvs.tar.gz', required=False)  # must build kwwidgets after vtk
+# `pkg_dicts` is a list of dict, containing the following keys:
+#    pacakge_name, version, script, tarball, required
+# where 'required' determines whether it's required for a FreeSurfer minimal build
+pkg_dict_keys = ('name', 'version', 'script', 'tarball', 'required')
+pkg_dict_values = [
+    ('jpeg',        '6b',     'build_jpeg.sh',      'jpeg-6b.tar.gz',         True),
+    ('tiff',        '3.6.1',  'build_tiff.sh',      'tiff-3.6.1.tar.gz',      True),
+    ('expat',       '2.0.1',  'build_expat.sh',     'expat-2.0.1.tar.gz',     True),
+    ('xml2',        '2.7.7',  'build_xml2.sh',      'xml2-2.7.7.tar.gz',      True),
+    ('glut',        '3.7',    'build_glut.sh',      'glut-3.7.tar.gz',        False),  # found in freesurfer/glut
+    ('netcdf',      '3.6.0',  'build_netcdf.sh',    'netcdf-3.6.0-p1.tar.gz', False),  # found in freesurfer/netcdf_3_6_0_p1
+    ('minc',        '1.5',    'build_minc.sh',      'minc-1.5.tar.gz',        False),  # found in freesurfer/minc_1_5_1
+    ('tetgen',      '1.4.1',  'build_tetgen.sh',    'tetgen-1.4.1.tar.gz',    True),
+    ('itk',         '4.13.0', 'build_itk.sh',       'itk-4.13.0.tar.gz',      True),
+    ('petsc',       '2.3.3',  'build_petsc.sh',     'petsc-2.3.3.tar.gz',     False),
+    ('ann',         '1.1.2',  'build_ann.sh',       'ann-1.1.2.tar.gz',       False),
+    ('vtk',         '5.10.1', 'build_vtk.sh',       'vtk-5.10.1.tar.gz',      False),
+    ('kwwidgets',   'CVS',    'build_kwwidgets.sh', 'kwwidgets-cvs.tar.gz',   False)  # must build kwwidgets after vtk
 ]
-
 # tcltk 8.4.6 cannot be built on modern OSX
 if platform.system() != 'Darwin':
-  pkgs.append(Package('tcltktixblt', '8.4.6', 'build_tcltk.sh', 'tcltktixblt-8.4.6.tar.gz', required=False))
+    pkg_dict_values.append(('tcltktixblt', '8.4.6', 'build_tcltk.sh', 'tcltktixblt-8.4.6.tar.gz', False))
+
+pkg_dicts = [dict(zip(pkg_dict_keys, values)) for values in pkg_dict_values]
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-# parse the command line inputs
-parser = argparse.ArgumentParser()
-parser.add_argument('destination', help="installation dir for the packages")
-parser.add_argument('-f', '--force', action='store_true', help="force rebuild")
-for package in pkgs:
-  parser.add_argument('--no-%s' % package.name, action='store_true', help="don't build %s %s" % (package.name, package.version))
-  parser.add_argument('--only-%s' % package.name, action='store_true', help="only build %s %s" % (package.name, package.version))
-args = parser.parse_args()  # parse the cmd line
+if __name__ == '__main__':
+    # parse the command line inputs
+    parser = argparse.ArgumentParser()
+    parser.add_argument('destination', help="installation dir for the packages")
+    parser.add_argument('-f', '--force', action='store_true', help="force rebuild")
+    for pkg in pkg_dicts:
+        parser.add_argument('--no-%s' % pkg['name'], action='store_true',
+                            help="don't build %s %s" % (pkg['name'], pkg['version']))
+        parser.add_argument('--only-%s' % pkg['name'], action='store_true',
+                            help="only build %s %s" % (pkg['name'], pkg['version']))
+    args = parser.parse_args()  # parse the cmd line
 
-# check to see if any '--only-package' flags were provided
-skip_by_default = False
-for package in pkgs:
-  if vars(args)['only_%s' % package.name]: skip_by_default = True
+    # check to see if any '--only-package' flags were provided
+    skip_by_default = False
+    for pkg in pkg_dicts:
+        if vars(args)['only_%s' % pkg['name']]:
+            skip_by_default = True
 
-# create the packages destination dir
-destination_dir = os.path.abspath(args.destination)
-if not os.path.exists(destination_dir): os.makedirs(destination_dir)
+    # create the packages destination dir
+    destination_dir = os.path.abspath(args.destination)
+    if not os.path.exists(destination_dir):
+        os.makedirs(destination_dir)
 
-failures = []
-for package in pkgs:
-  # cd into packages install destination
-  os.chdir(destination_dir)
-  
-  # make sure we aren't skipping this one
-  if (vars(args)['no_%s' % package.name]) or (skip_by_default and not vars(args)['only_%s' % package.name]):
-    print('skipping %s%s %s%s...' % (term.bold, package.name, package.version, term.end))
-    continue
-  
-  # get the actual package install dir
-  package_dir = os.path.join(destination_dir, package.name, package.version)
-  src_dir = os.path.join(package_dir, 'src')
+    failures = []
+    for pkg in pkg_dicts:
+        # cd into packages install destination
+        os.chdir(destination_dir)
 
-  # compute the new MD5 of the tarball + build script
-  md5 = hashlib.md5()
-  f = open(package.tarball, 'rb')
-  while True:
-    tardata = f.read(2**20)
-    if not tardata: break
-    md5.update(tardata)
-  f.close()
-  # with open(package.script, 'r') as f: md5.update(f.read().encode('utf-8'))
-  md5_current = md5.hexdigest()
+        # make sure we aren't skipping this one
+        if (vars(args)['no_%s' % pkg['name']]) or (skip_by_default and not vars(args)['only_%s' % pkg['name']]):
+            print('skipping %s%s %s%s...' % (term.bold, pkg['name'], pkg['version'], term.end))
+            continue
 
-  # read in the previous MD5
-  md5_filename = os.path.join(src_dir, 'md5')
-  if os.path.isfile(md5_filename):
-    with open(md5_filename, 'r') as f: md5_old = f.read().replace('\n', '')
-    # check for any difference
-    if md5_old == md5_current and not args.force:
-      print('It appears that %s%s %s%s has already been built successfully. '
-            'To force a rebuild, use the --force option or delete %s' % (term.bold, package.name,
-             package.version, term.end, md5_filename))
-      continue
+        # create the Package object only if it is needed to be built
+        # this makes sure the tarball and script exist
+        package = Package(**pkg)
 
-  print('\n%sBuilding %s %s...%s\n' % (term.bold, package.name, package.version, term.end))
+        # get the actual package install dir
+        package_dir = os.path.join(destination_dir, package.name, package.version)
+        src_dir = os.path.join(package_dir, 'src')
 
-  # setup the package install directory
-  if not os.path.exists(package_dir): os.makedirs(package_dir)
+        # compute the new MD5 of the tarball + build script
+        md5 = hashlib.md5()
+        f = open(package.tarball, 'rb')
+        while True:
+            tardata = f.read(2**20)
+            if not tardata:
+                break
+            md5.update(tardata)
+        f.close()
+        # with open(package.script, 'r') as f: md5.update(f.read().encode('utf-8'))
+        md5_current = md5.hexdigest()
 
-  # clean the src directory and cd into it
-  if os.path.exists(src_dir): shutil.rmtree(src_dir)
-  os.makedirs(src_dir)
-  os.chdir(src_dir)
+        # read in the previous MD5
+        md5_filename = os.path.join(src_dir, 'md5')
+        if os.path.isfile(md5_filename):
+            with open(md5_filename, 'r') as f:
+                md5_old = f.read().replace('\n', '')
+            # check for any difference
+            if md5_old == md5_current and not args.force:
+                print('It appears that %s%s %s%s has already been built successfully. '
+                      'To force a rebuild, use the --force option or delete %s' % (term.bold, package.name, package.version, term.end, md5_filename))
+                continue
 
-  # untar the tar
-  ret = subprocess.call('tar -xzf %s' % package.tarball, shell=True)
-  if ret != 0: exit(ret)
+        print('\n%sBuilding %s %s...%s\n' % (term.bold, package.name, package.version, term.end))
 
-  # run the build script
-  ret = subprocess.call('%s %s' % (package.script, package_dir), shell=True)
-  if ret == 0:
-    # if the build runs smoothly, save the tarball MD5
-    with open(md5_filename, "w") as f: f.write(md5_current)
-  else:
-    failures.append(package)
+        # setup the package install directory
+        if not os.path.exists(package_dir):
+            os.makedirs(package_dir)
 
-# finish up
-print('')
-if failures:
-  for package in failures:
-    error('could not build %s %s. Take a look at %s to debug' % (package.name, package.version, package.script))
-    if not package.required:
-      print('%snote:%s FreeSurfer can be (limitedly) built without %s. If building it locally is '
-            'too troublesome, you can skip it by using the --no-%s flag' % (term.yellow, term.end, package.name, package.name))
-  exit(1)
-else:
-  print('%sDONE: FreeSurfer packages succesfully built!%s\n' % (term.green, term.end))
+        # clean the src directory and cd into it
+        if os.path.exists(src_dir):
+            shutil.rmtree(src_dir)
+        os.makedirs(src_dir)
+        os.chdir(src_dir)
+
+        # untar the tar
+        ret = subprocess.call('tar -xzf %s' % package.tarball, shell=True)
+        if ret != 0:
+            exit(ret)
+
+        # run the build script
+        ret = subprocess.call('%s %s' % (package.script, package_dir), shell=True)
+        if ret == 0:
+            # if the build runs smoothly, save the tarball MD5
+            with open(md5_filename, "w") as f:
+                f.write(md5_current)
+        else:
+            failures.append(package)
+
+    # finish up
+    print('')
+    if failures:
+        for package in failures:
+            error('could not build %s %s. Take a look at %s to debug' % (package.name, package.version, package.script))
+            if not package.required:
+                print('%snote:%s FreeSurfer can be (limitedly) built without %s. If building it locally is '
+                      'too troublesome, you can skip it by using the --no-%s flag' % (term.yellow, term.end, package.name, package.name))
+        exit(1)
+    else:
+        print('%sDONE: FreeSurfer packages succesfully built!%s\n' % (term.green, term.end))

--- a/python/freesurfer/__init__.py
+++ b/python/freesurfer/__init__.py
@@ -1,6 +1,22 @@
-from .util import *
 from .log import *
-from ._surface import *
-from ._normalize import *
-from .freeview import fv
-from . import metrics
+from .util import *
+
+# these require 3rd party dependencies
+# make sure they're installed before importing
+try:
+    from . import metrics
+except ModuleNotFoundError as e:
+    warning(e.msg + ", used in freesurfer python package 'metrics'")
+try:
+    from .freeview import fv
+except ModuleNotFoundError as e:
+    warning(e.msg + ", used in freesurfer python package 'freeview'")
+try:
+    from ._normalize import *
+except ModuleNotFoundError as e:
+    warning(e.msg + ", used in freesurfer python package '_normalize'")
+
+try:
+    from ._surface import *
+except ModuleNotFoundError as e:
+    warning(e.msg + ", used in freesurfer python package '_surface'")

--- a/python/freesurfer/_surface.py
+++ b/python/freesurfer/_surface.py
@@ -1,5 +1,6 @@
-import numpy as np
 import math
+
+import numpy as np
 
 from . import errorExit
 

--- a/python/freesurfer/log.py
+++ b/python/freesurfer/log.py
@@ -1,6 +1,6 @@
-import sys
 import re
 import platform
+import sys
 
 
 # check if file descriptor is a terminal device

--- a/python/freesurfer/metrics.py
+++ b/python/freesurfer/metrics.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from . import error
 
 

--- a/python/freesurfer/util.py
+++ b/python/freesurfer/util.py
@@ -1,9 +1,10 @@
-import sys
-import os
-import shutil
-import select
 import datetime as dt
+import os
+import select
+import shutil
 import subprocess as sp
+import sys
+
 from .log import error
 
 


### PR DESCRIPTION
This PR fixes #553  (although Andrew's commit 66d7075 also fixes this in a different way), adding a number of of changes to the `python/freesurfer` and `build_packages.py` code to allow packages to be built without importing `nibabel` or `numpy`, while still keeping nicer terminal logging. 

Also, within the build script, the `Package` objects aren't created until they are about to be built, so that the package tarballs/scripts don't need to exist if they aren't being built.  This is useful for the case of a minimal build, so that the tarballs for e.g. GUI-based packages aren't needed. 

Some stylistic (mostly [PEP8](https://www.python.org/dev/peps/pep-0008/)-based) changes are also introduced:
- using 4 spaces for indents
- alphabetizing imports, splitting them into sections for stdlib, 3rd-party, and local (`python/freesurfer`) imports
- using `python3` instead of `python`
- avoiding compound statements (multiple statements on the same line), so this:
  ``` python
  if os.path.exists(src_dir): shutil.rmtree(src_dir)
  ```
  becomes
  ``` python
  if os.path.exists(src_dir):
      shutil.rmtree(src_dir)
  ```
Additionally, `mri_seg_overlap` is added to the `.gitignore`

Let me know if you have any suggestions, or would prefer to keep the previous code styling. 

