### PR TITLE
Prevent early exits.

### DIFF
--- a/mris_fix_topology/mris_fix_topology.c
+++ b/mris_fix_topology/mris_fix_topology.c
@@ -214,15 +214,7 @@ main(int argc, char *argv[])
   eno = MRIScomputeEulerNumber(mris, &nvert, &nfaces, &nedges) ;
   fprintf(stderr, "before topology correction, eno=%d (nv=%d, nf=%d, ne=%d,"
           " g=%d)\n", eno, nvert, nfaces, nedges, (2-eno)/2) ;
-  if(eno == 2 ){
-    printf("The Euler Number of this surface is 2, nothing to do\n");
-    sprintf(fname, "%s/%s/surf/%s.%s%s", sdir, sname, hemi, out_name,suffix);
-    printf("writing output surface to %s...\n", fname) ;
-    if(MRISwrite(mris, fname)) exit(1);
-    printf("#VMPC# mris_fix_topology VmPeak  %d\n",GetVmPeak());
-    printf("mris_fix_topology done\n");
-    exit(0);
-  }
+
   MRISprojectOntoSphere(mris, mris, 100.0f) ;
 
   MRISsmoothOnSphere(mris,sphere_smooth);


### PR DESCRIPTION
In some cases, there are still defects to be corrected, and a smoothed version of the ?h.orig needs to be saved (instead of the sphere).