### PR TITLE
Fix Test Data tarballs

### DIFF
--- a/mri_aparc2aseg/CMakeLists.txt
+++ b/mri_aparc2aseg/CMakeLists.txt
@@ -7,5 +7,7 @@ add_help(mri_aparc2aseg mri_aparc2aseg.help.xml)
 target_link_libraries(mri_aparc2aseg utils)
 
 add_test_script(NAME mri_aparc2aseg_test SCRIPT test_mri_aparc2aseg DEPENDS mri_aparc2aseg)
+configure_file(testdata.tar.gz . COPYONLY)
+configure_file(testdata2.tar.gz . COPYONLY)
 
 install(TARGETS mri_aparc2aseg DESTINATION bin)

--- a/mri_ca_label/CMakeLists.txt
+++ b/mri_ca_label/CMakeLists.txt
@@ -7,5 +7,6 @@ add_help(mri_ca_label mri_ca_label.help.xml)
 target_link_libraries(mri_ca_label utils)
 
 add_test_script(NAME mri_ca_label_test SCRIPT test_mri_ca_label DEPENDS mri_ca_label)
+configure_file(testdata.tar.gz . COPYONLY)
 
 install(TARGETS mri_ca_label DESTINATION bin)

--- a/mri_ca_normalize/CMakeLists.txt
+++ b/mri_ca_normalize/CMakeLists.txt
@@ -8,6 +8,7 @@ target_link_libraries(mri_ca_normalize utils)
 install(TARGETS mri_ca_normalize DESTINATION bin)
 
 add_test_script(NAME mri_ca_normalize_test SCRIPT test_mri_ca_normalize DEPENDS mri_ca_normalize)
+configure_file(testdata.tar.gz . COPYONLY)
 
 add_executable(mri_cal_normalize mri_cal_normalize.c)
 target_link_libraries(mri_cal_normalize utils)

--- a/mri_ca_register/CMakeLists.txt
+++ b/mri_ca_register/CMakeLists.txt
@@ -7,5 +7,6 @@ add_help(mri_ca_register mri_ca_register.help.xml)
 target_link_libraries(mri_ca_register utils)
 
 add_test_script(NAME mri_ca_register_test SCRIPT test_mri_ca_register DEPENDS mri_ca_register)
+configure_file(testdata.tar.gz . COPYONLY)
 
 install(TARGETS mri_ca_register DESTINATION bin)

--- a/mri_concatenate_lta/CMakeLists.txt
+++ b/mri_concatenate_lta/CMakeLists.txt
@@ -6,5 +6,6 @@ add_executable(mri_concatenate_lta mri_concatenate_lta.c)
 target_link_libraries(mri_concatenate_lta utils)
 
 add_test_script(NAME mri_concatenate_lta_test SCRIPT test_mri_concatenate_lta DEPENDS mri_concatenate_lta)
+configure_file(testdata.tar.gz . COPYONLY)
 
 install(TARGETS mri_concatenate_lta DESTINATION bin)

--- a/mri_coreg/CMakeLists.txt
+++ b/mri_coreg/CMakeLists.txt
@@ -6,5 +6,6 @@ add_executable(mri_coreg mri_coreg.c)
 target_link_libraries(mri_coreg utils)
 
 add_test_script(NAME mri_coreg_test SCRIPT test_mri_coreg DEPENDS mri_coreg)
+configure_file(testdata.tar.gz . COPYONLY)
 
 install(TARGETS mri_coreg DESTINATION bin)

--- a/mri_em_register/CMakeLists.txt
+++ b/mri_em_register/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
 )
 
 add_test_script(NAME mri_em_register_test SCRIPT test_mri_em_register DEPENDS mri_em_register)
+configure_file(testdata.tar.gz . COPYONLY)
 
 add_executable(mri_em_register ${SOURCES})
 add_help(mri_em_register mri_em_register.help.xml)

--- a/mri_glmfit/CMakeLists.txt
+++ b/mri_glmfit/CMakeLists.txt
@@ -6,5 +6,6 @@ add_executable(mri_glmfit mri_glmfit.c)
 target_link_libraries(mri_glmfit utils fsgdf)
 
 add_test_script(NAME mri_glmfit_test SCRIPT test_mri_glmfit DEPENDS mri_glmfit)
+configure_file(teststats.tar.gz . COPYONLY)
 
 install(TARGETS mri_glmfit DESTINATION bin RENAME mri_glmfit)

--- a/mri_robust_register/CMakeLists.txt
+++ b/mri_robust_register/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(mri_robust_template utils ${FORTRAN_LIBS})
 add_help(mri_robust_template mri_robust_template.help.xml)
 add_test_script(NAME mri_robust_template_test SCRIPT test_mri_robust_template DEPENDS mri_robust_template)
 add_test_script(NAME libgfortran_linker SCRIPT test_libgfortran DEPENDS mri_robust_template)
+configure_file(testdata.tar.gz . COPYONLY)
 install(TARGETS mri_robust_template DESTINATION bin)
 
 # lta_diff

--- a/mri_segstats/CMakeLists.txt
+++ b/mri_segstats/CMakeLists.txt
@@ -7,5 +7,6 @@ add_help(mri_segstats mri_segstats.help.xml)
 target_link_libraries(mri_segstats utils)
 
 add_test_script(NAME mri_segstats_test SCRIPT test_mri_segstats DEPENDS mri_segstats)
+configure_file(testdata.tar.gz . COPYONLY)
 
 install(TARGETS mri_segstats DESTINATION bin)

--- a/mris_anatomical_stats/CMakeLists.txt
+++ b/mris_anatomical_stats/CMakeLists.txt
@@ -7,5 +7,11 @@ add_help(mris_anatomical_stats mris_anatomical_stats.help.xml)
 target_link_libraries(mris_anatomical_stats utils)
 
 add_test_script(NAME mris_anatomical_stats_test SCRIPT test_mris_anatomical_stats DEPENDS mris_anatomical_stats)
+configure_file(testdata2.tar.gz . COPYONLY)
+configure_file(test1.expected . COPYONLY)
+configure_file(test2.expected . COPYONLY)
+configure_file(test2_logfile.expected . COPYONLY)
+configure_file(test3.expected . COPYONLY)
+configure_file(test6.expected . COPYONLY)
 
 install(TARGETS mris_anatomical_stats DESTINATION bin)

--- a/mris_ca_label/CMakeLists.txt
+++ b/mris_ca_label/CMakeLists.txt
@@ -7,5 +7,6 @@ add_help(mris_ca_label mris_ca_label.help.xml)
 target_link_libraries(mris_ca_label utils)
 
 add_test_script(NAME mris_ca_label_test SCRIPT test_mris_ca_label DEPENDS mris_ca_label)
+configure_file(testdata.tar.gz . COPYONLY)
 
 install(TARGETS mris_ca_label DESTINATION bin)

--- a/mris_convert/CMakeLists.txt
+++ b/mris_convert/CMakeLists.txt
@@ -7,5 +7,6 @@ target_link_libraries(mris_convert utils)
 
 add_test_script(NAME mris_convert_test SCRIPT test_mris_convert DEPENDS mris_convert)
 add_test_script(NAME mris_convert_gifti_test SCRIPT test_gifti DEPENDS mris_convert)
+configure_file(giftidata.tar.gz . COPYONLY)
 
 install(TARGETS mris_convert DESTINATION bin)

--- a/mris_curvature/CMakeLists.txt
+++ b/mris_curvature/CMakeLists.txt
@@ -7,5 +7,6 @@ add_help(mris_curvature mris_curvature.help.xml)
 target_link_libraries(mris_curvature utils)
 
 add_test_script(NAME mris_curvature_test SCRIPT test_mris_curvature DEPENDS mris_curvature)
+configure_file(testdata.tar.gz . COPYONLY)
 
 install(TARGETS mris_curvature DESTINATION bin)

--- a/mris_expand/CMakeLists.txt
+++ b/mris_expand/CMakeLists.txt
@@ -6,5 +6,6 @@ add_executable(mris_expand mris_expand.c)
 target_link_libraries(mris_expand utils)
 
 add_test_script(NAME mris_expand_test SCRIPT test_mris_expand DEPENDS mris_expand)
+configure_file(testdata.tar.gz . COPYONLY)
 
 install(TARGETS mris_expand DESTINATION bin)

--- a/mris_inflate/CMakeLists.txt
+++ b/mris_inflate/CMakeLists.txt
@@ -7,5 +7,6 @@ add_help(mris_inflate mris_inflate.help.xml)
 target_link_libraries(mris_inflate utils)
 
 add_test_script(NAME mris_inflate_posix_test SCRIPT test_fs_posix DEPENDS mris_inflate)
+configure_file(testdata.tar.gz . COPYONLY)
 
 install(TARGETS mris_inflate DESTINATION bin)

--- a/mris_jacobian/CMakeLists.txt
+++ b/mris_jacobian/CMakeLists.txt
@@ -7,5 +7,6 @@ add_help(mris_jacobian mris_jacobian.help.xml)
 target_link_libraries(mris_jacobian utils)
 
 add_test_script(NAME mris_jacobian_posix_test SCRIPT test_fs_posix DEPENDS mris_jacobian)
+configure_file(testdata.tar.gz . COPYONLY)
 
 install(TARGETS mris_jacobian DESTINATION bin)

--- a/mris_make_surfaces/CMakeLists.txt
+++ b/mris_make_surfaces/CMakeLists.txt
@@ -8,6 +8,7 @@ target_link_libraries(mris_make_surfaces utils)
 install(TARGETS mris_make_surfaces DESTINATION bin)
 
 add_test_script(NAME mris_make_surfaces_test SCRIPT test_mris_make_surfaces DEPENDS mris_make_surfaces)
+configure_file(testdata.tar.gz . COPYONLY)
 
 add_executable(mris_refine_surfaces mris_refine_surfaces.c)
 target_link_libraries(mris_refine_surfaces utils)

--- a/mris_register/CMakeLists.txt
+++ b/mris_register/CMakeLists.txt
@@ -7,5 +7,6 @@ add_help(mris_register mris_register.help.xml)
 target_link_libraries(mris_register utils)
 
 add_test_script(NAME mris_register_test SCRIPT test_mris_register DEPENDS mris_register)
+configure_file(testdata.tar.gz . COPYONLY)
 
 install(TARGETS mris_register DESTINATION bin)

--- a/mris_smooth/CMakeLists.txt
+++ b/mris_smooth/CMakeLists.txt
@@ -7,5 +7,6 @@ add_help(mris_smooth mris_smooth.help.xml)
 target_link_libraries(mris_smooth utils)
 
 add_test_script(NAME mris_smooth_posix_test SCRIPT test_fs_posix DEPENDS mris_smooth)
+configure_file(testdata.tar.gz . COPYONLY)
 
 install(TARGETS mris_smooth DESTINATION bin)

--- a/mris_sphere/CMakeLists.txt
+++ b/mris_sphere/CMakeLists.txt
@@ -9,6 +9,7 @@ install(TARGETS mris_sphere DESTINATION bin)
 
 add_test_script(NAME mris_sphere_test SCRIPT test.py DEPENDS mris_sphere)
 add_test_script(NAME mris_sphere_posix_test SCRIPT test_fs_posix DEPENDS mris_sphere)
+configure_file(testdata.tar.gz . COPYONLY)
 
 add_executable(mris_remove_negative_vertices mris_remove_negative_vertices.c)
 target_link_libraries(mris_remove_negative_vertices utils)

--- a/mris_volmask/CMakeLists.txt
+++ b/mris_volmask/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(mris_volmask utils)
 install(TARGETS mris_volmask DESTINATION bin)
 
 add_test_script(NAME mris_volmask_test SCRIPT test_mris_volmask DEPENDS mris_volmask)
+configure_file(testdata2.tar.gz . COPYONLY)
 
 add_executable(mris_volmask_novtk mris_volmask_old.cpp cmd_line_interface.cpp)
 target_compile_definitions(mris_volmask_novtk PRIVATE NO_VTK)

--- a/optseq2/CMakeLists.txt
+++ b/optseq2/CMakeLists.txt
@@ -6,5 +6,6 @@ add_executable(optseq2 optseq2.c)
 target_link_libraries(optseq2 utils)
 
 add_test_script(NAME optseq2_test SCRIPT test_optseq2.csh DEPENDS optseq2)
+configure_file(test_data.tar.gz . COPYONLY)
 
 install(TARGETS optseq2 DESTINATION bin)

--- a/utils/test/MRIScomputeBorderValues/CMakeLists.txt
+++ b/utils/test/MRIScomputeBorderValues/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_executable(test_border_values EXCLUDE_FROM_ALL test_MRIScomputeBorderValues.cpp)
 target_link_libraries(test_border_values utils)
 add_test_script(NAME border_values_test SCRIPT run_test_MRIScomputeBorderValues DEPENDS test_border_values)
+configure_file(testdata.tar.gz . COPYONLY)

--- a/utils/test/mriBuildVoronoiDiagramFloat/CMakeLists.txt
+++ b/utils/test/mriBuildVoronoiDiagramFloat/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_executable(test_voronoi EXCLUDE_FROM_ALL test_mriBuildVoronoiDiagramFloat.cpp)
 target_link_libraries(test_voronoi utils)
 add_test_script(NAME voronoi_test SCRIPT test_mriBuildVoronoiDiagramFloat_withData DEPENDS test_voronoi)
+configure_file(testdata.tar.gz . COPYONLY)

--- a/utils/test/mriSoapBubbleFloat/CMakeLists.txt
+++ b/utils/test/mriSoapBubbleFloat/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_executable(test_soapbubble EXCLUDE_FROM_ALL test_mriSoapBubbleFloat.cpp)
 target_link_libraries(test_soapbubble utils)
 add_test_script(NAME soapbubble_test SCRIPT test_mriSoapBubbleFloat_withData DEPENDS test_soapbubble)
+configure_file(testdata.tar.gz . COPYONLY)


### PR DESCRIPTION
Add CMake commands to copy the various tarballs of test data to the proper locations
This is to allow for out-of-source builds and test runs