### PR TITLE
Fix a segv caused by wrong calculation of change in number of disp_storage entries

### DIFF
--- a/utils/mrisurf_base.c
+++ b/utils/mrisurf_base.c
@@ -450,7 +450,7 @@ bool MRISreallocVertices(MRIS * mris, int max_vertices, int nvertices) {
 #endif
   }
   
-  change = max_vertices - mris->nvertices;
+  change = max_vertices - mris->max_vertices;
   if (change > 0) {
     bzero(mris->dist_storage      + mris->max_vertices, change*sizeof(void*));
     bzero(mris->dist_orig_storage + mris->max_vertices, change*sizeof(void*));


### PR DESCRIPTION
Doug reported a crash

This is the trivial fix

No change in results

We need a test for mris_decimate