### PR TITLE
Correcting spelling to "occipital" from "occiptal" for lobes.

### DIFF
--- a/distribution/FreeSurferColorLUT.txt
+++ b/distribution/FreeSurferColorLUT.txt
@@ -622,14 +622,14 @@
 
 1301    ctx-lh-frontal-lobe                  25  100 40  0
 1303    ctx-lh-cingulate-lobe                100 25  0   0
-1304    ctx-lh-occiptal-lobe                 120 70  50  0
+1304    ctx-lh-occipital-lobe                120 70  50  0
 1305    ctx-lh-temporal-lobe                 220 20  100 0
 1306    ctx-lh-parietal-lobe                 220 20  10  0
 1307    ctx-lh-insula-lobe                   255 192 32  0
 
 2301    ctx-rh-frontal-lobe                  25  100 40  0
 2303    ctx-rh-cingulate-lobe                100 25  0   0
-2304    ctx-rh-occiptal-lobe                 120 70  50  0
+2304    ctx-rh-occipitae-lobe                120 70  50  0
 2305    ctx-rh-temporal-lobe                 220 20  100 0
 2306    ctx-rh-parietal-lobe                 220 20  10  0
 2307    ctx-rh-insula-lobe                   255 192 32  0
@@ -644,14 +644,14 @@
 
 3201    wm-lh-frontal-lobe                  235 35  95  0
 3203    wm-lh-cingulate-lobe                35  75  35  0
-3204    wm-lh-occiptal-lobe                 135 155 195 0
+3204    wm-lh-occipital-lobe                135 155 195 0
 3205    wm-lh-temporal-lobe                 115 35  35  0
 3206    wm-lh-parietal-lobe                 35  195 35  0
 3207    wm-lh-insula-lobe                   20  220 160 0
 
 4201    wm-rh-frontal-lobe                  235 35  95  0
 4203    wm-rh-cingulate-lobe                35  75  35  0
-4204    wm-rh-occiptal-lobe                 135 155 195 0
+4204    wm-rh-occipital-lobe                135 155 195 0
 4205    wm-rh-temporal-lobe                 115 35  35  0
 4206    wm-rh-parietal-lobe                 35  195 35  0
 4207    wm-rh-insula-lobe                   20  220 160 0

--- a/freeview/resource/FreeSurferColorLUT.txt
+++ b/freeview/resource/FreeSurferColorLUT.txt
@@ -622,14 +622,14 @@
 
 1301    ctx-lh-frontal-lobe                  25  100 40  0
 1303    ctx-lh-cingulate-lobe                100 25  0   0
-1304    ctx-lh-occiptal-lobe                 120 70  50  0
+1304    ctx-lh-occipital-lobe                120 70  50  0
 1305    ctx-lh-temporal-lobe                 220 20  100 0
 1306    ctx-lh-parietal-lobe                 220 20  10  0
 1307    ctx-lh-insula-lobe                   255 192 32  0
 
 2301    ctx-rh-frontal-lobe                  25  100 40  0
 2303    ctx-rh-cingulate-lobe                100 25  0   0
-2304    ctx-rh-occiptal-lobe                 120 70  50  0
+2304    ctx-rh-occipital-lobe                120 70  50  0
 2305    ctx-rh-temporal-lobe                 220 20  100 0
 2306    ctx-rh-parietal-lobe                 220 20  10  0
 2307    ctx-rh-insula-lobe                   255 192 32  0
@@ -644,14 +644,14 @@
 
 3201    wm-lh-frontal-lobe                  235 35  95  0
 3203    wm-lh-cingulate-lobe                35  75  35  0
-3204    wm-lh-occiptal-lobe                 135 155 195 0
+3204    wm-lh-occipetal-lobe                135 155 195 0
 3205    wm-lh-temporal-lobe                 115 35  35  0
 3206    wm-lh-parietal-lobe                 35  195 35  0
 3207    wm-lh-insula-lobe                   20  220 160 0
 
 4201    wm-rh-frontal-lobe                  235 35  95  0
 4203    wm-rh-cingulate-lobe                35  75  35  0
-4204    wm-rh-occiptal-lobe                 135 155 195 0
+4204    wm-rh-occipital-lobe                135 155 195 0
 4205    wm-rh-temporal-lobe                 115 35  35  0
 4206    wm-rh-parietal-lobe                 35  195 35  0
 4207    wm-rh-insula-lobe                   20  220 160 0


### PR DESCRIPTION
Just added an "i" to two LUT files.