### PR TITLE
Remove `Thalamus-Proper` from ASegStatsLUT

### DIFF
--- a/distribution/ASegStatsLUT.txt
+++ b/distribution/ASegStatsLUT.txt
@@ -12,7 +12,7 @@
   5  Left-Inf-Lat-Vent                     196   58  250    0
   7  Left-Cerebellum-White-Matter          220  248  164    0
   8  Left-Cerebellum-Cortex                230  148   34    0
- 10  Left-Thalamus-Proper                    0  118   14    0
+ 10  Left-Thalamus                           0  118   14    0
  11  Left-Caudate                          122  186  220    0
  12  Left-Putamen                          236   13  176    0
  13  Left-Pallidum                          12   48  255    0
@@ -32,7 +32,7 @@
  44  Right-Inf-Lat-Vent                    196   58  250    0
  46  Right-Cerebellum-White-Matter         220  248  164    0
  47  Right-Cerebellum-Cortex               230  148   34    0
- 49  Right-Thalamus-Proper                   0  118   14    0
+ 49  Right-Thalamus                          0  118   14    0
  50  Right-Caudate                         122  186  220    0
  51  Right-Putamen                         236   13  176    0
  52  Right-Pallidum                         13   48  255    0


### PR DESCRIPTION
The segmentation label numbers (10, 49) in the `ASegStatsLUT.txt` match the `Thalamus` segmentation (and it appears `Thalamus-Proper` has been renamed to `Thalamus-unused` in the `FreeSurferColorLUT.txt`). This update would make it so `aseg.stats` uses the `Thalamus` structure name that matches the label id.