### PR TITLE
Added support for GDiag to mris_register

### DIFF
--- a/mris_register/mris_register.c
+++ b/mris_register/mris_register.c
@@ -163,6 +163,7 @@ main(int argc, char *argv[])
   argc -= nargs;
 
   TimerStart(&start) ;
+  Gdiag |= DIAG_SHOW ;
   Progname = argv[0] ;
   ErrorInit(NULL, NULL, NULL) ;
   DiagInit(NULL, NULL, NULL) ;


### PR DESCRIPTION
Now -W causes snapshots to be written

$ ../mris_register -W 5 -curv -rusage rusage.mris_register.lh.dat lh.sphere lh.folding.atlas.acfb40.noaparc.i12.2016-08-02.tif lh.sphere.reg

cwd /home/rheticus/freesurfer_repo_dev/freesurfer/mris_register/testdata
cmdline ../mris_register -W 5 -curv -rusage rusage.mris_register.lh.dat lh.sphere lh.folding.atlas.acfb40.noaparc.i12.2016-08-02.tif lh.sphere.reg

...
Starting MRISrigidBodyAlignGlobal()
000: dt: 0.000, sse: 1052527.9 (0.205, 21.2, 0.337, 1.697), neg: 0 (%0.00:%0.00), avgs: 1024
writing ./lh.sphere.reg0000done.
...