### PR TITLE
Fixes to allow the CUDA parts of GEMS2 to compile

### DIFF
--- a/GEMS2/CMakeLists.txt
+++ b/GEMS2/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 
 if(GEMS_BUILD_CUDA)
   find_package(CUDA REQUIRED)
-  set(CMAKE_CXX_FLAGS "-g ${CMAKE_CXX_FLAGS}")
+  set(CMAKE_CXX_FLAGS "-g ${CMAKE_CXX_FLAGS} -std=c++11")
   include_directories(${CUDA_INCLUDE_DIRS})
   set(CMAKE_CXX_FLAGS "-DCUDA_FOUND ${CMAKE_CXX_FLAGS}")
   include_directories(cuda)

--- a/GEMS2/cuda/cudaimage.hpp
+++ b/GEMS2/cuda/cudaimage.hpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <algorithm>
 #include <limits>
+#include <vector>
 
 #include <cuda_runtime.h>
 


### PR DESCRIPTION
Two fixes to allow the CUDA additions to GEMS2 to compile
- Add missing #include <vector>
- Make sure that nvcc instructs the host compiler to use c++11