### PR TITLE
change pybind_python_version to 3.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,7 +306,7 @@ if(DISTRIBUTE_FSPYTHON)
 endif()
 
 # initialize pybind for python wrapping
-set(PYBIND11_PYTHON_VERSION 3.5)  # minimum version required
+set(PYBIND11_PYTHON_VERSION 3.6)  # minimum version required
 add_subdirectory(packages/pybind11)
 
 if(NOT DISTRIBUTE_FSPYTHON)

--- a/GEMS2/CMakeLists.txt
+++ b/GEMS2/CMakeLists.txt
@@ -37,7 +37,7 @@ else()
   set(FS_SOURCE_DIR ${CMAKE_SOURCE_DIR}/..)
   # Make sure pybind is accessible during GEMS-only build
   if(GEMS_BUILD_PYTHON)
-    set(PYBIND11_PYTHON_VERSION 3.5)
+    set(PYBIND11_PYTHON_VERSION 3.6)
     add_subdirectory(${CMAKE_SOURCE_DIR}/../packages/pybind11 ${CMAKE_BINARY_DIR}/pybind11)
   endif()
 endif()


### PR DESCRIPTION
Could the `PYBIND11_PYTHON_VERSION` be set to `3.6` by default? If `DISTRIBUTE_FS_PYTHON` is used (which is default), Python version 3.6 is installed, so should these two match?