### PR TITLE
WIP: make code py2/3 compatible, use /usr/bin/env python

### DIFF
--- a/packages/build_packages.py
+++ b/packages/build_packages.py
@@ -17,6 +17,7 @@
 # if this script is rerun, the package is only rebuilt when the source code has been
 # modified/updated.
 
+from __future__ import print_function
 import os
 import sys
 import platform

--- a/scripts/LongQdecTable.py
+++ b/scripts/LongQdecTable.py
@@ -1,6 +1,7 @@
 # Original author - Martin Reuter
 # $Id: LongQdecTable.py,v 1.5 2012/05/30 22:50:21 mreuter Exp $
 from __future__ import print_function
+from __future__ import division
 import os
 import logging
 import sys
@@ -154,7 +155,7 @@ class LongQdecTable:
             sys.exit(1)        
         
         if col == 'fsid-base':
-            for key,value in self.subjects_tp_map.items():
+            for key,value in list(self.subjects_tp_map.items()):
                 stpmap = StableDict()
                 stpmap[key] = value
                 alltables.append(LongQdecTable(stpmap,self.variables,"",key,self.cross))        
@@ -167,7 +168,7 @@ class LongQdecTable:
                 sys.exit(1)
             colnum = poscols[0] + 1
               
-            for bid,value in self.subjects_tp_map.items():
+            for bid,value in list(self.subjects_tp_map.items()):
                 key = value[0][colnum]
                 print('Key: '+str(key)+'\n')
                 for tpdata in value:
@@ -196,7 +197,7 @@ class LongQdecTable:
         # numerical values will be averaged
         # for other values we take the first occurence (hopefully basline if the table was sorted)
         #subjects_new_map = StableDict()        
-        for key,value in self.subjects_tp_map.items():
+        for key,value in list(self.subjects_tp_map.items()):
             subjentry = [ key ]
             for i in range(1,len(value[0])):
                 try:
@@ -223,7 +224,7 @@ class LongQdecTable:
                sys.exit(1)
             colnum = poscols[0]   
         
-        for key,value in self.subjects_tp_map.items():
+        for key,value in list(self.subjects_tp_map.items()):
             #print('Key before: '+key+'  ->  '+str(value)+'\n')
             #a = sorted(value, key=lambda tpdata: tpdata[colnum])
             #print('Key after : '+key+'  ->  '+str(a)+'\n')
@@ -246,7 +247,7 @@ class LongQdecTable:
         first = True
         crossnames = True
         #iterate through current table
-        for subjectid, tplist in self.subjects_tp_map.items():
+        for subjectid, tplist in list(self.subjects_tp_map.items()):
             
         
             if not statstable.cross:
@@ -261,7 +262,7 @@ class LongQdecTable:
                 addtplist = statstable.subjects_tp_map[subjectid]
                 
                 # check if all time points are in same order
-                for i,tpdata,addtpdata in itertools.izip(itertools.count(),tplist,addtplist):
+                for i,tpdata,addtpdata in zip(itertools.count(),tplist,addtplist):
                     if tpdata[0] != addtpdata[0]:
                         print('ERROR: time point id'+tpdata[0]+' not found in other table!')
                         sys.exit(1)
@@ -269,7 +270,7 @@ class LongQdecTable:
                     self.subjects_tp_map[subjectid][i] = list(itertools.chain(*[self.subjects_tp_map[subjectid][i], addtplist[i][1:]]))
             else:
                 # if saved in cross format
-                for i,tpdata in itertools.izip(itertools.count(),tplist):
+                for i,tpdata in zip(itertools.count(),tplist):
                     #determin if fsid is cross or long (only once)
                     if first:
                         first=False
@@ -302,7 +303,7 @@ class LongQdecTable:
             fp.write('fsid '+" ".join(self.variables)+'\n')
         else:
             fp.write('fsid fsid-base '+" ".join(self.variables)+'\n')
-        for key,value in self.subjects_tp_map.items():
+        for key,value in list(self.subjects_tp_map.items()):
             for tpdata in value:
                 if self.cross:
                     fp.write(tpdata[0]+' '+ ' '.join(tpdata[1:])+'\n')

--- a/scripts/dgmsocket.py
+++ b/scripts/dgmsocket.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # 
 # NAME
 #

--- a/scripts/dsh
+++ b/scripts/dsh
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import 	os
 import 	sys
 import 	getopt
@@ -214,7 +215,7 @@ G_dieNow	= 0
 
 class dijkResultLogHandler(SocketServer.BaseRequestHandler) :
 	def handle(self):
-		print self.request[0]
+		print(self.request[0])
 			
 class dijkSysLogHandler(SocketServer.BaseRequestHandler) :
 	def handle(self):
@@ -226,26 +227,26 @@ class dijkSysLogHandler(SocketServer.BaseRequestHandler) :
 			Gb_threadREADY = 1
 def vprint(str_msg):
 	global verbose
-	if(verbose): print str_msg
+	if(verbose): print(str_msg)
 
 def synopsis_show(void=0):
-	print G_SYNOPSIS
+	print(G_SYNOPSIS)
 	
 def shutdown(exitCode):
 	global verbose
 	if(verbose):
-		print Gstr_SELF
-		print "\n\tNormal termination to system with code %d.\n" % exitCode
+		print(Gstr_SELF)
+		print("\n\tNormal termination to system with code %d.\n" % exitCode)
 	sys.exit(exitCode)
 
 def error_exit(str_action, str_msg, code):
-	print Gstr_SELF
-	print "\n"
-	print "\tSorry, but some error occurred."
-	print "\tWhile " + str_action + ','
-	print "\t" + str_msg
-	print "\n"
-	print "Exiting to system with code %d.\n" % code
+	print(Gstr_SELF)
+	print("\n")
+	print("\tSorry, but some error occurred.")
+	print("\tWhile " + str_action + ',')
+	print("\t" + str_msg)
+	print("\n")
+	print("Exiting to system with code %d.\n" % code)
 	os._exit(code)
 	sys.exit(code)
 	
@@ -269,7 +270,7 @@ def transmit(str_msg):
 	global verbose
 		
 	if(verbose): 
-		print "\n(%d): Transmitting <%s>" % (thread.get_ident(), str_msg)
+		print("\n(%d): Transmitting <%s>" % (thread.get_ident(), str_msg))
 	str_transmit =  'SSocket_client --silent --host ' + Gstr_host
 	str_transmit += ' --port ' + Gstr_port
 	str_transmit += ' --msg "' + str_msg + '"'
@@ -294,7 +295,7 @@ def dijkstra_spawn(str_port):
 	str_start	= '%s' 		% Gstr_exec
         str_cmd         = '%s'          % Gstr_exec
         str_arg         = ''
-	if(verbose): print "Starting " + str_start
+	if(verbose): print("Starting " + str_start)
 	#(dijkstra_stdout, dijkstra_stdin, dijkstra_stderr)	= popen2.popen3(str_start)
         p       = Popen([str_cmd, str_arg], bufsize=-1,                 \
                     stdin=PIPE, stdout=PIPE, close_fds=True)
@@ -308,10 +309,10 @@ def dijkstra_spawn(str_port):
 		#else:
 			#break
 		if line:
-			print line,
+			print(line, end=' ')
 		else:
 			break
-	print "process died."
+	print("process died.")
  	#print "stdout:\t" + dijkstra_stdout.read() + "\n"
  	#print "stderr:\t" + dijkstra_stderr.read() + "\n"
 	error_exit(	"attempting dijkstra_spawn()", 
@@ -331,9 +332,9 @@ def thread_dijkstra(str_port):
 	
 	global verbose
 	
-	if(verbose): print "thread dijkstra start"
+	if(verbose): print("thread dijkstra start")
 	thread.start_new_thread(dijkstra_spawn, (str_port,))
-	if(verbose): print "thread dijkstra return"
+	if(verbose): print("thread dijkstra return")
 	
 		
 def thread_transmit(str_msg):
@@ -347,9 +348,9 @@ def thread_transmit(str_msg):
 	
 	global verbose, Gb_timerReset
 	
-	if(verbose): print "thread transmit start"
+	if(verbose): print("thread transmit start")
 	thread.start_new_thread(transmit, (str_msg,))
-	if(verbose): print "thread transmit return"
+	if(verbose): print("thread transmit return")
 	Gb_timerReset = 1
 
 def sysLog_listenFor(port, str_ready):
@@ -390,9 +391,9 @@ def thread_sysLog_listenFor(str_port, str_ready):
 	
 	global verbose
 	
-	if(verbose): print "thread sysLog_listenFor start"
+	if(verbose): print("thread sysLog_listenFor start")
 	thread.start_new_thread(sysLog_listenFor, (string.atoi(str_port), str_ready))
-	if(verbose): print "thread sysLog_listenFor return"
+	if(verbose): print("thread sysLog_listenFor return")
 	
 		
 def resultLog_listenFor(port):
@@ -425,9 +426,9 @@ def thread_resultLog_listenFor(str_port):
 	
 	global verbose
 	
-	if(verbose): print "thread resultLog_listenFor start"
+	if(verbose): print("thread resultLog_listenFor start")
 	thread.start_new_thread(resultLog_listenFor, (string.atoi(str_port),))
-	if(verbose): print "thread resultLog_listenFor return"
+	if(verbose): print("thread resultLog_listenFor return")
 
 def line_send(str_line, b_synchronise = 1):
 	#
@@ -458,7 +459,7 @@ def thread_waitTERM():
 	
 	global	Gb_threadTERM, verbose
 	
-	if(verbose): print "Waiting for thread termination..."
+	if(verbose): print("Waiting for thread termination...")
 	while(not Gb_threadTERM):
 		pass
 	Gb_threadTERM	= 0
@@ -467,15 +468,15 @@ def SYNCsend():
 	global Gb_timerReset, Gb_threadTimerStarted
 	global Gtimer_READY
         if Gb_syncSend:
-            print "%s %s pulsing engine with 'SYNC'... " % \
-                (time.asctime(time.localtime()), Gstr_thisHost)
+            print("%s %s pulsing engine with 'SYNC'... " % \
+                (time.asctime(time.localtime()), Gstr_thisHost))
             thread_transmit("SYNC")
             Gtimer_READY.cancel()
             Gb_timerReset 		= 1
             Gb_threadTimerStarted 	= 0
             dijkstraRunning		= dijkstra_isRunning()
             if(dijkstraRunning == 256):
-                    print "(Engine failure detected - code %s)" % dijkstraRunning
+                    print("(Engine failure detected - code %s)" % dijkstraRunning)
                     error_exit("sending 'SYNC'",
                             "it appears as though the engine has died.",
                             10)
@@ -497,7 +498,7 @@ def thread_waitREADY():
 	Gb_timerReset 		= 1
 	Gb_threadTimerStarted	= 0
 	
-	if(verbose): print "Waiting for Gb_threadREADY to become TRUE..."
+	if(verbose): print("Waiting for Gb_threadREADY to become TRUE...")
 	while(not Gb_threadREADY):
 		if(Gb_timerReset):
 			if(Gb_threadTimerStarted):
@@ -530,8 +531,8 @@ def userInput_get():
 
         count = staticUserInputCount()
         if count == 1:
-            print "Engine successfully started and environment parsed."
-            print "Ready for user input. Type 'HELP' for help."
+            print("Engine successfully started and environment parsed.")
+            print("Ready for user input. Type 'HELP' for help.")
 	str_userInput = raw_input("%d > " % count)
 	return str_userInput	
 	
@@ -573,11 +574,11 @@ for o, a in opts:
 		Gstr_optionsFile 	= a
 	if(o == '-h'):
 		Gstr_host		= a
-		print "Warning! I cannot start a '%s' process" % Gstr_exec
-		print "on any host other than localhost! The <host>"
-		print "option is currently only useful in controlling"
-		print "a '%s' process that has already been"    % Gstr_exec
-		print "started."
+		print("Warning! I cannot start a '%s' process" % Gstr_exec)
+		print("on any host other than localhost! The <host>")
+		print("option is currently only useful in controlling")
+		print("a '%s' process that has already been"    % Gstr_exec)
+		print("started.")
 	if(o == '-p'):
 		Gstr_port		= a
 	if(o == '-R'):
@@ -588,7 +589,7 @@ for o, a in opts:
 		str_verbose		= a
 		verbose			= string.atoi(str_verbose)
 	if(o == '-V'):
-		print Gstr_VERSION
+		print(Gstr_VERSION)
 		sys.exit(0)
 	if(o == '-x'):
 		synopsis_show()
@@ -604,12 +605,12 @@ for o, a in opts:
 # Startup messages
 #
 if(not Gb_nonInteractive):
-	print "Welcome to the mris_pmake shell, 'dsh', running on '%s'" % Gstr_thisHost
-	print "CVS version " + Gstr_VERSION
-	print "\nType 'quit' to return gracefully to system."
-	print "Note that this will terminate any running 'mris_pmake' engine.\n"
-	print "Type 'exit' to terminate this shell."
-	print "Note that any 'mris_pmake' engine active will remain running.\n"
+	print("Welcome to the mris_pmake shell, 'dsh', running on '%s'" % Gstr_thisHost)
+	print("CVS version " + Gstr_VERSION)
+	print("\nType 'quit' to return gracefully to system.")
+	print("Note that this will terminate any running 'mris_pmake' engine.\n")
+	print("Type 'exit' to terminate this shell.")
+	print("Note that any 'mris_pmake' engine active will remain running.\n")
 															
 # Check if dijsktra_p1 has already been started on 'localhost'
 if Gstr_host == 'localhost':
@@ -620,7 +621,7 @@ if Gstr_host == 'localhost':
             str_msg += "\tThere might be a delay of a few seconds as the program\n"
             str_msg += "\tstarts and parses its initial environment.\n\n"
             str_msg += "\tPlease be patient..."
-            if(not Gb_nonInteractive): print str_msg
+            if(not Gb_nonInteractive): print(str_msg)
 
             thread_dijkstra(Gstr_port)
 
@@ -628,31 +629,31 @@ if Gstr_host == 'localhost':
                 sys.exit(G_dieNow)
 
             if(not Gb_nonInteractive):
-                print "\tBack-end engine has been successfully started!"
-                print "\tAny console output from this 'mris_pmake' process"
-                print "\twill be captured by this shell.\n"
-                print "\tWaiting on threads while environment is parsed...\n"
+                print("\tBack-end engine has been successfully started!")
+                print("\tAny console output from this 'mris_pmake' process")
+                print("\twill be captured by this shell.\n")
+                print("\tWaiting on threads while environment is parsed...\n")
         else:
             if(not Gb_nonInteractive):
-                print "\n\t'mris_pmake' is already running on ",
-                print "host '" + Gstr_thisHost + "'."
-                print "\n\tI will connect to this process."
-                print "\tPlease note that I cannot capture console output"
-                print "\tfrom an already running 'mris_pmake' process. Any."
-                print "\tdata transmitted to my resultLog server, however, will"
-                print "\tbe captured and displayed.\n"
-                print "\tIf you want a fully interactive session, please type"
-                print "\t'quit' at the prompt and re-run 'dsh'.\n"
+                print("\n\t'mris_pmake' is already running on ", end=' ')
+                print("host '" + Gstr_thisHost + "'.")
+                print("\n\tI will connect to this process.")
+                print("\tPlease note that I cannot capture console output")
+                print("\tfrom an already running 'mris_pmake' process. Any.")
+                print("\tdata transmitted to my resultLog server, however, will")
+                print("\tbe captured and displayed.\n")
+                print("\tIf you want a fully interactive session, please type")
+                print("\t'quit' at the prompt and re-run 'dsh'.\n")
 else:
 	if(not Gb_nonInteractive):
-            print "\tYou have specified a host other than <localhost>. I cannot"
-            print "\tstart 'mris_pmake' on any host other than <localhost>, and"
-            print "\twill assume that this process is running on <"+Gstr_host+">."
-            print "\tIf the back end engine is not currently started on that host"
-            print "\tplease login and start. Note that this shell will block until"
-            print "\tit receives a transmission from the engine. Also note that"
-            print "\tthis engine needs to at the very least direct its syslog"
-            print "\tto this shell - use 'ENV syslog set <hostname>:<port>.'"
+            print("\tYou have specified a host other than <localhost>. I cannot")
+            print("\tstart 'mris_pmake' on any host other than <localhost>, and")
+            print("\twill assume that this process is running on <"+Gstr_host+">.")
+            print("\tIf the back end engine is not currently started on that host")
+            print("\tplease login and start. Note that this shell will block until")
+            print("\tit receives a transmission from the engine. Also note that")
+            print("\tthis engine needs to at the very least direct its syslog")
+            print("\tto this shell - use 'ENV syslog set <hostname>:<port>.'")
 	
 # Start the result and system log server threads
 thread_resultLog_listenFor(Gstr_portResult)
@@ -693,30 +694,30 @@ if Gb_nonInteractive:
 else:
 	while (str_userInput != "exit" and str_userInput != "quit"):
 		str_userInput = userInput_get()
-		if str_userInput == "help": print G_SYNOPSIS
+		if str_userInput == "help": print(G_SYNOPSIS)
 		if re.search("source", str_userInput):
 			words = string.split(str_userInput)
 			if len(words) >= 2:
 				str_sourceScript = words[1]
 				if len(str_sourceScript):
-					print "Sourcing " + str_sourceScript + "..."
+					print("Sourcing " + str_sourceScript + "...")
 					F_sourceScript	= open(str_sourceScript, 'r')
 					for line in F_sourceScript.readlines():
 						line_send(line)
 					F_sourceScript.close()
                 elif str_userInput == "noSync":
-                        print "Disabling re-sync pulsing"
+                        print("Disabling re-sync pulsing")
                         Gb_syncSend     = 0
 		elif str_userInput == "version":
-			print Gstr_VERSION
+			print(Gstr_VERSION)
 		else:
 			line_send(str_userInput)
 		time.sleep(0.2)
 	if(str_userInput == "quit"):	
-		print "Quitting (and turning off any running engines)..."
+		print("Quitting (and turning off any running engines)...")
 		thread_transmit("TERM")
 	if(str_userInput == "exit"):
-		print "Exiting from shell. Note that the engine is still running."
+		print("Exiting from shell. Note that the engine is still running.")
 
 # goodbye
 str_cheers	= "SYSECHO Goodbye from " + Gstr_SELF

--- a/scripts/easyfv
+++ b/scripts/easyfv
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: latin-1 -*-
 from __future__ import print_function
 import sys

--- a/scripts/fspalm
+++ b/scripts/fspalm
@@ -2,6 +2,7 @@
 
 # user will need dev (3/15/2018) version of mri_surfcluster and mri_volcluster
 
+from __future__ import print_function
 import os
 import sys
 import shlex

--- a/scripts/long_mris_slopes
+++ b/scripts/long_mris_slopes
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: latin-1 -*-
 
 #
@@ -24,6 +24,7 @@
 #
 #
 from __future__ import print_function
+from __future__ import division
 import warnings
 warnings.filterwarnings('ignore', '.*negative int.*')
 import os
@@ -685,7 +686,7 @@ if __name__=="__main__":
         defaultvar = options.time
         # compute correct index (starting with 1, 0 is the tpID)
         foundidx = False
-        for index in (i for i in xrange(len(variables)) if variables[i].upper()==defaultvar.upper()):
+        for index in (i for i in range(len(variables)) if variables[i].upper()==defaultvar.upper()):
             varidx = index
             foundidx = True
             #print('found: '+str(varidx)+' '+variables[varidx])
@@ -737,7 +738,7 @@ if __name__=="__main__":
         tpc1fit = {}
         tspc    = {}
         tresid  = {}
-        for subjectid, tplist in qdectable.subjects_tp_map.items():
+        for subjectid, tplist in list(qdectable.subjects_tp_map.items()):
             print('\nSubject-Template: '+subjectid)
             
             # check if basedir exists

--- a/scripts/long_qdec_table
+++ b/scripts/long_qdec_table
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: latin-1 -*-
 
 #

--- a/scripts/long_stats_combine
+++ b/scripts/long_stats_combine
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: latin-1 -*-
 
 #
@@ -251,7 +251,7 @@ if __name__=="__main__":
         retcode = 0
         all = ""
         slist = []
-        for subjectid, tplist in qdectable.subjects_tp_map.items():
+        for subjectid, tplist in list(qdectable.subjects_tp_map.items()):
             print('\nSubject-Template: '+subjectid)
                     
             # extract ids:

--- a/scripts/long_stats_slopes
+++ b/scripts/long_stats_slopes
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: latin-1 -*-
 
 #
@@ -24,6 +24,7 @@
 #
 #
 from __future__ import print_function
+from __future__ import division
 import warnings
 warnings.filterwarnings('ignore', '.*negative int.*')
 import os
@@ -373,7 +374,7 @@ if __name__=="__main__":
         defaultvar = options.time
         # compute correct index (starting with 1, 0 is the tpID)
         foundidx = False
-        for index in (i for i in xrange(len(variables)) if variables[i].upper()==defaultvar.upper()):
+        for index in (i for i in range(len(variables)) if variables[i].upper()==defaultvar.upper()):
             varidx = index
             foundidx = True
             #print('found: '+str(varidx)+' '+variables[varidx])
@@ -408,7 +409,7 @@ if __name__=="__main__":
     allpc1fit = []
     allrate= []
     allresid= []
-    for subjectid, tplist in qdectable.subjects_tp_map.items():
+    for subjectid, tplist in list(qdectable.subjects_tp_map.items()):
         print('\nSubject-Template: '+subjectid)
         
         # check if basedir exists

--- a/scripts/long_stats_tps
+++ b/scripts/long_stats_tps
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: latin-1 -*-
 
 #
@@ -232,7 +232,7 @@ if __name__=="__main__":
     qcolidx = -1;
     if options.qcol is not None:
         foundidx = False
-        for index in (i for i in xrange(len(variables)) if variables[i].upper()==options.qcol.upper()):
+        for index in (i for i in range(len(variables)) if variables[i].upper()==options.qcol.upper()):
             qcolidx = index
             foundidx = True
             #print('found: '+str(varidx)+' '+variables[varidx])
@@ -254,7 +254,7 @@ if __name__=="__main__":
     all = ""
     qcoldata = []
     slist = []
-    for subjectid, tplist in qdectable.subjects_tp_map.items():
+    for subjectid, tplist in list(qdectable.subjects_tp_map.items()):
         print('\nSubject-Template: '+subjectid)
                 
         # check if 2 or more time points

--- a/scripts/long_submit_jobs
+++ b/scripts/long_submit_jobs
@@ -531,7 +531,7 @@ def run_cross(qdectable,options):
     error    = []
     submitted= 0
     total = 0
-    for subjectid, tplist in qdectable.subjects_tp_map.items():
+    for subjectid, tplist in list(qdectable.subjects_tp_map.items()):
         print('\n========================================\n')
         print('[CROSS] Subject: '+subjectid+'\n')
 
@@ -640,7 +640,7 @@ def run_base(qdectable,options):
     submitted= 0
     total = 0
     less2 = 0
-    for subjectid, tplist in qdectable.subjects_tp_map.items():
+    for subjectid, tplist in list(qdectable.subjects_tp_map.items()):
         print('\n========================================\n')
         print('[BASE] Subject: '+subjectid+'\n')
         total = total+1
@@ -813,7 +813,7 @@ def run_long(qdectable,options):
     norights = []
     error    = []
     submitted= 0
-    for subjectid, tplist in qdectable.subjects_tp_map.items():
+    for subjectid, tplist in list(qdectable.subjects_tp_map.items()):
         print('\n========================================\n')
         print('[LONG] Subject: '+subjectid+'\n')
 
@@ -1005,7 +1005,7 @@ def check_long(qdectable,options):
     donetps = 0
     notexist = []
     running = []
-    for subjectid, tplist in qdectable.subjects_tp_map.items():
+    for subjectid, tplist in list(qdectable.subjects_tp_map.items()):
         allids = allids + 1
         alltps = alltps + len(tplist)
         print('\n========================================\n')

--- a/scripts/long_submit_postproc
+++ b/scripts/long_submit_postproc
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: latin-1 -*-
 
 #

--- a/scripts/mcparams2reg
+++ b/scripts/mcparams2reg
@@ -7,6 +7,7 @@
 
 # $Id: mcparams2reg,v 1.3 2015/11/24 20:09:36 greve Exp $
 
+from __future__ import print_function
 import sys;
 import os;
 import string;
@@ -37,7 +38,7 @@ class MCRegClass:
     try:
       fp = open(self.mcpfile, 'r');
     except:
-      print "ERROR: opening %s" % (self.mcpfile);
+      print("ERROR: opening %s" % (self.mcpfile));
       sys.exit(1);
     #endtry
     # Count number of time points
@@ -52,7 +53,7 @@ class MCRegClass:
       linesplit = line.split();
       linelen = len(linesplit);
       if((self.mcpfiletype == 0 and linelen != 6) or (self.mcpfiletype == 1 and linelen < 7)):
-        print "ERROR: format line %s " % (line);
+        print("ERROR: format line %s " % (line));
         sys.exit(1);
       #end if
       for k in range(0,6):
@@ -176,22 +177,22 @@ def RMSregDiffMJ(T1,T2,radius):
 
 #---------------------------------------------------------
 def print_help():
-  print "USAGE: mcparams2reg - create regressor matrix from motion correction parameter files";
-  print "  --o output.mtx";
-  print "  --mcdat mcpfile : as created by FSFAST";
-  print "  --flirt mcpfile : as created by FSL MCFLIRT";
-  print "  --od order delay (order >= 1, delay >= 0)";
-  print "  --fd : compute frame-wise displacment (output becomes this)";
-  print "  --no-demean : do not demean parameters before computing matrix";
-  print "  --no-demeanmtx : do not demean final matrix";
-  print "  --debug : print out debugging info";
-  print ""
+  print("USAGE: mcparams2reg - create regressor matrix from motion correction parameter files");
+  print("  --o output.mtx");
+  print("  --mcdat mcpfile : as created by FSFAST");
+  print("  --flirt mcpfile : as created by FSL MCFLIRT");
+  print("  --od order delay (order >= 1, delay >= 0)");
+  print("  --fd : compute frame-wise displacment (output becomes this)");
+  print("  --no-demean : do not demean parameters before computing matrix");
+  print("  --no-demeanmtx : do not demean final matrix");
+  print("  --debug : print out debugging info");
+  print("")
   return 0;
 #end def print_help:
 
 #---------------------------------------------------------
 def argnerr(narg,flag):
-  print "ERROR: flag %s requires %d arguments" % (flag,narg);
+  print("ERROR: flag %s requires %d arguments" % (flag,narg));
   sys.exit(1);
 #end def parse_args(argv)
 
@@ -204,7 +205,7 @@ def parse_args(argv):
   while(len(argv) != 0):
     flag = argv[0];
     del argv[0];
-    if(mcreg.debug): print "flag = %s" % flag;
+    if(mcreg.debug): print("flag = %s" % flag);
     if(flag == "--o"):
       if(len(argv) < 1): argnerr(1,flag);
       mcreg.output = argv[0]; del argv[0];
@@ -220,7 +221,7 @@ def parse_args(argv):
       if(len(argv) < 2): argnerr(2,flag);
       order = int(argv[0]); del argv[0];
       if(order < 1):
-        print "ERROR: order=%d, must be >=1" % (order);
+        print("ERROR: order=%d, must be >=1" % (order));
         sys.exit(1);
       delay = int(argv[0]); del argv[0];
       mcreg.odsets.append([order, delay]);
@@ -237,7 +238,7 @@ def parse_args(argv):
     elif(flag == "--debug"):
       mcreg.debug = 1;
     else:
-      print "ERROR: flag %s not recognized" % flag; 
+      print("ERROR: flag %s not recognized" % flag); 
       sys.exit(1);
     #endif
   #endwhile
@@ -248,19 +249,19 @@ def parse_args(argv):
 def check_args():
   global mcreg;
   if(len(mcreg.output) == 0):
-    print "ERROR: output needed";
+    print("ERROR: output needed");
     sys.exit(1);
   #endif    
   if(len(mcreg.mcpfile) == 0):
-    print "ERROR: mcpfile needed";
+    print("ERROR: mcpfile needed");
     sys.exit(1);
   #endif    
   if(len(mcreg.odsets) == 0 and not mcreg.DoFD):
-    print "ERROR: at least one odset needed or --fd";
+    print("ERROR: at least one odset needed or --fd");
     sys.exit(1);
   #endif    
   if(len(mcreg.odsets) != 0 and mcreg.DoFD):
-    print "ERROR: cannot spec --od and --fd";
+    print("ERROR: cannot spec --od and --fd");
     sys.exit(1);
   #endif    
   return 0;
@@ -286,17 +287,17 @@ if(nargs == 0):
 parse_args(sys.argv);
 check_args();
 
-print "%s" % (mcreg.version);
+print("%s" % (mcreg.version));
 
 mcreg.Load();
 mcreg.MotionMetrics();
-print "FD %g %g %g" % (mcreg.fdkvdmn,mcreg.fdpowmn,mcreg.fdrmsmn);
+print("FD %g %g %g" % (mcreg.fdkvdmn,mcreg.fdpowmn,mcreg.fdrmsmn));
 
 if(mcreg.DoFD):
   fp = open(mcreg.output,'w');
   fp.write("%20.10f %20.10f %20.10f \n" % (mcreg.fdkvdmn,mcreg.fdpowmn,mcreg.fdrmsmn));
   fp.close();
-  print "mcparams2reg done";
+  print("mcparams2reg done");
   sys.exit(0);
 #endif
 
@@ -309,13 +310,13 @@ if(mcreg.debug):
     k = k + 1;
     order = odset[0];
     delay = odset[1];
-    print "%d %d %d" % (k,order,delay);
+    print("%d %d %d" % (k,order,delay));
   #endfor
 #endif
 
 
 if(mcreg.debug):
-  print "n odsets = %d, %d, %d time points " % (mcreg.nodsets,mcreg.mcpfiletype,mcreg.ntp);
+  print("n odsets = %d, %d, %d time points " % (mcreg.nodsets,mcreg.mcpfiletype,mcreg.ntp));
 #endif
 
 mcreg.CreateMatrix();
@@ -334,7 +335,7 @@ for tp in range(0,mcreg.X.shape[0]):
 
 mcreg.MotionMetrics();
 
-print "mcparams2reg done";
+print("mcparams2reg done");
 sys.exit(0);
 #-------------------------------------------------#
 

--- a/scripts/merge_stats_tables
+++ b/scripts/merge_stats_tables
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- coding: latin-1 -*-
 
 #
@@ -329,7 +329,7 @@ def make_table2d(disorganized_table, segnamelist):
     for _spec, _id_name_map, _ml in dt:
         for seg in segnamelist:
             try:
-                idindex = _id_name_map.values().index(seg)
+                idindex = list(_id_name_map.values()).index(seg)
                 table[_spec][seg] = _ml[idindex]
             except ValueError:
                 table[_spec][seg] = 0.0

--- a/scripts/overlapstats2table
+++ b/scripts/overlapstats2table
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 from __future__ import print_function
 import warnings
 warnings.filterwarnings('ignore', '.*negative int.*')
@@ -180,9 +180,9 @@ def sanitize_table(options, disorganized_table):
 
     _union = []
     _spec, _label_measure_map = dt[0]
-    intersection = _label_measure_map.keys()
+    intersection = list(_label_measure_map.keys())
     for spec, label_measure_map in dt:
-        labels = label_measure_map.keys()
+        labels = list(label_measure_map.keys())
         _union.append(labels)
         intersection = fsutils.intersect_order(intersection, labels)
         l.debug('-'*20)

--- a/scripts/slicedelay
+++ b/scripts/slicedelay
@@ -1,30 +1,31 @@
 #!/usr/bin/python
+from __future__ import print_function
 import sys;
 import os;
 import string;
 
 #---------------------------------------------------------
 def print_usage():
-  print "USAGE: slicedelay --help";
-  print "  --o slicedelayfile";
-  print "  --nslices nslices : total number of slices in the volume";
-  print "  --order order (up,down,odd,even,siemens)";
-  print "  --ngroups ngroups (number of slice groups for SMS)";
+  print("USAGE: slicedelay --help");
+  print("  --o slicedelayfile");
+  print("  --nslices nslices : total number of slices in the volume");
+  print("  --order order (up,down,odd,even,siemens)");
+  print("  --ngroups ngroups (number of slice groups for SMS)");
   return 0;
 #end def print_usage:
 
 #---------------------------------------------------------
 def print_help():
   print_usage();
-  print "\nCreates an FSL custom slice delay file for use with slicetimer (--tcustom=sdfile).\n"\
+  print("\nCreates an FSL custom slice delay file for use with slicetimer (--tcustom=sdfile).\n"\
       "It has a single column of values, one for each slice. Each value is the slice delay\n" \
       "measured as a fraction of the TR and range from +0.5 (beginning of the TR) to \n"\
-      "-0.5 (end of the TR). Used for slice-time correction of fMRI.\n"
+      "-0.5 (end of the TR). Used for slice-time correction of fMRI.\n")
 #end def print_help:
 
 #---------------------------------------------------------
 def argnerr(narg,flag):
-  print "ERROR: flag %s requires %d arguments" % (flag,narg);
+  print("ERROR: flag %s requires %d arguments" % (flag,narg));
   sys.exit(1);
 #end def parse_args(argv)
 
@@ -41,7 +42,7 @@ def parse_args(argv):
   while(len(argv) != 0):
     flag = argv[0];
     del argv[0];
-    if(debug): print "flag = %s" % flag;
+    if(debug): print("flag = %s" % flag);
 
     if(flag == "--o"):
       if(len(argv) < 1): argnerr(1,flag);
@@ -66,7 +67,7 @@ def parse_args(argv):
     elif(flag == "--debug"):
       debug = 1;
     else:
-      print "ERROR: flag %s not recognized" % flag; 
+      print("ERROR: flag %s not recognized" % flag); 
       sys.exit(1);
     #endif
   #endwhile
@@ -90,15 +91,15 @@ def check_args():
   global debug;
 
   if(len(sdf) == 0):
-    print "ERROR: output file needed";
+    print("ERROR: output file needed");
     sys.exit(1);
   #endif    
   if(nslices == 0):
-    print "ERROR: nslices needed";
+    print("ERROR: nslices needed");
     sys.exit(1);
   #endif    
   if(len(order) == 0):
-    print "ERROR: order needed";
+    print("ERROR: order needed");
     sys.exit(1);
   #endif  
 
@@ -125,28 +126,28 @@ check_args();
 
 err = nslices%ngroups;
 if(err):
-  print "ERROR: cannot divide nslices=%d by ngroups=%d " % (nslices,ngroups);
+  print("ERROR: cannot divide nslices=%d by ngroups=%d " % (nslices,ngroups));
   sys.exit(0);
 #endif
 nslicespg = nslices/ngroups;
 
-print "sdf %s" % sdf;
-print "nslices %d" % nslices;
-print "order %s" % order;
-print "ngroups %d" % ngroups;
-print "nslicespg %d" % nslicespg;
+print("sdf %s" % sdf);
+print("nslices %d" % nslices);
+print("order %s" % order);
+print("ngroups %d" % ngroups);
+print("nslicespg %d" % nslicespg);
 
 AcqSliceDelay = [];
 for sno in range(1,nslicespg+1):
   D = ((nslicespg-1.0)/2.0-(sno-1.0))/nslicespg;
   AcqSliceDelay.append(D);
 #end
-print  AcqSliceDelay
+print(AcqSliceDelay)
 
 AnatSliceDelay = [];
 AnatSliceOrder = ();
 for sg in range(1,ngroups+1):
-  print "sg %d" % (sg);
+  print("sg %d" % (sg));
   if(order == "up"):   AnatSliceOrder = range(1,nslicespg+1,+1);
   if(order == "down"): AnatSliceOrder = range(nslicespg,0,-1);
   if(order == "odd"):  AnatSliceOrder = range(1,nslicespg+1,+2) + range(2,nslicespg+1,+2);
@@ -159,7 +160,7 @@ for sg in range(1,ngroups+1):
     #endif
   #endif
   if(len(AnatSliceOrder) == 0):
-    print "ERROR: slice order %s not recognized " % (order);
+    print("ERROR: slice order %s not recognized " % (order));
     sys.exit(0);
   #endif
 

--- a/scripts/spherically_project.py
+++ b/scripts/spherically_project.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-from __future__ import print_function
+#!/usr/bin/env python
+from __future__ import print_function, division
 
 import optparse
 import os

--- a/scripts/stattablediff
+++ b/scripts/stattablediff
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from __future__ import print_function
 import sys;
 import os;
 import string;
@@ -6,24 +7,24 @@ from numpy  import *;
 
 #---------------------------------------------------------
 def print_help():
-  print "USAGE: stattablediff - creates a table of the differences between two tables";
-  print "  --t1 table1 : input table 1 (output of asegstats2table or aparcstats2table)";
-  print "  --t2 table2 : input table 2 (output of asegstats2table or aparcstats2table)";
-  print "  --o  tablediff : output file";
-  print "  --percent compute percent diff with respect to mean of tables";
-  print "  --percent1 compute percent diff with respect to table1";
-  print "  --percent2 compute percent diff with respect to table2";
-  print "  --mul mulval : multiply by mulval";
-  print "  --div divval : divide by divval";
-  print "  --common : compute diff on common segs (may reorder)";
-  print "  --rm-exvivo : remove the string 'exvivo' from the column header"
-  print "  --debug : print out debugging info";
+  print("USAGE: stattablediff - creates a table of the differences between two tables");
+  print("  --t1 table1 : input table 1 (output of asegstats2table or aparcstats2table)");
+  print("  --t2 table2 : input table 2 (output of asegstats2table or aparcstats2table)");
+  print("  --o  tablediff : output file");
+  print("  --percent compute percent diff with respect to mean of tables");
+  print("  --percent1 compute percent diff with respect to table1");
+  print("  --percent2 compute percent diff with respect to table2");
+  print("  --mul mulval : multiply by mulval");
+  print("  --div divval : divide by divval");
+  print("  --common : compute diff on common segs (may reorder)");
+  print("  --rm-exvivo : remove the string 'exvivo' from the column header")
+  print("  --debug : print out debugging info");
   return 0;
 #end def print_help:
 
 #---------------------------------------------------------
 def argnerr(narg,flag):
-  print "ERROR: flag %s requires %d arguments" % (flag,narg);
+  print("ERROR: flag %s requires %d arguments" % (flag,narg));
   sys.exit(1);
 #end def parse_args(argv)
 
@@ -44,7 +45,7 @@ def parse_args(argv):
   while(len(argv) != 0):
     flag = argv[0];
     del argv[0];
-    if(debug): print "flag = %s" % flag;
+    if(debug): print("flag = %s" % flag);
     if(flag == "--t1"):
       if(len(argv) < 1): argnerr(1,flag);
       table1 = argv[0]; del argv[0];
@@ -73,7 +74,7 @@ def parse_args(argv):
     elif(flag == "--debug"):
       debug = 1;
     else:
-      print "ERROR: flag %s not recognized" % flag; 
+      print("ERROR: flag %s not recognized" % flag); 
       sys.exit(1);
     #endif
   #endwhile
@@ -95,15 +96,15 @@ def check_args():
   global tablediff;
 
   if(len(table1) == 0):
-    print "ERROR: table1 needed";
+    print("ERROR: table1 needed");
     sys.exit(1);
   #endif    
   if(len(table2) == 0):
-    print "ERROR: table2 needed";
+    print("ERROR: table2 needed");
     sys.exit(1);
   #endif    
   if(len(tablediff) == 0):
-    print "ERROR: output needed";
+    print("ERROR: output needed");
     sys.exit(1);
   #endif    
 
@@ -136,7 +137,7 @@ check_args();
 try:
   fp = open(table1, 'r');
 except:
-  print "ERROR: opening %s" % (table1);
+  print("ERROR: opening %s" % (table1));
   sys.exit(1);
 #endtry
 header1 = fp.readline();
@@ -155,7 +156,7 @@ fp.close;
 try:
   fp = open(table2, 'r');
 except:
-  print "ERROR: opening %s" % (table2);
+  print("ERROR: opening %s" % (table2));
   sys.exit(1);
 #endtry
 fp = open(table2, 'r');
@@ -172,12 +173,12 @@ for line in fp:
 fp.close;
 
 if(debug):
-  print "nrows1 %d, ncols1 %d" % (nrows1,ncols1);
-  print "nrows2 %d, ncols2 %d" % (nrows2,ncols2);
+  print("nrows1 %d, ncols1 %d" % (nrows1,ncols1));
+  print("nrows2 %d, ncols2 %d" % (nrows2,ncols2));
 #endif
 
 if(nrows1 != nrows2):
-  print "ERROR: rows are not equal %d %d" % (nrows1,nrows2);
+  print("ERROR: rows are not equal %d %d" % (nrows1,nrows2));
   sys.exit(0);
 #end
 
@@ -186,13 +187,13 @@ comcollist = list(set(collist1) & set(collist2));
 ncolscom = len(comcollist);
 if(ncols1 != ncolscom or ncols2 != ncolscom):
   if(AllowCommon): 
-    print "INFO: cols have different segs, doing common segs (%d,%d)" % (ncols1,ncols2);
+    print("INFO: cols have different segs, doing common segs (%d,%d)" % (ncols1,ncols2));
     DoCommon = 1;
     ncols1 = ncolscom;
     ncols2 = ncolscom;
   else:
-    print "ERROR: cols have different segs (%d,%d)" % (ncols1,ncols2);
-    print "  Use --common to only compute the difference on the common segs"
+    print("ERROR: cols have different segs (%d,%d)" % (ncols1,ncols2));
+    print("  Use --common to only compute the difference on the common segs")
     sys.exit(0);
   #end
 #end
@@ -276,7 +277,7 @@ for row in range(0, nrows1):
 #end
 fp.close;
 
-print "stattablediff done";
+print("stattablediff done");
 sys.exit(0);
 #-------------------------------------------------#
 


### PR DESCRIPTION
**_WIP: Please don't merge yet_**
Uses [`futurize`](https://python-future.org/automatic_conversion.html) (with manual intervention) to convert (known) python in the packages/scripts dir to Python2/3 compatible code.

Note that `futurize` stage 2 can add a 3rd party dependency to the modules `builtins` or `past` from the package `future`. After inspecting all the automated changes, it seems that any code relying on this was unnecessary, so the imports were removed. These fell into the following categories:
- getting integer division (default for Python 2) in Python3, which didn't seem to be the intent of division anywhere in these changed files
- getting the `range` generator (default in Python 3), as opposed to the the list version of `range` in Python 2. again, doesn't seem necessary for these cases
- importing `from builtins import str`. It seems like nothing fancy was done with strings in these files, so that Py2/Py3 strings should be interchangable