### PR TITLE
Update save_nifti.m

### DIFF
--- a/matlab/save_nifti.m
+++ b/matlab/save_nifti.m
@@ -68,7 +68,11 @@ hdr.db_name = [hdr.db_name(:)' repmat(' ',[1 18])];
 hdr.db_name = hdr.db_name(1:18);
 
 hdr.dim = ones(1,8);
-hdr.dim(1) = 4;
+if size(hdr.vol,4)>1
+  hdr.dim(1) = 4;
+else 
+  hdr.dim(1) = 3;
+end
 hdr.dim(2) = size(hdr.vol,1);
 hdr.dim(3) = size(hdr.vol,2);
 hdr.dim(4) = size(hdr.vol,3);


### PR DESCRIPTION
When using the BIDS-validator on T1-weighted anatomicals that have been saved from MATLAB as a nifti file through save_nifti, the validator complains about the dimensionality of the image. This was traced back to the niftihdr by default having a dim(1) of 4 (as per line 71 of save_nifti).

I propose to change this hardcoded '4' into a value that is conditional on size(hdr.vol,4).