### PR TITLE
Nf: GCAM support for mri_mask

### DIFF
--- a/mri_mask/CMakeLists.txt
+++ b/mri_mask/CMakeLists.txt
@@ -6,4 +6,6 @@ add_executable(mri_mask mri_mask.c)
 add_help(mri_mask mri_mask.help.xml)
 target_link_libraries(mri_mask utils)
 
+add_test_script(NAME mri_mask_test SCRIPT test.py DEPENDS mri_mask)
 install(TARGETS mri_mask DESTINATION bin)
+

--- a/mri_mask/mri_mask.c
+++ b/mri_mask/mri_mask.c
@@ -127,12 +127,6 @@ int main(int argc, char *argv[])
     ErrorExit(ERROR_BADPARM, "%s: could not read mask volume %s",
               Progname, argv[2]) ;
 
-//  if(mri_src->width != mri_mask->width)
-//  {
-//    printf("ERROR: dimension mismatch between source and mask\n");
-//    exit(1);
-//  }
-
   printf("DoAbs = %d\n",DoAbs);
 
   /* Read LTA transform and apply it to mri_mask */
@@ -155,22 +149,6 @@ int main(int argc, char *argv[])
         ErrorExit(ERROR_NOFILE, "%s: could not read transform file %s",
                   Progname, xform_fname) ;
 
-      if (transform_type == FSLREG_TYPE)
-      {
-        if (lta_src == 0 || lta_dst == 0)
-        {
-          fprintf(stderr,
-                  "ERROR: fslmat does not have information on "
-                  "the src and dst volumes\n");
-          fprintf(stderr,
-                  "ERROR: you must give options '-lta_src' "
-                  "and '-lta_dst' to specify the src and dst volume infos\n");
-        }
-
-        LTAmodifySrcDstGeom(lta, lta_src, lta_dst);
-        // add src and dst information
-        LTAchangeType(lta, LINEAR_VOX_TO_VOX);
-      }
       if (lta->xforms[0].src.valid == 0)
       {
         if (lta_src == 0)
@@ -186,7 +164,6 @@ int main(int argc, char *argv[])
         else
         {
           LTAmodifySrcDstGeom(lta, lta_src, NULL); // add src information
-          //      getVolGeom(lta_src, &lt->src);
         }
       }
       if (lta->xforms[0].dst.valid == 0)
@@ -218,7 +195,8 @@ int main(int argc, char *argv[])
       ErrorExit(ERROR_BADPARM,
                 "transform is not of MNI, nor Register.dat, nor FSLMAT type");
     }
-
+    LTAchangeType(lta, LINEAR_VOX_TO_VOX);
+    
     if (invert)
     {
       VOL_GEOM vgtmp;
@@ -244,7 +222,6 @@ int main(int argc, char *argv[])
       copyVolGeom(&vgtmp, &lt->src);
     }
 
-    //    LTAchangeType(lta, LINEAR_VOX_TO_VOX);
     mri_tmp =
       MRIalloc(mri_src->width,
                mri_src->height,

--- a/mri_mask/mri_mask.help.xml
+++ b/mri_mask/mri_mask.help.xml
@@ -23,9 +23,9 @@
 ]>
 
 <help>
-	<name>mri_mask - applies a mask volume ( typically skull stripped )</name>
+	<name>mri_mask - applies a mask volume (typically skull stripped)</name>
 	<synopsis>mri_mask [options] &lt;in vol&gt; &lt;mask vol&gt; &lt;out vol&gt;</synopsis>
-	<description>This program applies a mask volume ( typically skull stripped ).</description>
+	<description>This program applies a mask volume (typically skull stripped).</description>
   <arguments>
     <positional>
       <argument>in vol</argument>
@@ -35,9 +35,7 @@
     </positional>
     <optional-flagged>
       <argument>-xform %s</argument>
-      <explanation>apply LTA transform to align mask to input volume</explanation>
-      <argument>-invert</argument>
-      <explanation>reversely apply -xform</explanation>
+      <explanation>apply M3Z/LTA to transform mask to space of input volume (will be inverted if needed)</explanation>
       <argument>-lta_src %s</argument>
       <explanation>source volume for -xform (if not available from the xform file)</explanation>
       <argument>-lta_dst %s</argument>

--- a/mri_mask/test.py
+++ b/mri_mask/test.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+import sys, os.path as op
+sys.path.append(op.join(op.dirname(sys.argv[0]), '../python'))
+import freesurfer.test as fst
+
+rt = fst.RegressionTest()
+
+# apply mask
+rt.run('mri_mask nu.1.mgz brainmask.1.mgz mask.mgz')
+rt.mridiff('mask.mgz', 'mask.ref.mgz')
+
+# transform mask using LTA
+rt.run('mri_mask -xform 2_to_1.lta nu.1.mgz brainmask.2.mgz lta.mgz')
+rt.mridiff('lta.mgz', 'lta.ref.mgz')
+
+# transform mask using inverse LTA
+rt.run('mri_mask -xform 1_to_2.lta nu.1.mgz brainmask.2.mgz inv.mgz')
+rt.mridiff('inv.mgz', 'inv.ref.mgz')
+
+# transform mask with FSLMAT
+rt.run(('mri_mask'
+        ' -xform 2_to_1.fslmat'
+        ' -lta_src nu.2.mgz'
+        ' -lta_dst nu.1.mgz'
+        ' nu.1.mgz brainmask.2.mgz fslmat.mgz'))
+rt.mridiff('fslmat.mgz', 'fslmat.ref.mgz')
+
+# transform mask with GCAM
+rt.run('mri_mask -xform 2_to_1.m3z nu.1.mgz brainmask.2.mgz gcam.mgz')
+rt.mridiff('gcam.mgz', 'gcam.ref.mgz')
+
+# only transfer WM edits (255) and deletions (1)
+rt.run(('mri_mask'
+        ' -transfer 255'
+        ' -keep_mask_deletion_edits'
+        ' nu.2.mgz wm.2.mgz edits.mgz'))
+rt.mridiff('edits.mgz', 'edits.ref.mgz')
+
+rt.cleanup()
+

--- a/mri_mask/test.py
+++ b/mri_mask/test.py
@@ -10,24 +10,24 @@ rt.run('mri_mask nu.1.mgz brainmask.1.mgz mask.mgz')
 rt.mridiff('mask.mgz', 'mask.ref.mgz')
 
 # transform mask using LTA
-rt.run('mri_mask -xform 2_to_1.lta nu.1.mgz brainmask.2.mgz lta.mgz')
-rt.mridiff('lta.mgz', 'lta.ref.mgz')
+rt.run('mri_mask -xform 2_to_1.lta nu.1.mgz brainmask.2.mgz mask.lta.mgz')
+rt.mridiff('mask.lta.mgz', 'mask.lta.ref.mgz')
 
 # transform mask using inverse LTA
-rt.run('mri_mask -xform 1_to_2.lta nu.1.mgz brainmask.2.mgz inv.mgz')
-rt.mridiff('inv.mgz', 'inv.ref.mgz')
+rt.run('mri_mask -xform 1_to_2.lta nu.1.mgz brainmask.2.mgz mask.lta.inv.mgz')
+rt.mridiff('mask.lta.inv.mgz', 'mask.lta.inv.ref.mgz')
 
 # transform mask with FSLMAT
 rt.run(('mri_mask'
         ' -xform 2_to_1.fslmat'
         ' -lta_src nu.2.mgz'
         ' -lta_dst nu.1.mgz'
-        ' nu.1.mgz brainmask.2.mgz fslmat.mgz'))
-rt.mridiff('fslmat.mgz', 'fslmat.ref.mgz')
+        ' nu.1.mgz brainmask.2.mgz mask.fsl.mgz'))
+rt.mridiff('mask.fsl.mgz', 'mask.fsl.ref.mgz')
 
 # transform mask with GCAM
-rt.run('mri_mask -xform 2_to_1.m3z nu.1.mgz brainmask.2.mgz gcam.mgz')
-rt.mridiff('gcam.mgz', 'gcam.ref.mgz')
+rt.run('mri_mask -xform 2_to_1.m3z nu.1.mgz brainmask.2.mgz mask.gcam.mgz')
+rt.mridiff('mask.gcam.mgz', 'mask.gcam.ref.mgz')
 
 # transfer edits
 rt.run(('mri_mask'
@@ -51,6 +51,13 @@ rt.run(('mri_mask'
         ' -keep_mask_deletion_edits'
         ' nu.1.mgz wm.2.mgz edits.gcam.mgz'))
 rt.mridiff('edits.gcam.mgz', 'edits.gcam.ref.mgz')
+
+# transfer 255 only using inverse GCAM
+rt.run(('mri_mask'
+        ' -xform 1_to_2.m3z'
+        ' -transfer 255'
+        ' nu.1.mgz wm.2.mgz edits.gcam.inv.mgz'))
+rt.mridiff('edits.gcam.inv.mgz', 'edits.gcam.inv.ref.mgz')
 
 rt.cleanup()
 

--- a/mri_mask/test.py
+++ b/mri_mask/test.py
@@ -29,12 +29,28 @@ rt.mridiff('fslmat.mgz', 'fslmat.ref.mgz')
 rt.run('mri_mask -xform 2_to_1.m3z nu.1.mgz brainmask.2.mgz gcam.mgz')
 rt.mridiff('gcam.mgz', 'gcam.ref.mgz')
 
-# only transfer WM edits (255) and deletions (1)
+# transfer edits
 rt.run(('mri_mask'
         ' -transfer 255'
         ' -keep_mask_deletion_edits'
         ' nu.2.mgz wm.2.mgz edits.mgz'))
 rt.mridiff('edits.mgz', 'edits.ref.mgz')
+
+# transfer edits using LTA
+rt.run(('mri_mask'
+        ' -xform 2_to_1.lta'
+        ' -transfer 255'
+        ' -keep_mask_deletion_edits'
+        ' nu.1.mgz wm.2.mgz edits.lta.mgz'))
+rt.mridiff('edits.lta.mgz', 'edits.lta.ref.mgz')
+
+# transfer edits using GCAM
+rt.run(('mri_mask'
+        ' -xform 2_to_1.m3z'
+        ' -transfer 255'
+        ' -keep_mask_deletion_edits'
+        ' nu.1.mgz wm.2.mgz edits.gcam.mgz'))
+rt.mridiff('edits.gcam.mgz', 'edits.gcam.ref.mgz')
 
 rt.cleanup()
 

--- a/utils/transform.c
+++ b/utils/transform.c
@@ -2764,6 +2764,7 @@ MRI *TransformApplyInverseType(TRANSFORM *transform, MRI *mri_src, MRI *mri_dst,
       // mri_dst = MRIinverseLinearTransform(mri_src, NULL,
       //      ((LTA *)transform->xform)->xforms[0].m_L);
       lta = (LTA *)transform->xform;
+      LTAfillInverse(lta);
       mri_dst = LTAinverseTransformInterp(mri_src, mri_dst, lta, interp_type);
       break;
   }


### PR DESCRIPTION
Added GCAM support to mri_mask. To facilitate this, replaced '-invert' flag with automated transform inversion (if permitted by source and destination geometries). Flag was not used anywhere in the code base. Test data can be found here: http://gate.nmr.mgh.harvard.edu/filedrop2/?p=bmkp3e20qxg