### PR TITLE
Improve behaviour of recon-all buckner 144

### DIFF
--- a/include/mrisurf.h
+++ b/include/mrisurf.h
@@ -2870,6 +2870,8 @@ void mrisSetVertexFaceIndex(MRIS *mris, int vno, int fno);
     // is being used outside mrissurf_topology but shouldn't be
     
 void setFaceAttachmentDeferred(MRIS* mris, bool to);                                // for performance reasons, defer adding them; or do all the deferred ones
+int mrisCountAttachedFaces(MRIS* mris, int vno0, int vno1);
+bool mrisCanAttachFaceToVertices(MRIS* mris, int vno1, int vno2, int vno3);         // returns whether such a face would be legal
 void mrisAttachFaceToEdges   (MRIS* mris, int fno, int vno1, int vno2, int vno3);   // edges must already exist
 void mrisAttachFaceToVertices(MRIS* mris, int fno, int vno1, int vno2, int vno3);   // adds any needed edges
 
@@ -2943,3 +2945,4 @@ void mrisComputeOriginalVertexDistancesIfNecessaryWkr(MRIS *mris, bool* laterTim
   }
 
 void MRIScheckForNans(MRIS *mris);
+void MRIScheckIsPolyhedron(MRIS *mris, const char* file, int line);

--- a/utils/mrisurf_defect.c
+++ b/utils/mrisurf_defect.c
@@ -7093,6 +7093,10 @@ static void detectDefectFaces(MRIS *mris, DEFECT_PATCH *dp)
 
       for (m = 0; m < v->vnum; m++) {
         vn2 = v->v[m];
+        
+        // edges should not go between the same vno!
+        // but this checks anyway...
+        //
         if (vn1 == vn2) {
           continue;
         }
@@ -7117,6 +7121,9 @@ static void detectDefectFaces(MRIS *mris, DEFECT_PATCH *dp)
           continue;
         }
 
+        if (!mrisCanAttachFaceToVertices(mris, vno, vn1, vn2)) {
+          continue;
+        }
         /* add this new face to the defect faces */
         mrisAddFace(mris, vno, vn1, vn2);
         if (nthings == nfaces) {
@@ -13565,6 +13572,7 @@ static NOINLINE int mrisComputeOptimalRetessellation_wkr(MRI_SURFACE *mris,
   dno++ ;  /* for debugging */
   tessellatePatch(mri,mris, mris_corrected, defect,
                   vertex_trans, et, nedges, NULL, NULL,parms);
+  MRIScheckIsPolyhedron(mris_corrected, __FILE__,__LINE__);
 
   return(NO_ERROR) ;
 

--- a/utils/mrisurf_deform.c
+++ b/utils/mrisurf_deform.c
@@ -13228,6 +13228,7 @@ int mrisAddFace(MRI_SURFACE *mris, int vno0, int vno1, int vno2)
     DiagBreak();
   }
 
+  cheapAssert(mrisCanAttachFaceToVertices(mris, vno0, vno1, vno2));
   f = &mris->faces[fno];
   f->v[0] = vno0;
   f->v[1] = vno1;


### PR DESCRIPTION
Same results on recon-all bert

When adding more faces to a defect fix, don't add more than two faces to an edge

Adds consistency checking code as well, but it is disabled