### PR TITLE
Bf more managed xyz and dist

### DIFF
--- a/label2patch/label2patch.c
+++ b/label2patch/label2patch.c
@@ -120,7 +120,7 @@ main(int argc, char *argv[]) {
   }
 
   LabelRipRestOfSurface(label, mris) ;
-  MRISripFaces(mris) ;
+  MRISsetRipInFacesWithRippedVertices(mris) ;
   if (writesurf)
   {
      MRISwrite(mris, out_fname) ;

--- a/mri_surf2surf/mri_surf2surf.c
+++ b/mri_surf2surf/mri_surf2surf.c
@@ -1141,7 +1141,7 @@ int main(int argc, char **argv)
     }
     printf("Dilating %d\n",nPatchDil);
     MRISdilateRipped(SurfTrg, nPatchDil);
-    MRISripFaces(SurfTrg);
+    MRISsetRipInFacesWithRippedVertices(SurfTrg);
     SurfTrg->patch = 1 ;
     SurfTrg->status = MRIS_CUT ;
     for (tvtx = 0 ; tvtx < SurfTrg->nvertices ; tvtx++)

--- a/mris_anatomical_stats/mris_anatomical_stats.c
+++ b/mris_anatomical_stats/mris_anatomical_stats.c
@@ -1473,7 +1473,7 @@ MRISripVerticesWithMark(MRI_SURFACE *mris, int mark)
       v->ripflag = 1 ;
     }
   }
-  MRISripFaces(mris) ;
+  MRISsetRipInFacesWithRippedVertices(mris) ;
   return(NO_ERROR) ;
 }
 
@@ -1496,7 +1496,7 @@ MRISripVerticesWithoutMark(MRI_SURFACE *mris, int mark)
       v->ripflag = 1 ;
     }
   }
-  MRISripFaces(mris) ;
+  MRISsetRipInFacesWithRippedVertices(mris) ;
   return(NO_ERROR) ;
 }
 
@@ -1542,7 +1542,7 @@ MRISripVerticesWithAnnotation(MRI_SURFACE *mris, int annotation)
       v->ripflag = 1 ;
     }
   }
-  MRISripFaces(mris) ;
+  MRISsetRipInFacesWithRippedVertices(mris) ;
   return(NO_ERROR) ;
 }
 
@@ -1571,7 +1571,7 @@ MRISripVerticesWithoutAnnotation(MRI_SURFACE *mris, int annotation)
       v->ripflag = 0 ;
     }
   }
-  MRISripFaces(mris) ;
+  MRISsetRipInFacesWithRippedVertices(mris) ;
   return(NO_ERROR) ;
 }
 

--- a/mris_flatten/mris_flatten.c
+++ b/mris_flatten/mris_flatten.c
@@ -396,7 +396,7 @@ main(int argc, char *argv[])
       MRISclearMarks(mris) ;
       LabelMark(area, mris) ;
       MRISripUnmarked(mris) ;
-      MRISripFaces(mris);
+      MRISsetRipInFacesWithRippedVertices(mris);
       mris->patch = 1 ;
       mris->status = MRIS_CUT ;
       LabelFree(&area) ;

--- a/mris_make_surfaces/mris_mef_surfaces.c
+++ b/mris_make_surfaces/mris_mef_surfaces.c
@@ -2059,7 +2059,7 @@ MRISpositionSurface_mef(MRI_SURFACE *mris, MRI *mri_30, MRI *mri_5,
   MRISstoreMetricProperties(mris) ;
 
   MRIScomputeNormals(mris) ;
-  mrisClearDistances(mris) ;
+  MRISclearD(mris) ;
 
   MRISclearCurvature(mris) ;  /* curvature will be used to calculate sulc */
 

--- a/mris_map_cuts/mris_map_cuts.c
+++ b/mris_map_cuts/mris_map_cuts.c
@@ -345,7 +345,7 @@ MRISmapCuts(MRI_SURFACE *mris_in, MRI_SURFACE *mris_out)
     }
   }
 
-  MRISripFaces(mris_out) ;
+  MRISsetRipInFacesWithRippedVertices(mris_out) ;
   MRISrestoreRipFlags(mris_in) ;
 
   MHTfree(&mht_in) ; MHTfree(&mht_out) ;

--- a/mris_ms_refine/mris_ms_refine.c
+++ b/mris_ms_refine/mris_ms_refine.c
@@ -682,7 +682,7 @@ main(int argc, char *argv[]) {
       sprintf(fname, "./%s-white%2.2f.w", hemi, current_sigma) ;
       MRISwriteValues(mris, fname) ;
     }
-    MRISclearDistances(mris) ;
+    MRISclearD(mris) ;
     MRISpositionSurfaces(mris, mri_flash, nvolumes, &parms);
     if (add) {
       for (max_len = 1.5*8 ; max_len > 1 ; max_len /= 2)

--- a/mris_sphere/mris_sphere.c
+++ b/mris_sphere/mris_sphere.c
@@ -378,7 +378,7 @@ main(int argc, char *argv[])
     MRISwrite(mris, "after") ;
   }
   fprintf(stderr,"surface projected - minimizing metric distortion...\n");
-  MRISsetNeighborhoodSizeAndDist(mris, nbrs) ;
+  MRISsetNeighborhoodSize(mris, nbrs) ;
   if (MRIScountNegativeFaces(mris) > nint(.8*mris->nfaces))
   {
     printf("!!!!!!!!!  everted surface detected - correcting !!!!!!!!!!!!!!\n") ;

--- a/mris_thickness/mris_cluster_profiles.c
+++ b/mris_thickness/mris_cluster_profiles.c
@@ -1016,7 +1016,7 @@ rip_bad_vertices(MRI_SURFACE *mris, MRI *mri_profiles) {
     }
 
   }
-  MRISripFaces(mris) ;
+  MRISsetRipInFacesWithRippedVertices(mris) ;
   MRIScomputeMetricProperties(mris) ;
   return(NO_ERROR) ;
 }

--- a/tksurfer/tksurfer.c
+++ b/tksurfer/tksurfer.c
@@ -17361,7 +17361,7 @@ dilate_ripped(void)
   int    vno, n, nripped ;
   VERTEX *v, *vn ;
 
-  MRISclearDistances(mris) ;
+  MRISclearD(mris) ;
   nripped = 0 ;
   for (vno = 0 ; vno < mris->nvertices ; vno++)
   {

--- a/utils/gw_ic2562.c
+++ b/utils/gw_ic2562.c
@@ -2044,27 +2044,12 @@ MRI_SURFACE *ic2562_make_two_icos(float x1, float y1, float z1, float r1, float 
   //----------------------------------------
   for (vno = 0; vno < mris->nvertices; vno++) {
     VERTEX_TOPOLOGY* const vt = &mris->vertices_topology[vno];
-    VERTEX*          const v  = &mris->vertices         [vno];
     vt->vtotal = vt->vnum;
     vt->f = (int *)calloc(vt->num, sizeof(int));
     if (!vt->f) ErrorExit(ERROR_NO_MEMORY, "ic2562: could not allocate %d faces", vt->num);
     vt->n = (unsigned char *)calloc(vt->num, sizeof(unsigned char));
     if (!vt->n) ErrorExit(ERROR_NO_MEMORY, "ic2562: could not allocate %d nbrs", vt->n);
     vt->num = 0; /* for use as counter in next section */
-    v->dist = (float *)calloc(vt->vnum, sizeof(float));
-    if (!v->dist)
-      ErrorExit(ERROR_NOMEMORY,
-                "ic2562: could not allocate list of %d "
-                "dists at v=%d",
-                vt->vnum,
-                vno);
-    v->dist_orig = (float *)calloc(vt->vnum, sizeof(float));
-    if (!v->dist_orig)
-      ErrorExit(ERROR_NOMEMORY,
-                "ic2562: could not allocate list of %d "
-                "dists at v=%d",
-                vt->vnum,
-                vno);
   }
 
   //----------------------------------------------

--- a/utils/gw_utils.c
+++ b/utils/gw_utils.c
@@ -34,6 +34,7 @@
 #include "error.h"
 #include "gw_utils.h"
 #include "mrishash_internals.h"
+#include "mrisurf_topology.h"
 
 /*-----------------------------------------------
   GWU_make_surface_from_lists
@@ -123,30 +124,13 @@ MRI_SURFACE *GWU_make_surface_from_lists(GWUTILS_VERTEX *vertices, int vertexcou
   //--------------------------------------------
   for (vno = 0; vno < vertexcount; vno++) {
     VERTEX_TOPOLOGY* const vt = &mris->vertices_topology[vno];
-    VERTEX         * const v  = &mris->vertices         [vno];
     vt->f = (int *)calloc(vt->num, sizeof(int));
     if (!vt->f) ErrorExit(ERROR_NO_MEMORY, "%s: could not allocate %d faces", __func__, vt->num);
     vt->n = (uchar *)calloc(vt->num, sizeof(uchar));
     if (!vt->n) ErrorExit(ERROR_NO_MEMORY, "%s: could not allocate %d nbrs", __func__, vt->n);
     vt->num = 0; /* for use as counter in next section */
-    v->dist = (float *)calloc(vt->vnum, sizeof(float));
-    if (!v->dist)
-      ErrorExit(ERROR_NOMEMORY,
-                "%s: could not allocate list of %d "
-                "dists at v=%d",
-                __func__,
-                vt->vnum,
-                vno);
-    v->dist_orig = (float *)calloc(vt->vnum, sizeof(float));
-    if (!v->dist_orig)
-      ErrorExit(ERROR_NOMEMORY,
-                "%s: could not allocate list of %d "
-                "dists at v=%d",
-                __func__,
-                vt->vnum,
-                vno);
-    vt->nsizeMax = vt->nsizeCur = 1;
-    vt->vtotal = vt->vnum;
+    vt->nsizeMax = 1;
+    MRIS_setNsizeCur(mris, vno, 1);
   }
 
   //---------------------------------------------

--- a/utils/icosahedron.c
+++ b/utils/icosahedron.c
@@ -29,6 +29,7 @@
 #include "diag.h"
 #include "error.h"
 #include "icosahedron.h"
+#include "mrisurf_topology.h"
 #include "utils.h"  //fgetl
 
 IC_VERTEX ic0_vertices[12] = {{.0000, .0000, 1.0000},
@@ -1798,29 +1799,13 @@ static MRIS *ICOtoScaledMRIS(ICOSAHEDRON const * const ico, int max_vertices, in
   /* now allocate face arrays in vertices */
   for (vno = 0; vno < ico->nvertices; vno++) {
     VERTEX_TOPOLOGY * const vt = &mris->vertices_topology[vno];
-    VERTEX          * const v  = &mris->vertices         [vno];
     vt->f = (int *)calloc(vt->num, sizeof(int));
     if (!vt->f) ErrorExit(ERROR_NO_MEMORY, "ICOread: could not allocate %d faces", vt->num);
     vt->n = (unsigned char *)calloc(vt->num, sizeof(unsigned char));
     if (!vt->n) ErrorExit(ERROR_NO_MEMORY, "ICOread: could not allocate %d nbrs", vt->n);
     vt->num = 0; /* for use as counter in next section */
-    v->dist = (float *)calloc(vt->vnum, sizeof(float));
-    if (!v->dist)
-      ErrorExit(ERROR_NOMEMORY,
-                "ICOread: could not allocate list of %d "
-                "dists at v=%d",
-                vt->vnum,
-                vno);
-    v->dist_orig = (float *)calloc(vt->vnum, sizeof(float));
-    if (!v->dist_orig)
-      ErrorExit(ERROR_NOMEMORY,
-                "ICOread: could not allocate list of %d "
-                "dists at v=%d",
-                vt->vnum,
-                vno);
     vt->nsizeMax = 1;
-    vt->nsizeCur = 1;
-    vt->vtotal   = vt->vnum;
+    MRIS_setNsizeCur(mris, vno, 1);
   }
 
   /* fill in face indices in vertex structures */

--- a/utils/label.c
+++ b/utils/label.c
@@ -643,7 +643,7 @@ int LabelRipRestOfSurface(LABEL *area, MRI_SURFACE *mris)
     v = &mris->vertices[vno];
     v->ripflag = 0;
   }
-  MRISripFaces(mris);
+  MRISsetRipInFacesWithRippedVertices(mris);
   MRISremoveRipped(mris);
   return (NO_ERROR);
 }
@@ -676,7 +676,7 @@ int LabelRipRestOfSurfaceWithThreshold(LABEL *area, MRI_SURFACE *mris, float thr
     v = &mris->vertices[vno];
     v->ripflag = 0;
   }
-  MRISripFaces(mris);
+  MRISsetRipInFacesWithRippedVertices(mris);
   MRISremoveRipped(mris);
   return (NO_ERROR);
 }

--- a/utils/mrisurf_base.c
+++ b/utils/mrisurf_base.c
@@ -267,6 +267,7 @@ static void MRIS_EDGEdtr(MRI_EDGE* e) {
 static void changeDistOrDistOrig(bool doOrig, MRIS *mris, int vno, int oldCapacity, int newCapacity) 
 {
   if (oldCapacity >= newCapacity) return;
+  
   char const flag = (char)(1)<<doOrig;
   mris->dist_alloced_flags |= flag;
 

--- a/utils/mrisurf_base.c
+++ b/utils/mrisurf_base.c
@@ -266,6 +266,7 @@ static void MRIS_EDGEdtr(MRI_EDGE* e) {
 //
 static void changeDistOrDistOrig(bool doOrig, MRIS *mris, int vno, int oldCapacity, int newCapacity) 
 {
+  if (oldCapacity >= newCapacity) return;
   char const flag = (char)(1)<<doOrig;
   mris->dist_alloced_flags |= flag;
 
@@ -356,18 +357,6 @@ void MRISfreeDistOrigs(MRIS* mris)
   // Maybe should not be here...
 {
   freeDistsOrDistOrigs(true,mris);
-}
-
-
-void MRISfreeDists(MRI_SURFACE *mris)
-  // Maybe should not be here...
-{
-  MRISfreeDistsButNotOrig(mris);
-  MRISfreeDistOrigs(mris);
-  int vno;					// weird because this affects neighbours as well
-  for (vno = 0; vno < mris->nvertices; vno++) {
-    mris->vertices_topology[vno].vtotal = 0;
-  }
 }
 
 
@@ -1290,6 +1279,16 @@ int MRISallocExtraGradients(MRIS *mris)
   return (NO_ERROR);
 }
 
+
+void MRIScheckForNans(MRIS *mris)
+{
+  int vno;
+  for (vno = 0; vno < mris->nvertices; vno++) {
+    VERTEX const * const v = &mris->vertices[vno];
+    checkNotNanf(v->odx); checkNotNanf(v->ody); checkNotNanf(v->odz);
+    checkNotNanf(v-> dx); checkNotNanf(v-> dy); checkNotNanf(v-> dz);
+  }  
+}
 
 int slprints(char *apch_txt)
 {

--- a/utils/mrisurf_base.h
+++ b/utils/mrisurf_base.h
@@ -347,6 +347,8 @@ void MRIStruncateNFaces             (MRIS* mris, int nfaces);
 void MRISremovedFaces               (MRIS* mris, int nfaces);
 void MRISoverAllocVerticesAndFaces  (MRIS* mris, int max_vertices, int max_faces, int nvertices, int nfaces);
 
+void MRISgrowDist(MRIS *mris, int vno, int minimumCapacity);
+
 void insertActiveRealmTree(MRIS const * const mris, RealmTree* realmTree, GetXYZ_FunctionType getXYZ);
 void removeActiveRealmTree(RealmTree* realmTree);
 

--- a/utils/mrisurf_deform.c
+++ b/utils/mrisurf_deform.c
@@ -72,7 +72,7 @@ int MRISremoveTopologicalDefects(MRI_SURFACE *mris, float curv_thresh)
     }
   }
 
-  /*  MRISripFaces(mris) ;*/
+  /*  MRISsetRipInFacesWithRippedVertices(mris) ;*/
   VectorFree(&v_i);
   VectorFree(&v_n);
   VectorFree(&v_e1);
@@ -10980,7 +10980,8 @@ MRIS *MRISextractMarkedVertices(MRIS *mris)
       continue;
     }
     
-    VERTEX_TOPOLOGY * const vdstt = &mris_corrected->vertices_topology[vertex_trans[vno]];
+    int const vno_dst = vertex_trans[vno];
+    VERTEX_TOPOLOGY * const vdstt = &mris_corrected->vertices_topology[vno_dst];
 
     /* count # of good triangles attached to this vertex */
     for (vdstt->num = n = 0; n < vt->num; n++)
@@ -11003,14 +11004,14 @@ MRIS *MRISextractMarkedVertices(MRIS *mris)
       if (mris->vertices[vt->v[n]].marked == 0) {
         vdstt->vnum++;
       }
-    vdstt->nsizeCur = vdstt->nsizeMax = 1;
-    vdstt->vtotal = vdstt->vnum;
-    vdstt->nsizeCur = vdstt->nsizeMax = 1;
+    vdstt->nsizeMax = 1;
     vdstt->v = (int *)calloc(vdstt->vnum, sizeof(int));
     for (i = n = 0; n < vt->vnum; n++)
       if (mris->vertices[vt->v[n]].marked == 0) {
         vdstt->v[i++] = vertex_trans[vt->v[n]];
       }
+      
+    MRIS_setNsizeCur(mris_corrected,vno_dst,1);
   }
 
   mrisCheckVertexFaceTopology(mris_corrected);
@@ -11678,14 +11679,15 @@ MRIS *MRISremoveRippedSurfaceElements(MRIS *mris)
       if (mris->vertices[vt->v[n]].ripflag == 0) {
         vdstt->vnum++;
       }
-    vdstt->nsizeCur = vdstt->nsizeMax = 1;
-    vdstt->vtotal = vdstt->vnum;
-    vdstt->nsizeMax = vdstt->nsizeCur = 1;
+
+    vdstt->nsizeMax = 1;
     vdstt->v = (int *)calloc(vdstt->vnum, sizeof(int));
     for (i = n = 0; n < vt->vnum; n++)
       if (mris->vertices[vt->v[n]].ripflag == 0) {
         vdstt->v[i++] = vertex_trans[vt->v[n]];
       }
+      
+    MRIS_setNsizeCur(mris_corrected, vno_dst, 1);
   }
 
   free(vertex_trans);
@@ -12142,7 +12144,7 @@ int MRISripMedialWall(MRI_SURFACE *mris)
       v->ripflag = 1;
     }
   }
-  MRISripFaces(mris);
+  MRISsetRipInFacesWithRippedVertices(mris);
   return (NO_ERROR);
 }
 
@@ -12169,7 +12171,7 @@ int MRISzeroMedialWallCurvature(MRI_SURFACE *mris)
       v->curv = 0;
     }
   }
-  MRISripFaces(mris);
+  MRISsetRipInFacesWithRippedVertices(mris);
   return (NO_ERROR);
 }
 
@@ -12737,6 +12739,8 @@ MRI_SURFACE *MRISprojectOntoSphere(MRI_SURFACE *mris_src, MRI_SURFACE *mris_dst,
 
   mris_dst->radius = r;
 
+  MRISfreeDistsButNotOrig(mris_dst);
+  
   for (total_dist = vno = 0; vno < mris_dst->nvertices; vno++) {
     v = &mris_dst->vertices[vno];
     if (v->ripflag) /* shouldn't happen */
@@ -13604,7 +13608,7 @@ int MRISinverseSphericalMap(MRIS *mris, MRIS *mris_ico)
   int fno, vno, num_ambiguous = 0, nfound, i, max_count;
   short *vcount = (short *)calloc(mris->nfaces, sizeof(short));
 
-  MRISfreeDists(mris);
+  MRISfreeDistsButNotOrig(mris);
 
   /* make sure they are they same size */
   r = MRISaverageRadius(mris_ico);

--- a/utils/mrisurf_integrate.c
+++ b/utils/mrisurf_integrate.c
@@ -3513,8 +3513,8 @@ int MRISinflateBrain(MRI_SURFACE *mris, INTEGRATION_PARMS *parms)
       mrisTearStressedRegions(mris, parms)  ;
       if (parms->explode_flag)
       {
-	MRISremoveRippedFaces(mris) ;
-	MRISremoveRippedVertices(mris) ;
+        MRISsetOrigArea(mris);  // used to happen inside MRISrenumberRemovingRippedFacesAndVertices
+	MRISrenumberRemovingRippedFacesAndVertices(mris);
       }
   
 #if 0

--- a/utils/mrisurf_io.c
+++ b/utils/mrisurf_io.c
@@ -1,5 +1,4 @@
 #define COMPILING_MRISURF_TOPOLOGY_FRIEND_CHECKED
-#define COMPILING_MRISURF_METRIC_PROPERTIES_FRIEND
 
 /*
  * @file utilities operating on Original
@@ -910,7 +909,7 @@ int MRISreadFlattenedCoordinates(MRI_SURFACE *mris, const char *sname)
   for (vno = 0; vno < mris->nvertices; vno++) {
     v = &mris->vertices[vno];
     if (v->ripflag) {
-      v->z = -10000;
+      MRISsetXYZ(mris,vno, v->x, v->y, -10000);
       v->ripflag = 0;
     }
   }
@@ -996,32 +995,18 @@ int MRISreadCanonicalCoordinates(MRI_SURFACE *mris, const char *sname)
   ------------------------------------------------------*/
 int MRISreadPatchNoRemove(MRI_SURFACE *mris, const char *pname)
 {
+  char fname[STRLEN];
+  MRISbuildFileName(mris, pname, fname);
+
+  int const type = MRISfileNameType(fname); /* using extension to get type */
+
   int ix, iy, iz, k, i, j, npts;
   double rx, ry, rz;
   FILE *fp = NULL;
-  char fname[STRLEN];
-  int type;
   char line[256];
   char *cp;
 
-#if 0
-  char        path[STRLEN], *cp ;
-  cp = strchr(pname, '/') ;
-  if (cp)
-  {
-    strcpy(fname, pname) ;  /* path already specified */
-  }
-  else                        /* no path - use same as was used in MRISread */
-  {
-    FileNamePath(mris->fname, path) ;
-    sprintf(fname, "%s/%s", path, pname) ;
-  }
-#else
-  MRISbuildFileName(mris, pname, fname);
-#endif
-
   // check whether the patch file is ascii or binary
-  type = MRISfileNameType(fname); /* using extension to get type */
   if (type == MRIS_GIFTI_FILE)    /* .gii */
   {
     mris = MRISread(fname);
@@ -1034,7 +1019,7 @@ int MRISreadPatchNoRemove(MRI_SURFACE *mris, const char *pname)
     sscanf(cp, "%d %*s", &npts);  // get points
     if (Gdiag & DIAG_SHOW)
       fprintf(stdout,
-              "reading patch %s with %d vertices (%2.1f%% of total)\n",
+              "reading .ASC patch %s with %d vertices (%2.1f%% of total)\n",
               pname,
               npts,
               100.0f * (float)npts / (float)mris->nvertices);
@@ -1084,28 +1069,10 @@ int MRISreadPatchNoRemove(MRI_SURFACE *mris, const char *pname)
                      j));
 
       // convert it to mm, i.e. change the vertex position
-      mris->vertices[k].x = rx;
-      mris->vertices[k].y = ry;
-      mris->vertices[k].z = rz;
-      // change the hi, lo values
-      if (mris->vertices[k].x > mris->xhi) {
-        mris->xhi = mris->vertices[k].x;
-      }
-      if (mris->vertices[k].x < mris->xlo) {
-        mris->xlo = mris->vertices[k].x;
-      }
-      if (mris->vertices[k].y > mris->yhi) {
-        mris->yhi = mris->vertices[k].y;
-      }
-      if (mris->vertices[k].y < mris->ylo) {
-        mris->ylo = mris->vertices[k].y;
-      }
-      if (mris->vertices[k].z > mris->zhi) {
-        mris->zhi = mris->vertices[k].z;
-      }
-      if (mris->vertices[k].z < mris->zlo) {
-        mris->zlo = mris->vertices[k].z;
-      }
+      MRISsetXYZ(mris,k,
+        rx,
+        ry,
+        rz);
       if (k == Gdiag_no && Gdiag & DIAG_SHOW)
         fprintf(stdout,
                 "vertex %d read @ (%2.2f, %2.2f, %2.2f)\n",
@@ -1127,7 +1094,7 @@ int MRISreadPatchNoRemove(MRI_SURFACE *mris, const char *pname)
     if (npts >= 0) {
       if (Gdiag & DIAG_SHOW)
         fprintf(stdout,
-                "reading patch %s with %d vertices (%2.1f%% of total)\n",
+                "reading binary patch %s with %d vertices (%2.1f%% of total)\n",
                 pname,
                 npts,
                 100.0f * (float)npts / (float)mris->nvertices);
@@ -1163,28 +1130,10 @@ int MRISreadPatchNoRemove(MRI_SURFACE *mris, const char *pname)
         fread2(&iy, fp);
         fread2(&iz, fp);
         // convert it to mm, i.e. change the vertex position
-        mris->vertices[k].x = ix / 100.0;
-        mris->vertices[k].y = iy / 100.0;
-        mris->vertices[k].z = iz / 100.0;
-        // change the hi, lo values
-        if (mris->vertices[k].x > mris->xhi) {
-          mris->xhi = mris->vertices[k].x;
-        }
-        if (mris->vertices[k].x < mris->xlo) {
-          mris->xlo = mris->vertices[k].x;
-        }
-        if (mris->vertices[k].y > mris->yhi) {
-          mris->yhi = mris->vertices[k].y;
-        }
-        if (mris->vertices[k].y < mris->ylo) {
-          mris->ylo = mris->vertices[k].y;
-        }
-        if (mris->vertices[k].z > mris->zhi) {
-          mris->zhi = mris->vertices[k].z;
-        }
-        if (mris->vertices[k].z < mris->zlo) {
-          mris->zlo = mris->vertices[k].z;
-        }
+        MRISsetXYZ(mris,k,
+          ix / 100.0,
+          iy / 100.0,
+          iz / 100.0);
         if (k == Gdiag_no && Gdiag & DIAG_SHOW)
           fprintf(stdout,
                   "vertex %d read @ (%2.2f, %2.2f, %2.2f)\n",
@@ -1200,7 +1149,7 @@ int MRISreadPatchNoRemove(MRI_SURFACE *mris, const char *pname)
       npts = freadInt(fp);
       if (Gdiag & DIAG_SHOW)
         fprintf(stdout,
-                "reading patch %s with %d vertices (%2.1f%% of total)\n",
+                "reading new surface format patch %s with %d vertices (%2.1f%% of total)\n",
                 pname,
                 npts,
                 100.0f * (float)npts / (float)mris->nvertices);
@@ -1233,28 +1182,10 @@ int MRISreadPatchNoRemove(MRI_SURFACE *mris, const char *pname)
         mris->vertices[k].ripflag = FALSE;
         // read 3 positions
         // convert it to mm, i.e. change the vertex position
-        mris->vertices[k].x = freadFloat(fp);
-        mris->vertices[k].y = freadFloat(fp);
-        mris->vertices[k].z = freadFloat(fp);
-        // change the hi, lo values
-        if (mris->vertices[k].x > mris->xhi) {
-          mris->xhi = mris->vertices[k].x;
-        }
-        if (mris->vertices[k].x < mris->xlo) {
-          mris->xlo = mris->vertices[k].x;
-        }
-        if (mris->vertices[k].y > mris->yhi) {
-          mris->yhi = mris->vertices[k].y;
-        }
-        if (mris->vertices[k].y < mris->ylo) {
-          mris->ylo = mris->vertices[k].y;
-        }
-        if (mris->vertices[k].z > mris->zhi) {
-          mris->zhi = mris->vertices[k].z;
-        }
-        if (mris->vertices[k].z < mris->zlo) {
-          mris->zlo = mris->vertices[k].z;
-        }
+        float x = freadFloat(fp);
+        float y = freadFloat(fp);
+        float z = freadFloat(fp);
+        MRISsetXYZ(mris,k,x,y,z);
         if (k == Gdiag_no && Gdiag & DIAG_SHOW)
           fprintf(stdout,
                   "vertex %d read @ (%2.2f, %2.2f, %2.2f)\n",
@@ -1274,7 +1205,8 @@ int MRISreadPatchNoRemove(MRI_SURFACE *mris, const char *pname)
     }
 
   // remove ripflag set vertices
-  MRISripFaces(mris);
+  MRISremoveRipped(mris);
+  mrisComputeSurfaceDimensions(mris);
   // set the patch flag
   mris->patch = 1;
   mris->status = MRIS_CUT;
@@ -2470,20 +2402,21 @@ int MRISreadVertexPositions(MRI_SURFACE *mris, const char *name)
 
     for (vno = 0; vno < nvertices; vno++) {
       VERTEX_TOPOLOGY const * const vertext = &mris->vertices_topology[vno];
-      VERTEX                * const vertex  = &mris->vertices         [vno];
       if (version == -1) {
         fread2(&ix, fp);
         fread2(&iy, fp);
         fread2(&iz, fp);
-        vertex->x = ix / 100.0;
-        vertex->y = iy / 100.0;
-        vertex->z = iz / 100.0;
+        MRISsetXYZ(mris,vno,
+          ix / 100.0,
+          iy / 100.0,
+          iz / 100.0);
       }
       else /* version == -2 */
       {
-        vertex->x = freadFloat(fp);
-        vertex->y = freadFloat(fp);
-        vertex->z = freadFloat(fp);
+        float x = freadFloat(fp);
+        float y = freadFloat(fp);
+        float z = freadFloat(fp);
+        MRISsetXYZ(mris,vno, x,y,z);
       }
       if (version == 0) /* old surface format */
       {
@@ -2531,7 +2464,9 @@ int MRISreadOriginalProperties(MRI_SURFACE *mris, const char *sname)
   MRIScomputeTriangleProperties(mris);
   MRISstoreMetricProperties(mris);
   mris->status = old_status;
+  
   MRISrestoreVertexPositions(mris, TMP_VERTICES);
+  
   MRIScomputeMetricProperties(mris);
   MRIScomputeTriangleProperties(mris);
   mrisOrientSurface(mris);
@@ -2941,13 +2876,11 @@ MRI_SURFACE *MRISreadVTK(MRI_SURFACE *mris, const char *fname)
   /* read vertices... */
   int vno;
   for (vno = 0; vno < mris->nvertices; vno++) {
-    VERTEX v;
-    fscanf(fp, "%f %f %f", &v.x, &v.y, &v.z);
+    float x,y,z;
+    fscanf(fp, "%f %f %f", &x, &y, &z);
     if (newMris)  // if passed an mris struct, dont overwrite x,y,z
     {
-      mris->vertices[vno].x = v.x;
-      mris->vertices[vno].y = v.y;
-      mris->vertices[vno].z = v.z;
+      MRISsetXYZ(mris,vno,x,y,z);
     }
   }
 
@@ -3379,7 +3312,6 @@ static MRI_SURFACE *mrisReadAsciiFile(const char *fname)
   MRI_SURFACE *mris;
   char line[STRLEN], *cp;
   int vno, fno, n, nvertices, nfaces, patch, rip;
-  VERTEX *v;
   FACE *face;
   FILE *fp;
 
@@ -3396,8 +3328,10 @@ static MRI_SURFACE *mrisReadAsciiFile(const char *fname)
   mris->type = MRIS_TRIANGULAR_SURFACE;
 #endif
   for (vno = 0; vno < mris->nvertices; vno++) {
-    v = &mris->vertices[vno];
-    fscanf(fp, "%f  %f  %f  %d\n", &v->x, &v->y, &v->z, &rip);
+    VERTEX * v = &mris->vertices[vno];
+    float x,y,z;
+    fscanf(fp, "%f  %f  %f  %d\n", &x, &y, &z, &rip);
+    MRISsetXYZ(mris, vno,x,y,z);
     v->ripflag = rip;
     if (v->ripflag) {
       patch = 1;
@@ -3472,8 +3406,9 @@ static MRI_SURFACE *mrisReadGeoFile(const char *fname)
   mris = MRISalloc(nvertices, nfaces);
   mris->type = MRIS_GEO_TRIANGLE_FILE;
   for (vno = 0; vno < mris->nvertices; vno++) {
-    VERTEX * const v = &mris->vertices[vno];
-    fscanf(fp, "%e %e %e", &v->x, &v->y, &v->z);
+    float x,y,z;
+    fscanf(fp, "%e %e %e", &x, &y, &z);
+    MRISsetXYZ(mris,vno,x,y,z);
     if (ISODD(vno)) {
       fscanf(fp, "\n");
     }
@@ -3518,7 +3453,6 @@ static int mrisReadGeoFilePositions(MRI_SURFACE *mris, const char *fname)
 {
   char line[202], *cp;
   int vno, nvertices, nfaces, patch, vertices_per_face, nedges;
-  VERTEX *v;
   FILE *fp;
 
   fp = fopen(fname, "r");
@@ -3544,8 +3478,9 @@ static int mrisReadGeoFilePositions(MRI_SURFACE *mris, const char *fname)
 
   cp = fgetl(line, 200, fp); /* nfaces again */
   for (vno = 0; vno < mris->nvertices; vno++) {
-    v = &mris->vertices[vno];
-    fscanf(fp, "%e %e %e", &v->x, &v->y, &v->z);
+    float x,y,z;
+    fscanf(fp, "%e %e %e", &x, &y, &z);
+    MRISsetXYZ(mris,vno, x,y,z);
     if (ISODD(vno)) {
       fscanf(fp, "\n");
     }
@@ -3806,8 +3741,10 @@ static MRI_SURFACE *mrisReadSTLfile(const char *fname)
 	  Key* keyPtr = vertices[undupVertexNo];
           int vertexNo = keyPtr->vertexNo;
   	  if (vertexNo == nextVertexNo) { 
-  	    VERTEX* v = &mris->vertices[vertexNo];
-  	    v->x = keyPtr->x; v->y = keyPtr->y; v->z = keyPtr->z;
+  	    MRISsetXYZ(mris,vertexNo,
+  	      keyPtr->x, 
+              keyPtr->y, 
+              keyPtr->z);
   	    nextVertexNo++;
 	  }
        	  face->v[faceVertexNo] = vertexNo;
@@ -3887,26 +3824,11 @@ static MRI_SURFACE *mrisReadSTLfile(const char *fname)
     /* now allocate face arrays in vertices */
     for (vno = 0; vno < mris->nvertices; vno++) {
       VERTEX_TOPOLOGY * const vt = &mris->vertices_topology[vno];
-      VERTEX          * const v  = &mris->vertices         [vno];
       vt->f = (int *)calloc(vt->num, sizeof(int));
       if (!vt->f) ErrorExit(ERROR_NO_MEMORY, "MRISreadSTLfileICOread: could not allocate %d faces", vt->num);
       vt->n = (unsigned char *)calloc(vt->num, sizeof(unsigned char));
       if (!vt->n) ErrorExit(ERROR_NO_MEMORY, "MRISreadSTLfile: could not allocate %d nbrs", vt->n);
       vt->num = 0; /* for use as counter in next section */
-      v->dist = (float *)calloc(vt->vnum, sizeof(float));
-      if (!v->dist)
-        ErrorExit(ERROR_NOMEMORY,
-                  "MRISreadSTLfile: could not allocate list of %d "
-                  "dists at v=%d",
-                  vt->vnum,
-                  vno);
-      v->dist_orig = (float *)calloc(vt->vnum, sizeof(float));
-      if (!v->dist_orig)
-        ErrorExit(ERROR_NOMEMORY,
-                  "MRISreadSTLfile: could not allocate list of %d "
-                  "dists at v=%d",
-                  vt->vnum,
-                  vno);
       vt->vtotal = vt->vnum;
     }
 
@@ -4075,15 +3997,17 @@ MRI_SURFACE *MRISreadOverAlloc(const char *fname, double nVFMultiplier)
         fread2(&ix, fp);
         fread2(&iy, fp);
         fread2(&iz, fp);
-        vertex->x = ix / 100.0;
-        vertex->y = iy / 100.0;
-        vertex->z = iz / 100.0;
+        MRISsetXYZ(mris,vno,
+          ix / 100.0,
+          iy / 100.0,
+          iz / 100.0);
       }
       else /* version == -2 */ /* NEW_QUAD_FILE_MAGIC_NUMBER */
       {
-        vertex->x = freadFloat(fp);
-        vertex->y = freadFloat(fp);
-        vertex->z = freadFloat(fp);
+        float x = freadFloat(fp);
+        float y = freadFloat(fp);
+        float z = freadFloat(fp);
+        MRISsetXYZ(mris,vno, x,y,z);
       }
 #if 0
       vertex->label = NO_LABEL ;
@@ -4323,7 +4247,9 @@ MRI_SURFACE *MRISreadOverAlloc(const char *fname, double nVFMultiplier)
   
   MRIScomputeNormals(mris);
   mrisComputeVertexDistances(mris);
+
   mrisReadTransform(mris, fname);
+
   if (type == MRIS_ASCII_TRIANGLE_FILE || type == MRIS_GEO_TRIANGLE_FILE) {
 #if 0
     MRISsetNeighborhoodSizeAndDist(mris, 2) ;
@@ -4627,6 +4553,7 @@ int mrisReadTransform(MRIS *mris, const char *mris_fname)
     if (mris->lta->type != LINEAR_RAS_TO_RAS)
       ErrorExit(ERROR_BADPARM, "the transform is not RAS-TO-RAS.  not supported.");
   }
+  
   //////////////////////////////////////////////////////////////////////
   // thus if transform->src is not set, set it to the orig
   lt = &mris->lta->xforms[0];
@@ -4745,6 +4672,8 @@ int mrisReadTransform(MRIS *mris, const char *mris_fname)
   }
 #endif
 
+  mrisCheckVertexFaceTopology(mris);
+  
   return (NO_ERROR);
 }
 
@@ -5384,7 +5313,6 @@ static SMALL_SURFACE *mrisReadTriangleFileVertexPositionsOnly(const char *fname)
   ------------------------------------------------------*/
 static int mrisReadTriangleFilePositions(MRI_SURFACE *mris, const char *fname)
 {
-  VERTEX *v;
   int nvertices, nfaces, magic, vno;
   char line[STRLEN];
   FILE *fp;
@@ -5418,11 +5346,12 @@ static int mrisReadTriangleFilePositions(MRI_SURFACE *mris, const char *fname)
   if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
     fprintf(stdout, "surface %s: %d vertices and %d faces.\n", fname, nvertices, nfaces);
 
+  MRISfreeDistsButNotOrig(mris);
   for (vno = 0; vno < nvertices; vno++) {
-    v = &mris->vertices[vno];
-    v->x = freadFloat(fp);
-    v->y = freadFloat(fp);
-    v->z = freadFloat(fp);
+    float x = freadFloat(fp);
+    float y = freadFloat(fp);
+    float z = freadFloat(fp);
+    MRISsetXYZ(mris, vno, x,y,z);
   }
 
 #if 0
@@ -5480,9 +5409,12 @@ static MRI_SURFACE *mrisReadTriangleFile(const char *fname, double nVFMultiplier
     if (vno == Gdiag_no) {
       DiagBreak();
     }
-    v->x = freadFloat(fp);
-    v->y = freadFloat(fp);
-    v->z = freadFloat(fp);
+
+    float x = freadFloat(fp);
+    float y = freadFloat(fp);
+    float z = freadFloat(fp);
+    
+    MRISsetXYZ(mris,vno, x, y, z);
 
     vt->num = 0; /* will figure it out */
     if (fabs(v->x) > 10000 || !isfinite(v->x))

--- a/utils/mrisurf_metricProperties.c
+++ b/utils/mrisurf_metricProperties.c
@@ -122,6 +122,8 @@ int MRISimportVertexCoords(MRIS * const mris, float * locations[3], int const wh
 {
   int const nvertices = mris->nvertices;
 
+  if (which == CURRENT_VERTICES) MRISfreeDistsButNotOrig(mris);  // it is either this or adjust them...
+   
   int vno;
   for (vno = 0; vno < nvertices; vno++) {
     VERTEX *v = &mris->vertices[vno];
@@ -314,6 +316,8 @@ int MRISreverse(MRIS *mris, int which, int reverse_face_order)
 
 int MRISscale(MRIS *mris, double scale)
 {
+  MRISfreeDistsButNotOrig(mris);  // it is either this or adjust them...
+   
   int vno;
   for (vno = 0; vno < mris->nvertices; vno++) {
     VERTEX *v = &mris->vertices[vno];
@@ -347,6 +351,8 @@ int MRISscale(MRIS *mris, double scale)
 
 int mrisFlipPatch(MRIS *mris)
 {
+  MRISfreeDistsButNotOrig(mris);  // it is either this or adjust them...
+   
   int vno;
   for (vno = 0; vno < mris->nvertices; vno++) {
     VERTEX *v = &mris->vertices[vno];
@@ -391,7 +397,9 @@ int MRIStranslate(MRIS *mris, float dx, float dy, float dz)
 int MRISanisotropicScale(MRIS *mris, float sx, float sy, float sz)
 {
   mrisComputeSurfaceDimensions(mris);
-  
+ 
+  MRISfreeDistsButNotOrig(mris);  // it is either this or adjust them...
+   
   /* scale around the center */
   float const x0 = mris->xctr;
   float const y0 = mris->yctr;
@@ -472,6 +480,8 @@ MRI_SURFACE *MRIStalairachTransform(MRI_SURFACE *mris_src, MRI_SURFACE *mris_dst
   xhi = yhi = zhi = -10000;
   xlo = ylo = zlo = 10000;
 
+  MRISfreeDistsButNotOrig(mris_dst);  // it is either this or adjust them...
+
   int vno;
   for (vno = 0; vno < mris_src->nvertices; vno++) {
     VERTEX * v = &mris_dst->vertices[vno];
@@ -508,34 +518,16 @@ MRI_SURFACE *MRIStalairachTransform(MRI_SURFACE *mris_src, MRI_SURFACE *mris_dst
 
 void mrisDisturbVertices(MRIS* mris, double amount)
 {
-  int vno ;
+  MRISfreeDistsButNotOrig(mris);  // it is either this or adjust them...
 
-  for (vno = 0 ; vno < mris->nvertices ; vno++)
-  {
+  int vno ;
+  for (vno = 0 ; vno < mris->nvertices ; vno++) {
     VERTEX *v = &mris->vertices[vno] ;
     v->x += randomNumber(-amount, amount) ;
     v->y += randomNumber(-amount, amount) ;
   }
 
   MRIScomputeMetricProperties(mris) ;
-}
-
-
-int MRISscaleDistances(MRIS *mris, float scale)
-{
-  // This operation seems wrong, since this is a derived metric
-  // but there are two users...
-  //
-  int vno;
-  for (vno = 0; vno < mris->nvertices; vno++) {
-    VERTEX * const v = &mris->vertices[vno];
-    int vsize = mrisVertexVSize(mris, vno);
-    int n;
-    for (n = 0; n < vsize; n++) {
-      v->dist[n] *= scale;
-    }
-  }
-  return (NO_ERROR);
 }
 
 
@@ -574,6 +566,8 @@ MRIS* MRISprojectOntoTranslatedSphere(
 
   mris_dst->radius = r ;
 
+  MRISfreeDistsButNotOrig(mris_dst);  // it is either this or adjust them...
+
   int vno ;
   for (vno = 0 ; vno < mris_dst->nvertices ; vno++) {
     VERTEX* const v = &mris_dst->vertices[vno];
@@ -609,6 +603,9 @@ MRIS* MRISprojectOntoTranslatedSphere(
 
 
 void MRISblendXYZandTXYZ(MRIS* mris, float xyzScale, float txyzScale) {
+
+  MRISfreeDistsButNotOrig(mris);  // it is either this or adjust them...
+
   int vno;
   for (vno = 0; vno < mris->nvertices; vno++) {
     VERTEX* v = &mris->vertices[vno];
@@ -1165,35 +1162,234 @@ int mrisOrientSurface(MRI_SURFACE *mris)
 }
 
 
-int MRISclearOrigArea(MRI_SURFACE *mris)
+// Distances
+//
+int MRISscaleDistances(MRIS *mris, float scale)
 {
+  // This operation seems wrong, since this is a derived metric
+  // but there are two users...
+  //
   int vno;
-  VERTEX *v;
-
   for (vno = 0; vno < mris->nvertices; vno++) {
-    v = &mris->vertices[vno];
-    if (v->ripflag) {
+    VERTEX * const v = &mris->vertices[vno];
+    int vsize = mrisVertexVSize(mris, vno);
+    int n;
+    for (n = 0; n < vsize; n++) {
+      v->dist[n] *= scale;
+    }
+  }
+  return (NO_ERROR);
+}
+
+
+/*-----------------------------------------------------------------
+  Calculate distances between each vertex and each of its neighbors.
+  ----------------------------------------------------------------*/
+static bool mrisComputeVertexDistancesWkr(MRIS *mris, int new_dist_nsize, bool check);
+
+bool mrisCheckDist(MRIS const * mris) {
+  if (!mris->dist_nsize) return true;
+  return mrisComputeVertexDistancesWkr((MRIS*)mris, mris->dist_nsize, true);
+}
+
+int mrisComputeVertexDistances(MRIS *mris) {
+  cheapAssert(0 < mris->nsize);
+  mrisComputeVertexDistancesWkr(mris, mris->nsize, false);
+  mris->dist_nsize = mris->nsize;
+  mrisCheckDist(mris);
+  return NO_ERROR;
+}
+
+static bool mrisComputeVertexDistancesWkr(MRIS *mris, int new_dist_nsize, bool check)
+{
+  cheapAssert(0 < new_dist_nsize);
+  cheapAssert(new_dist_nsize <= 3);
+  
+  if (debugNonDeterminism) {
+    fprintf(stdout, "%s:%d stdout ",__FILE__,__LINE__);
+    mris_print_hash(stdout, mris, "mris ", "\n");
+  }
+
+  int errors = 0;
+  
+  int vno;
+
+  switch (mris->status) {
+    default: /* don't really know what to do in other cases */
+
+    case MRIS_PLANE:
+
+      ROMP_PF_begin		// mris_fix_topology
+#ifdef HAVE_OPENMP
+      #pragma omp parallel for if_ROMP(shown_reproducible) reduction(+:errors)
+#endif
+      for (vno = 0; vno < mris->nvertices; vno++) {
+        ROMP_PFLB_begin
+    
+        if (vno == Gdiag_no) DiagBreak();
+
+        VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
+        VERTEX                * const v  = &mris->vertices         [vno];
+        if (v->ripflag) continue;
+
+        if (!check) MRISmakeDist(mris,vno);
+        else if (!v->dist) continue;
+
+        int *pv;
+        int const vtotal = check ? VERTEXvnum(vt,new_dist_nsize) : vt->vtotal;
+        int n;
+        for (pv = vt->v, n = 0; n < vtotal; n++) {
+          VERTEX const * const vn = &mris->vertices[*pv++];
+          // if (vn->ripflag) continue;
+          float xd = v->x - vn->x;
+          float yd = v->y - vn->y;
+          float zd = v->z - vn->z;
+          float d = xd * xd + yd * yd + zd * zd;
+
+          if (!check) 
+            v->dist[n] = sqrt(d);
+          else if (v->dist[n] != (float)(sqrt(d))) 
+            errors++;
+        }
+
+        ROMP_PFLB_end
+      }
+      ROMP_PF_end
+  
+      break;
+
+    case MRIS_PARAMETERIZED_SPHERE:
+    case MRIS_SPHERE: {
+
+      ROMP_PF_begin		// mris_fix_topology
+#ifdef HAVE_OPENMP
+      #pragma omp parallel for if_ROMP(shown_reproducible) reduction(+:errors)
+#endif
+      for (vno = 0; vno < mris->nvertices; vno++) {
+        ROMP_PFLB_begin
+    
+        if (vno == Gdiag_no) DiagBreak();
+
+        VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
+        VERTEX          const * const v  = &mris->vertices         [vno];
+        if (v->ripflag) continue;
+
+        if (!check) MRISmakeDist(mris,vno);
+        else if (!v->dist) continue;
+
+        XYZ xyz1_normalized;
+        float xyz1_length;
+        XYZ_NORMALIZED_LOAD(&xyz1_normalized, &xyz1_length, v->x, v->y, v->z);  // length 1 along radius vector
+
+        float const radius = xyz1_length;
+
+        int *pv;
+        int const vtotal = check ? VERTEXvnum(vt,new_dist_nsize) : vt->vtotal;
+        int n;
+        for (pv = vt->v, n = 0; n < vtotal; n++) {
+          VERTEX const * const vn = &mris->vertices[*pv++];
+          if (vn->ripflag) continue;
+          
+          float angle = fabs(XYZApproxAngle(&xyz1_normalized, vn->x, vn->y, vn->z));
+            // radians, so 2pi around the circumference
+
+          float d = angle * radius;
+            // the length of the arc, rather than the straight line distance
+
+          if (!check) 
+            v->dist[n] = d;
+          else if (v->dist[n] != (float)(d)) 
+            errors++;
+        }
+        ROMP_PFLB_end
+      }
+      ROMP_PF_end
+
+      break;
+    }
+  }
+
+  return (errors == 0);
+}
+
+
+int mrisComputeOriginalVertexDistances(MRIS *mris)
+{
+  VECTOR* v1 = VectorAlloc(3, MATRIX_REAL);
+  VECTOR* v2 = VectorAlloc(3, MATRIX_REAL);
+
+  float circumference = 0.0f;
+  
+  bool allOrigXZero = true;
+  
+  int vno;
+  for (vno = 0; vno < mris->nvertices; vno++) {
+    VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
+    VERTEX          const * const v  = &mris->vertices         [vno];
+
+    if (v->ripflag || v->dist_orig == NULL) {
       continue;
     }
-    v->origarea = 0;
+    if (vno == Gdiag_no) {
+      DiagBreak();
+    }
+
+    allOrigXZero &= (v->origx == 0.0f);
+
+    int const vtotal = vt->vtotal;
+
+    switch (mris->status) {
+      default: 
+        // seen to happen - e.g. mris_sphere test   cheapAssert(false);
+      
+      case MRIS_PLANE: {
+        int n, *pv;
+        for (pv = vt->v, n = 0; n < vtotal; n++) {
+          VERTEX const * const vn = &mris->vertices[*pv++];
+          if (vn->ripflag) continue;
+
+          float xd = v->origx - vn->origx;
+          float yd = v->origy - vn->origy;
+          float zd = v->origz - vn->origz;
+          float d = xd * xd + yd * yd + zd * zd;    // should be double
+
+          v->dist_orig[n] = sqrt(d);
+        }
+        DiagBreak();
+      } break;
+  
+      case MRIS_PARAMETERIZED_SPHERE:
+      case MRIS_SPHERE: {
+        VECTOR_LOAD(v1, v->origx, v->origy, v->origz); /* radius vector */
+        if (FZERO(circumference))                      /* only calculate once */
+          circumference = M_PI * 2.0 * V3_LEN(v1);
+ 
+        int n, *pv;
+        for (pv = vt->v, n = 0; n < vtotal; n++) {
+          VERTEX const * const vn = &mris->vertices[*pv++];
+          if (vn->ripflag) continue;
+ 
+          VECTOR_LOAD(v2, vn->origx, vn->origy, vn->origz); /* radius vector */
+          float angle = fabsf(Vector3Angle(v1, v2));
+          float d     = circumference * angle / (2.0 * M_PI);
+
+          v->dist_orig[n] = d;
+        }
+      } break;
+    }
   }
+
+  if (allOrigXZero) {
+    static bool laterTime;
+    if (!laterTime) { laterTime = true;
+      fprintf(stdout, "%s:%d origx have not been set - probably a logic error\n",__FILE__,__LINE__);
+    }
+  }
+  
+  VectorFree(&v1);
+  VectorFree(&v2);
   return (NO_ERROR);
 }
-
-
-int MRISclearDistances(MRI_SURFACE *mris)
-{
-  int vno;
-  VERTEX *v;
-
-  for (vno = 0; vno < mris->nvertices; vno++) {
-    v = &mris->vertices[vno];
-    v->d = 0.0;
-  }
-
-  return (NO_ERROR);
-}
-
 
 int MRISclearOrigDistances(MRI_SURFACE *mris)
 {
@@ -1207,6 +1403,76 @@ int MRISclearOrigDistances(MRI_SURFACE *mris)
     for (n = 0; n < vt->vtotal; n++) {
       v->dist_orig[n] = 0;
     }
+  }
+  return (NO_ERROR);
+}
+
+
+double MRISpercentDistanceError(MRIS *mris)
+{
+  double dist_scale;
+  if (mris->patch) {
+    dist_scale = 1.0;
+  } else {
+    cheapAssert(mris->total_area > 0.0);
+    cheapAssert(mris->orig_area  > 0.0);
+    dist_scale = sqrt(mris->orig_area / mris->total_area);
+  }
+
+  double mean_odist = 0.0;
+  double mean_error = 0.0;
+  double pct        = 0.0;
+  int    nnbrs      = 0;
+  
+  int vno;
+  for (vno = 0; vno < mris->nvertices; vno++) {
+    VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
+    VERTEX          const * const v  = &mris->vertices         [vno];
+    if (v->ripflag) continue;
+
+    int n;
+    for (n = 0; n < vt->vtotal; n++) {
+      double dist  = v->dist     [n] * dist_scale;
+      double odist = v->dist_orig[n];
+      
+      nnbrs++;
+      mean_odist += odist;
+      mean_error += fabs(dist - odist);
+      if (!FZERO(odist)) pct += fabs(dist - odist) / odist;
+    }
+  }
+
+  if (mean_odist == 0.0f) {
+    fprintf(stdout, "%s:%d MRISpercentDistanceError called when all dist_orig zero\n", __FILE__, __LINE__);
+  }
+  
+  if (nnbrs == 0) nnbrs = 1;
+  
+  mean_odist /= (double)nnbrs;
+  mean_error /= (double)nnbrs;
+  if (!FZERO(mean_odist)) {
+    pct = mean_error / mean_odist;
+  } else {
+    pct = 1000.0; /* should never happen */
+  }
+
+  return (100.0 * pct);
+}
+
+
+// Area
+//
+int MRISclearOrigArea(MRI_SURFACE *mris)
+{
+  int vno;
+  VERTEX *v;
+
+  for (vno = 0; vno < mris->nvertices; vno++) {
+    v = &mris->vertices[vno];
+    if (v->ripflag) {
+      continue;
+    }
+    v->origarea = 0;
   }
   return (NO_ERROR);
 }
@@ -2406,13 +2672,12 @@ int MRIStransform(MRIS *mris, MRI *mri, TRANSFORM *transform, MRI *mri_dst)
 float mrisComputeArea(MRIS *mris, int fac, int n)
 {
   int n0, n1;
-  face_type *f;
   float v0[3], v1[3], d1, d2, d3, dot, area;
 
   n0 = (n == 0) ? VERTICES_PER_FACE - 1 : n - 1;
   n1 = (n == VERTICES_PER_FACE - 1) ? 0 : n + 1;
 
-  f = &mris->faces[fac];
+  FACE const * const f = &mris->faces[fac];
 
   v0[0] = mris->vertices[f->v[n]].x - mris->vertices[f->v[n0]].x;
   v0[1] = mris->vertices[f->v[n]].y - mris->vertices[f->v[n0]].y;
@@ -2438,6 +2703,28 @@ float mrisComputeArea(MRIS *mris, int fac, int n)
 
   return area;
 }
+
+
+float MRIScomputeOrigArea(MRIS* mris)
+{
+  float orig_area = 0.0f;
+  int fno;
+  for (fno = 0; fno < mris->nfaces; fno++) {
+    FACE const * const f = &mris->faces[fno];
+    if (f->ripflag) continue;
+    FaceNormCacheEntry const * const fNorm = getFaceNorm(mris, fno);
+    orig_area += fNorm->orig_area;
+  }
+  return orig_area;
+}
+
+
+void MRISsetOrigArea(MRIS* mris) 
+{
+  mris->orig_area = MRIScomputeOrigArea(mris);
+}
+
+
 
 /*-----------------------------------------------------
   Parameters:
@@ -3627,82 +3914,7 @@ double MRIScomputeFolding(MRIS *mris)
   return (folding);
 }
 
-/*-----------------------------------------------------
-  Parameters:
 
-  Returns value:
-
-  Description
-  ------------------------------------------------------*/
-double MRISpercentDistanceError(MRIS *mris)
-{
-  int vno, n, nvertices;
-  double dist_scale, pct, dist, odist, mean, mean_error;
-
-  if (mris->patch) {
-    dist_scale = 1.0;
-  }
-  else {
-    dist_scale = sqrt(mris->orig_area / mris->total_area);
-  }
-
-  mean = 0.0;
-  for (pct = 0.0, nvertices = vno = 0; vno < mris->nvertices; vno++) {
-    VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
-    VERTEX          const * const v  = &mris->vertices         [vno];
-    if (v->ripflag) {
-      continue;
-    }
-    for (n = 0; n < vt->vtotal; n++) {
-      nvertices++;
-      dist = dist_scale * v->dist[n];
-      odist = v->dist_orig[n];
-      if (!FZERO(odist)) {
-        pct += fabs(dist - odist) / odist;
-      }
-      mean += odist;
-    }
-  }
-
-  for (mean_error = 0.0, vno = 0; vno < mris->nvertices; vno++) {
-    VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
-    VERTEX          const * const v  = &mris->vertices         [vno];
-    if (v->ripflag) {
-      continue;
-    }
-    for (n = 0; n < vt->vtotal; n++)
-    {
-      dist = dist_scale * v->dist[n];
-      odist = v->dist_orig[n];
-      mean_error += fabs(dist - odist);
-      if (fabs(dist - odist) > 50) {
-        DiagBreak();
-      }
-    }
-  }
-  mean /= (double)nvertices;
-  mean_error /= (double)nvertices;
-#if 0
-  pct /= (double)nvertices ;
-#else
-  if (!FZERO(mean)) {
-    pct = mean_error / mean;
-  }
-  else {
-    pct = 1000.0; /* should never happen */
-  }
-#endif
-  return (100.0 * pct);
-}
-
-
-/*-----------------------------------------------------
-  Parameters:
-
-  Returns value:
-
-  Description
-  ------------------------------------------------------*/
 int MRIScomputeCanonicalCoordinates(MRIS *mris)
 {
   float theta, phi, r, d, x, y, z;
@@ -4381,19 +4593,38 @@ double MRIScomputeTotalVertexSpacingStats(
   Expand the list of neighbors of each vertex, reallocating
   the v->v array to hold the expanded list.
   ------------------------------------------------------*/
-static void MRISsetNeighborhoodSizeAndDistWkr(MRIS *mris, int nsize);
+static void MRISsetNeighborhoodSizeAndDistWkr(MRIS *mris, int nsize, bool alwaysDoDist);
 
-void MRISsetNeighborhoodSizeAndDist(MRIS *mris, int nsize) {
+static void MRISsetNeighborhoodSizeAndOptionallyDist(MRIS *mris, int nsize, bool alwaysDoDist) {
+  static int count, limit;
+  if (++count == limit) {
+    fprintf(stdout, "%s:%d MRISsetNeighborhoodSizeAndDist count:%d\n",__FILE__,__LINE__,count);
+  }
   mrisCheckVertexFaceTopology(mris);
-  MRISsetNeighborhoodSizeAndDistWkr(mris, nsize);
+  
+  MRISsetNeighborhoodSizeAndDistWkr(mris, nsize, alwaysDoDist);
+  
+  if (!(mris->dist_alloced_flags & 1))  { cheapAssert(mris->dist_nsize == 0);     }
+  else                                  { cheapAssert(mris->dist_nsize >= nsize); }
   mrisCheckVertexFaceTopology(mris);
 }
 
-static void MRISsetNeighborhoodSizeAndDistWkr(MRIS *mris, int nsize)
+void MRISsetNeighborhoodSize(MRIS *mris, int nsize) {
+    MRISsetNeighborhoodSizeAndOptionallyDist(mris, nsize, false);
+}
+
+void MRISsetNeighborhoodSizeAndDist(MRIS *mris, int nsize) {
+    MRISsetNeighborhoodSizeAndOptionallyDist(mris, nsize, true);
+}
+
+#if 1
+
+// THIS IS OLD CODE - THE NEW CODE BELOW SHOULD BE CHANGED TO AND DEBUGGED
+//
+static void MRISsetNeighborhoodSizeAndDistWkr(MRIS *mris, int nsize, bool alwaysDoDist)
 {
   cheapAssert(1 <= nsize && nsize < 4);
-  int vno, niter, ntotal, vtotal;
-
+  
   /*
     now build a list of 2-connected neighbors. After this is done,
     reallocate the v->n list and arrange the 2-connected neighbors
@@ -4402,255 +4633,214 @@ static void MRISsetNeighborhoodSizeAndDistWkr(MRIS *mris, int nsize)
 
   if (nsize <= mris->max_nsize) {
     ROMP_PF_begin
+    int vno;
+
 #ifdef HAVE_OPENMP
     #pragma omp parallel for if_ROMP(shown_reproducible)
 #endif
     for (vno = 0; vno < mris->nvertices; vno++) {
       ROMP_PFLB_begin
 
-      VERTEX_TOPOLOGY * const v = &mris->vertices_topology[vno];
-      
       // seen to fail!  cheapAssert(mris->vertices[vno].marked == 0);
-      
+
       if (mris->vertices[vno].ripflag) continue;
       if (vno == Gdiag_no) DiagBreak();
 
-      cheapAssert(nsize <= v->nsizeMax);
-      switch (nsize) {
-        case 1:
-          v->vtotal = v->vnum;
-          break;
-        case 2:
-          v->vtotal = v->v2num;
-          break;
-        case 3:
-          v->vtotal = v->v3num;
-          break;
-        default:
-          cheapAssert(false);
-      }
-      v->nsizeCur = nsize;
+      MRIS_setNsizeCur(mris,vno,nsize);
 
       ROMP_PFLB_end
     }
     ROMP_PF_end
 
     mris->nsize = nsize;
-    
-    MRIS_check_vertexNeighbours(mris);
-    return;
-  }
-  
-  MRISclearMarks(mris);     // added because of the seen-to-fail above
-  
-  // setting neighborhood size to a value larger than it has been in the past
-  mris->max_nsize = nsize;
-  for (niter = 0; niter < nsize - mris->nsize; niter++) {
-    // this can't be parallelized due to the marking of neighbors
-    for (vno = 0; vno < mris->nvertices; vno++) {
-      int i, n, neighbors, j, vnum, nb_vnum;
-      int vtmp[MAX_NEIGHBORS];
 
-      VERTEX_TOPOLOGY * const vt = &mris->vertices_topology[vno];    
-      VERTEX          * const v  = &mris->vertices         [vno];
-      if (vno == Gdiag_no) DiagBreak();
+  } else {
 
-      cheapAssert(v->marked == 0);
+    alwaysDoDist |= (mris->dist_alloced_flags & 1);
 
-      vnum = vt->vtotal;
-      if (v->ripflag || !vnum) continue;
+    MRISclearMarks(mris);     // added because of the seen-to-fail above
 
-      memmove(vtmp, vt->v, vnum * sizeof(int));
+    int niter;
+    for (niter = 0; niter < nsize - mris->nsize; niter++) {
+      // this can't be parallelized due to the marking of neighbors
+      int vno;
+      for (vno = 0; vno < mris->nvertices; vno++) {
+        int i, n, neighbors, j, vnum, nb_vnum;
+        int vtmp[MAX_NEIGHBORS];
 
-      /* mark 1-neighbors so we don't count them twice */
-      v->marked = 1;
-      for (i = 0; i < vnum; i++) mris->vertices[vt->v[i]].marked = 1;
+        VERTEX_TOPOLOGY * const vt = &mris->vertices_topology[vno];    
+        VERTEX          * const v  = &mris->vertices         [vno];
+        if (vno == Gdiag_no) DiagBreak();
 
-      /* count 2-neighbors */
-      for (neighbors = vnum, i = 0; neighbors < MAX_NEIGHBORS && i < vnum; i++) {
-        n = vt->v[i];
-        VERTEX_TOPOLOGY const * const vnbt = &mris->vertices_topology[n];
-        VERTEX                * const vnb  = &mris->vertices         [n];
-        vnb->marked = 1;
-        if (vnb->ripflag) continue;
+        cheapAssert(v->marked == 0);
 
-        nb_vnum = vnbt->vnum;
+        vnum = vt->vtotal;
+        if (v->ripflag || !vnum) continue;
 
-        for (j = 0; j < nb_vnum; j++) {
-          VERTEX * const vnb2 = &mris->vertices[vnbt->v[j]];
-          if (vnb2->ripflag || vnb2->marked) continue;
+        memmove(vtmp, vt->v, vnum * sizeof(int));
 
-          vtmp[neighbors] = vnbt->v[j];
-          vnb2->marked = 1;
-          if (++neighbors >= MAX_NEIGHBORS) {
-            fprintf(stderr, "vertex %d has too many neighbors!\n", vno);
+        /* mark 1-neighbors so we don't count them twice */
+        v->marked = 1;
+        for (i = 0; i < vnum; i++) mris->vertices[vt->v[i]].marked = 1;
+
+        /* count 2-neighbors */
+        for (neighbors = vnum, i = 0; neighbors < MAX_NEIGHBORS && i < vnum; i++) {
+          n = vt->v[i];
+          VERTEX_TOPOLOGY const * const vnbt = &mris->vertices_topology[n];
+          VERTEX                * const vnb  = &mris->vertices         [n];
+          vnb->marked = 1;
+          if (vnb->ripflag) continue;
+
+          nb_vnum = vnbt->vnum;
+
+          for (j = 0; j < nb_vnum; j++) {
+            VERTEX * const vnb2 = &mris->vertices[vnbt->v[j]];
+            if (vnb2->ripflag || vnb2->marked) continue;
+
+            vtmp[neighbors] = vnbt->v[j];
+            vnb2->marked = 1;
+            if (++neighbors >= MAX_NEIGHBORS) {
+              fprintf(stderr, "vertex %d has too many neighbors!\n", vno);
+              break;
+            }
+          }
+        }
+        /*
+          now reallocate the v->v structure and
+          place the 2-connected neighbors
+          suquentially after the 1-connected neighbors.
+        */
+        free(vt->v);
+        vt->v = (int *)calloc(neighbors, sizeof(int));
+        if (!vt->v)
+          ErrorExit(ERROR_NO_MEMORY,
+                    "MRISsetNeighborhoodSize: could not allocate list of %d "
+                    "nbrs at v=%d",
+                    neighbors,
+                    vno);
+
+        v->marked = 0;
+        for (n = 0; n < neighbors; n++) {
+          vt->v[n] = vtmp[n];
+          mris->vertices[vtmp[n]].marked = 0;
+        }
+
+        vt->nsizeMax++;
+        switch (vt->nsizeMax) {
+          case 2:
+            vt->v2num = neighbors;
             break;
+          case 3:
+            vt->v3num = neighbors;
+            break;
+          default: /* store old neighborhood size in v3num */
+            vt->v3num = vt->vtotal;
+            break;
+        }
+        vt->nsizeCur = vt->nsizeMax;
+        vt->vtotal = neighbors;
+        for (n = 0; n < neighbors; n++)
+          for (i = 0; i < neighbors; i++)
+            if (i != n && vt->v[i] == vt->v[n])
+              fprintf(stderr, "warning: vertex %d has duplicate neighbors %d and %d!\n", vno, i, n);
+        if ((vno == Gdiag_no) && (Gdiag & DIAG_SHOW) && DIAG_VERBOSE_ON) {
+          fprintf(stdout, "v %d: vnum=%d, v2num=%d, vtotal=%d\n", vno, vt->vnum, vt->v2num, vt->vtotal);
+          for (n = 0; n < neighbors; n++) {
+            fprintf(stdout, "v[%d] = %d\n", n, vt->v[n]);
           }
         }
       }
-      /*
-        now reallocate the v->v structure and
-        place the 2-connected neighbors
-        suquentially after the 1-connected neighbors.
-      */
-      free(vt->v);
-      vt->v = (int *)calloc(neighbors, sizeof(int));
-      if (!vt->v)
-        ErrorExit(ERROR_NO_MEMORY,
-                  "MRISsetNeighborhoodSize: could not allocate list of %d "
-                  "nbrs at v=%d",
-                  neighbors,
-                  vno);
-
-      v->marked = 0;
-      for (n = 0; n < neighbors; n++) {
-        vt->v[n] = vtmp[n];
-        mris->vertices[vtmp[n]].marked = 0;
-      }
-
-      if (v->dist)      free(v->dist);
-      if (v->dist_orig) free(v->dist_orig);
-
-      v->dist = (float *)calloc(neighbors, sizeof(float));
-      if (!v->dist)
-        ErrorExit(ERROR_NOMEMORY,
-                  "MRISsetNeighborhoodSize: could not allocate list of %d "
-                  "dists at v=%d",
-                  neighbors,
-                  vno);
-      v->dist_orig = (float *)calloc(neighbors, sizeof(float));
-      if (!v->dist_orig)
-        ErrorExit(ERROR_NOMEMORY,
-                  "MRISsetNeighborhoodSize: could not allocate list of %d "
-                  "dists at v=%d",
-                  neighbors,
-                  vno);
-      vt->nsizeMax++;
-      switch (vt->nsizeMax) {
-        case 2:
-          vt->v2num = neighbors;
-          break;
-        case 3:
-          vt->v3num = neighbors;
-          break;
-        default: /* store old neighborhood size in v3num */
-          vt->v3num = vt->vtotal;
-          break;
-      }
-      vt->nsizeCur = vt->nsizeMax;
-      vt->vtotal = neighbors;
-      for (n = 0; n < neighbors; n++)
-        for (i = 0; i < neighbors; i++)
-          if (i != n && vt->v[i] == vt->v[n])
-            fprintf(stderr, "warning: vertex %d has duplicate neighbors %d and %d!\n", vno, i, n);
-      if ((vno == Gdiag_no) && (Gdiag & DIAG_SHOW) && DIAG_VERBOSE_ON) {
-        fprintf(stdout, "v %d: vnum=%d, v2num=%d, vtotal=%d\n", vno, vt->vnum, vt->v2num, vt->vtotal);
-        for (n = 0; n < neighbors; n++) {
-          fprintf(stdout, "v[%d] = %d\n", n, vt->v[n]);
-        }
-      }
     }
+
+    mris->max_nsize = nsize;
   }
+  
   MRIS_check_vertexNeighbours(mris);
 
-#ifndef __APPLE__
-  // The parallel loop fails under mcheck with an arcane 
-  //        *** Error in `../mris_fix_topology': free(): invalid pointer: 0x0000000007bda5f0 ***
-  // errors.  I suspect mcheck has some threading issues.
-  //
-  // With this loop serial, no problems are detected either here or in the entire mris_fix_topology test
-  // and the only strange thing about this loop is it is intensely free/calloc intensive which is why
-  // I suspect a problem in mcheck rather than here.
-  //
-  // Freeing all the pointers before allocating any gives mcheck a chance to detect duplicate pointers.
-  // It does not find any problems - but when this loop is done in parallel, it complains - further reinforcing
-  // my belief this is a mcheck problem.
-  //
-  static bool allowParallelFreeingOfDist = true;
-  {
-    static long once;
-    if (!once++) {
-      allowParallelFreeingOfDist = (mprobe(malloc(1)) == MCHECK_DISABLED);
-      if (!allowParallelFreeingOfDist) 
-        fprintf(stderr, "%s:%d Disabling this parallel loop because mcheck in use\n",__FILE__,__LINE__);
-    }
-  }
-
-  if (!allowParallelFreeingOfDist) {
-    fprintf(stderr, "%s:%d Doing free's first because mcheck in use - detect duplicate pointers\n",__FILE__,__LINE__);
-    for (vno = 0; vno < mris->nvertices; vno++) {
-      VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];    
-      VERTEX                * const v  = &mris->vertices         [vno];
-      if (vt->vtotal > 0) {
-        if (v->dist)      { free(v->dist);        v->dist      = NULL; }
-        if (v->dist_orig) { free(v->dist_orig);   v->dist_orig = NULL; }
-      }
-    }
-    fprintf(stderr, "%s:%d Free's done, now do allocations\n",__FILE__,__LINE__);
-  }
-#endif
-
-  ntotal = vtotal = 0;
-  ROMP_PF_begin		// mris_fix_topology
-
-#ifdef HAVE_OPENMP
-#ifndef __APPLE__
-  #pragma omp parallel for if_ROMP2(allowParallelFreeingOfDist,shown_reproducible) reduction(+ : ntotal, vtotal)
-#else
-  #pragma omp parallel for if_ROMP(shown_reproducible) reduction(+ : ntotal, vtotal)
-#endif
-#endif
-
-  for (vno = 0; vno < mris->nvertices; vno++) {
-    ROMP_PFLB_begin
+  if (nsize <= mris->dist_nsize) return;
+  
+  int ntotal = 0, vtotal = 0;
+  
+  int vno;
+  for (vno = 0; vno < mris->nvertices; vno++) {    
     VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];    
     VERTEX                * const v  = &mris->vertices         [vno];
-    int vsize = mrisVertexVSize(mris, vno);
-    if (vsize > vt->vtotal) {
-        static int count;
-        if (count++ < 10) {
-            fprintf(stdout, "%s:%d vsize:%d > vt->vtotal:%d so wrong amount was copied. vt->nsizeCur:%d vt->nsizeMax:%d\n", __FILE__, __LINE__,
-                vsize, vt->vtotal, vt->nsizeCur, vt->nsizeMax);
-        }
-    }
     
-    if (vsize > 0) {
-      if (v->dist) free(v->dist);
-
-      if (v->dist_orig) free(v->dist_orig);
-
-      v->dist = (float *)calloc(vsize, sizeof(float));
-      if (!v->dist)
-        ErrorExit(ERROR_NOMEMORY,
-                  "MRISsetNeighborhoodSize: could not allocate list of %d "
-                  "dists at v=%d",
-                  vt->vtotal,
-                  vno);
-      v->dist_orig = (float *)calloc(vsize, sizeof(float));
-      if (!v->dist_orig)
-        ErrorExit(ERROR_NOMEMORY,
-                  "MRISsetNeighborhoodSize: could not allocate list of %d "
-                  "orig dists at v=%d",
-                  vt->vtotal,
-                  vno);
-    }
-
     if (v->ripflag) continue;
 
     vtotal += vt->vtotal;
     ntotal++;
-    ROMP_PFLB_end
   }
-  ROMP_PF_end
 
   mris->avg_nbrs = (float)vtotal / (float)ntotal;
   mris->nsize = nsize;
   if (Gdiag & DIAG_SHOW && mris->nsize > 1 && DIAG_VERBOSE_ON) fprintf(stdout, "avg_nbrs = %2.1f\n", mris->avg_nbrs);
 
+  if (alwaysDoDist) {
+    mrisComputeVertexDistances(mris);
+    mrisComputeOriginalVertexDistances(mris);
+  }
+}
+
+#else
+
+static void MRISsetNeighborhoodSizeAndDistWkr(MRIS *mris, int nsize, bool alwaysDoDist)
+{
+  Dont forget to implement alwaysDoDist
+  
+  cheapAssert(1 <= nsize && nsize < 4);
+
+  if (nsize <= mris->max_nsize) {
+    MRISresetNeighborhoodSize(mris, nsize);
+    return;
+  }
+  
+  // rebuild all the neighbor caches
+  //
+  int vno;
+  for (vno = 0; vno < mris->nvertices; vno++) {
+    int vlist[MAX_NEIGHBORS], hops[MAX_NEIGHBORS];
+    MRISfindNeighborsAtVertex(mris, vno, nsize, MAX_NEIGHBORS, vlist, hops);
+  }
+  MRISresetNeighborhoodSize(mris, nsize);
+
+  if (nsize <= mris->dist_nsize) return;
+
+  int ntotal = 0, vtotal = 0;
+  ROMP_PF_begin
+#ifdef HAVE_OPENMP
+  #pragma omp parallel for if_ROMP(shown_reproducible) reduction(+ : ntotal, vtotal)
+#endif
+  for (vno = 0; vno < mris->nvertices; vno++) {
+    ROMP_PFLB_begin
+
+    VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];    
+    VERTEX                * const v  = &mris->vertices         [vno];
+
+    int needed = mrisVertexVSize(mris, vno);
+    
+    v->dist      = (float*)realloc(v->dist,      needed*sizeof(float));
+    v->dist_orig = (float*)realloc(v->dist_orig, needed*sizeof(float));
+    
+    int i;
+    for (i = 0; i < needed; i++) v->dist[i] = v->dist_orig[i] = 0.0f;   // NaN would be a better init value 
+    
+    if (v->ripflag) continue;
+
+    vtotal += vt->vtotal;
+    ntotal++;
+
+    ROMP_PFLB_end
+  }
+  ROMP_PF_end
+
+  mris->avg_nbrs = (float)vtotal / (float)ntotal;
+  
   mrisComputeVertexDistances(mris);
   mrisComputeOriginalVertexDistances(mris);
 }
 
+#endif
 
 
 int MRISsampleFaceCoordsCanonical(
@@ -8076,193 +8266,6 @@ int MRIScountNegativeTriangles(MRIS *mris)
 }
 
 
-/*-----------------------------------------------------
-  Parameters:
-
-  Returns value:
-
-  Description
-  ------------------------------------------------------*/
-int mrisClearDistances(MRIS *mris)
-{
-  int vno, nvertices;
-  VERTEX *v;
-
-  nvertices = mris->nvertices;
-  for (vno = 0; vno < nvertices; vno++) {
-    v = &mris->vertices[vno];
-    if (v->ripflag) {
-      continue;
-    }
-    v->d = 0;
-  }
-  return (NO_ERROR);
-}
-
-
-/*-----------------------------------------------------------------
-  Calculate distances between each vertex and each of its neighbors.
-  ----------------------------------------------------------------*/
-int mrisComputeVertexDistances(MRIS *mris)
-{
-  int vno;
-
-  if (debugNonDeterminism) {
-    fprintf(stdout, "%s:%d stdout ",__FILE__,__LINE__);
-    mris_print_hash(stdout, mris, "mris ", "\n");
-  }
-
-  switch (mris->status) {
-    default: /* don't really know what to do in other cases */
-
-    case MRIS_PLANE:
-
-      ROMP_PF_begin		// mris_fix_topology
-#ifdef HAVE_OPENMP
-      #pragma omp parallel for if_ROMP(shown_reproducible)
-#endif
-      for (vno = 0; vno < mris->nvertices; vno++) {
-        ROMP_PFLB_begin
-    
-        if (vno == Gdiag_no) DiagBreak();
-
-        VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
-        VERTEX                * const v  = &mris->vertices         [vno];
-        if (v->ripflag || v->dist == NULL) continue;
-
-        int *pv;
-        int const vtotal = vt->vtotal;
-        int n;
-        for (pv = vt->v, n = 0; n < vtotal; n++) {
-          VERTEX const * const vn = &mris->vertices[*pv++];
-          // if (vn->ripflag) continue;
-          float xd = v->x - vn->x;
-          float yd = v->y - vn->y;
-          float zd = v->z - vn->z;
-          float d = xd * xd + yd * yd + zd * zd;
-          v->dist[n] = sqrt(d);
-        }
-
-        ROMP_PFLB_end
-      }
-      ROMP_PF_end
-  
-      break;
-
-    case MRIS_PARAMETERIZED_SPHERE:
-    case MRIS_SPHERE: {
-
-      ROMP_PF_begin		// mris_fix_topology
-#ifdef HAVE_OPENMP
-      #pragma omp parallel for if_ROMP(shown_reproducible)
-#endif
-      for (vno = 0; vno < mris->nvertices; vno++) {
-        ROMP_PFLB_begin
-    
-        if (vno == Gdiag_no) DiagBreak();
-
-        VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
-        VERTEX          const * const v  = &mris->vertices         [vno];
-        if (v->ripflag || v->dist == NULL) continue;
-
-        XYZ xyz1_normalized;
-        float xyz1_length;
-        XYZ_NORMALIZED_LOAD(&xyz1_normalized, &xyz1_length, v->x, v->y, v->z);  // length 1 along radius vector
-
-        float const radius = xyz1_length;
-
-        int *pv;
-        int const vtotal = vt->vtotal;
-        int n;
-        for (pv = vt->v, n = 0; n < vtotal; n++) {
-          VERTEX const * const vn = &mris->vertices[*pv++];
-          if (vn->ripflag) continue;
-          
-          float angle = fabs(XYZApproxAngle(&xyz1_normalized, vn->x, vn->y, vn->z));
-            // radians, so 2pi around the circumference
-
-          float d = angle * radius;
-            // the length of the arc, rather than the straight line distance
-
-          v->dist[n] = d;
-        }
-        ROMP_PFLB_end
-      }
-      ROMP_PF_end
-
-      break;
-    }
-  }
-    
-  return (NO_ERROR);
-}
-
-
-int mrisComputeOriginalVertexDistances(MRIS *mris)
-{
-  int vno, n, vtotal, *pv;
-  float d, xd, yd, zd, circumference = 0.0f, angle;
-  VECTOR *v1, *v2;
-
-  v1 = VectorAlloc(3, MATRIX_REAL);
-  v2 = VectorAlloc(3, MATRIX_REAL);
-
-  for (vno = 0; vno < mris->nvertices; vno++) {
-    VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
-    VERTEX          const * const v  = &mris->vertices         [vno];
-    if (v->ripflag || v->dist_orig == NULL) {
-      continue;
-    }
-    if (vno == Gdiag_no) {
-      DiagBreak();
-    }
-    vtotal = vt->vtotal;
-    switch (mris->status) {
-      default: /* don't really know what to do in other cases */
-      case MRIS_PLANE:
-        for (pv = vt->v, n = 0; n < vtotal; n++) {
-          VERTEX const * const vn = &mris->vertices[*pv++];
-          if (vn->ripflag) {
-            continue;
-          }
-          xd = v->origx - vn->origx;
-          yd = v->origy - vn->origy;
-          zd = v->origz - vn->origz;
-          d = xd * xd + yd * yd + zd * zd;
-          v->dist_orig[n] = sqrt(d);
-        }
-        DiagBreak();
-        break;
-      case MRIS_PARAMETERIZED_SPHERE:
-      case MRIS_SPHERE:
-        VECTOR_LOAD(v1, v->origx, v->origy, v->origz); /* radius vector */
-        if (FZERO(circumference))                      /* only calculate once */
-        {
-          circumference = M_PI * 2.0 * V3_LEN(v1);
-        }
-        for (pv = vt->v, n = 0; n < vtotal; n++) {
-          VERTEX const * const vn = &mris->vertices[*pv++];
-          if (vn->ripflag) {
-            continue;
-          }
-          VECTOR_LOAD(v2, vn->origx, vn->origy, vn->origz); /* radius vector */
-          angle = fabs(Vector3Angle(v1, v2));
-          d = circumference * angle / (2.0 * M_PI);
-          if (angle > M_PI || angle < -M_PI || d > circumference / 2 || angle < 0) {
-            DiagBreak();
-          }
-          v->dist_orig[n] = d;
-        }
-        break;
-    }
-  }
-
-  VectorFree(&v1);
-  VectorFree(&v2);
-  return (NO_ERROR);
-}
-
-
 //==================================================================================================================
 // More complicated properties
 //
@@ -8454,33 +8457,32 @@ int MRIScomputeAllDistances(MRIS *mris)
     // make huge v, dist, dist_orig    
     //
     int const old_vtotal = vt->vtotal;
-   if (v->dist_orig) free(v->dist_orig);
-
-    if (v->dist) {
-      free(v->dist);
-    }
-    int* old_v = vt->v;
-    v->dist_orig = (float *)calloc(nvalid - 1, sizeof(float));
-    v->dist = (float *)calloc(nvalid - 1, sizeof(float));
-    vt->v = (int *)calloc(nvalid - 1, sizeof(int));
-    if (!vt->v || !v->dist || !v->dist_orig)
+    vt->vtotal = nvalid - 1;                                        // set to something other then v->v#num
+    vt->v = (int *)realloc(vt->v, (nvalid - 1)*sizeof(int));
+    MRISmakeDist(mris, vno);
+    if (!vt->v || !v->dist || !v->dist_orig) {
       ErrorExit(ERROR_NOMEMORY, "MRIScomputeAllDistances: could not allocate %d-sized arrays", nvalid - 1);
-    memmove(vt->v, old_v, vt->vtotal * sizeof(vt->v[0]));
-    free(old_v);
+    }
+    
     MRISclearMarks(mris);
     v->marked = 1;  // don't add self to list
+    
     // keep the v[0..old_vtotal) so v#num stays right
     //
     int n;
     for (n = 0; n < old_vtotal; n++) {
       VERTEX * const vn = &mris->vertices[vt->v[n]];
-      v->dist[n] = v->dist_orig[n] = vn->val;  // v->dist will be restored by caller
+      v->dist[n] = v->dist_orig[n] = vn->val;                       // v->dist will be restored by caller
       vn->marked = 1;
     }
+    
     // fill in the rest
     // this trashes the values between vtotal and vnums[nsizeMax] which is bad
     // so note the loss
     //
+    mris->max_nsize = mris->nsize;
+    vt->nsizeMax = vt->nsizeCur;
+    
     int vno2;
     for (vno2 = 0; vno2 < mris->nvertices; vno2++) {
       VERTEX * const vn = &mris->vertices[vno2];
@@ -8489,8 +8491,9 @@ int MRIScomputeAllDistances(MRIS *mris)
       v->dist[n] = v->dist_orig[n] = vn->val;                   // set to a different definition of 'distance'
       vt->v[n++] = vno2;
       vn->marked = 1;
+      cheapAssert(n < nvalid);
     }
-    vt->vtotal = nvalid - 1;
+    
     if (vno == Gdiag_no) {
       char fname[STRLEN];
       sprintf(fname, "vno%d.mgz", vno);
@@ -15656,9 +15659,9 @@ MRIS* MRISclone(MRIS const * mris_src)
     vdstt->v2num    = vsrct->v2num;
     vdstt->v3num    = vsrct->v3num;
     vdstt->nsizeMax = vsrct->nsizeMax;
-    vdstt->nsizeCur = vsrct->nsizeCur;
-    vdstt->vtotal   = vsrct->vtotal;
     vdstt->nsizeMaxClock = vsrct->nsizeMaxClock;
+
+    MRIS_setNsizeCur(mris_dst,vno,vsrct->nsizeCur);
     
     {
       int vSize = mrisVertexVSize(mris_src, vno);
@@ -15671,10 +15674,8 @@ MRIS* MRISclone(MRIS const * mris_src)
         }
       }
 
-      vdst->dist      = (float *)calloc(vSize, sizeof(float));
-      vdst->dist_orig = (float *)calloc(vSize, sizeof(float));
-      if (!vdst->dist     ) ErrorExit(ERROR_NO_MEMORY, "MRISclone: could not allocate %d num", vSize);
-      if (!vdst->dist_orig) ErrorExit(ERROR_NO_MEMORY, "MRISclone: could not allocate %d num", vSize);
+      MRISmakeDist(mris_dst, vno);
+
       if (vsrc->dist)
         for (n = 0; n < vSize; n++) {
           vdst->dist[n] = vsrc->dist[n];

--- a/utils/mrisurf_metricProperties.c
+++ b/utils/mrisurf_metricProperties.c
@@ -1381,7 +1381,7 @@ int mrisComputeOriginalVertexDistances(MRIS *mris)
     }
   }
 
-  if (allOrigXZero) {
+  if (false && allOrigXZero) {
     static bool laterTime;
     if (!laterTime) { laterTime = true;
       fprintf(stdout, "%s:%d origx have not been set - probably a logic error\n",__FILE__,__LINE__);

--- a/utils/mrisurf_metricProperties.c
+++ b/utils/mrisurf_metricProperties.c
@@ -71,7 +71,8 @@ void MRISsetXYZwkr(MRIS *mris, int vno, float x, float y, float z, const char * 
   const float * pcx = &v->x;  float * px = (float*)pcx; *px = x;
   const float * pcy = &v->y;  float * py = (float*)pcy; *py = y;
   const float * pcz = &v->z;  float * pz = (float*)pcz; *pz = z;
-  
+ 
+#if 0 
   if (mris->dist_alloced_flags & 1) {
     if (!*laterTime) {
       *laterTime = true;
@@ -79,6 +80,7 @@ void MRISsetXYZwkr(MRIS *mris, int vno, float x, float y, float z, const char * 
     }
     // THIS WOULD CAUSE A DATA RACE ON VERTEX::dist etc.  MRISfreeDistsButNotOrig(mris);
   }
+#endif
 }
 
 

--- a/utils/mrisurf_metricProperties.h
+++ b/utils/mrisurf_metricProperties.h
@@ -29,9 +29,7 @@
 
 int mrisCheckSurface(MRIS *mris);
 
-void MRISgrowDist(MRIS *mris, int vno, int minimumCapacity);
 void MRISmakeDist(MRIS *mris, int vno);
-int MRISfreeDists(MRIS *mris) ;
 
 typedef struct PerThreadMRIDistance {
   MRI const * mri_distance;
@@ -106,10 +104,6 @@ void mrisurf_undeferSetFaceNorms(MRIS* mris);
 
 int mrisMarkIntersections(MRIS *mris);
 
-int mrisClearDistances(MRIS *mris);
-
-int MRIScomputeAllDistances(MRIS *mris);
-
 #define OUTSIDE_VERTEX 0
 #define INSIDE_VERTEX 1               /* not yet used */
 #define EDGE_VERTEX 2                 /* part of an edge */
@@ -120,15 +114,21 @@ int MRIScomputeAllDistances(MRIS *mris);
 
 void mrisDumpFace(MRIS *mris, int fno, FILE *fp);
 
-float mrisComputeArea(MRIS *mris, int fac, int n);
 
 int    mrisComputeSurfaceDimensions      (MRIS *mris);
+
+int    MRIScomputeAllDistances           (MRIS *mris);
 int    mrisComputeVertexDistances        (MRIS *mris);
 int    mrisComputeOriginalVertexDistances(MRIS *mris);
 void   MRIScomputeAvgInterVertexDist     (MRIS *Surf, double *StdDev);
 void   mrisSetAvgInterVertexDist         (MRIS *Surf, double to);
 int    mrisTrackTotalDistance            (MRIS *mris);
 int    mrisTrackTotalDistanceNew         (MRIS *mris);
+
+float  mrisComputeArea                   (MRIS *mris, int fac, int n);
+float  MRIScomputeOrigArea               (MRIS* mris);
+void   MRISsetOrigArea                   (MRIS* mris);
+
 
 int mrisComputeBoundaryNormals(MRIS *mris);
 

--- a/utils/mrisurf_mri.c
+++ b/utils/mrisurf_mri.c
@@ -100,7 +100,7 @@ int MRISpositionSurfaces(MRI_SURFACE *mris, MRI **mri_flash, int nvolumes, INTEG
   MRISstoreMetricProperties(mris);
 
   MRIScomputeNormals(mris);
-  mrisClearDistances(mris);
+  MRISclearD(mris);
 
   MRISrestoreVertexPositions(mris, ORIGINAL_VERTICES);
   MRIScomputeMetricProperties(mris);
@@ -454,7 +454,7 @@ int MRISpositionSurface(MRI_SURFACE *mris, MRI *mri_brain, MRI *mri_smooth, INTE
   MRISstoreMetricProperties(mris);
 
   MRIScomputeNormals(mris);
-  mrisClearDistances(mris);  // v->d=0 for unripped
+  MRISclearD(mris);  // v->d=0 for unripped
 
   MRISclearCurvature(mris); /* v->curv=0 for unripped, curvature will be used to calculate sulc */
 
@@ -845,7 +845,7 @@ int MRISpositionSurface_mef(
   MRISstoreMetricProperties(mris);
 
   MRIScomputeNormals(mris);
-  mrisClearDistances(mris);
+  MRISclearD(mris);
 
   MRISclearCurvature(mris); /* curvature will be used to calculate sulc */
 

--- a/utils/mrisurf_obsolete.c
+++ b/utils/mrisurf_obsolete.c
@@ -176,7 +176,7 @@ static int mrisComputeVectorCorrelationTerm(MRI_SURFACE *mris, INTEGRATION_PARMS
 static int mrisComputePolarVectorCorrelationTerm(MRI_SURFACE *mris, INTEGRATION_PARMS *parms);
 static int mrisComputeAngleAreaTerms(MRI_SURFACE *mris, INTEGRATION_PARMS *parms);
 static int mrisComputeNonlinearAreaTerm(MRI_SURFACE *mris, INTEGRATION_PARMS *parms);
-static int mrisClearDistances(MRI_SURFACE *mris);
+static int MRISclearD(MRI_SURFACE *mris);
 static int mrisClearExtraGradient(MRI_SURFACE *mris);
 static int mrisClearMomentum(MRI_SURFACE *mris);
 static int mrisValidFaces(MRI_SURFACE *mris);

--- a/utils/mrisurf_topology.c
+++ b/utils/mrisurf_topology.c
@@ -118,7 +118,35 @@ bool mrisCheckVertexVertexTopologyWkr(const char* file, int line, MRIS const *mr
   
   int vno1;
   for (vno1 = 0; vno1 < mris->nvertices; vno1++) {
-    VERTEX_TOPOLOGY const * const v = &mris->vertices_topology[vno1];
+    VERTEX_TOPOLOGY const * const v         = &mris->vertices_topology[vno1];
+    VERTEX          const * const v_nontopo = &mris->vertices         [vno1];
+
+#if 0
+    // HACK TO HELP FIND A SPECIFIC BUG
+    //
+    if (vno1 == 0) {
+      typedef struct Debugging { bool dist_orig_is_0; } Debugging;        
+      if (!v_nontopo->debugging) {
+        mris->vertices[vno1].debugging = calloc(1,sizeof(Debugging));
+      }
+      Debugging* debugging = (Debugging*)(v_nontopo->debugging);
+      bool dist_orig_is_0 = !v_nontopo->dist_orig || !v_nontopo->dist_orig[0];
+      if (debugging->dist_orig_is_0 != dist_orig_is_0) {
+        fprintf(stdout,"%s:%d dist_orig_is_0:%d\n",file,line,dist_orig_is_0);
+        debugging->dist_orig_is_0 = dist_orig_is_0;
+      }
+    }
+#endif
+    
+    if ( (v_nontopo->dist      && !(mris->dist_alloced_flags&1))
+      || (v_nontopo->dist_orig && !(mris->dist_alloced_flags&2))) {
+      if (true
+      && !(reported & Reported_da)) { reported |= Reported_da;
+        if (shouldReport(file,line,reported))
+          fprintf(stdout, "dist or dist_orig non-null when !mris->dist_alloced\n");
+        DiagBreak();
+      } 
+    }
 
     if (mris->vertices[vno1].ripflag) continue;
       
@@ -186,6 +214,20 @@ bool mrisCheckVertexVertexTopologyWkr(const char* file, int line, MRIS const *mr
     }
   }
   
+  static int laterTime, checkDist;
+  if (!laterTime) { 
+    laterTime++; 
+    checkDist = !!getenv("FREESURFER_checkDist"); 
+    if (checkDist) fprintf(stdout, "%s:%d checking dist[] contents\n", __FILE__, __LINE__);
+  }
+  if (checkDist) {
+    extern bool mrisCheckDist(MRIS const * mris);               // gross hack for now
+    if (!mrisCheckDist(mris) &&
+      !(reported & Reported_dd)) { reported |= Reported_dd;
+        fprintf(stdout, "Bad dist\n");
+    }
+  }
+
   return reported == 0;
 }
 
@@ -284,13 +326,14 @@ void mrisAddEdge(MRIS *mris, int vno1, int vno2)
   mrisAddEdgeWkr(mris, vno1, vno2);
 }
 
+
 void mrisRemoveEdge(MRIS *mris, int vno1, int vno2)
 {
   // BUG doesn't adjust v2num etc.
   
-  int i;
   VERTEX_TOPOLOGY * const v1 = &mris->vertices_topology[vno1];
 
+  int i;
   for (i = 0; i < v1->vnum; i++)
     if (v1->v[i] == vno2) {
       v1->vnum--;
@@ -605,63 +648,51 @@ int mrisStoreVtotalInV3num(MRIS *mris)
   return (NO_ERROR);
 }
 
-static void resizeVertexD(VERTEX_TOPOLOGY const * const vt, VERTEX* const v, int newSize, int oldSize) {
+
+static void resizeVertexV(MRIS* mris, int vno, int newSize, int oldSize) {
+
+  VERTEX_TOPOLOGY * const vt = &mris->vertices_topology[vno]; 
+  VERTEX          * const v  = &mris->vertices         [vno];
 
   // allocating zero is a free: keep the pointers around to optimize growing them again
   //           non-zero:        change to the new size
   
   if (newSize > 0) {
-    int const floatSize = newSize*sizeof(float);
-    v->dist      = (float *)realloc(v->dist,      floatSize);
-    v->dist_orig = (float *)realloc(v->dist_orig, floatSize);
-    if (!v->dist || !v->dist_orig) {
-      ErrorExit(ERROR_NO_MEMORY, "mrisVertexReplacingNeighbors: could not allocate dist %d num", newSize);
-    }
+    int const intSize = newSize*sizeof(int);
+    vt->v = (int*)realloc(vt->v, intSize);
   }
       
   // Zero the added storage, if any
   //
   if (oldSize < newSize) {
-    int const floatSizeChange = (newSize - oldSize)*sizeof(float);
-    bzero(v->dist      + oldSize, floatSizeChange); 
-    bzero(v->dist_orig + oldSize, floatSizeChange);
+    int const intSizeChange = (newSize - oldSize)*sizeof(int);
+    bzero(vt->v + oldSize, intSizeChange);
   }
-}
-
-static void resizeVertexVandD(VERTEX_TOPOLOGY* const vt, VERTEX* const v, int newSize, int oldSize) {
-
-  // allocating zero is a free: keep the pointers around to optimize growing them again
-  //           non-zero:        change to the new size
   
-  if (newSize > 0) {
-    int const intSize   = newSize*sizeof(int);
-    vt->v        = (int   *)realloc(vt->v,        intSize);
-  }
-      
-  // Zero the added storage, if any
+  // Follow the tradition of keep ::dist at least as big as ::v
+  // but don't make it if not already made
   //
-  if (oldSize < newSize) {
-    int const intSizeChange   = (newSize - oldSize)*sizeof(int);
-    bzero(vt->v        + oldSize,   intSizeChange);
-  }
-  
-  resizeVertexD(vt, v, newSize, oldSize);
+  if (v->dist) MRISgrowDist(mris, vno, newSize);
 }
 
 
 void mrisVertexReplacingNeighbors(MRIS * const mris, int const vno, int const vnum)
 {
   VERTEX_TOPOLOGY * const vt = &mris->vertices_topology[vno];
-  VERTEX          * const v  = &mris->vertices         [vno];
 
-  resizeVertexVandD(vt,v, vnum, vt->vnum);
+  mris->max_nsize = vt->nsizeMax = vt->nsizeCur = 1; 
+  if (mris->nsize != 1) mris->nsize = -1;               // vertices are now inconsistent
+  MRISfreeDistsButNotOrig(mris);                        // distances are wrong
+  
+  int const old_vt_vnum = vt->vnum;
+
+  resizeVertexV(mris,vno, vnum, old_vt_vnum);
 
   vt->vnum  = vnum; 
   vt->v2num = 0;
   vt->v3num = 0;
   
-  vt->nsizeCur = vt->nsizeMax = 1; 
-  vt->vtotal   = vt->vnum;
+  vt->vtotal = vt->vnum;
 }
 
 
@@ -670,6 +701,7 @@ void mrisForgetNeighborhoods(MRIS * const mris) {
   for (vno = 0; vno < mris->nvertices; vno++) {
     mrisVertexReplacingNeighbors(mris, vno, mris->vertices_topology[vno].vnum);
   }
+  mris->nsize = 1;                                     // vertices are now consistent again
 }
 
 
@@ -735,30 +767,15 @@ int MRISresetNeighborhoodSize(MRI_SURFACE *mris, int nsize)
     }
     switch (nsize) {
       default: /* reset back to original */
-        switch (vt->nsizeMax) {
-          default:
-          case 1:
-            vt->vtotal = vt->vnum;
-            break;
-          case 2:
-            vt->vtotal = vt->v2num;
-            break;
-          case 3:
-            vt->vtotal = vt->v3num;
-            break;
-        }
+        cheapAssert(vt->nsizeMax > 0);
+        MRIS_setNsizeCur(mris, vno, vt->nsizeMax);
         if (new_mris_nsize < 0) new_mris_nsize = vt->nsizeMax;
         else                    cheapAssert(new_mris_nsize == vt->nsizeMax);
-        vt->nsizeCur = vt->nsizeMax;
         break;
       case 1:
-        vt->vtotal = vt->vnum;  cheapAssert(nsize <= vt->nsizeMax); vt->nsizeCur = nsize;
-        break;
       case 2:
-        vt->vtotal = vt->v2num; cheapAssert(nsize <= vt->nsizeMax); vt->nsizeCur = nsize;
-        break;
       case 3:
-        vt->vtotal = vt->v3num; cheapAssert(nsize <= vt->nsizeMax); vt->nsizeCur = nsize;
+        MRIS_setNsizeCur(mris, vno, nsize);
         break;
     }
   }
@@ -1025,6 +1042,7 @@ static int MRISfindNeighborsAtVertex_new(MRIS *mris, int vno, int nlinks, size_t
       if (vt->nsizeMax >= 3) vnums[nsize++] = vt->v3num;
     }
   }
+  // vnums[nsize-1] is valid, vnums[nsize] is not
   
   // The center is assumed to be in the set, so it is not added again
   //
@@ -1055,7 +1073,7 @@ static int MRISfindNeighborsAtVertex_new(MRIS *mris, int vno, int nlinks, size_t
       // TODO cope with added edges
       
       if (vCandidate->ripflag) { 
-        nsize = ringLinks-1;    // cause this ring to get rewritten and no further rings to be used
+        nsize = ringLinks;      // cause this ring to get rewritten and no further rings to be used
         continue;               // other vCandidates in this ring are still okay
       }
       
@@ -1107,25 +1125,34 @@ static int MRISfindNeighborsAtVertex_new(MRIS *mris, int vno, int nlinks, size_t
     vnums[ringLinks] = neighborCount;
   }
 
+  // Make nsize the highest current valid vt->nsizeCur
+  //
+  // nsize is the number of valid rings, which is 1 more than the last valid index
+  // it might be 1 when there is a ripped immediate neighbour
+  //
+  cheapAssert(nsize > 0);
+  nsize -= 1;
+    
   // Update the cache
   //
   if (!noCache) {
-    int const newPossibleNsizeMax = MIN(3, ringLinks-1);
-    if (nsize-1 < newPossibleNsizeMax) {
-      cheapAssert(nsize > 0);
 
-      int oldSize = vnums[nsize-1];
+    int const newPossibleNsizeMax = MIN(3, ringLinks-1);
+    if (nsize < newPossibleNsizeMax) {
+
+      int oldSize = vnums[nsize];
       int newSize = vnums[newPossibleNsizeMax];    
-      resizeVertexVandD(vt,v, newSize, oldSize);
+      resizeVertexV(mris,vno, newSize, oldSize);
 
       int i;
       for (i = oldSize; i < newSize; i++) vt->v[i] = vlist[i];
 
       int cachedRing;
-      for (cachedRing = nsize; cachedRing <= newPossibleNsizeMax; cachedRing++) {
+      for (cachedRing = nsize+1; cachedRing <= newPossibleNsizeMax; cachedRing++) {
         switch (cachedRing) {
-        case 2: vt->v2num = vnums[cachedRing]; break;
-        case 3: vt->v3num = vnums[cachedRing]; break;
+        case 1: vt->vnum  = vnums[cachedRing];          break;   // happens when encounters ripped vertexs
+        case 2: vt->v2num = vnums[cachedRing];          break;
+        case 3: vt->v3num = vnums[cachedRing];          break;
         default: cheapAssert(false);
         }
         vt->nsizeMax = newPossibleNsizeMax; vt->nsizeMaxClock = mris->nsizeMaxClock; 
@@ -1321,27 +1348,6 @@ static int mrisInitializeNeighborhood(MRI_SURFACE *mris, int vno)
     vt->v[n] = vtmp[n];
     mris->vertices[vtmp[n]].marked = 0;
   }
-  if (v->dist) {
-    free(v->dist);
-  }
-  if (v->dist_orig) {
-    free(v->dist_orig);
-  }
-
-  v->dist = (float *)calloc(neighbors, sizeof(float));
-  if (!v->dist)
-    ErrorExit(ERROR_NOMEMORY,
-              "MRISsetNeighborhoodSize: could not allocate list of %d "
-              "dists at v=%d",
-              neighbors,
-              vno);
-  v->dist_orig = (float *)calloc(neighbors, sizeof(float));
-  if (!v->dist_orig)
-    ErrorExit(ERROR_NOMEMORY,
-              "MRISsetNeighborhoodSize: could not allocate list of %d "
-              "dists at v=%d",
-              neighbors,
-              vno);
 
   for (n = 0; n < neighbors; n++)
     for (i = 0; i < neighbors; i++)
@@ -1383,6 +1389,9 @@ bool mrisCheckVertexFaceTopologyWkr(const char* file, int line, MRIS const * mri
     int n;
     for (n = 0; n < VERTICES_PER_FACE; n++) {
       int const vno = f->v[n];
+      if (f->ripflag) continue;
+      if ((f->v[0]|f->v[1]|f->v[2]) == 0) continue; // HACK this is what an unattached face looks like
+      
       VERTEX_TOPOLOGY const * const v = &mris->vertices_topology[vno];
 
       int i = -1;
@@ -2229,14 +2238,8 @@ static void mrisCompleteTopology_new(MRI_SURFACE *mris)
   }
   setFaceAttachmentDeferred(mris,false);
 
-  int vno;
-  for (vno = 0; vno < mris->nvertices; vno++) {
-    VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];    
-    VERTEX                * const v  = &mris->vertices         [vno];
-    if (!v->dist) resizeVertexD(vt, v, mrisVertexVSize(mris,vno), 0);
-  }
-  
   int ntotal = 0, vtotal = 0;
+  int vno;
   for (vno = 0; vno < mris->nvertices; vno++) {
     VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];    
     VERTEX          const * const v  = &mris->vertices         [vno];
@@ -2266,7 +2269,6 @@ static void mrisCompleteTopology_old(MRI_SURFACE *mris) // was mrisFindNeighbors
       DiagBreak();
     }
     VERTEX_TOPOLOGY * const vt = &mris->vertices_topology[k];    
-    VERTEX          * const v  = &mris->vertices         [k];
     vt->vnum = 0;
     for (m = 0; m < vt->num; m++) {
       n = vt->n[m];               /* # of this vertex in the mth face that it is in */
@@ -2299,27 +2301,6 @@ static void mrisCompleteTopology_old(MRI_SURFACE *mris) // was mrisFindNeighbors
       vt->v[i] = vtmp[i];
     }
 
-    if (v->dist) {
-      free(v->dist);
-    }
-    if (v->dist_orig) {
-      free(v->dist_orig);
-    }
-
-    v->dist = (float *)calloc(vt->vnum, sizeof(float));
-    if (!v->dist)
-      ErrorExit(ERROR_NOMEMORY,
-                "mrisFindNeighbors: could not allocate list of %d "
-                "dists at v=%d",
-                vt->vnum,
-                k);
-    v->dist_orig = (float *)calloc(vt->vnum, sizeof(float));
-    if (!v->dist_orig)
-      ErrorExit(ERROR_NOMEMORY,
-                "mrisFindNeighbors: could not allocate list of %d "
-                "dists at v=%d",
-                vt->vnum,
-                k);
     /*
       if (vt->num != vt->vnum)
       printf("%d: num=%d vnum=%d\n",k,vt->num,vt->vnum);
@@ -2363,39 +2344,16 @@ static void mrisCompleteTopology_old(MRI_SURFACE *mris) // was mrisFindNeighbors
 
 
 
-/*-----------------------------------------------------
-  remove this face, as well as any links that only exist through this face.
-  ------------------------------------------------------*/
-int mrisRemoveFace(MRIS *mris, int fno)
-{
-  int vno1, vno2, vno;
-  FACE *face;
-
-  face = &mris->faces[fno];
-  face->ripflag = 1;
-  for (vno = 0; vno < VERTICES_PER_FACE; vno++) {
-    vno1 = face->v[vno];
-    vno2 = face->v[vno < VERTICES_PER_FACE - 1 ? vno + 1 : 0];
-    if (!mrisCountValidLinks(mris, vno1, vno2)) {
-      mrisRemoveEdge(mris, vno1, vno2);
-      mrisRemoveEdge(mris, vno2, vno1);
-    }
-  }
-
-  return (NO_ERROR);
-}
-
-
-int MRISripFaces(MRIS *mris)
+void MRISsetRipInFacesWithRippedVertices(MRIS *mris)
 {
   int n, k;
-  face_type *f;
 
   for (k = 0; k < mris->nfaces; k++) {
     mris->faces[k].ripflag = FALSE;
   }
+  
   for (k = 0; k < mris->nfaces; k++) {
-    f = &mris->faces[k];
+    face_type *f = &mris->faces[k];
     for (n = 0; n < VERTICES_PER_FACE; n++)
       if (mris->vertices[f->v[n]].ripflag) {
         f->ripflag = TRUE;
@@ -2405,13 +2363,35 @@ int MRISripFaces(MRIS *mris)
   for (k = 0; k < mris->nvertices; k++) {
     mris->vertices[k].border = FALSE;
   }
+  
   for (k = 0; k < mris->nfaces; k++)
     if (mris->faces[k].ripflag) {
-      f = &mris->faces[k];
+      face_type *f = &mris->faces[k];
       for (n = 0; n < VERTICES_PER_FACE; n++) {
         mris->vertices[f->v[n]].border = TRUE;
       }
     }
+}
+
+
+/*-----------------------------------------------------
+  remove this face, as well as any links that only exist through this face.
+  ------------------------------------------------------*/
+int mrisRemoveFace(MRIS *mris, int fno)
+{
+  FACE* face = &mris->faces[fno];
+  face->ripflag = 1;
+  
+  int vno;
+  for (vno = 0; vno < VERTICES_PER_FACE; vno++) {
+    int vno1 = face->v[vno];
+    int vno2 = face->v[vno < VERTICES_PER_FACE - 1 ? vno + 1 : 0];
+    if (!mrisCountValidLinks(mris, vno1, vno2)) {
+      mrisRemoveEdge(mris, vno1, vno2);
+      mrisRemoveEdge(mris, vno2, vno1);
+    }
+  }
+
   return (NO_ERROR);
 }
 
@@ -2425,7 +2405,7 @@ int MRISripFaces(MRIS *mris)
   Remove ripped vertices and faces from the v->v and the
   v->f arrays respectively.
   ------------------------------------------------------*/
-int MRISremoveRippedFaces(MRI_SURFACE *mris)
+static void removeRippedFaces(MRI_SURFACE *mris)
 {
   int    vno, n, fno, *out_faces, out_fno, nfaces;
   FACE   *face;
@@ -2477,29 +2457,9 @@ int MRISremoveRippedFaces(MRI_SURFACE *mris)
   MRISremovedFaces(mris, nfaces);
 
   free(out_faces) ;
-
-  /* now recompute total original area for scaling */
-  mris->orig_area = 0.0f;
-  for (fno = 0; fno < mris->nfaces; fno++) {
-    face = &mris->faces[fno];
-    if (face->ripflag) {
-      continue;
-    }
-    FaceNormCacheEntry const * const fNorm = getFaceNorm(mris, fno);
-    mris->orig_area += fNorm->orig_area;
-  }
-  return (NO_ERROR);
 }
-/*-----------------------------------------------------
-  Parameters:
 
-  Returns value:
-
-  Description
-  Remove ripped vertices and faces from the v->v and the
-  v->f arrays respectively.
-  ------------------------------------------------------*/
-int MRISremoveRippedVertices(MRI_SURFACE *mris)
+static void removeRippedVertices(MRI_SURFACE *mris)
 {
   int    vno, n, fno, *out_vnos, out_vno, nvertices;
   FACE   *face;
@@ -2573,295 +2533,236 @@ int MRISremoveRippedVertices(MRI_SURFACE *mris)
   MRISremovedVertices(mris, nvertices);
 
   free(out_vnos) ;
+}
 
+
+void MRISrenumberRemovingRippedFacesAndVertices(MRIS* mris) {
+
+  cheapAssert(!mris->dist_alloced_flags);
+  
   mrisCheckVertexFaceTopology(mris);
 
+  removeRippedFaces(mris);
+  removeRippedVertices(mris);
 
-  /* now recompute total original area for scaling */
-  mris->orig_area = 0.0f;
-  for (fno = 0; fno < mris->nfaces; fno++) {
-    face = &mris->faces[fno];
-    if (face->ripflag) {
-      continue;
-    }
-    FaceNormCacheEntry const * const fNorm = getFaceNorm(mris, fno);
-    mris->orig_area += fNorm->orig_area;
-  }
-  
-  return (NO_ERROR);
+  mrisCheckVertexFaceTopology(mris);
 }
+
+
 /*-----------------------------------------------------
-  Parameters:
-
-  Returns value:
-
-  Description
-  Remove ripped vertices and faces from the v->v and the
-  v->f arrays respectively.
+  Remove ripped vertices and faces from the 
+  v->v and the v->f arrays
   ------------------------------------------------------*/
-int MRISremoveRipped(MRI_SURFACE *mris)
+void MRISremoveRipped(MRIS *mris)
 {
-  int vno, n, fno, nripped, remove, vno2;
-  FACE *face;
-
-  if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON) {
-    fprintf(stdout, "removing ripped vertices and faces...\n");
-  }
-  do {
-    nripped = 0;
-    // go through all vertices
+  float* distCache          = (float*)calloc(mris->nvertices,sizeof(float));
+  float* distOrigCache      = (float*)calloc(mris->nvertices,sizeof(float));
+  int* affectedVnosPlus2    = (int  *)calloc(mris->nvertices,sizeof(int));
+    // 0 means unused
+    // 1 means end of list
+    // 2 or more is an entry in the list other than at the end
+    
+  int  headAffectedVnosPlus2  = 1;
+  int  affectedSize           = 0;
+  
+  int  largestNsizeMax = 0;
+  
+  // For the non-ripped vno
+  //    Calculate the largest known neighbourhood   (used later)
+  // For all ripped vno
+  //    Rip all the faces they are attached to, adding to those already marked
+  //    Add to the affected neighbours list
+  //
+  {
+    int vno;
     for (vno = 0; vno < mris->nvertices; vno++) {
-      VERTEX_TOPOLOGY * const vt = &mris->vertices_topology[vno];
-      VERTEX          * const v  = &mris->vertices         [vno];
-      if (vno == Gdiag_no)
-	DiagBreak() ;
-      // if rip flag set
-      if (v->ripflag) {
-// remove it
-#if 0
-        if (v->dist)
-        {
-          free(v->dist) ;
-        }
-        if (v->dist_orig)
-        {
-          free(v->dist_orig) ;
-        }
-        v->dist = v->dist_orig = NULL ;
-#endif
+      VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
+      VERTEX          const * const v  = &mris->vertices         [vno];
+
+      if (!v->ripflag) {
+        if (largestNsizeMax < vt->nsizeMax) largestNsizeMax = vt->nsizeMax;
         continue;
       }
 
-      for (n = 0; n < vt->vnum; n++) {
-        /* remove this vertex from neighbor list if it is ripped */
-        if (mris->vertices[vt->v[n]].ripflag) {
-          if (n < vt->vtotal - 1) /* not the last one in the list */
-          {
-            memmove(vt->v + n,        vt->v + n + 1,        (vt->vtotal - n - 1) * sizeof(int));
-            memmove(v->dist + n,      v->dist + n + 1,      (vt->vtotal - n - 1) * sizeof(float));
-            memmove(v->dist_orig + n, v->dist_orig + n + 1, (vt->vtotal - n - 1) * sizeof(float));
-          }
-          if (n < vt->vnum) /* it was a 1-neighbor */
-          {
-            vt->vnum--;
-          }
-          if (n < vt->v2num) /* it was a 2-neighbor */
-          {
-            vt->v2num--;
-          }
-          if (n < vt->v3num) /* it was a 3-neighbor */
-          {
-            vt->v3num--;
-          }
-          if ((n < vt->vnum) || ((n < vt->v2num) && mris->nsize >= 2) || (mris->nsize >= 3 && (n < vt->v3num))) {
-            vt->vtotal--;
-          }
-          n--;
-        }
+      cheapAssert(vt->vtotal == VERTEXvnum(vt, vt->nsizeCur));
+          // since this is what the following code will set to later
+
+      int n;
+      for (n = 0; n < vt->num; n++) {
+        int const fno = vt->f[n];
+        FACE * const face = &mris->faces[fno];
+        face->ripflag = 1;
       }
 
-      // make sure every nbr is a member of at least one unripped face
-      for (n = 0; n < vt->vnum; n++) {
-        int members, m;
-
-        vno2 = vt->v[n];
-        if (mris->vertices[vt->v[n]].ripflag) {
-          continue;
-        }
-
-        remove = 1;
-        for (fno = 0; fno < vt->num; fno++) {
-          face = &mris->faces[vt->f[fno]];
-          if (face->ripflag == 1)  // only consider unripped
-          {
-            continue;
-          }
-          for (members = m = 0; m < VERTICES_PER_FACE; m++)
-            if (face->v[m] == vno || face->v[m] == vno2) {
-              members++;
-            }
-          if (members >= 2) {
-            remove = 0;
-            break;
-          }
-        }
-
-        if (remove) {
-          if (n < vt->vtotal - 1) /* not the last one in the list */
-          {
-            memmove(vt->v + n,        vt->v + n + 1,        (vt->vtotal - n - 1) * sizeof(int));
-            memmove(v->dist + n,      v->dist + n + 1,      (vt->vtotal - n - 1) * sizeof(float));
-            memmove(v->dist_orig + n, v->dist_orig + n + 1, (vt->vtotal - n - 1) * sizeof(float));
-          }
-          if (n < vt->vnum) /* it was a 1-neighbor */
-          {
-            vt->vnum--;
-          }
-          if (n < vt->v2num) /* it was a 2-neighbor */
-          {
-            vt->v2num--;
-          }
-          if (n < vt->v3num) /* it was a 3-neighbor */
-          {
-            vt->v3num--;
-          }
-          if ((n < vt->vnum) || ((n < vt->v2num) && mris->nsize >= 2) || (mris->nsize >= 3 && (n < vt->v3num))) {
-            vt->vtotal--;
-          }
-          n--;
-        }
-      }
-
-      // go through 2-nbr list and make sure each one is a nbr of a 1-nbr
-      for (n = vt->vnum; n < vt->v2num; n++) {
-        int n2, n3;
-
-        remove = 1;
-
-        vno2 = vt->v[n];
-        VERTEX_TOPOLOGY const * const vn = &mris->vertices_topology[vno2];
-        for (n2 = 0; n2 < vn->vnum; n2++)  // 1-nbrs of the central node
-        {
-          VERTEX_TOPOLOGY const * const vn2 = &mris->vertices_topology[vn->v[n2]];
-          for (n3 = 0; remove && n3 < vn2->vnum; n3++)  // 1 nbrs of nbr
-            if (vn2->v[n3] == vno2) {
-              remove = 0;  // they still share a 1-nbr, keep it
-              break;
-            }
-        }
-        if (remove) {
-          nripped++;
-          if (n < vt->vtotal - 1) /* not the last one in the list */
-          {
-            memmove(vt->v + n,        vt->v + n + 1,        (vt->vtotal - n - 1) * sizeof(int));
-            memmove(v->dist + n,      v->dist + n + 1,      (vt->vtotal - n - 1) * sizeof(float));
-            memmove(v->dist_orig + n, v->dist_orig + n + 1, (vt->vtotal - n - 1) * sizeof(float));
-          }
-          if (n < vt->vnum) /* it was a 1-neighbor */
-          {
-            vt->vnum--;
-          }
-          if (n < vt->v2num) /* it was a 2-neighbor */
-          {
-            vt->v2num--;
-          }
-          if (n < vt->v3num) /* it was a 3-neighbor */
-          {
-            vt->v3num--;
-          }
-          if ((n < vt->vnum) || ((n < vt->v2num) && mris->nsize >= 2) || (mris->nsize >= 3 && (n < vt->v3num))) {
-            vt->vtotal--;
-          }
-          n--;
-        }
-      }
-
-      // go through 3-nbr list and make sure each one is a nbr of a 2-nbr
-      for (n = vt->v2num; n < vt->v3num; n++) {
-        int n2, n3;
-
-        remove = 1;
-
-        vno2 = vt->v[n];
-        VERTEX_TOPOLOGY const * const vn = &mris->vertices_topology[vno2];
-        for (n2 = vn->vnum; n2 < vn->v2num; n2++)  // 2-nbrs of the central node
-        {
-          VERTEX_TOPOLOGY const * const vn2 = &mris->vertices_topology[vn->v[n2]];
-          for (n3 = 0; remove && n3 < vn2->vnum; n3++)  // 1 nbrs of nbr
-            if (vn2->v[n3] == vno2) {
-              remove = 0;  // they still share a 1- or 2-nbr, keep it
-              break;
-            }
-        }
-        if (remove) {
-          if (n < vt->vtotal - 1) /* not the last one in the list */
-          {
-            memmove(vt->v + n,        vt->v + n + 1,        (vt->vtotal - n - 1) * sizeof(int));
-            memmove(v->dist + n,      v->dist + n + 1,      (vt->vtotal - n - 1) * sizeof(float));
-            memmove(v->dist_orig + n, v->dist_orig + n + 1, (vt->vtotal - n - 1) * sizeof(float));
-          }
-          if (n < vt->vnum) /* it was a 1-neighbor */
-          {
-            vt->vnum--;
-          }
-          if (n < vt->v2num) /* it was a 2-neighbor */
-          {
-            vt->v2num--;
-          }
-          if (n < vt->v3num) /* it was a 3-neighbor */
-          {
-            vt->v3num--;
-          }
-          if ((n < vt->vnum) || ((n < vt->v2num) && mris->nsize >= 2) || (mris->nsize >= 3 && (n < vt->v3num))) {
-            vt->vtotal--;
-          }
-          n--;
-        }
-      }
-
-      for (fno = 0; fno < vt->num; fno++) {
-        /* remove this face from face list if it is ripped */
-        if (mris->faces[vt->f[fno]].ripflag) {
-          if (fno < vt->num - 1) /* not the last one in the list */
-          {
-            memmove(vt->f + fno, vt->f + fno + 1, (vt->num - fno - 1) * sizeof(int));
-            memmove(vt->n + fno, vt->n + fno + 1, (vt->num - fno - 1) * sizeof(uchar));
-          }
-          vt->num--;
-          fno--;
-        }
-      }
-#if 0
-      if (vt->num <= 0 || vt->vnum <= 0)  /* degenerate vertex */
-      {
-        v->ripflag = 1 ;
-        nripped++ ;
-      }
-#endif
+      affectedVnosPlus2[vno] = headAffectedVnosPlus2;             // add to list
+      headAffectedVnosPlus2  = vno+2;
+      affectedSize++;
     }
-  } while (nripped > 0);
-
-  // rip all faces that each ripped vertex is part of
-  for (vno = 0 ; vno < mris->nvertices ; vno++)
-  {
-    VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
-    VERTEX                * const v  = &mris->vertices         [vno];
-    if (v->ripflag)
-    {
-      for (n = 0 ; n < vt->num ; n++)
-      {
-	int  n2, fno ;
-	FACE *face ;
-
-	fno = vt->f[n] ;
-	if (fno == Gdiag_no)
-	  DiagBreak() ;
-	face = &mris->faces[fno] ;
-	face->ripflag = 1 ;
-	// find the other vertices that have this face in their
-	// face list and remove it
-	for (n2 = 0 ; n2 < VERTICES_PER_FACE ; n2++)
-	  if (face->v[n2] != vno)
-	  {
-	    int n3 ;
-
-	    VERTEX_TOPOLOGY * const vn = &mris->vertices_topology[face->v[n2]] ;
-	    for (n3 = 0 ; n3 < vn->num ; n3++)
-	      if (vn->f[n3] == fno)  // found the ripped face - remove it
-	      {
-		memmove(vn->f+n3, vn->f+n3+1, (vn->num-n3-1) * sizeof(*(vn->f)));
-		memmove(vn->n+n3, vn->n+n3+1, (vn->num-n3-1) * sizeof(*(vn->n)));
-		vn->num-- ;
-		n3-- ;
-	      }
-	  }
+  }
+  int const startOfRippedTail = headAffectedVnosPlus2;
+  
+  // Grow the affected neighbours set to include all that are within largestNsizeMax
+  //
+  int nsize;
+  int endOfList = 1;
+  for (nsize = 0; nsize <= largestNsizeMax; nsize++) {
+    int startOfList = headAffectedVnosPlus2;
+    int vno, vnoPlus2;
+    for (vnoPlus2 = headAffectedVnosPlus2; vnoPlus2 != endOfList; vnoPlus2 = affectedVnosPlus2[vno]) {
+      vno = vnoPlus2 - 2;
+      VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
+      if (affectedVnosPlus2[vno]) continue;                     // already noted, includes ripped
+      int n;
+      for (n = 0; n < vt->vnum; n++) {
+        int const vnoNbr = vt->v[n];
+        if (affectedVnosPlus2[vnoNbr]) continue;                // already noted, includes ripped
+        affectedVnosPlus2[vnoNbr] = headAffectedVnosPlus2;      // add to list
+        headAffectedVnosPlus2     = vnoNbr + 2;
+        affectedSize++;
       }
     }
+    endOfList = startOfList;
+  }
+  
+  // Recompute the neighbourhoods of all the non-ripped vertices on the list
+  // Clear out the list for reuse in the next step
+  //
+  { 
+    int vlist[MAX_NEIGHBORS], hops[MAX_NEIGHBORS];
+
+    int vnoPlus2 = headAffectedVnosPlus2; 
+    headAffectedVnosPlus2 = 1;
+
+    while (vnoPlus2 != startOfRippedTail) {
+      int const vno = vnoPlus2 - 2;
+
+      VERTEX_TOPOLOGY * const vt = &mris->vertices_topology[vno];
+      VERTEX          * const v  = &mris->vertices         [vno];
+
+      int* const old_vt_v     = vt->v;
+      int  const old_nsizeMax = vt->nsizeMax;
+      int  const old_nsizeCur = vt->nsizeCur;
+      int  const old_vtotal   = vt->vtotal;
+      int  const old_cached   = VERTEXvnum(vt, old_nsizeMax);
+      int  const old_vno_beyond_nsizeMax =   // used for a consistency check
+        (old_vtotal > old_cached) ? vt->v[old_cached] : -1;
+      
+      // Must preserve the dist and dist_orig for all the vtotal entries
+      // even though the v list will get reordered.  The ripped nodes may
+      // change the #hops to a neighbour from 2 to 4 so it is not adequate
+      // to simply strip the ripped nodes out of the v list, because that
+      // might keep the neighbour at the wrong distance.
+      //
+      // Also must preserve the non-ripped nodes after old_nsizeMax up to vtotal because
+      // these are the sampled ones, and the same sample must be used to keep their
+      // dist and distOrig valid.  These can not have moved closer because removing 
+      // nodes just increases hops.
+      //
+      int i;
+      if (v->dist)      for (i = 0; i < vt->vtotal; i++) distCache    [vt->v[i]] = v->dist     [i];
+      if (v->dist_orig) for (i = 0; i < vt->vtotal; i++) distOrigCache[vt->v[i]] = v->dist_orig[i];
+      
+      MRISfindNeighborsAtVertex_new(mris, vno, old_nsizeMax, MAX_NEIGHBORS, vlist, hops, false);    
+        // Note: this code copes with ripped and removes them, even out of the vnum portion!
+        // Fortunately it doesn't realloc v->v
+        
+      MRIS_setNsizeCur(mris, vno, old_nsizeCur);
+      
+      if (old_vtotal > old_cached) {
+        cheapAssert(old_vt_v == vt->v);
+        cheapAssert(old_vno_beyond_nsizeMax == -1 || old_vno_beyond_nsizeMax == vt->v[old_cached]);
+        
+        int new_vtotal = VERTEXvnum(vt, old_nsizeMax);
+      
+        for (i = old_cached; i < old_vtotal; i++) {
+          VERTEX const * const vnbr = &mris->vertices[vt->v[i]];
+          if (!vnbr->ripflag) vt->v[new_vtotal++] = vt->v[i];
+        }
+        
+        cheapAssert(old_vtotal >= new_vtotal);
+        vt->vtotal = new_vtotal;
+      }
+      
+      if (v->dist)      for (i = 0; i < vt->vtotal; i++) v->dist     [i] = distCache    [vt->v[i]];
+      if (v->dist_orig) for (i = 0; i < vt->vtotal; i++) v->dist_orig[i] = distOrigCache[vt->v[i]];
+      
+      // Clear this entry
+      //
+      vnoPlus2 = affectedVnosPlus2[vno];
+      affectedVnosPlus2[vno] = 0;
+      affectedSize--;
+    }
+    
+    while (vnoPlus2 != 1) {
+      int const vno = vnoPlus2 - 2;
+      vnoPlus2 = affectedVnosPlus2[vno];
+      affectedVnosPlus2[vno] = 0;
+      affectedSize--;
+    }
+  }
+  
+  // Above should have emptied the list
+  //
+  cheapAssert(affectedSize == 0);
+  cheapAssert(headAffectedVnosPlus2 == 1);
+
+  // For all the ripped faces
+  //    create a set of their vertices, including their ripped ones (so don't need to read the VERTEX in this loop)
+  //    delete all their knowledge of their vertices
+  //
+  int fno;
+  for (fno = 0; fno < mris->nfaces; fno++) {
+    FACE * const face = &mris->faces[fno];
+    if (!face->ripflag) continue;
+    int n;
+    for (n = 0; n < VERTICES_PER_FACE; n++) {
+      int vno = face->v[n];
+      cheapAssertValidVno(mris,vno);
+      
+      face->v[n] = 0;                                       // should be -1 but uninit'ed faces have 0's
+      
+      if (affectedVnosPlus2[vno]) continue;                 // already noted
+
+      affectedVnosPlus2[vno] = headAffectedVnosPlus2;       // add to list
+      headAffectedVnosPlus2 = vno + 2;
+      affectedSize++;
+    }
+  }
+  cheapAssert(affectedSize <= mris->nvertices);
+
+  // Fix the face info of all the affected vno
+  //
+  int count = 0;
+  int vnoPlus2;
+  for (vnoPlus2 = headAffectedVnosPlus2; vnoPlus2 >= 2; vnoPlus2 = affectedVnosPlus2[vnoPlus2 - 2]) {
+    
+    count++;
+    cheapAssert(count <= mris->nvertices);
+    
+    int const vno = vnoPlus2 - 2;
+    VERTEX_TOPOLOGY       * const vt = &mris->vertices_topology[vno];
+    VERTEX          const * const v  = &mris->vertices         [vno];
+    if (v->ripflag) continue;                               // ripped
+    int num = 0;
+    int i;
+    for (i = 0; i < vt->num; i++) {
+      int fno = vt->f[i];
+      FACE const * const f = &mris->faces[fno];
+      if (f->ripflag) continue;                             // entry to be deleted
+      if (num != i) {
+        vt->f[num] = fno;
+        vt->n[num] = vt->n[i];                              // the face will not have had any of its vertexs removed
+      }                                                     // since it is not being ripped...
+      num++;
+    }
+    vt->num = num;
   }
 
   mrisCheckVertexFaceTopology(mris);
 
-  return (NO_ERROR);
+  freeAndNULL(affectedVnosPlus2);
+  freeAndNULL(distCache);
+  freeAndNULL(distOrigCache);
 }
 
 
@@ -2931,8 +2832,8 @@ int MRISevertSurface(MRIS *mris)
     int vno1 = face->v[1];
     face->v[0] = vno1;
     face->v[1] = vno0;
-    // mrisSetVertexFaceIndex(mris, vno0, fno);
-    // mrisSetVertexFaceIndex(mris, vno1, fno);
+    mrisSetVertexFaceIndex(mris, vno0, fno);
+    mrisSetVertexFaceIndex(mris, vno1, fno);
   }
   mrisCheckVertexFaceTopology(mris);
 

--- a/utils/test/topology_test.c
+++ b/utils/test/topology_test.c
@@ -195,6 +195,15 @@ int test2Wkr(int verticesLog2)
     }
   }
   
+  // Randomly rip a few vertices
+  //
+  for (vno2 = 0; vno2 < nvertices; vno2++) {
+    if (vno2%31 == 0) src->vertices[vno2].ripflag = 1;
+  }
+  MRISremoveRipped(src);
+  
+  mrisCheckVertexFaceTopologyWkr(__FILE__,__LINE__,src,true);
+  
   // Done
   //  
 Done:


### PR DESCRIPTION
Move the calculation of the surface dimensions (xlo, xhi, ...  cx,...) into a single function rather than replicating the code that does it

Centralize the mgmt of the VERTEX::dist  and ::dist_orig fields so their allocations can be kept in sync with the MRIS::nsize and VERTEX_TOPOLOGY::nsize fields

Defer the creation of the ::dist vectors until they can have the correct values written into them

Rename some functions to reflect whether they set the ripflag or really remove the vertex or face

recon-all bert  and  make test  get identical results

