### PR TITLE
Bf/nf: Downsampling of GCAMs

### DIFF
--- a/mri_concatenate_gcam/mri_concatenate_gcam.cpp
+++ b/mri_concatenate_gcam/mri_concatenate_gcam.cpp
@@ -35,6 +35,7 @@ struct Parameters
   std::vector<std::string> fileList;
   bool reduce = false;
   bool invert = false;
+  bool downsample = false;
 };
 
 
@@ -82,6 +83,12 @@ int main(int argc, char *argv[])
     LTA *tmp = (LTA *)out->xform;
     out->xform = (void *)LTAreduce(tmp);
     LTAfree(&tmp);
+  }
+  
+  if (par.downsample && out->type==MORPH_3D_TYPE) {
+    GCAM *gcam = (GCAM *)out->xform;
+    out->xform = (void *)GCAMdownsample2(gcam);
+    GCAMfree(&gcam);
   }
   
   TransformWrite(out, par.outFile.c_str());
@@ -139,20 +146,26 @@ static void parseCommand(int argc, char *argv[], Parameters &par)
       continue;
     }
     
-    if (!strcmp(*argv, "--srcgeom") || !strcmp(*argv, "-s")) {
+    if (!strcmp(*argv, "--downsample") || !strcmp(*argv, "-d")) {
+      forward(argc, argv);
+      par.downsample = true;
+      continue;
+    }
+    
+    if (!strcmp(*argv, "--change-source") || !strcmp(*argv, "-s")) {
       forward(argc, argv);
       if (argc==0 || ISOPTION(*argv[0])) {
-        ErrorExit(ERROR_BADPARM, "ERROR: no volume for source image geometry.");
+        ErrorExit(ERROR_BADPARM, "ERROR: no volume for source image geometry");
       }
       par.srcImage = std::string(*argv);
       forward(argc, argv);
       continue;
     }
     
-    if (!strcmp(*argv, "--dstgeom") || !strcmp(*argv, "-d")) {
+    if (!strcmp(*argv, "--change-target") || !strcmp(*argv, "-t")) {
       forward(argc, argv);
       if (argc==0 || ISOPTION(*argv[0])) {
-        ErrorExit(ERROR_BADPARM, "ERROR: no volume for destination geometry.");
+        ErrorExit(ERROR_BADPARM, "ERROR: no volume for target image geometry");
       }
       par.dstImage = std::string(*argv);
       forward(argc, argv);

--- a/mri_concatenate_gcam/mri_concatenate_gcam.help.xml
+++ b/mri_concatenate_gcam/mri_concatenate_gcam.help.xml
@@ -25,29 +25,31 @@
 
 <help>
   <name>mri_concatenate_gcam -- concatenate transforms</name>
-  <synopsis>mri_concatenate_gcam [options] input ... ouput</synopsis>
-  <description>This program concatenates a combination of input LTAs (linear transform) and GCAMs (non-linear M3Z warps). The passed transforms are applied in the order specified on the command line, that is the first transform would be applied to an image first (but to coordinates last, as the transforms applied to coordinates are the inverse of those applied to images).
-      Note that binaries such as mri_convert or mri_vol2vol ignore the source and target geometry of M3Zs. To morph an image from or to a differrent space, the M3Z geometry needs to be changed first.
+  <synopsis>mri_concatenate_gcam [options] &lt;input 1&gt; ... &lt;output&gt;</synopsis>
+  <description>This program concatenates a combination of input LTAs (linear transform array) and GCAMs (Gaussian classifier atlas, M3Z). The passed transforms are applied in the order specified on the command line, i.e. the first transform would be applied to images first - but to coordinates last, as transforms applied to coordinates are the inverse of those applied to images.
+      Note that binaries such as mri_convert or mri_vol2vol ignore source and target geometries of M3Zs. To morph an image from or to a differrent space, the M3Z geometry needs to be changed first.
   </description>
   <arguments>
     <positional>
       <argument>input</argument>
-      <explanation>combination of LTAs and M3Zs</explanation>
+      <explanation>Combination of LTAs and M3Zs</explanation>
       <argument>output</argument>
-      <explanation>concatenated output transform, saved as an LTA or M3Z depending on the input transforms</explanation>
+      <explanation>Concatenated output transform, saved as an LTA or M3Z depending on the input transforms</explanation>
     </positional>
     <required-flagged>
       <intro>None</intro>
     </required-flagged>
     <optional-flagged>
-      <argument>-s, --srcgeom</argument>
-      <explanation>Change source image geometry of output M3Z, useful e.g. for GCAM inversion if the path of the original source volume changed (ignored if output is M3Z)</explanation>
-      <argument>-d, --dstgeom</argument>
-      <explanation>Change destination image geometry of output transform, the transform is modified accordingly (ignored if output is M3Z)</explanation>
+      <argument>-s, --change-source &lt;source image&gt;</argument>
+      <explanation>Change source image geometry of output M3Z, useful e.g. for GCAM inversion if the path of the original source volume changed; the warp is modified accordingly</explanation>
+      <argument>-t, --change-target &lt;target image&gt;</argument>
+      <explanation>Change destination image geometry of output M3Z; the warp is modified accordingly</explanation>
       <argument>-r, --reduce</argument>
-      <explanation>Reduce to single LTA (ignored if output is M3Z)</explanation>
+      <explanation>Reduce output LTA to single LT</explanation>
       <argument>-i, --invert</argument>
-      <explanation>Invert the output transformation</explanation>
+      <explanation>Invert the output transform</explanation>
+      <argument>-d, --downsample</argument>
+      <explanation>Downsample output M3Z by factor of 2</explanation>
     </optional-flagged>
   </arguments>
   <outputs>
@@ -59,8 +61,8 @@
   <example>Concatenate transforms:
     mri_concatenate_gcam in1.fslmat in2.m3z in3.m3z in4.lta out.m3z</example>
   <example>Change M3Z to reflect different source image geometry:
-    mri_concatenate_gcam --srcgeom norm.nii in.m3z out.m3z</example>
+    mri_concatenate_gcam -s norm.nii in.m3z out.m3z</example>
   <bugs>None</bugs>
   <reporting>Report bugs to &lt;freesurfer@nmr.mgh.harvard.edu&gt;</reporting>
-  <see-also>mri_concatenate_lta, mri_warp_convert</see-also>
+  <see-also>mri_concatenate_lta, mri_info, mri_convert</see-also>
 </help>

--- a/mri_concatenate_gcam/test.py
+++ b/mri_concatenate_gcam/test.py
@@ -46,9 +46,10 @@ rt.run('mri_concatenate_gcam im2_to_im3.m3z im3_to_im2.m3z gcam.m3z && ' +
        mri_convert + ' -at gcam.m3z im2.mgz gcam_gcam.mgz')
 rt.mridiff('gcam_gcam.mgz', 'gcam_gcam.ref.mgz')
 
-# downsample GCAM by factor of 2
+# downsample GCAM - leave some capacity for change
 rt.run('mri_concatenate_gcam -d im2_to_im3.m3z gcam.m3z && ' +
        mri_convert + ' -at gcam.m3z im2.mgz down.mgz')
-rt.mridiff('down.mgz', 'down.ref.mgz', thresh=1.0)
+rt.mridiff('down.mgz', 'down.ref.mgz', thresh=0.5)
 
 rt.cleanup()
+

--- a/mri_concatenate_gcam/test.py
+++ b/mri_concatenate_gcam/test.py
@@ -17,12 +17,12 @@ rt.diff('concat.lta', 'concat.ref.lta', ignore_comments=True)
 mri_convert = rt.findPath(rt.testdatadir, 'mri_convert/mri_convert')
 
 # change the GCAM source image space
-rt.run('mri_concatenate_gcam --srcgeom im1.mgz im2_to_im3.m3z gcam.m3z && ' +
+rt.run('mri_concatenate_gcam -s im1.mgz im2_to_im3.m3z gcam.m3z && ' +
         mri_convert + ' -at gcam.m3z im2_in_space1.mgz src.mgz')
 rt.mridiff('src.mgz', 'src.ref.mgz')
 
-# change the GCAM destination space
-rt.run('mri_concatenate_gcam --dstgeom im1.mgz im2_to_im3.m3z gcam.m3z && ' +
+# change the GCAM target image space
+rt.run('mri_concatenate_gcam -t im1.mgz im2_to_im3.m3z gcam.m3z && ' +
         mri_convert + ' -at gcam.m3z im2.mgz dest.mgz')
 rt.mridiff('dest.mgz', 'dest.ref.mgz')
 
@@ -45,5 +45,10 @@ rt.mridiff('lta_gcam_lta.mgz', 'lta_gcam_lta.ref.mgz')
 rt.run('mri_concatenate_gcam im2_to_im3.m3z im3_to_im2.m3z gcam.m3z && ' +
        mri_convert + ' -at gcam.m3z im2.mgz gcam_gcam.mgz')
 rt.mridiff('gcam_gcam.mgz', 'gcam_gcam.ref.mgz')
+
+# downsample GCAM by factor of 2
+rt.run('mri_concatenate_gcam -d im2_to_im3.m3z gcam.m3z && ' +
+       mri_convert + ' -at gcam.m3z im2.mgz down.mgz')
+rt.mridiff('down.mgz', 'down.ref.mgz', thresh=1.0)
 
 rt.cleanup()

--- a/mri_convert/mri_convert.c
+++ b/mri_convert/mri_convert.c
@@ -970,7 +970,8 @@ int main(int argc, char *argv[])
       get_floats(argc, argv, &i, downsample_factor, 3);
       downsample_flag = TRUE;
     }
-    else if(strcmp(argv[i], "--downsample2") == 0)
+    else if(strcmp(argv[i], "-ds2") == 0 ||
+            strcmp(argv[i], "--downsample2") == 0)
     {
       downsample2_flag = TRUE;
     }
@@ -1737,7 +1738,6 @@ int main(int argc, char *argv[])
   printf("$Id: mri_convert.c,v 1.227 2017/02/16 19:15:42 greve Exp $\n");
   printf("reading from %s...\n", in_name_only);
 
-#if  0
   if (in_volume_type == MGH_MORPH)
   {
     GCA_MORPH *gcam, *gcam_out ;
@@ -1754,7 +1754,6 @@ int main(int argc, char *argv[])
     GCAMwrite(gcam_out, out_name) ;
     exit(0) ;
   }
-#endif
 
   if (in_volume_type == OTL_FILE)
   {

--- a/mri_convert/mri_convert.help.xml
+++ b/mri_convert/mri_convert.help.xml
@@ -82,6 +82,8 @@ Supply the orientation information in the form of an orientation string  (ostrin
       <explanation>specify the size (mm) - useful for upsampling or downsampling</explanation>
       <argument>-ds, --downsample &lt;ds_x&gt; &lt;ds_y&gt; &lt;ds_z&gt;</argument>
       <explanation>specify the downsampling or upsampling factor</explanation>
+      <argument>-ds2, --downsample2</argument>
+      <explanation>downsample m3z file by factor of 2</explanation>
       <argument>-ois, --out_i_size &lt;size&gt;</argument>
       <argument>-ojs, --out_j_size &lt;size&gt;</argument>
       <argument>-oks, --out_k_size &lt;size&gt;</argument>

--- a/utils/gcamorph.c
+++ b/utils/gcamorph.c
@@ -19537,7 +19537,9 @@ GCA_MORPH *GCAMdownsample2(GCA_MORPH *gcam)
   gcam_dst->type = gcam->type;
   gcam_dst->m_affine = gcam->m_affine;
   gcam_dst->det = gcam->det;
-
+  // Averaging neighboring nodes not necessary: when applied, e.g. using
+  // GCAMmorphToAtlas(), a weighted mean is computed. Interpolating twice
+  // increases differences between downsampled and original warp.
   for (xd = 0; xd < gcam_dst->width; xd++) {
     for (yd = 0; yd < gcam_dst->height; yd++) {
       for (zd = 0; zd < gcam_dst->depth; zd++) {

--- a/utils/gcamorph.c
+++ b/utils/gcamorph.c
@@ -19523,13 +19523,13 @@ GCA_MORPH *GCAMfillInverse(GCA_MORPH *gcam)
 }
 GCA_MORPH *GCAMdownsample2(GCA_MORPH *gcam)
 {
-  int xs, ys, zs, xd, yd, zd, labels[MAX_CMA_LABELS], l, max_l, max_count;
-  GCA_MORPH_NODE *gcamn_src, *gcamn_dst;
+  int xd, yd, zd;
+  GCA_MORPH_NODE *node_src, *node_dst;
   GCA_MORPH *gcam_dst;
 
   gcam_dst = GCAMalloc(gcam->width / 2, gcam->height / 2, gcam->depth / 2);
-  *(&gcam_dst->image) = *(&gcam->image);
-  *(&gcam_dst->atlas) = *(&gcam->atlas);
+  gcam_dst->image = gcam->image;
+  gcam_dst->atlas = gcam->atlas;
   gcam_dst->spacing = 2 * gcam->spacing;
   gcam_dst->ninputs = gcam->ninputs;
   gcam_dst->gca = gcam->gca;
@@ -19541,81 +19541,42 @@ GCA_MORPH *GCAMdownsample2(GCA_MORPH *gcam)
   for (xd = 0; xd < gcam_dst->width; xd++) {
     for (yd = 0; yd < gcam_dst->height; yd++) {
       for (zd = 0; zd < gcam_dst->depth; zd++) {
-        gcamn_dst = &gcam->nodes[xd][yd][zd];
-        memset(labels, 0, sizeof(labels));
+        node_dst = &gcam_dst->nodes[xd][yd][zd];
+        node_src = &gcam->nodes[xd*2][yd*2][zd*2];
+        
+        node_dst->x = node_src->x;
+        node_dst->y = node_src->y;
+        node_dst->z = node_src->z;
 
-        for (xs = xd * 2; xs <= xd * 2 + 1; xs++)
-          for (ys = yd * 2; ys <= yd * 2 + 1; ys++)
-            for (zs = zd * 2; zs <= zd * 2 + 1; zs++) {
-              gcamn_src = &gcam->nodes[xs][ys][zs];
-              labels[gcamn_src->label]++;
+        node_dst->origx = node_src->origx;
+        node_dst->origy = node_src->origy;
+        node_dst->origz = node_src->origz;
 
-              gcamn_dst->x += gcamn_src->x;
-              gcamn_dst->y += gcamn_src->y;
-              gcamn_dst->z += gcamn_src->z;
+        node_dst->xs2 = node_src->xs2;
+        node_dst->ys2 = node_src->ys2;
+        node_dst->zs2 = node_src->zs2;
 
-              gcamn_dst->origx += gcamn_src->origx;
-              gcamn_dst->origy += gcamn_src->origy;
-              gcamn_dst->origz += gcamn_src->origz;
+        node_dst->xs = node_src->xs;
+        node_dst->ys = node_src->ys;
+        node_dst->zs = node_src->zs;
 
-              gcamn_dst->xs2 += gcamn_src->xs2;
-              gcamn_dst->ys2 += gcamn_src->ys2;
-              gcamn_dst->zs2 += gcamn_src->zs2;
+        node_dst->xn = node_src->xn;
+        node_dst->yn = node_src->yn;
+        node_dst->zn = node_src->zn;
 
-              gcamn_dst->xs += gcamn_src->xs;
-              gcamn_dst->ys += gcamn_src->ys;
-              gcamn_dst->zs += gcamn_src->zs;
+        node_dst->saved_origx = node_src->saved_origx;
+        node_dst->saved_origy = node_src->saved_origy;
+        node_dst->saved_origz = node_src->saved_origz;
 
-              gcamn_dst->xn += gcamn_src->xn;
-              gcamn_dst->yn += gcamn_src->yn;
-              gcamn_dst->zn += gcamn_src->zn;
-
-              gcamn_dst->saved_origx += gcamn_src->saved_origx;
-              gcamn_dst->saved_origy += gcamn_src->saved_origy;
-              gcamn_dst->saved_origz += gcamn_src->saved_origz;
-
-              gcamn_dst->prior += gcamn_src->prior;
-              gcamn_dst->area += gcamn_src->area;
-              gcamn_dst->area1 += gcamn_src->area1;
-              gcamn_dst->area2 += gcamn_src->area2;
-              gcamn_dst->orig_area1 += gcamn_src->orig_area1;
-              gcamn_dst->orig_area2 += gcamn_src->orig_area2;
-              if (gcamn_src->invalid) {
-                gcamn_dst->invalid = 1;
-              }
-              if (gcamn_src->status > 0) {
-                gcamn_dst->status = gcamn_src->status;
-              }
-            }
-
-        gcamn_dst->x /= 8;
-        gcamn_dst->y /= 8;
-        gcamn_dst->z /= 8;
-
-        gcamn_dst->origx /= 8;
-        gcamn_dst->origy /= 8;
-        gcamn_dst->origz /= 8;
-
-        gcamn_dst->xs2 /= 8;
-        gcamn_dst->ys2 /= 8;
-        gcamn_dst->zs2 /= 8;
-
-        gcamn_dst->xs /= 8;
-        gcamn_dst->ys /= 8;
-        gcamn_dst->zs /= 8;
-
-        gcamn_dst->xn /= 8;
-        gcamn_dst->yn /= 8;
-        gcamn_dst->zn /= 8;
-
-        max_count = labels[0];
-        max_l = 0;
-        for (l = 1; l < MAX_CMA_LABELS; l++)
-          if (labels[l] > max_count) {
-            max_count = labels[l];
-            max_l = l;
-          }
-        gcamn_dst->label = max_l;
+        node_dst->prior = node_src->prior;
+        node_dst->area = node_src->area;
+        node_dst->area1 = node_src->area1;
+        node_dst->area2 = node_src->area2;
+        node_dst->orig_area1 = node_src->orig_area1;
+        node_dst->orig_area2 = node_src->orig_area2;
+        node_dst->invalid = node_src->invalid;
+        node_dst->status = node_src->status;
+        node_dst->label = node_src->label;
       }
     }
   }


### PR DESCRIPTION
Added flag for downsampling GCAMs by factor of 2 to mri_concatenate_gcam, and fixed bugs in utils/gcamorph.c:GCAMdownsample2():

(1) Data were not written to destination but to source GCAM.
(2) Coordinates of allocated destination GCAM were assumed, wrongly, to be initialised to zero.
(3) Interpolation asymmetry/shift was introduced by setting xd(n) to mean of xs(2n) and xs(2n+1).

When downsampling GCAMs, averaging neighbouring nodes is not necessary: during application, e.g. using GCAMmorphToAtlas(), a weighted mean of nodes is computed anyway, e.g. in GCAMsampleMorph(). Averaging twice makes the applied downsampled warp more different from the original warp.

Updated test for mri_concatenate_gcam; new complete test data can be found here: 
http://gate.nmr.mgh.harvard.edu/filedrop2/?p=agzrygshpxe