### PR TITLE
Bf more managed xyz and dist 1

### DIFF
--- a/dngtester/dngtester.c
+++ b/dngtester/dngtester.c
@@ -133,17 +133,22 @@ int main(int argc, char **argv)
   for(s=0; s < surf->nvertices; s++){
     v = &(surf->vertices[s]);
     for(c=0; c<3; c++){
-      if(c==0) v->x += delta;
-      if(c==1) v->y += delta;
-      if(c==2) v->z += delta;
+      double dx = (c==0) ? delta : 0.0;
+      double dy = (c==1) ? delta : 0.0;
+      double dz = (c==2) ? delta : 0.0;
+      MRISsetXYZ(surf,s,
+        v->x + dx,
+        v->y + dy,
+        v->z + dz);
       MRISfaceNormalGrad(surf, 0);
       MRISedgeGradDot(surf);
       //d1 = MRISbbrCost(bbrpar, NULL);
       d1 = MRISedgeCost(surf, NULL);
       gnum->rptr[1][c+1] = (d1-d)/delta;
-      if(c==0) v->x -= delta;
-      if(c==1) v->y -= delta;
-      if(c==2) v->z -= delta;
+      MRISsetXYZ(surf,s,
+        v->x - dx,
+        v->y - dy,
+        v->z - dz);
     }
     printf("#@# %d ",s);
     for(c=0; c<3; c++) printf("%12.10lf ",100000*(dJ->rptr[s+1][c+1]-gnum->rptr[1][c+1]));
@@ -378,9 +383,10 @@ int MRISmatrix2Vertex(MRIS *surf, int vtxno, DMATRIX *vm)
     printf("ERROR: MRISmatrix2Vertex(): vm wrong dim %d %d\n",vm->rows,vm->cols);
     return(1);
   }
-  surf->vertices[vtxno].x = vm->rptr[1][1];
-  surf->vertices[vtxno].y = vm->rptr[2][1];
-  surf->vertices[vtxno].z = vm->rptr[3][1];
+  MRISsetXYZ(surf,vtxno,
+    vm->rptr[1][1],
+    vm->rptr[2][1],
+    vm->rptr[3][1]);
   return(0);
 }
 
@@ -391,9 +397,10 @@ int MRISscaleVertices(MRIS *surf, double scale)
   VERTEX *v;
   for(vtxno = 0; vtxno < surf->nvertices; vtxno++){
     v = &(surf->vertices[vtxno]);
-    v->x *= scale;
-    v->y *= scale;
-    v->z *= (scale*(1+fabs(v->z)));
+    MRISsetXYZ(surf,vtxno,
+      v->x * scale,
+      v->y * scale,
+      v->z * (scale*(1+fabs(v->z))));
   }
   return(0);
 }
@@ -421,9 +428,10 @@ int UpdateVertexPosition(MRIS *surf, double stepsize, DMATRIX *grad)
   #endif
   for(vtxno = 0; vtxno < surf->nvertices; vtxno++){
     VERTEX *v = &(surf->vertices[vtxno]);
-    v->x -= (stepsize*grad->rptr[vtxno+1][1]);
-    v->y -= (stepsize*grad->rptr[vtxno+1][2]);
-    v->z -= (stepsize*grad->rptr[vtxno+1][3]);
+    MRISsetXYZ(surf,vtxno,
+      v->x - (stepsize*grad->rptr[vtxno+1][1]),
+      v->y - (stepsize*grad->rptr[vtxno+1][2]),
+      v->z - (stepsize*grad->rptr[vtxno+1][3]));
   }
   return(0);
 }

--- a/fem_elastic/morph.cpp
+++ b/fem_elastic/morph.cpp
@@ -1082,6 +1082,10 @@ VolumeMorph::apply_transforms(MRIS* input) const
 {
   MRI_SURFACE* const mris = MRISclone( input );
 
+  MRISfreeDistsButNotOrig(mris);
+    // MRISsetXYZ will invalidate all of these,
+    // so make sure they are recomputed before being used again!
+
   int const nvertices = input->nvertices;
   for (int ui = 0; ui < nvertices; ++ui) 
   {

--- a/fem_elastic/surf_energy.cpp
+++ b/fem_elastic/surf_energy.cpp
@@ -66,6 +66,10 @@ apply_lin_transform(MRI_SURFACE* mris, float* transform)
     std::cout << std::endl;
   }
 
+  MRISfreeDistsButNotOrig(mris);
+    // MRISsetXYZ will invalidate all of these,
+    // so make sure they are recomputed before being used again!
+
   for (int index = 0; index < mris->nvertices; index++)
   {
     VERTEX * const vertex = &mris->vertices[index];

--- a/fem_elastic/surf_utils.cpp
+++ b/fem_elastic/surf_utils.cpp
@@ -22,6 +22,10 @@ convert_surf_to_vox(MRI_SURFACE* mris,
 {
   int const nvertices = mris->nvertices;
 
+  MRISfreeDistsButNotOrig(mris);
+    // MRISsetXYZ will invalidate all of these,
+    // so make sure they are recomputed before being used again!
+
   for (int vno=0; vno < nvertices; ++vno )
   {
     VERTEX const * v = &mris->vertices[vno];
@@ -52,6 +56,10 @@ convert_vox_to_surf(MRI_SURFACE* mris,
                     MRI* vol)
 {
   int const nvertices = mris->nvertices;
+
+  MRISfreeDistsButNotOrig(mris);
+    // MRISsetXYZ will invalidate all of these,
+    // so make sure they are recomputed before being used again!
 
   for (int vno=0; vno < nvertices; ++vno )
   {

--- a/include/base.h
+++ b/include/base.h
@@ -98,6 +98,20 @@ void assertFailed(const char* file, int line, const char* tst);
 #define cheapAssertValidFno(_MRIS, _FNO) cheapAssert((0 <= _FNO) && (_FNO < _MRIS->nfaces))
 #define cheapAssertValidVno(_MRIS, _VNO) cheapAssert((0 <= _VNO) && (_VNO < _MRIS->nvertices))
 
+typedef enum LogicProblemResponse {
+  LogicProblemResponse_old,
+  LogicProblemResponse_fix
+} LogicProblemResponse;
+
+bool spendTimeCheckingForLogicProblem(const char* file, int line);
+LogicProblemResponse copeWithLogicProblem2(
+    bool* wasReported,          // set to whether reported
+    const char* envvarFixer,    // user told to set this env var to fix, as part of the report
+    const char* msg,            // the report
+    const char* file, int line, // multiple reports at the same location are partially elided
+    const char* function);
+#define copeWithLogicProblem(ENV, MSG) copeWithLogicProblem2(NULL, (ENV), (MSG), __FILE__, __LINE__, __MYFUNCTION__)
+
 // Regardless of whether the __real_malloc etc. or the __wrap_ ones, it is still desirable
 // to know where in the program the allocations are happening.  This mechanism allows that to happen.
 //

--- a/include/utilsmath.h
+++ b/include/utilsmath.h
@@ -161,6 +161,10 @@ namespace Math
   */
   void ConvertSurfaceRASToVoxel(MRIS *mris, MRI *mri_template)
   {
+    MRISfreeDistsButNotOrig(mris);
+      // MRISsetXYZ will invalidate all of these,
+      // so make sure they are recomputed before being used again!
+
     for (int i=0; i< mris->nvertices; i++)
     {
       VERTEX const * const vertex = &mris->vertices[i];

--- a/mri_segreg/mri_segreg.c
+++ b/mri_segreg/mri_segreg.c
@@ -1949,6 +1949,12 @@ int MRISbbrSurfs(char *subject)
 
     printf("GM Proj: %d %lf %lf\n",DoGMProjFrac,GMProjFrac,GMProjAbs);
     printf("WM Proj: %d %lf %lf\n",DoWMProjFrac,WMProjFrac,WMProjAbs);
+
+    MRISfreeDistsButNotOrig(lhwm);
+    MRISfreeDistsButNotOrig(lhctx);
+      // MRISsetXYZ will invalidate all of these,
+      // so make sure they are recomputed before being used again!
+
     for(n = 0; n < lhwm->nvertices; n++){
       if(DoWMProjAbs)  ProjNormDist(&fx, &fy, &fz, lhwm,  n, -WMProjAbs);
       if(DoWMProjFrac) ProjNormFracThick(&fx, &fy, &fz, lhwm,  n, -WMProjFrac);
@@ -2038,6 +2044,11 @@ int MRISbbrSurfs(char *subject)
     }
     
     printf("Projecting RH Surfs\n");
+    MRISfreeDistsButNotOrig(rhwm);
+    MRISfreeDistsButNotOrig(rhctx);
+      // MRISsetXYZ will invalidate all of these,
+      // so make sure they are recomputed before being used again!
+    
     for(n = 0; n < rhwm->nvertices; n++){
       if(DoWMProjAbs)  ProjNormDist(&fx, &fy, &fz, rhwm,  n, -WMProjAbs);
       if(DoWMProjFrac) ProjNormFracThick(&fx, &fy, &fz, rhwm,  n, -WMProjFrac);

--- a/mri_surf2surf/mri_surf2surf.c
+++ b/mri_surf2surf/mri_surf2surf.c
@@ -636,6 +636,11 @@ int main(int argc, char **argv)
     }
 
     MRIScomputeMetricProperties(SurfSrc);
+    
+    MRISfreeDistsButNotOrig(SurfSrc);
+      // MRISsetXYZ will invalidate all of these,
+      // so make sure they are recomputed before being used again!
+
     if(UseSurfSrc == SURF_SRC_XYZ || UseSurfSrc == SURF_SRC_TAL_XYZ) {
       if(DoProj) {
         if(ProjType == 2) {

--- a/mris_left_right_register/mris_left_right_register.c
+++ b/mris_left_right_register/mris_left_right_register.c
@@ -325,6 +325,11 @@ main(int argc, char *argv[])
     parms.start_t = 0 ;
   }
 
+  MRISfreeDistsButNotOrig(mris_lh);
+  MRISfreeDistsButNotOrig(mris_rh);
+    // MRISsetXYZ will invalidate all of these,
+    // so make sure they are recomputed before being used again!
+
   // average lh and rh warps and projects back onto sphere
   for (h = LEFT_HEMISPHERE ; h <= RIGHT_HEMISPHERE ; h++)   // register left to right and right to left
   {

--- a/mris_register/mris_register.c
+++ b/mris_register/mris_register.c
@@ -163,7 +163,6 @@ main(int argc, char *argv[])
   argc -= nargs;
 
   TimerStart(&start) ;
-  Gdiag |= DIAG_SHOW ;
   Progname = argv[0] ;
   ErrorInit(NULL, NULL, NULL) ;
   DiagInit(NULL, NULL, NULL) ;
@@ -1209,6 +1208,7 @@ get_option(int argc, char *argv[])
       fprintf(stderr, "using niterations = %d\n", parms.niterations) ;
       break ;
     case 'W':
+      Gdiag |= DIAG_SHOW ;
       Gdiag |= DIAG_WRITE ;
       sscanf(argv[2], "%d", &parms.write_iterations) ;
       nargs = 1 ;

--- a/mris_register_to_volume/mris_register_to_volume.c
+++ b/mris_register_to_volume/mris_register_to_volume.c
@@ -1917,6 +1917,10 @@ write_snapshot(MRI_SURFACE *mris, MATRIX *m, char *name, int n)
   }
 
   MRISsaveVertexPositions(mris, TMP_VERTICES) ;
+
+  MRISfreeDistsButNotOrig(mris);
+    // MRISsetXYZ will invalidate all of these,
+    // so make sure they are recomputed before being used again!
   
   for (vno = 0 ; vno < mris->nvertices ; vno++)
   {

--- a/mris_sphere/mris_sphere.c
+++ b/mris_sphere/mris_sphere.c
@@ -372,13 +372,25 @@ main(int argc, char *argv[])
   {
     MRISwrite(mris, "before") ;
   }
+
+  if (1) {
+    fprintf(stdout, "%s:%d should but doesn't set orig x et al here \n", __FILE__, __LINE__);
+  } else {
+    MRISsetOriginalXYZfromXYZ(mris);
+    mrisComputeOriginalVertexDistances(mris);
+  }
+  
   MRISprojectOntoSphere(mris, mris, target_radius) ;
+
   if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON)
   {
     MRISwrite(mris, "after") ;
   }
+  
   fprintf(stderr,"surface projected - minimizing metric distortion...\n");
+  
   MRISsetNeighborhoodSize(mris, nbrs) ;
+  
   if (MRIScountNegativeFaces(mris) > nint(.8*mris->nfaces))
   {
     printf("!!!!!!!!!  everted surface detected - correcting !!!!!!!!!!!!!!\n") ;

--- a/nmovie_qt/RenderWidget.h
+++ b/nmovie_qt/RenderWidget.h
@@ -1,7 +1,7 @@
 #ifndef RENDERWIDGET_H
 #define RENDERWIDGET_H
 
-#include <QtOpenGL/QGLWidget>
+#include <QGLWidget>
 #include <QTimer>
 #include <QImage>
 

--- a/scripts/recon-all
+++ b/scripts/recon-all
@@ -826,6 +826,12 @@ if( ! $RunIt) then
   echo "may not have accurate arguments!" |& tee -a $LF
 endif
 
+if ( $DoRestart) then
+    if( -e $RestartFile) then
+        echo "Restart file $RestartFile exists <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+        goto Restart
+    endif
+endif
 
 #------------         --------------#
 ##-----------  -clean --------------#
@@ -1725,6 +1731,7 @@ if($DoMotionCor) then
   endif
 
 endif # Motion Correction
+
 
 # MOD: this takes the externally supplied mask and resamples it into the
 # orig space so that it can be used with mri_em_register
@@ -2909,6 +2916,31 @@ if($DoCALabel) then
   if($RunIt) $fs_time $cmd |& tee -a $LF
   if($status) goto error_exit;
 endif
+
+
+Restart:
+
+if ( $DoRestart) then
+    if( ! -e $RestartFile) then
+    else
+        if($DoCALabel) then
+            set DoCCSeg = 1; # Force
+        endif
+        mkdir -p mri
+        cd mri
+    endif
+    echo "Restart: Label " `pwd` "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+    if( ! -e $RestartFile) then
+        echo "Create Restart File $RestartFile <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+        tar cvf $RestartFile .
+    else
+        echo "Restart using $RestartFile  <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+        tar xvf $RestartFile .
+    endif
+    printenv 
+    set
+endif
+
 
 #--- Corpus Callosum Segmentation ---#
 # Run mri_cc to create aseg.auto.mgz. Note that DoCCSeg
@@ -5600,12 +5632,20 @@ endif
 parse_args:
 #-------------------------------------------------#
 set cmdline = ($argv);
+set DoRestart = 0
+
 while( $#argv != 0 )
 
   set flag = $argv[1]; shift;
 
   switch($flag)
 
+    case "-restart": 
+        if ( $#argv < 1) goto arg1err;
+        set RestartFile = $argv[1]; shift;
+        set DoRestart = 1
+        breaksw;
+        
     case "-no-cerebellum":
     case "-nocerebellum":
     case "-NO-CEREBELLUM":

--- a/utils/gcamorph.c
+++ b/utils/gcamorph.c
@@ -6123,6 +6123,11 @@ int GCAMsampleInverseMorphRAS(
 int GCAMmorphSurf(MRIS *mris, GCA_MORPH *gcam)
 {
   // printf("Applying Inverse Morph \n");
+
+  MRISfreeDistsButNotOrig(mris);
+    // MRISsetXYZ will invalidate all of these,
+    // so make sure they are recomputed before being used again!
+
   int vtxno;
   for (vtxno = 0; vtxno < mris->nvertices; vtxno++) {
     VERTEX *v = &mris->vertices[vtxno];

--- a/utils/gifti_local.c
+++ b/utils/gifti_local.c
@@ -665,9 +665,6 @@ MRIS *mrisReadGIFTIdanum(const char *fname, MRIS *mris, int daNum)
     }
 
     /* Copy in the vertices. */
-    float xhi, xlo, yhi, ylo, zhi, zlo;
-    xhi = yhi = zhi = -1000000;
-    xlo = ylo = zlo = 1000000;
     int vertex_index;
     for (vertex_index = 0; vertex_index < num_vertices; vertex_index++) {
       mris->vertices_topology[vertex_index].num = 0;
@@ -676,35 +673,9 @@ MRIS *mrisReadGIFTIdanum(const char *fname, MRIS *mris, int daNum)
       float z = (float)gifti_get_DA_value_2D(coords, vertex_index, 2);
       MRISsetXYZ(mris,vertex_index,x,y,z);
       mris->vertices[vertex_index].origarea = -1;
-      if (x > xhi) {
-        xhi = x;
-      }
-      if (x < xlo) {
-        xlo = x;
-      }
-      if (y > yhi) {
-        yhi = y;
-      }
-      if (y < ylo) {
-        ylo = y;
-      }
-      if (z > zhi) {
-        zhi = z;
-      }
-      if (z < zlo) {
-        zlo = z;
-      }
     }
-    mris->xlo = xlo;
-    mris->ylo = ylo;
-    mris->zlo = zlo;
-    mris->xhi = xhi;
-    mris->yhi = yhi;
-    mris->zhi = zhi;
-    mris->xctr = (xhi + xlo) / 2;
-    mris->yctr = (yhi + ylo) / 2;
-    mris->zctr = (zhi + zlo) / 2;
-
+    mrisComputeSurfaceDimensions(mris);
+    
     /* Copy in the faces. */
     int face_index;
     for (face_index = 0; face_index < num_faces; face_index++) {
@@ -739,7 +710,7 @@ MRIS *mrisReadGIFTIdanum(const char *fname, MRIS *mris, int daNum)
       }
     }
 
-    mrisCheckVertexFaceTopology(mris);
+    mrisCompleteTopology(mris);
     
     // check-for and read coordsys struct for talairach xform
     if (coords->coordsys && (coords->numCS > 0)) {

--- a/utils/gw_ic2562.c
+++ b/utils/gw_ic2562.c
@@ -2036,6 +2036,8 @@ MRI_SURFACE *ic2562_make_two_icos(float x1, float y1, float z1, float r1, float 
         }
         if (vn >= 0) vt->v[vt->vnum++] = vn;
       }
+      
+      vt->nsizeMax = vt->nsizeCur = 1;
     }
   }
 

--- a/utils/icosahedron.c
+++ b/utils/icosahedron.c
@@ -1951,6 +1951,10 @@ int ICOreadVertexPositions(MRI_SURFACE * const mris, const char * const fname, i
   if (ico->nvertices != mris->nvertices || ico->nfaces != mris->nfaces)
     ErrorReturn(ERROR_BADPARM, (ERROR_BADPARM, "ICOreadVertexPositions: different size surfaces"));
 
+  MRISfreeDistsButNotOrig(mris);
+    // MRISsetXYZ will invalidate all of these,
+    // so make sure they are recomputed before being used again!
+
   /* position vertices */
   int vno;
   for (vno = 0; vno < ico->nvertices; vno++) {

--- a/utils/mri2.c
+++ b/utils/mri2.c
@@ -3068,6 +3068,10 @@ void MRIConvertSurfaceVertexCoordinates(MRIS* mris, MRI* vol)
 {
   int const nvertices = mris->nvertices;
 
+  MRISfreeDistsButNotOrig(mris);
+    // MRISsetXYZ will invalidate all of these,
+    // so make sure they are recomputed before being used again!
+
   int vno;
   for (vno = 0; vno < nvertices; vno++) {
 

--- a/utils/mrisComputeVertexDistancesWkr_extracted.h
+++ b/utils/mrisComputeVertexDistancesWkr_extracted.h
@@ -1,0 +1,131 @@
+static bool FUNCTION_NAME(MRIS *mris, int new_dist_nsize, bool check)
+{
+  cheapAssert(0 < new_dist_nsize);
+  cheapAssert(new_dist_nsize <= 3);
+  
+  if (debugNonDeterminism) {
+    fprintf(stdout, "%s:%d %s stdout ",__FILE__,__LINE__, 
+        FUNCTION_NAME == mrisComputeVertexDistancesWkr 
+        ? "mrisComputeVertexDistancesWkr"
+        : "mrisComputeOriginalVertexDistancesWkr");
+    mris_print_hash(stdout, mris, "mris ", "\n");
+  }
+
+  int nonZeroInputXCount = 0;
+  
+  int errors = 0;
+  
+  int vno;
+
+  switch (mris->status) {
+    default: /* don't really know what to do in other cases */
+
+    case MRIS_PLANE:
+
+      ROMP_PF_begin		// mris_fix_topology
+#ifdef HAVE_OPENMP
+      #pragma omp parallel for if_ROMP(shown_reproducible) reduction(+:errors)  reduction(+:nonZeroInputXCount)
+#endif
+      for (vno = 0; vno < mris->nvertices; vno++) {
+        ROMP_PFLB_begin
+    
+        if (vno == Gdiag_no) DiagBreak();
+
+        VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
+        VERTEX                * const v  = &mris->vertices         [vno];
+        if (v->ripflag) continue;
+
+        if (!check) OUTPUT_MAKER(mris,vno);
+        else if (!v->OUTPUT_DIST) continue;
+
+	if (v->INPUT_X != 0.0f) nonZeroInputXCount++;
+
+        int *pv;
+        int const vtotal = check ? VERTEXvnum(vt,new_dist_nsize) : vt->vtotal;
+        int n;
+        for (pv = vt->v, n = 0; n < vtotal; n++) {
+          VERTEX const * const vn = &mris->vertices[*pv++];
+          // if (vn->ripflag) continue;
+          float xd = v->INPUT_X - vn->INPUT_X;
+          float yd = v->INPUT_Y - vn->INPUT_Y;
+          float zd = v->INPUT_Z - vn->INPUT_Z;
+          float d = xd * xd + yd * yd + zd * zd;
+
+          if (!check) 
+            v->OUTPUT_DIST[n] = sqrt(d);
+          else if (v->OUTPUT_DIST[n] != (float)(sqrt(d))) 
+            errors++;
+        }
+
+        ROMP_PFLB_end
+      }
+      ROMP_PF_end
+  
+      break;
+
+    case MRIS_PARAMETERIZED_SPHERE:
+    case MRIS_SPHERE: {
+
+      ROMP_PF_begin		// mris_fix_topology
+#ifdef HAVE_OPENMP
+      #pragma omp parallel for if_ROMP(shown_reproducible) reduction(+:errors) reduction(+:nonZeroInputXCount)
+#endif
+      for (vno = 0; vno < mris->nvertices; vno++) {
+        ROMP_PFLB_begin
+    
+        if (vno == Gdiag_no) DiagBreak();
+
+        VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
+        VERTEX          const * const v  = &mris->vertices         [vno];
+        if (v->ripflag) continue;
+
+        if (!check) OUTPUT_MAKER(mris,vno);
+        else if (!v->OUTPUT_DIST) continue;
+
+	if (v->INPUT_X != 0.0f) nonZeroInputXCount++;
+
+        XYZ xyz1_normalized;
+        float xyz1_length;
+        XYZ_NORMALIZED_LOAD(&xyz1_normalized, &xyz1_length, v->INPUT_X, v->INPUT_Y, v->INPUT_Z);  // length 1 along radius vector
+
+        float const radius = xyz1_length;
+
+        int *pv;
+        int const vtotal = check ? VERTEXvnum(vt,new_dist_nsize) : vt->vtotal;
+        int n;
+        for (pv = vt->v, n = 0; n < vtotal; n++) {
+          VERTEX const * const vn = &mris->vertices[*pv++];
+          if (vn->ripflag) continue;
+          
+          float angle = fabs(XYZApproxAngle(&xyz1_normalized, vn->INPUT_X, vn->INPUT_Y, vn->INPUT_Z));
+            // radians, so 2pi around the circumference
+
+          float d = angle * radius;
+            // the length of the arc, rather than the straight line distance
+
+          if (!check) 
+            v->OUTPUT_DIST[n] = d;
+          else if (v->OUTPUT_DIST[n] != (float)(d)) 
+            errors++;
+        }
+        ROMP_PFLB_end
+      }
+      ROMP_PF_end
+
+      break;
+    }
+  }
+
+  if (nonZeroInputXCount == 0) {
+    copeWithLogicProblem(NULL, "all xyz inputs zero - cant fix");
+  }
+  
+  return (errors == 0);
+}
+
+#undef FUNCTION_NAME 
+#undef INPUT_X 
+#undef INPUT_Y 
+#undef INPUT_Z
+#undef OUTPUT_DIST
+#undef OUTPUT_MAKER

--- a/utils/mrisurf_base.h
+++ b/utils/mrisurf_base.h
@@ -359,6 +359,3 @@ void notifyActiveRealmTreesChangedNFacesNVertices(MRIS const * const mris);
 extern const char *mrisurf_surface_names[3];
 extern const char *curvature_names[3];
 int MRISprintCurvatureNames(FILE *fp);
-
-
-bool MRISshouldReport(const char* file, int line);

--- a/utils/mrisurf_metricProperties.c
+++ b/utils/mrisurf_metricProperties.c
@@ -30,11 +30,131 @@ int mrisurf_orig_clock;
 //==================================================================================================================
 // Simple properties
 //
-//  orig[xyz] are set during the creation of a surface
-//  and during deformations that create an improved 'original' surface.
+// xyz are set in over 100 places
 //
-void MRISsetOriginalXYZ(MRIS *mris, int vno, float origx, float origy, float origz) 
+static void MRISsetXYZwkr1(MRIS *mris, const char * file, int line, bool* laterTime) {
+  if (mris->dist_alloced_flags & 1) {
+    if (!*laterTime) { *laterTime = true;
+      fprintf(stdout, "%s:%d setXYZ with dist not freed.  Add call to MRISfreeDistsButNotOrig(MRIS*)\n", file,line);
+    }
+    cheapAssert(true);  // HACK should be true
+  }
+}
+
+static void MRISsetXYZwkr2(MRIS *mris, int vno, float x, float y, float z) {
+  cheapAssertValidVno(mris,vno);
+  VERTEX * v = &mris->vertices[vno];
+
+  const float * pcx = &v->x;  float * px = (float*)pcx; *px = x;
+  const float * pcy = &v->y;  float * py = (float*)pcy; *py = y;
+  const float * pcz = &v->z;  float * pz = (float*)pcz; *pz = z;
+}
+
+void MRISsetXYZwkr(MRIS *mris, int vno, float x, float y, float z, const char * file, int line, bool* laterTime) 
 {
+  MRISsetXYZwkr1(mris, file, line, laterTime);
+  MRISsetXYZwkr2(mris, vno, x, y, z);
+}
+
+void MRISexportXYZ(MRIS *mris,       float*       * ppx,       float*       * ppy,       float*       * ppz) {
+  int const nvertices = mris->nvertices;
+
+  float* px = (float*)memalign(64, nvertices*sizeof(float));    // cache aligned to improve the performance
+  float* py = (float*)memalign(64, nvertices*sizeof(float));    //      of loops that use the vectors
+  float* pz = (float*)memalign(64, nvertices*sizeof(float));
+  
+  int vno;
+  for (vno = 0; vno < nvertices; vno++) {
+    VERTEX * v = &mris->vertices[vno];
+    px[vno] = v->x; py[vno] = v->y; pz[vno] = v->z;
+  }
+  
+  *ppx = px;
+  *ppy = py;
+  *ppz = pz;
+}
+
+#define SURFACE_DIMENSION_CALC_INIT \
+  float xlo = 10000, ylo = xlo, zlo = ylo, xhi = -xlo, yhi = -ylo, zhi = -zlo;
+
+#define SURFACE_DIMENSION_CALC_ITER \
+    if (x > xhi) xhi = x; \
+    if (x < xlo) xlo = x; \
+    if (y > yhi) yhi = y; \
+    if (y < ylo) ylo = y; \
+    if (z > zhi) zhi = z; \
+    if (z < zlo) zlo = z; \
+    // end of macro
+
+#define SURFACE_DIMENSION_CALC_FINI \
+  mris->xlo = xlo; \
+  mris->xhi = xhi; \
+  mris->ylo = ylo; \
+  mris->yhi = yhi; \
+  mris->zlo = zlo; \
+  mris->zhi = zhi; \
+  \
+  mris->xctr = 0.5f * (float)((double)xlo + (double)xhi); \
+  mris->yctr = 0.5f * (float)((double)ylo + (double)yhi); \
+  mris->zctr = 0.5f * (float)((double)zlo + (double)zhi); \
+  // end of macro
+
+
+void MRISimportXYZ(MRIS *mris, const float* const    px, const float* const    py, const float* const    pz) 
+{
+  static bool laterTime;
+  MRISsetXYZwkr1(mris, __FILE__, __LINE__, &laterTime);
+
+  int const nvertices = mris->nvertices;
+
+  SURFACE_DIMENSION_CALC_INIT
+  int vno;
+  for (vno = 0; vno < nvertices; vno++) {
+    float x = px[vno], y = py[vno], z = pz[vno];
+
+    MRISsetXYZwkr2(mris, vno, x,y,z);
+
+    SURFACE_DIMENSION_CALC_ITER
+  }
+  
+  SURFACE_DIMENSION_CALC_FINI
+}
+
+
+void MRIScopyXYZ(MRIS *mris, MRIS* mris_from) {
+  static bool laterTime;
+  MRISsetXYZwkr1(mris, __FILE__, __LINE__, &laterTime);
+  
+  int const nvertices = mris->nvertices;
+  cheapAssert(nvertices == mris_from->nvertices);
+  
+  SURFACE_DIMENSION_CALC_INIT
+  int vno;
+  for (vno = 0; vno < nvertices; vno++) {
+    VERTEX * v = &mris_from->vertices[vno];
+    float x = v->x, y = v->y, z = v->z;
+    
+    MRISsetXYZwkr2(mris, vno, x, y, z);
+    
+    SURFACE_DIMENSION_CALC_ITER
+  }
+  
+  SURFACE_DIMENSION_CALC_FINI
+}
+
+
+//  orig[xyz] are set during the creation of a surface
+//  and during deformations that create an improved 'original' surface
+//
+void MRISsetOriginalXYZwkr(MRIS *mris, int vno, float origx, float origy, float origz, const char * file, int line, bool* laterTime) 
+{
+  if (mris->dist_alloced_flags & 2) {
+    if (!*laterTime) { *laterTime = true;
+      fprintf(stdout, "%s:%d setOriginalXYZ with dist_orig not freed.  Add call to MRISfreeDistOrigs(MRIS*)\n", file,line);
+    }
+    cheapAssert(true);  // HACK should be false
+  }
+
   cheapAssertValidVno(mris,vno);
   VERTEX * v = &mris->vertices[vno];
     
@@ -47,7 +167,12 @@ void MRISsetOriginalXYZ(MRIS *mris, int vno, float origx, float origy, float ori
   }
 }
 
+
 void MRISsetOriginalXYZfromXYZ(MRIS *mris) {
+  
+  MRISfreeDistOrigs(mris);  
+    // Old values no longer valid
+  
   int vno;
   for (vno = 0; vno < mris->nvertices; vno++) {
     VERTEX * v = &mris->vertices[vno];
@@ -61,29 +186,8 @@ void MRISsetOriginalXYZfromXYZ(MRIS *mris) {
 }
 
 
-// xyz are set in over 100 places
+// These should become invalid when XYZ are changed - NYI
 //
-void MRISsetXYZwkr(MRIS *mris, int vno, float x, float y, float z, const char * file, int line, bool* laterTime) 
-{
-  cheapAssertValidVno(mris,vno);
-  VERTEX * v = &mris->vertices[vno];
-    
-  const float * pcx = &v->x;  float * px = (float*)pcx; *px = x;
-  const float * pcy = &v->y;  float * py = (float*)pcy; *py = y;
-  const float * pcz = &v->z;  float * pz = (float*)pcz; *pz = z;
- 
-#if 0 
-  if (mris->dist_alloced_flags & 1) {
-    if (!*laterTime) {
-      *laterTime = true;
-      fprintf(stdout, "%s:%d setting XYZ when dist allocated\n",file,line);
-    }
-    // THIS WOULD CAUSE A DATA RACE ON VERTEX::dist etc.  MRISfreeDistsButNotOrig(mris);
-  }
-#endif
-}
-
-
 int mrisComputeSurfaceDimensions(MRIS *mris)
 {
   float xlo, ylo, zlo, xhi, yhi, zhi;
@@ -117,7 +221,6 @@ int mrisComputeSurfaceDimensions(MRIS *mris)
   
   return (NO_ERROR);
 }
-
 
 
 int MRISimportVertexCoords(MRIS * const mris, float * locations[3], int const which)
@@ -396,6 +499,69 @@ int MRIStranslate(MRIS *mris, float dx, float dy, float dz)
 }
 
 
+void MRISscaleThenTranslate (MRIS *mris, double sx, double sy, double sz, double dx, double dy, double dz) {
+  //
+  // This uses double because mri_brain_volume was using double,
+  // and because the combined scaling and adding could be much less accurate in float.
+  //
+  int vno;
+  for (vno = 0; vno < mris->nvertices; vno++) {
+    VERTEX *v = &mris->vertices[vno];
+    v->x = v->x*sx + dx;
+    v->y = v->y*sy + dy;
+    v->z = v->z*sz + dz;
+  }
+
+  // Emulate mrisComputeSurfaceDimensions(mris)
+  //
+  double xlo = mris->xlo;
+  double xhi = mris->xhi;
+  double ylo = mris->ylo;
+  double yhi = mris->yhi;
+  double zlo = mris->zlo;
+  double zhi = mris->zhi;
+  double xctr = mris->xctr;
+  double yctr = mris->yctr;
+  double zctr = mris->zctr;
+  
+  xlo *= sx;
+  xhi *= sx;
+  ylo *= sy;
+  yhi *= sy;
+  zlo *= sz;
+  zhi *= sz;
+  
+  if (sx < 0) { double t = xlo; xlo = xhi; xlo = t; }
+  if (sy < 0) { double t = ylo; ylo = yhi; ylo = t; }
+  if (sz < 0) { double t = zlo; zlo = zhi; zlo = t; }
+  
+  xctr *= sx;
+  yctr *= sy;
+  zctr *= sz;
+  
+  xlo += dx;
+  xhi += dx;
+  ylo += dy;
+  yhi += dy;
+  zlo += dz;
+  zhi += dz;
+  
+  xctr += dx;
+  yctr += dy;
+  zctr += dz;
+
+  mris->xlo = (float)xlo;
+  mris->xhi = (float)xhi;
+  mris->ylo = (float)ylo;
+  mris->yhi = (float)yhi;
+  mris->zlo = (float)zlo;
+  mris->zhi = (float)zhi;
+  mris->xctr = (float)xctr;
+  mris->yctr = (float)yctr;
+  mris->zctr = (float)zctr;
+}
+
+
 int MRISanisotropicScale(MRIS *mris, float sx, float sy, float sz)
 {
   mrisComputeSurfaceDimensions(mris);
@@ -614,6 +780,24 @@ void MRISblendXYZandTXYZ(MRIS* mris, float xyzScale, float txyzScale) {
     v->x = xyzScale*v->x + txyzScale*v->tx;
     v->y = xyzScale*v->y + txyzScale*v->ty;
     v->z = xyzScale*v->z + txyzScale*v->tz;
+  }
+
+  // current only user did not have this, but did immediately call MRIScomputeMetricProperties(mris)
+  //
+  // mrisComputeSurfaceDimensions(mris);
+}
+
+
+void MRISblendXYZandNXYZ(MRIS* mris, float nxyzScale) 
+{
+  MRISfreeDistsButNotOrig(mris);  // it is either this or adjust them...
+
+  int vno;
+  for (vno = 0; vno < mris->nvertices; vno++) {
+    VERTEX* v = &mris->vertices[vno];
+    v->x = v->x + nxyzScale*v->nx;
+    v->y = v->y + nxyzScale*v->ny;
+    v->z = v->z + nxyzScale*v->nz;
   }
 
   // current only user did not have this, but did immediately call MRIScomputeMetricProperties(mris)
@@ -1187,211 +1371,82 @@ int MRISscaleDistances(MRIS *mris, float scale)
 /*-----------------------------------------------------------------
   Calculate distances between each vertex and each of its neighbors.
   ----------------------------------------------------------------*/
-static bool mrisComputeVertexDistancesWkr(MRIS *mris, int new_dist_nsize, bool check);
+static bool mrisComputeVertexDistancesWkr        (MRIS *mris, int new_dist_nsize, bool check);
+static bool mrisComputeOriginalVertexDistancesWkr(MRIS *mris, int new_dist_nsize, bool check);
 
 bool mrisCheckDist(MRIS const * mris) {
   if (!mris->dist_nsize) return true;
   return mrisComputeVertexDistancesWkr((MRIS*)mris, mris->dist_nsize, true);
 }
 
+bool mrisCheckDistOrig(MRIS const * mris) {
+  if (!mris->dist_orig_nsize) return true;
+  return mrisComputeOriginalVertexDistancesWkr((MRIS*)mris, mris->dist_orig_nsize, true);
+}
+
 int mrisComputeVertexDistances(MRIS *mris) {
-  cheapAssert(0 < mris->nsize);
   mrisComputeVertexDistancesWkr(mris, mris->nsize, false);
   mris->dist_nsize = mris->nsize;
   mrisCheckDist(mris);
   return NO_ERROR;
 }
 
-static bool mrisComputeVertexDistancesWkr(MRIS *mris, int new_dist_nsize, bool check)
-{
-  cheapAssert(0 < new_dist_nsize);
-  cheapAssert(new_dist_nsize <= 3);
-  
-  if (debugNonDeterminism) {
-    fprintf(stdout, "%s:%d stdout ",__FILE__,__LINE__);
-    mris_print_hash(stdout, mris, "mris ", "\n");
-  }
-
-  int errors = 0;
-  
-  int vno;
-
-  switch (mris->status) {
-    default: /* don't really know what to do in other cases */
-
-    case MRIS_PLANE:
-
-      ROMP_PF_begin		// mris_fix_topology
-#ifdef HAVE_OPENMP
-      #pragma omp parallel for if_ROMP(shown_reproducible) reduction(+:errors)
-#endif
-      for (vno = 0; vno < mris->nvertices; vno++) {
-        ROMP_PFLB_begin
-    
-        if (vno == Gdiag_no) DiagBreak();
-
-        VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
-        VERTEX                * const v  = &mris->vertices         [vno];
-        if (v->ripflag) continue;
-
-        if (!check) MRISmakeDist(mris,vno);
-        else if (!v->dist) continue;
-
-        int *pv;
-        int const vtotal = check ? VERTEXvnum(vt,new_dist_nsize) : vt->vtotal;
-        int n;
-        for (pv = vt->v, n = 0; n < vtotal; n++) {
-          VERTEX const * const vn = &mris->vertices[*pv++];
-          // if (vn->ripflag) continue;
-          float xd = v->x - vn->x;
-          float yd = v->y - vn->y;
-          float zd = v->z - vn->z;
-          float d = xd * xd + yd * yd + zd * zd;
-
-          if (!check) 
-            v->dist[n] = sqrt(d);
-          else if (v->dist[n] != (float)(sqrt(d))) 
-            errors++;
-        }
-
-        ROMP_PFLB_end
-      }
-      ROMP_PF_end
-  
-      break;
-
-    case MRIS_PARAMETERIZED_SPHERE:
-    case MRIS_SPHERE: {
-
-      ROMP_PF_begin		// mris_fix_topology
-#ifdef HAVE_OPENMP
-      #pragma omp parallel for if_ROMP(shown_reproducible) reduction(+:errors)
-#endif
-      for (vno = 0; vno < mris->nvertices; vno++) {
-        ROMP_PFLB_begin
-    
-        if (vno == Gdiag_no) DiagBreak();
-
-        VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
-        VERTEX          const * const v  = &mris->vertices         [vno];
-        if (v->ripflag) continue;
-
-        if (!check) MRISmakeDist(mris,vno);
-        else if (!v->dist) continue;
-
-        XYZ xyz1_normalized;
-        float xyz1_length;
-        XYZ_NORMALIZED_LOAD(&xyz1_normalized, &xyz1_length, v->x, v->y, v->z);  // length 1 along radius vector
-
-        float const radius = xyz1_length;
-
-        int *pv;
-        int const vtotal = check ? VERTEXvnum(vt,new_dist_nsize) : vt->vtotal;
-        int n;
-        for (pv = vt->v, n = 0; n < vtotal; n++) {
-          VERTEX const * const vn = &mris->vertices[*pv++];
-          if (vn->ripflag) continue;
-          
-          float angle = fabs(XYZApproxAngle(&xyz1_normalized, vn->x, vn->y, vn->z));
-            // radians, so 2pi around the circumference
-
-          float d = angle * radius;
-            // the length of the arc, rather than the straight line distance
-
-          if (!check) 
-            v->dist[n] = d;
-          else if (v->dist[n] != (float)(d)) 
-            errors++;
-        }
-        ROMP_PFLB_end
-      }
-      ROMP_PF_end
-
-      break;
-    }
-  }
-
-  return (errors == 0);
+int mrisComputeOriginalVertexDistances(MRIS *mris) {
+  mrisComputeOriginalVertexDistancesWkr(mris, mris->nsize, false);
+  mris->dist_orig_nsize = mris->nsize;
+  mrisCheckDistOrig(mris);
+  return NO_ERROR;
 }
 
-
-int mrisComputeOriginalVertexDistances(MRIS *mris)
+void mrisComputeOriginalVertexDistancesIfNecessaryWkr(MRIS *mris, bool* laterTime, const char* file, int line)
 {
-  VECTOR* v1 = VectorAlloc(3, MATRIX_REAL);
-  VECTOR* v2 = VectorAlloc(3, MATRIX_REAL);
-
-  float circumference = 0.0f;
+  if (mris->dist_alloced_flags&2) return;
   
-  bool allOrigXZero = true;
+  bool useOldBehaviour = true;
+  switch (copeWithLogicProblem("FREESURFER_fix_missing_dist_orig","dist_orig not already computed")) {
+  case LogicProblemResponse_old: 
+    break;
+  case LogicProblemResponse_fix:
+    useOldBehaviour = false;
+  }
+
+  // The old code did not compute this distance, but instead had zero's loaded into the already allocated dist_orig
+  // Computing it here may change the result, so the default is to zero the values after computing them
+  //    thereby allocating the correct size, checking the calculation, but reverting to the old behaviour
+  //
+  mrisComputeOriginalVertexDistances(mris);
+
+  if (!useOldBehaviour) return;
   
   int vno;
   for (vno = 0; vno < mris->nvertices; vno++) {
-    VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
-    VERTEX          const * const v  = &mris->vertices         [vno];
-
-    if (v->ripflag || v->dist_orig == NULL) {
-      continue;
-    }
-    if (vno == Gdiag_no) {
-      DiagBreak();
-    }
-
-    allOrigXZero &= (v->origx == 0.0f);
-
-    int const vtotal = vt->vtotal;
-
-    switch (mris->status) {
-      default: 
-        // seen to happen - e.g. mris_sphere test   cheapAssert(false);
-      
-      case MRIS_PLANE: {
-        int n, *pv;
-        for (pv = vt->v, n = 0; n < vtotal; n++) {
-          VERTEX const * const vn = &mris->vertices[*pv++];
-          if (vn->ripflag) continue;
-
-          float xd = v->origx - vn->origx;
-          float yd = v->origy - vn->origy;
-          float zd = v->origz - vn->origz;
-          float d = xd * xd + yd * yd + zd * zd;    // should be double
-
-          v->dist_orig[n] = sqrt(d);
-        }
-        DiagBreak();
-      } break;
-  
-      case MRIS_PARAMETERIZED_SPHERE:
-      case MRIS_SPHERE: {
-        VECTOR_LOAD(v1, v->origx, v->origy, v->origz); /* radius vector */
-        if (FZERO(circumference))                      /* only calculate once */
-          circumference = M_PI * 2.0 * V3_LEN(v1);
- 
-        int n, *pv;
-        for (pv = vt->v, n = 0; n < vtotal; n++) {
-          VERTEX const * const vn = &mris->vertices[*pv++];
-          if (vn->ripflag) continue;
- 
-          VECTOR_LOAD(v2, vn->origx, vn->origy, vn->origz); /* radius vector */
-          float angle = fabsf(Vector3Angle(v1, v2));
-          float d     = circumference * angle / (2.0 * M_PI);
-
-          v->dist_orig[n] = d;
-        }
-      } break;
-    }
+    VERTEX const * v = &mris->vertices[vno];
+    float* dist_orig = v->dist_orig;
+    bzero(dist_orig, v->dist_orig_capacity*sizeof(float));
   }
-
-  if (false && allOrigXZero) {
-    static bool laterTime;
-    if (!laterTime) { laterTime = true;
-      fprintf(stdout, "%s:%d origx have not been set - probably a logic error\n",__FILE__,__LINE__);
-    }
-  }
-  
-  VectorFree(&v1);
-  VectorFree(&v2);
-  return (NO_ERROR);
 }
+
+// The only difference between these should be
+// whether they use     xyz and write dist
+//                  origxyz and write dist_orig
+// but they diverged when these two did not share code.
+//
+#define FUNCTION_NAME mrisComputeVertexDistancesWkr
+#define INPUT_X x
+#define INPUT_Y y
+#define INPUT_Z z
+#define OUTPUT_DIST dist
+#define OUTPUT_MAKER MRISmakeDist
+#include "mrisComputeVertexDistancesWkr_extracted.h"
+
+#define FUNCTION_NAME mrisComputeOriginalVertexDistancesWkr
+#define INPUT_X origx
+#define INPUT_Y origy
+#define INPUT_Z origz
+#define OUTPUT_DIST dist_orig
+#define OUTPUT_MAKER MRISmakeDistOrig
+#include "mrisComputeVertexDistancesWkr_extracted.h"
+
 
 int MRISclearOrigDistances(MRI_SURFACE *mris)
 {
@@ -1421,6 +1476,7 @@ double MRISpercentDistanceError(MRIS *mris)
     dist_scale = sqrt(mris->orig_area / mris->total_area);
   }
 
+  double mean_dist  = 0.0;
   double mean_odist = 0.0;
   double mean_error = 0.0;
   double pct        = 0.0;
@@ -1434,16 +1490,21 @@ double MRISpercentDistanceError(MRIS *mris)
 
     int n;
     for (n = 0; n < vt->vtotal; n++) {
-      double dist  = v->dist     [n] * dist_scale;
-      double odist = v->dist_orig[n];
+      double dist  = !v->dist      ? 0.0 : v->dist     [n] * dist_scale;
+      double odist = !v->dist_orig ? 0.0 : v->dist_orig[n];
       
       nnbrs++;
+      mean_dist  +=  dist;
       mean_odist += odist;
       mean_error += fabs(dist - odist);
       if (!FZERO(odist)) pct += fabs(dist - odist) / odist;
     }
   }
 
+  if (mean_dist == 0.0f) {
+    fprintf(stdout, "%s:%d MRISpercentDistanceError called when all dist zero\n", __FILE__, __LINE__);
+  }
+  
   if (mean_odist == 0.0f) {
     fprintf(stdout, "%s:%d MRISpercentDistanceError called when all dist_orig zero\n", __FILE__, __LINE__);
   }
@@ -6768,9 +6829,14 @@ short MRIScomputeSecondFundamentalFormDiscrete(MRIS *apmris, short ab_signedPrin
 
   retKH = 1;
   retk1k2 = 1;
-  MRISclearMarks(apmris);
+
+  MRISclearMarks(apmris);   // not clear this is needed before the next line
   MRIScomputeTriangleProperties(apmris);
-  MRIScomputeGeometricProperties(apmris);
+
+  // maybe this should have been here MRISclearMarks(apmris);
+  MRIS_facesAtVertices_reorder(apmris);
+  // this leaves marked set - don't know if this is required for the next step
+  
   retKH = MRIS_discreteKH_compute(apmris);
   retk1k2 = MRIS_discretek1k2_compute(apmris, ab_signedPrinciples);
   return (retKH | retk1k2);
@@ -15676,16 +15742,19 @@ MRIS* MRISclone(MRIS const * mris_src)
         }
       }
 
-      MRISmakeDist(mris_dst, vno);
-
-      if (vsrc->dist)
+      if (vsrc->dist) {
+        MRISmakeDist(mris_dst, vno);
         for (n = 0; n < vSize; n++) {
           vdst->dist[n] = vsrc->dist[n];
         }
-      if (vsrc->dist_orig)
+      }
+      
+      if (vsrc->dist_orig) {
+        MRISmakeDistOrig(mris_dst, vno);
         for (n = 0; n < vSize; n++) {
           vdst->dist_orig[n] = vsrc->dist_orig[n];
         }
+      }
     }
     
     vdst->border   = vsrc->border;

--- a/utils/mrisurf_metricProperties.c
+++ b/utils/mrisurf_metricProperties.c
@@ -34,10 +34,7 @@ int mrisurf_orig_clock;
 //
 static void MRISsetXYZwkr1(MRIS *mris, const char * file, int line, bool* laterTime) {
   if (mris->dist_alloced_flags & 1) {
-    if (!*laterTime) { *laterTime = true;
-      fprintf(stdout, "%s:%d setXYZ with dist not freed.  Add call to MRISfreeDistsButNotOrig(MRIS*)\n", file,line);
-    }
-    cheapAssert(true);  // HACK should be true
+    copeWithLogicProblem2(laterTime, NULL,"dist not freed when setXYZ called.  Add call to MRISfreeDistsButNotOrig(MRIS*)",file,line,"<unknown>");
   }
 }
 
@@ -149,10 +146,7 @@ void MRIScopyXYZ(MRIS *mris, MRIS* mris_from) {
 void MRISsetOriginalXYZwkr(MRIS *mris, int vno, float origx, float origy, float origz, const char * file, int line, bool* laterTime) 
 {
   if (mris->dist_alloced_flags & 2) {
-    if (!*laterTime) { *laterTime = true;
-      fprintf(stdout, "%s:%d setOriginalXYZ with dist_orig not freed.  Add call to MRISfreeDistOrigs(MRIS*)\n", file,line);
-    }
-    cheapAssert(true);  // HACK should be false
+    copeWithLogicProblem2(laterTime, NULL,"dist_orig not freed when setOriginalXYZ called.  Add call to MRISfreeDistOrigs(MRIS*)",file,line,"<unknown>");
   }
 
   cheapAssertValidVno(mris,vno);

--- a/utils/mrisurf_metricProperties.h
+++ b/utils/mrisurf_metricProperties.h
@@ -115,11 +115,7 @@ int mrisMarkIntersections(MRIS *mris);
 void mrisDumpFace(MRIS *mris, int fno, FILE *fp);
 
 
-int    mrisComputeSurfaceDimensions      (MRIS *mris);
-
 int    MRIScomputeAllDistances           (MRIS *mris);
-int    mrisComputeVertexDistances        (MRIS *mris);
-int    mrisComputeOriginalVertexDistances(MRIS *mris);
 void   MRIScomputeAvgInterVertexDist     (MRIS *Surf, double *StdDev);
 void   mrisSetAvgInterVertexDist         (MRIS *Surf, double to);
 int    mrisTrackTotalDistance            (MRIS *mris);

--- a/utils/mrisutils.c
+++ b/utils/mrisutils.c
@@ -454,6 +454,11 @@ static int mrisLimitGradientDistance(MRI_SURFACE *mris, MHT *mht, int vno)
 static double mrisAsynchronousTimeStepNew(MRI_SURFACE *mris, float momentum, float delta_t, MHT *mht, float max_mag)
 {
   static int direction = 1;
+  
+  MRISfreeDistsButNotOrig(mris);
+    // MRISsetXYZ will invalidate all of these,
+    // so make sure they are recomputed before being used again!
+
   int i;
   for (i = 0; i < mris->nvertices; i++) {
     int const vno =
@@ -1006,6 +1011,10 @@ void MRISsmoothSurface2(MRI_SURFACE *mris, int niter, float step, int avrg)
     }
     
     mrisAverageSignedGradients(mris, avrg);
+
+    MRISfreeDistsButNotOrig(mris);
+      // MRISsetXYZ will invalidate all of these,
+      // so make sure they are recomputed before being used again!
     
     for (k = 0; k < mris->nvertices; k++) {
       VERTEX * const v = &mris->vertices[k];
@@ -2205,6 +2214,10 @@ int MRISsetPialUnknownToWhite(const MRIS *white, MRIS *pial)
     UseWhite = 1;
   else
     UseWhite = 0;
+ 
+  MRISfreeDistsButNotOrig(pial);
+    // MRISsetXYZ will invalidate all of these,
+    // so make sure they are recomputed before being used again!
 
   ROMP_PF_begin
 #ifdef HAVE_OPENMP

--- a/utils/surfgrad.c
+++ b/utils/surfgrad.c
@@ -398,6 +398,10 @@ int MRISedgeAngleCostEdgeVertexTest(MRIS *surf, int edgeno, int wrtvtxno, long d
   //MRISedgePrint(surf, edgeno, stdout);
   //printf("%3d %g %g %g  %g\n",surfvtxno,v->x,v->y,v->z,J0);
 
+  MRISfreeDistsButNotOrig(surf);
+    // MRISsetXYZ will invalidate all of these,
+    // so make sure they are recomputed before being used again!
+
   gnum = DMatrixAlloc(1,3,MATRIX_REAL);  
   for(wrtdimno=0; wrtdimno < 3; wrtdimno++){
 
@@ -1031,6 +1035,10 @@ double TestBBRCostFace(BBRPARAMS * const bbrpar, int const faceno, int const wrt
   
   double maxgrad = 0, maxdiff = 0;
   
+  MRISfreeDistsButNotOrig(mris);
+    // MRISsetXYZ will invalidate all of these,
+    // so make sure they are recomputed before being used again!
+
   // Go through each dimension in the WRT vertex
   //
   BBRFACE* bbrfgrad = NULL;     // these are reused around the loop

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -1733,3 +1733,79 @@ float fastApproxAtan2f(float y, float x) {
     if (ax != x && ay != y) r = -Pi+r;
     return r; 
 }
+
+
+// Support for reporting logic problems and other phenomona
+//
+typedef struct ReportEntry { 
+    struct ReportEntry* next;           // list for this line
+    const char*         file;           // key
+    int                 check_count; 
+    int                 check_elideUntil; 
+    int                 report_count; 
+    int                 report_elideUntil; 
+    } ReportEntry;
+
+static ReportEntry* reportEntry(const char* file, int line) {
+  static ReportEntry* entries[1000000];
+  cheapAssert(line <          1000000);
+  ReportEntry** ep = &entries[line];
+  while (*ep && strcmp((*ep)->file,file)) ep = &(*ep)->next;
+  ReportEntry* e = *ep;
+  if (!e) {
+    e = (ReportEntry*)calloc(1,sizeof(ReportEntry)); 
+    e->file              = file;
+    e->check_elideUntil  = 1;
+    e->report_elideUntil = 1;
+    *ep = e;
+  }
+  return e;
+}
+
+bool spendTimeCheckingForLogicProblem(const char* file, int line) {
+  ReportEntry* e = reportEntry(file, line);
+  if (!e) return false;
+  e->check_count++;
+  if (e->check_count < e->check_elideUntil) return false;
+  e->check_elideUntil = (e->check_elideUntil < 32) ? e->check_elideUntil + 1 : e->check_elideUntil*2;
+  return true;
+}
+
+LogicProblemResponse copeWithLogicProblem2(
+    bool* wasReported, 
+    const char* envvarFixer,
+    const char* msg, 
+    const char* file, int line, const char* function)
+{
+  static bool emitReport, getenvDone;
+  if (!getenvDone) { getenvDone = true;
+    emitReport = !getenv("FREESURFER_dontReportLogicErrors");
+  }
+
+  LogicProblemResponse response = LogicProblemResponse_old;
+  if (envvarFixer && !!getenv(envvarFixer)) response = LogicProblemResponse_fix;
+  
+  if (wasReported) *wasReported= false;
+  
+  if (!emitReport) return response;
+  
+  ReportEntry* e = reportEntry(file, line);
+  if (!e) return response;
+
+  e->report_count++;
+  if (e->report_count < e->report_elideUntil) return response;
+
+  e->report_elideUntil = (e->report_elideUntil < 32) ? e->report_elideUntil + 1 : e->report_elideUntil*2;
+
+  fprintf(stdout,
+    "%s:%d %s - probable logic error: %s%s\n%s%s%s",
+    file,line,function, msg, 
+    (response == LogicProblemResponse_fix) ? ", fixing it" : ", not fixing it",
+    envvarFixer?".  Set ":"",
+    envvarFixer?envvarFixer:"",
+    envvarFixer?" to fix it\n":"");
+
+  if (wasReported) *wasReported = true;
+
+  return response;
+}

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -1779,7 +1779,7 @@ LogicProblemResponse copeWithLogicProblem2(
 {
   static bool emitReport, getenvDone;
   if (!getenvDone) { getenvDone = true;
-    emitReport = !getenv("FREESURFER_dontReportLogicErrors");
+    emitReport = !!getenv("FREESURFER_reportLogicErrors");
   }
 
   LogicProblemResponse response = LogicProblemResponse_old;


### PR DESCRIPTION
Change a lot more modifies of xyz to use MRISsetXYZ

        Free the VERTEX::dist in many more places where the dist is invalid, to verify it is being recomputed with the new xyz values

        Use MRISexportXYZ rather than VERTEX::tdxyz in some cases to reduce usage of the tdxyz and get better memory traffic performance

        Add base.h copeWithLogicProblem that allows reporting and optional fixing of possible logic problems in the code

        Move origxyz after xyz in the VERTEX because xyz is the input and origxyz is the output

        Start keeping track of the dist_orig_nsize because changing dist_nsize did not always recompute the corresponding dist_orig values

        Replace calls to the badly misnamed MRIScomputeGeometricProperties with the existing MRIS_facesAtVertices_reorder, because that is what it does

        Passed __FILE__ and __LINE__ into MRISsetXYZ to allow for better warning messages

        Added and used MRISblendXYZandTXYZ   (mris, ...) rather than having multiple copies of the operation   (xyz = a * xyz + b * txyz)

        Added and used MRISscaleThenTranslate(mris, ...) rather than having multiple copies of the operation   (x = ax * x + bx), (y = ay * y + by), ...

        Use mrisComputeSurfaceDimensions rather than having multiple copies of the operation

        Logic errors being flagged
            mris_sphere/mris_sphere.c main()
                is not copying the xyz into the origxyz
                hence is later using zeroes rather than the correct values
            utils/mrisurf_integrate.c MRISinflateBrain()
                is not copying the xyz into the origxyz
                hence is later using zeroes rather than the correct values

        Add a primitive restart capability to recon-all
            so that the initial expensive mri section can be skipped when working on mris code

        Share the code for mrisComputeVertexDistance and mrisComputeOriginalVertexDistance
            so that they use the exact same definition of distance - the OriginalVertex version had not been updated when the Vertex version was sped up

        Speed up the deallocation and reallocation dist and dist_orig so it is cheap to have the dist and dist_orig fields NULL when the values are invalid

        Added mrisComputeOriginalVertexDistancesIfNecessary which will compute the dist_orig if they are not already computed
            This is useful for correctly logic errors where some paths had not computed the dist_orig and other paths might have

        Enhanced MRIS_facesAtVertices_reorder to fill in the topology correctly

        Renamed  MRIScomputeNormals  to  MRIScomputeNormalsPerturbingXYZ  because the former does not reveal the idea that the xyz might be changed by this call