### PR TITLE
Compiler Warning Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,7 @@ option(SUPPRESS_WARNINGS "Allow building in subdirs to supress warnings" ON)
 # option(SUPPRESS_WARNINGS "Allow building in subdirs to supress warnings" OFF)
 
 # compiler warnings
-set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wall")
+set(C_CXX_FLAGS "${C_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter")
 # clang complains about -Wno-unused-but-set-variable and says to use -Wno-unused-const-variable
 
 if(SUPPRESS_WARNINGS)

--- a/anatomicuts/AnatomiCuts_correspondences.cxx
+++ b/anatomicuts/AnatomiCuts_correspondences.cxx
@@ -550,7 +550,7 @@ int main(int narg, char*  arg[])
 			//std::cout << orientationFilter2->GetUpDown() << " " << orientationFilter2->GetFrontBack() << " " << orientationFilter2->GetLeftRight() << std::endl;	
 
 
-			typedef ImageType::IndexType IndexType;
+			// typedef ImageType::IndexType IndexType;
 			std::vector<itk::Vector<float>> direcciones1;
 			std::vector<itk::Vector<float>> direcciones2;
 			int possibles[3] = {0,1,-1};

--- a/anatomicuts/CMakeLists.txt
+++ b/anatomicuts/CMakeLists.txt
@@ -7,8 +7,11 @@ if(VTK_FOUND)
     ${FS_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/Code
     ${CMAKE_SOURCE_DIR}/freeview/track_io
-    ${ITK_INCLUDE_DIRS}
     ${VTK_INCLUDE_DIRS}
+  )
+
+  include_directories(
+    SYSTEM ${ITK_INCLUDE_DIRS}
   )
 
   include(${ITK_USE_FILE})  

--- a/anatomicuts/SaveHistograms.cxx
+++ b/anatomicuts/SaveHistograms.cxx
@@ -39,7 +39,7 @@ int main(int narg, char*  arg[])
 	}
 	const unsigned int PointDimension = 3;
 	typedef itk::Mesh< PixelType, PointDimension > MeshType;
-	typedef PolylineMeshToVTKPolyDataFilter<MeshType> VTKConverterType;
+	// typedef PolylineMeshToVTKPolyDataFilter<MeshType> VTKConverterType;
 	typedef VTKPolyDataToPolylineMeshFilter<MeshType> MeshConverterType;
 
 	const char* filename =cl.follow("histograms.csv",2,"-O","-o"); 
@@ -134,11 +134,12 @@ int main(int narg, char*  arg[])
 		MeshType::Pointer mesh =  converter->GetOutput();
 
 		MeshType::CellsContainer::ConstIterator itCell = mesh->GetCells()->Begin();
-		int cellId = 0;
+		// int cellId = 0;
 
 		std::vector<std::map<int,int>> histograms;
-		for( int i=0;i<direcciones.size();i++)
+		for( size_t i=0;i<direcciones.size();i++) {
 			histograms.push_back(std::map<int,int>());
+		}
 
 		for( ;itCell != mesh->GetCells()->End();itCell++)
 		{
@@ -157,7 +158,7 @@ int main(int narg, char*  arg[])
 				else
 					histograms[0][label]=1;
 
-				for(int i=0;i<direcciones.size();i++)
+				for(size_t i=0;i<direcciones.size();i++)
 				{
 					PixelType vecino = label;
 					itk::ContinuousIndex<float,3> continuousIndex = index;
@@ -191,7 +192,7 @@ int main(int narg, char*  arg[])
 				}
 			}
 		}
-		for(int i=0;i<indeces.size();i++)
+		for(size_t i=0;i<indeces.size();i++)
 		{
 			csv_file << fiberFile << ",D:"<<indeces[i][0]<< ":"<<indeces[i][1]<<":"<<indeces[i][2]<<",";
 			for(std::map<int,int>::iterator it=histograms[i].begin(); it!= histograms[i].end(); ++it)

--- a/anatomicuts/trk_tools.cxx
+++ b/anatomicuts/trk_tools.cxx
@@ -24,7 +24,7 @@ int main(int narg, char* arg[])
 	// typedef ImageType::IndexType 			IndexType;
 	typedef itk::Mesh< PixelType, Dimension > MeshType;
 	typedef itk::ImageFileWriter<ImageType>                               WriterType;
-	typedef itk::ImageFileReader<ImageType>                               ReaderType;
+	// typedef itk::ImageFileReader<ImageType>                               ReaderType;
 	typedef MeshToImageFilter<MeshType,ImageType> MeshToImageType;
 	typedef VTKPolyDataToPolylineMeshFilter<MeshType> MeshConverterType;
 	typedef itk::ImageFileReader<ImageType> ImageReaderType;

--- a/include/romp_for_begin.h
+++ b/include/romp_for_begin.h
@@ -24,7 +24,9 @@
 
     {
         typedef void FORVAR;    // make sure not shared
-        if (sizeof(FORVAR*));   // use to avoid a warning msg
+        if (sizeof(FORVAR*)) {
+	  ;   // use to avoid a warning msg
+	}
         
         // Decide the distribution of the loops
         // and start the sum reductions, if any
@@ -55,13 +57,22 @@
     {
         // Poison the reduced identifiers
 #ifdef ROMP_SUMREDUCTION0
-        typedef void ROMP_SUMREDUCTION0; if (sizeof(ROMP_SUMREDUCTION0*));  // use to avoid a warning msg
+        typedef void ROMP_SUMREDUCTION0;
+	if (sizeof(ROMP_SUMREDUCTION0*)) {
+	  ;  // use to avoid a warning msg
+	}
 #endif
 #ifdef ROMP_SUMREDUCTION1
-        typedef void ROMP_SUMREDUCTION1; if (sizeof(ROMP_SUMREDUCTION1*));  // use to avoid a warning msg
+        typedef void ROMP_SUMREDUCTION1;
+	if (sizeof(ROMP_SUMREDUCTION1*)) {
+	  ;  // use to avoid a warning msg
+	}
 #endif
 #ifdef ROMP_SUMREDUCTION2
-        typedef void ROMP_SUMREDUCTION2; if (sizeof(ROMP_SUMREDUCTION2*));  // use to avoid a warning msg
+        typedef void ROMP_SUMREDUCTION2;
+	if (sizeof(ROMP_SUMREDUCTION2*)) {
+	  ;  // use to avoid a warning msg
+	}
 #endif
                 
         // Parallel iteration over the partial sums

--- a/include/sort_definition.h
+++ b/include/sort_definition.h
@@ -128,7 +128,7 @@ static void SORT_NAME(SORT_ELEMENT* elts, size_t size, bool useThreads) {
         losIn  [nPartitions-1] = 0;
         sizesIn[nPartitions-1] = size;
         while (2*nPartitions <= PARTITIONS_CAPACITY) {
-            int p;
+            size_t p;
             #pragma omp parallel for schedule(guided)
             for (p = 0; p < nPartitions; p++) {
                 size_t lo     = losIn[p];
@@ -143,7 +143,7 @@ static void SORT_NAME(SORT_ELEMENT* elts, size_t size, bool useThreads) {
             temp = losIn;   losIn   = losOut;   losOut   = temp;
             temp = sizesIn; sizesIn = sizesOut; sizesOut = temp;
         }
-        int p;
+        size_t p;
         #pragma omp parallel for schedule(guided)
         for (p = 0; p < nPartitions; p++) {
             SORT_NAME(&elts[losIn[p]],sizesIn[p], false);

--- a/resurf/mris_profileClustering.cxx
+++ b/resurf/mris_profileClustering.cxx
@@ -68,7 +68,7 @@ int main(int narg, char * arg[])
 	typedef ClassifierType::ClassLabelVectorType                     ClassLabelVectorType;
 	typedef ClassifierType::MembershipFunctionVectorObjectType       MembershipFunctionVectorObjectType;
 	typedef ClassifierType::MembershipFunctionVectorType             MembershipFunctionVectorType;
-	typedef SurfaceType::TriangleType 				TriangleType;
+	// typedef SurfaceType::TriangleType 				TriangleType;
   	
 	GetPot cl(narg, const_cast<char**>(arg));
 	if(cl.size()==1 || cl.search(2,"--help","-h"))
@@ -125,7 +125,7 @@ int main(int narg, char * arg[])
 
 	OutputImageType::SizeType size;
 	OutputImageType::IndexType start;
-	float vol=0;	
+	// float vol=0;	
 	direction.SetIdentity();
 	for(int i=0;i<3;i++)
 	{
@@ -172,7 +172,7 @@ int main(int narg, char * arg[])
 		MeasurementVectorType mv;
 		mv.AllocateElements(vectorLenght);
 		mv.SetSize(vectorLenght);
-		for(int j=0; j<images.size();j++)
+		for(size_t j=0; j<images.size();j++)
 		{
 			for( int d=-deep;d<=deep;d++)
 			{
@@ -199,11 +199,11 @@ int main(int narg, char * arg[])
 
 	EstimatorType::Pointer estimator = EstimatorType::New();
 	EstimatorType::ParametersType initialMeans(vectorLenght*numClusters);
-	for(unsigned int c=0;c<numClusters;c++)
+	for(int c=0;c<numClusters;c++)
 	{
-		for(unsigned int i=0;i<=vectorLenght;i++)
+	  for(int i=0;i<=vectorLenght;i++) {
 			initialMeans[c*vectorLenght+i] = sample->GetMeasurementVector(c*(sample->Size()/numClusters))[i]; 
-		
+	  }	
 	}
 	estimator->SetParameters( initialMeans );
 	estimator->SetKdTree( treeGenerator->GetOutput() );
@@ -229,9 +229,9 @@ int main(int narg, char * arg[])
 	classifier->SetClassLabels( classLabelsObject );
 
 	ClassLabelVectorType &  classLabelsVector = classLabelsObject->Get();
-	for(unsigned int i=0; i<numClusters;i++)
+	for(int i=0; i<numClusters;i++) {
 		classLabelsVector.push_back( i );
-
+	}
 
 	MembershipFunctionVectorObjectType::Pointer membershipFunctionsObject =
 	MembershipFunctionVectorObjectType::New();
@@ -243,7 +243,7 @@ int main(int narg, char * arg[])
 	int index = 0;
 	std::vector<MembershipFunctionPointer> functions;
 	std::vector<MeasurementVectorType> clusterMeans;
-	for ( unsigned int i = 0 ; i < numClusters ; i++ )
+	for ( int i = 0 ; i < numClusters ; i++ )
 	{
 		MembershipFunctionPointer membershipFunction = MembershipFunctionType::New();
 		for ( unsigned int j = 0 ; j < sample->GetMeasurementVectorSize(); j++ )
@@ -280,7 +280,7 @@ int main(int narg, char * arg[])
 	int i=0;
 
 	COLOR_TABLE *ct;
-	int vtxno, vtx_clusterno, annot, n;
+	int annot;
 
 	ct = CTABalloc(numClusters+ 1);
 	surf->ct = ct;

--- a/utils/DICOMRead.c
+++ b/utils/DICOMRead.c
@@ -1351,7 +1351,7 @@ char *ElementValueString(DCM_ELEMENT *e, int DoBackslash)
     case DCM_OB:
       evstring = (char *) calloc(sizeof(char),e->length+1);
       len = e->length;
-      for (n = 0; n < e->length; n++) {
+      for (n = 0; n < (int)e->length; n++) {
         if (isprint(e->d.string[n]))
           evstring[n] = e->d.string[n];
         else if (e->d.string[n] == '\r' || e->d.string[n] == '\n' || e->d.string[n] == '\v')
@@ -1378,14 +1378,14 @@ char *ElementValueString(DCM_ELEMENT *e, int DoBackslash)
       break;
     case DCM_FL:
       sprintf(tmpstr, "%f ", (float)(e->d.fd[0]));
-      for (n = 1; n < e->multiplicity; n++) {
+      for (n = 1; n < (int)e->multiplicity; n++) {
         sprintf(tmpstr2, "%s %f ", tmpstr, (float)(e->d.fd[n]));
         sprintf(tmpstr, "%s", tmpstr2);
       }
       break;
     case DCM_FD:
       sprintf(tmpstr, "%lf ", (double)(e->d.fd[0]));
-      for (n = 1; n < e->multiplicity; n++) {
+      for (n = 1; n < (int)e->multiplicity; n++) {
         sprintf(tmpstr2, "%s %lf ", tmpstr, (double)(e->d.fd[n]));
         sprintf(tmpstr, "%s", tmpstr2);
       }
@@ -1593,7 +1593,7 @@ char *SiemensAsciiTagEx(const char *dcmfile, const char *TagString, int cleanup)
     // backslashes in front of any parens
     memset(&filename[0], 0, 1024);
     k = 0;
-    for (i = 0; i < strlen(dcmfile); i++) {
+    for (i = 0; i < (int)strlen(dcmfile); i++) {
       if (dcmfile[i] == '(' || dcmfile[i] == ')' || dcmfile[i] == '[' || dcmfile[i] == ']') {
         filename[k] = 92;  // 92 is ascii dec for backslash
         k++;
@@ -2017,7 +2017,7 @@ int dcmImageDirCos(const char *dcmfile, float *Vcx, float *Vcy, float *Vcz, floa
 
   /* replace back slashes with spaces */
   nbs = 0;
-  for (n = 0; n < strlen(s); n++) {
+  for (n = 0; n < (int)strlen(s); n++) {
     if (s[n] == '\\') {
       s[n] = ' ';
       nbs++;
@@ -2079,7 +2079,7 @@ int dcmImagePosition(const char *dcmfile, float *x, float *y, float *z)
 
   /* replace back slashes with spaces */
   nbs = 0;
-  for (n = 0; n < strlen(s); n++) {
+  for (n = 0; n < (int)strlen(s); n++) {
     if (s[n] == '\\') {
       s[n] = ' ';
       nbs++;
@@ -4386,9 +4386,9 @@ CONDITION GetMultiDoubleFromString(DCM_OBJECT **object, DCM_TAG tag, double *d[]
   i = 0;
   j = 0;
   mult = 0;
-  while (mult < multiplicity && i < attribute.length) {
+  while (mult < multiplicity && i < (int)attribute.length) {
     j = 0;
-    while (s[i] != '\\' && i < attribute.length) {
+    while (s[i] != '\\' && i < (int)attribute.length) {
       ss[j++] = s[i++];
     }
     i++;
@@ -4422,9 +4422,9 @@ CONDITION GetMultiShortFromString(DCM_OBJECT **object, DCM_TAG tag, short *us[],
   i = 0;
   j = 0;
   mult = 0;
-  while (mult < multiplicity && i < attribute.length) {
+  while (mult < multiplicity && i < (int)attribute.length) {
     j = 0;
-    while (s[i] != '\\' && i < attribute.length) {
+    while (s[i] != '\\' && i < (int)attribute.length) {
       ss[j++] = s[i++];
     }
     i++;
@@ -6912,7 +6912,7 @@ int dcmGetDWIParamsGE(DCM_OBJECT *dcm, double *pbval, double *pxbvec, double *py
     free(e);
     return (7);
   }
-  for (n = 0; n < strlen(e->d.string); n++)
+  for (n = 0; n < (int)strlen(e->d.string); n++)
     if (e->d.string[n] == '\\') e->d.string[n] = ' ';
   sscanf(e->d.string, "%lf", pbval);
   free(e);
@@ -7167,12 +7167,12 @@ int dcmGetDWIParamsSiemensAlt(DCM_OBJECT *dcm, double *pbval, double *pxbvec, do
   // Scroll through the nasty string and find the keywords
   bval_flag = 0;
   bvec_flag = 0;
-  for (n = 0; n < e->length; n++) {
+  for (n = 0; n < (int)e->length; n++) {
     c = e->d.string[n];
     if (c == 'B') {
       sscanf(&(e->d.string[n]), "%s", tmpstr);
       if (strcmp(tmpstr, "B_value") == 0) {
-        for (m = n; m < e->length; m++) {
+        for (m = n; m < (int)e->length; m++) {
           c = e->d.string[m];
           if (isdigit(c)) {
             sscanf(&(e->d.string[m]), "%lf", pbval);
@@ -7183,7 +7183,7 @@ int dcmGetDWIParamsSiemensAlt(DCM_OBJECT *dcm, double *pbval, double *pxbvec, do
         }    // for m
         // Skip past the number just read
         while (isdigit(c) || c == '.') {
-          if (m >= e->length) break;
+          if (m >= (int)e->length) break;
           m = m + 1;
           c = e->d.string[m];
         }
@@ -7194,7 +7194,7 @@ int dcmGetDWIParamsSiemensAlt(DCM_OBJECT *dcm, double *pbval, double *pxbvec, do
       sscanf(&(e->d.string[n]), "%s", tmpstr);
       if (strcmp(tmpstr, "DiffusionGradientDirection") == 0) {
         for (k = 0; k < 3; k++) {
-          for (m = n; m < e->length; m++) {
+          for (m = n; m < (int)e->length; m++) {
             c = e->d.string[m];
             if (isdigit(c) || c == '-' || c == '+' || c == '.') {
               sscanf(&(e->d.string[m]), "%lf", &val);
@@ -7208,7 +7208,7 @@ int dcmGetDWIParamsSiemensAlt(DCM_OBJECT *dcm, double *pbval, double *pxbvec, do
           }    // m
           // Skip past the number just read
           while (isdigit(c) || c == '-' || c == '+' || c == '.') {
-            if (m >= e->length) break;
+            if (m >= (int)e->length) break;
             m = m + 1;
             c = e->d.string[m];
           }
@@ -7282,7 +7282,7 @@ int dcmImageDirCosObject(DCM_OBJECT *dcm, double *Vcx, double *Vcy, double *Vcz,
 
   /* replace back slashes with spaces */
   nbs = 0;
-  for (n = 0; n < strlen(s); n++) {
+  for (n = 0; n < (int)strlen(s); n++) {
     if (s[n] == '\\') {
       s[n] = ' ';
       nbs++;

--- a/utils/MRISrigidBodyAlignGlobal.c
+++ b/utils/MRISrigidBodyAlignGlobal.c
@@ -83,7 +83,7 @@ void MRISrigidBodyAlignGlobal_findMinSSE(
   // Project these coordinates to the surface of a sphere of radius mris->radius
   // This assumes that the vertices are already well away from (0,0,0)
   //
-  { int i;
+  { size_t i;
     for (i = 0; i < verticesSize; i++) {
       float invLength = mris->radius/sqrtf(squaref(xv[i])+squaref(yv[i])+squaref(zv[i]));
       xv[i] *= invLength;
@@ -278,7 +278,7 @@ void MRISrigidBodyAlignGlobal_findMinSSE(
             ROMP_PFLB_begin
 
             int const viLo = partition*verticesPerPartition;
-            int const viHi = MIN(verticesSize, viLo + verticesPerPartition);
+            int const viHi = MIN((int)verticesSize, viLo + verticesPerPartition);
 
             double*                         const ssesForAlphas   = &  ssesForAlphasForPartitions[partition*forAlphasCapacity];
             MRISPfunctionValResultForAlpha* const fvsForAlphas    = &   fvsForAlphasForPartitions[partition*forAlphasCapacity];
@@ -310,7 +310,7 @@ void MRISrigidBodyAlignGlobal_findMinSSE(
                   alphasForAlphas, ajsSize, // input requests
                   vertexTrace);
 
-              int ajsI;
+              size_t ajsI;
               for (ajsI = 0; ajsI < ajsSize ; ajsI++) {
                 int    const aj     = ajsForAlphas[ajsI];
                 double const target = fvsForAlphas[ajsI].curr;
@@ -395,7 +395,7 @@ void MRISrigidBodyAlignGlobal_findMinSSE(
 
           // Add to the output centers
           //
-          int ajsI;
+          size_t ajsI;
           for (ajsI = 0; ajsI < ajsSize ; ajsI++) {
             int const aj = ajsForAlphas[ajsI];
             int const ai = center_ai + gridStride*(aj - nangles/2);

--- a/utils/afni.c
+++ b/utils/afni.c
@@ -825,7 +825,7 @@ MRI *afniRead(const char *fname, int read_volume)
           {
             pmem = (void *)malloc(bytes_per_voxel * mri->width);
             if (pmem) {
-              if (fread(pmem, bytes_per_voxel, mri->width, fp) != mri->width) {
+              if (fread(pmem, bytes_per_voxel, mri->width, fp) != (size_t)mri->width) {
                 fclose(fp);
                 MRIfree(&header);
                 errno = 0;

--- a/utils/bfileio.c
+++ b/utils/bfileio.c
@@ -279,8 +279,10 @@ float *bf_ldbfile(char *bfname, int *nrows, int *ncols, int *nfrms)
   short *sdata = NULL;
   float *fdata = NULL;
   FILE *fp;
-  int err, nread, type, endian, archendian, n;
+  int err, type, endian, archendian;
+  size_t nread;
   size_t ntot;
+  size_t n;
   bferr = 0;
 
   /* get endianness of current architecture */
@@ -323,7 +325,7 @@ float *bf_ldbfile(char *bfname, int *nrows, int *ncols, int *nfrms)
       sprintf(bfmsg, "bf_ldbfile(): error reading %s", bfname);
       bferr = 1;
       fprintf(stderr, "%s \n", bfmsg);
-      fprintf(stderr, " ntoberead = %d, nread = %d\n", (int)ntot, nread);
+      fprintf(stderr, " ntoberead = %zu, nread = %zu\n", ntot, nread);
       free(fdata);
       return (NULL);
     }
@@ -350,7 +352,7 @@ float *bf_ldbfile(char *bfname, int *nrows, int *ncols, int *nfrms)
       sprintf(bfmsg, "bf_ldbfile(): error reading %s", bfname);
       bferr = 1;
       fprintf(stderr, "%s \n", bfmsg);
-      fprintf(stderr, " ntoberead = %d, nread = %d\n", (int)ntot, nread);
+      fprintf(stderr, " ntoberead = %zu, nread = %zu\n", ntot, nread);
       free(fdata);
       free(sdata);
       return (NULL);
@@ -374,9 +376,11 @@ int bf_svbfile(float *bfdata, char *bfname, int nrows, int ncols, int nfrms, int
   float *fdata = NULL;
   char hdrfile[1000];
   FILE *fp;
-  int type, nwrote, archendian, n, err;
+  int type, archendian, err;
   int fdatadealloc = 0;
   size_t ntot;
+  size_t nwrote;
+  size_t n;
   bferr = 0;
 
   /* get endianness of current architecture */
@@ -436,7 +440,7 @@ int bf_svbfile(float *bfdata, char *bfname, int nrows, int ncols, int nfrms, int
       sprintf(bfmsg, "bf_svbfile(): error writing to %s", bfname);
       bferr = 1;
       fprintf(stderr, "%s \n", bfmsg);
-      fprintf(stderr, " ntobewritten = %d, nwritten = %d\n", (int)ntot, nwrote);
+      fprintf(stderr, " ntobewritten = %zd, nwritten = %zd\n", ntot, nwrote);
       return (1);
     }
   }
@@ -446,7 +450,7 @@ int bf_svbfile(float *bfdata, char *bfname, int nrows, int ncols, int nfrms, int
     /* copy data into a short buffer */
     sdata = (short *)calloc(ntot, sizeof(short));
     if (sdata == NULL) {
-      sprintf(bfmsg, "bf_svbfile(): could not alloc short %d\n", (int)ntot);
+      sprintf(bfmsg, "bf_svbfile(): could not alloc short %zd\n", ntot);
       bferr = 1;
       fprintf(stderr, "%s \n", bfmsg);
       return (1);
@@ -466,7 +470,7 @@ int bf_svbfile(float *bfdata, char *bfname, int nrows, int ncols, int nfrms, int
       sprintf(bfmsg, "bf_svbfile(): error writing to %s", bfname);
       bferr = 1;
       fprintf(stderr, "%s \n", bfmsg);
-      fprintf(stderr, " ntobewritten = %d, nwritten = %d\n", (int)ntot, nwrote);
+      fprintf(stderr, " ntobewritten = %zd, nwritten = %zd\n", ntot, nwrote);
       return (1);
     }
   }

--- a/utils/colortab.c
+++ b/utils/colortab.c
@@ -593,7 +593,7 @@ COLOR_TABLE *CTABreadFromBinaryV1(FILE *fp, int nentries)
                  len));
   }
   name = (char *)malloc(len + 1);
-  if (fread(name, sizeof(char), len, fp) != len) {
+  if (fread(name, sizeof(char), len, fp) != (size_t)len) {
     ErrorPrintf(ERROR_BADFILE, "CTABreadFromBinaryV1: could not read parameter(s)");
   }
   strncpy(ct->fname, name, sizeof(ct->fname));
@@ -624,7 +624,7 @@ COLOR_TABLE *CTABreadFromBinaryV1(FILE *fp, int nentries)
                    len));
     }
     name = (char *)malloc(len + 1);
-    if (fread(name, sizeof(char), len, fp) != len) {
+    if (fread(name, sizeof(char), len, fp) != (size_t)len) {
       ErrorPrintf(ERROR_BADFILE, "CTABreadFromBinaryV1: could not read parameter(s)");
     }
     strncpy(ct->entries[structure]->name, name, sizeof(ct->entries[structure]->name));
@@ -728,7 +728,7 @@ COLOR_TABLE *CTABreadFromBinaryV2(FILE *fp)
                  "was %d",
                  len));
   name = (char *)malloc(len + 1);
-  if (fread(name, sizeof(char), len, fp) != len) {
+  if (fread(name, sizeof(char), len, fp) != (size_t)len) {
     ErrorPrintf(ERROR_BADFILE, "CTABreadFromBinaryV1: could not read parameter(s)");
   }
   strncpy(ct->fname, name, sizeof(ct->fname));
@@ -778,7 +778,7 @@ COLOR_TABLE *CTABreadFromBinaryV2(FILE *fp)
                    len));
     }
     name = (char *)malloc(len + 1);
-    if (fread(name, sizeof(char), len, fp) != len) {
+    if (fread(name, sizeof(char), len, fp) != (size_t)len) {
       ErrorPrintf(ERROR_BADFILE, "CTABreadFromBinaryV1: could not read parameter(s)");
     }
     strncpy(ct->entries[structure]->name, name, sizeof(ct->entries[structure]->name));

--- a/utils/filter.c
+++ b/utils/filter.c
@@ -1495,7 +1495,7 @@ static int xoffsets[] = {0, -1, 0, 1, 0};
 static int yoffsets[] = {-1, 0, 0, 0, 1};
 #define ONE_EIGHTH (1.0f / 8.0f)
 static float weights[] = {ONE_EIGHTH, ONE_EIGHTH, -0.5f, ONE_EIGHTH, ONE_EIGHTH};
-#define LAPLACIAN_POINTS (sizeof(xoffsets) / sizeof(xoffsets[0]))
+#define LAPLACIAN_POINTS ((int)(sizeof(xoffsets) / sizeof(xoffsets[0])))
 
 IMAGE *ImageLaplacian(IMAGE *Isrc, IMAGE *outImage)
 {

--- a/utils/fsPrintHelp.c
+++ b/utils/fsPrintHelp.c
@@ -233,13 +233,13 @@ static void printName(xmlNodePtr cur)
 
 // Prints the text of a tag in the correct format
 // at most FSPRINT_MAX_CHARS characters per line with the correct number of tabs
-#define FSPRINT_MAX_CHARS 78
+const int FSPRINT_MAX_CHARS = 78;
 static void printContents(xmlDocPtr doc, xmlNodePtr cur)
 {
   xmlChar *contents;
   contents = xmlNodeListGetString(doc, cur->xmlChildrenNode, 1);
   int i = 0, j;
-  while (i < strlen((char *)contents)) {
+  while (i < (int)strlen((char *)contents)) {
     int tabNum = 1;
     printf("\n\t");
     if (tagNameIs("explanation", cur)) {
@@ -249,7 +249,7 @@ static void printContents(xmlDocPtr doc, xmlNodePtr cur)
     if (*(contents + i) == ' ') {
       i++;
     }
-    for (j = i; j < FSPRINT_MAX_CHARS - tabNum * 8 + i && j < strlen((char *)contents) &&
+    for (j = i; j < FSPRINT_MAX_CHARS - tabNum * 8 + i && j < (int)strlen((char *)contents) &&
                 (wrdLen((char *)(contents + j)) > FSPRINT_MAX_CHARS - tabNum * 8 ||
                  wrdLen((char *)(contents + j)) <= FSPRINT_MAX_CHARS - tabNum * 8 + i - j);
          j++) {
@@ -280,7 +280,7 @@ static int tagNameIs(char *c, xmlNodePtr cur) { return !(xmlStrcasecmp(cur->name
 static int wrdLen(char *c)
 {
   int i;
-  for (i = 0; i < strlen(c); i++) {
+  for (i = 0; i < (int)strlen(c); i++) {
     if (*(c + i) == ' ' || *(c + i) == '_' || *(c + i) == '/') {
       return i;
     }

--- a/utils/gca.c
+++ b/utils/gca.c
@@ -5230,7 +5230,7 @@ GCA_SAMPLE *GCAfindStableSamplesByLabel(GCA *gca, int nsamples, float min_prior)
     histo[n] = (float)nint(0.25 + histo[n] * (float)nsamples / total);
   }
 
-  for (n = 0; n < sizeof(exclude_classes) / sizeof(exclude_classes[0]); n++) {
+  for (n = 0; n < (int)(sizeof(exclude_classes) / sizeof(exclude_classes[0])); n++) {
     histo[exclude_classes[n]] = 0;
   }
 
@@ -18349,7 +18349,7 @@ int GCAcomputeRenormalizationWithAlignment(GCA *gca,
     h_mri = HISTOalloc(nbins);
     h_mtl = HISTOalloc(nbins);
     h_caudate = HISTOalloc(nbins);
-    for (j = 0; j < NALIGN_LABELS; j++) {
+    for (j = 0; j < (int)NALIGN_LABELS; j++) {
       l = align_labels[j];
       if (l == Gdiag_no) {
         DiagBreak();
@@ -18964,7 +18964,7 @@ int GCAcomputeRenormalizationWithAlignment(GCA *gca,
 
       HISTOmakePDF(h_mtl, h_mtl);
       mri_peak = HISTOfindHighestPeakInRegion(h_mtl, 0, h_mtl->nbins);
-      for (j = 0; j < MTL_LABELS; j++) {
+      for (j = 0; j < (int)MTL_LABELS; j++) {
         l = mtl_labels[j];
         h_gca = gcaGetLabelHistogram(gca, l, 0, 1);
         gca_peak = HISTOfindHighestPeakInRegion(h_gca, 0, h_gca->nbins);
@@ -19074,7 +19074,7 @@ int GCAcomputeRenormalizationWithAlignment(GCA *gca,
       }
     }
     fprintf(stdout, "not using caudate to estimate GM means\n");
-    for (k = 0; k < NHEMI_LABELS; k++) {
+    for (k = 0; k < (int)NHEMI_LABELS; k++) {
       int lhl, rhl;
       if (computed[lh_labels[k]] && !computed[rh_labels[k]]) {
         lhl = lh_labels[k];
@@ -19111,7 +19111,7 @@ int GCAcomputeRenormalizationWithAlignment(GCA *gca,
     num = 0;
     mean_gm_scale = 0;
     mean_gm_offset = 0;
-    for (k = 0; k < NGM_LABELS; k++) {
+    for (k = 0; k < (int)NGM_LABELS; k++) {
       label = gm_labels[k];
       if (computed[label]) {
         mean_gm_scale += label_scales[label];
@@ -19131,7 +19131,7 @@ int GCAcomputeRenormalizationWithAlignment(GCA *gca,
     num = 0;
     mean_wm_scale = 0;
     mean_wm_offset = 0;
-    for (k = 0; k < NWM_LABELS; k++) {
+    for (k = 0; k < (int)NWM_LABELS; k++) {
       label = wm_labels[k];
       if (computed[label]) {
         mean_wm_scale += label_scales[label];
@@ -19151,7 +19151,7 @@ int GCAcomputeRenormalizationWithAlignment(GCA *gca,
     num = 0;
     mean_csf_scale = 0;
     mean_csf_offset = 0;
-    for (k = 0; k < NCSF_LABELS; k++) {
+    for (k = 0; k < (int)NCSF_LABELS; k++) {
       label = csf_labels[k];
       if (computed[label]) {
         mean_csf_scale += label_scales[label];
@@ -19687,7 +19687,7 @@ int GCAcomputeRenormalizationWithAlignmentLongitudinal(GCA *gca,
   h_mri = HISTOalloc(nbins);
   h_mtl = HISTOalloc(nbins);
   h_caudate = HISTOalloc(nbins);
-  for (j = 0; j < NALIGN_LABELS; j++) {
+  for (j = 0; j < (int)NALIGN_LABELS; j++) {
     l = align_labels[j];
     if (l == Gdiag_no) DiagBreak();
 
@@ -20068,7 +20068,7 @@ int GCAcomputeRenormalizationWithAlignmentLongitudinal(GCA *gca,
 
     HISTOmakePDF(h_mtl, h_mtl);
     mri_peak = HISTOfindHighestPeakInRegion(h_mtl, 0, h_mtl->nbins);
-    for (j = 0; j < MTL_LABELS; j++) {
+    for (j = 0; j < (int)MTL_LABELS; j++) {
       l = mtl_labels[j];
       h_gca = gcaGetLabelHistogram(gca, l, 0, 1);
       gca_peak = HISTOfindHighestPeakInRegion(h_gca, 0, h_gca->nbins);
@@ -20178,7 +20178,7 @@ int GCAcomputeRenormalizationWithAlignmentLongitudinal(GCA *gca,
     }
   }
   fprintf(stdout, "not using caudate to estimate GM means\n");
-  for (k = 0; k < NHEMI_LABELS; k++) {
+  for (k = 0; k < (int)NHEMI_LABELS; k++) {
     int lhl, rhl;
     if (computed[lh_labels[k]] && !computed[rh_labels[k]]) {
       lhl = lh_labels[k];
@@ -20215,7 +20215,7 @@ int GCAcomputeRenormalizationWithAlignmentLongitudinal(GCA *gca,
   num = 0;
   mean_gm_scale = 0;
   mean_gm_offset = 0;
-  for (k = 0; k < NGM_LABELS; k++) {
+  for (k = 0; k < (int)NGM_LABELS; k++) {
     label = gm_labels[k];
     if (computed[label]) {
       mean_gm_scale += label_scales[label];
@@ -20235,7 +20235,7 @@ int GCAcomputeRenormalizationWithAlignmentLongitudinal(GCA *gca,
   num = 0;
   mean_wm_scale = 0;
   mean_wm_offset = 0;
-  for (k = 0; k < NWM_LABELS; k++) {
+  for (k = 0; k < (int)NWM_LABELS; k++) {
     label = wm_labels[k];
     if (computed[label]) {
       mean_wm_scale += label_scales[label];
@@ -20255,7 +20255,7 @@ int GCAcomputeRenormalizationWithAlignmentLongitudinal(GCA *gca,
   num = 0;
   mean_csf_scale = 0;
   mean_csf_offset = 0;
-  for (k = 0; k < NCSF_LABELS; k++) {
+  for (k = 0; k < (int)NCSF_LABELS; k++) {
     label = csf_labels[k];
     if (computed[label]) {
       mean_csf_scale += label_scales[label];
@@ -24178,7 +24178,7 @@ int GCArenormalizeWithEntropyMinimization(GCA *gca, MRI *mri, TRANSFORM *transfo
   HISTOGRAM *h_gca;
   MRI *mri_aseg;
 
-  for (i = 0; i < NUM_ENTROPY_LABELS; i++) {
+  for (i = 0; i < (int)NUM_ENTROPY_LABELS; i++) {
     scales[i] = 1.0;
     h_gca = gcaGetLabelHistogram(gca, entropy_labels[i], 0, 0);
     peak_bin = HISTOfindHighestPeakInRegion(h_gca, 0, h_gca->nbins);
@@ -24208,7 +24208,7 @@ int GCArenormalizeWithEntropyMinimization(GCA *gca, MRI *mri, TRANSFORM *transfo
     gcaScale(gca, entropy_labels, contra_entropy_labels, scales, NUM_ENTROPY_LABELS, 1);
     {
       int n;
-      for (n = 0; n < NUM_ENTROPY_LABELS; n++)
+      for (n = 0; n < (int)NUM_ENTROPY_LABELS; n++)
         printf("scales[%s] = %2.3f, peak = %2.0f (rh=%2.0f)\n",
                cma_label_to_name(entropy_labels[n]),
                scales[n],
@@ -24253,7 +24253,7 @@ int GCArenormalizeWithEntropyMinimization(GCA *gca, MRI *mri, TRANSFORM *transfo
     }
   } while (!done);
 
-  for (i = 0; i < NUM_ENTROPY_LABELS; i++) {
+  for (i = 0; i < (int)NUM_ENTROPY_LABELS; i++) {
     printf("scaling %s by %2.3f from %2.0f to %2.0f (rh=%2.0f)\n",
            cma_label_to_name(entropy_labels[i]),
            scales[i],

--- a/utils/gcsa.c
+++ b/utils/gcsa.c
@@ -622,8 +622,9 @@ GCSA *GCSAread(char *fname)
   else if (trace) fprintf(stdout, "GCSAread(%s): opened file", fname);
   
   magic = freadInt(fp);
-  if (magic != GCSA_MAGIC)
+  if (magic != (int)GCSA_MAGIC) {
     ErrorReturn(NULL, (ERROR_BADFILE, "GCSAread(%s): file magic #%x != GCSA_MAGIC (%x)", fname, magic, GCSA_MAGIC));
+  }
   ninputs = freadInt(fp);
   icno_classifiers = freadInt(fp);
   icno_priors = freadInt(fp);
@@ -637,7 +638,7 @@ GCSA *GCSAread(char *fname)
   for (i = 0; i < ninputs; i++) {
     gcsa->inputs[i].type = freadInt(fp);
     j = freadInt(fp);
-    if (fread(gcsa->inputs[i].fname, sizeof(char), j, fp) != j) {
+    if (fread(gcsa->inputs[i].fname, sizeof(char), j, fp) != (size_t)j) {
       ErrorPrintf(ERROR_BADFILE, "afniRead(): error reading from file %s", gcsa->inputs[i].fname);
     }
     gcsa->inputs[i].navgs = freadInt(fp);

--- a/utils/handle.c
+++ b/utils/handle.c
@@ -177,7 +177,7 @@ int HandleOk(PTR_HANDLE handle)
 {
   HandleInfo *handleInfo;
 
-  if ((handle <= (PTR_HANDLE)0) || (handle > nhandles)) return (0);
+  if ((handle <= (PTR_HANDLE)0) || (handle > (size_t)nhandles)) return (0);
 
   handleInfo = handleTable + (handle - 1);
   if (handleInfo->status == HANDLE_FREE) return (-1);

--- a/utils/hippo.c
+++ b/utils/hippo.c
@@ -34,7 +34,8 @@ static int non_hippo_labels[] = {
 
 MRI *HIPPOremoveNonHippoLabels(MRI *mri_src, MRI *mri_dst)
 {
-  int i, label;
+  int label;
+  size_t i;
 
   mri_dst = MRIcopy(mri_src, mri_dst);
 

--- a/utils/imageio.c
+++ b/utils/imageio.c
@@ -973,12 +973,12 @@ static IMAGE *TiffReadImage(const char *fname, int frame0)
           bitmap = (unsigned char *)calloc(scanlinesize, sizeof(unsigned char));
 
           memmove(bitmap, buf, scanlinesize);
-          for (col = b = 0; b < scanlinesize; b++, col += 8) {
+          for (col = b = 0; b < (unsigned int)scanlinesize; b++, col += 8) {
             byte_ = bitmap[b];
             if (byte_ > 0) DiagBreak();
             if (fillorder == FILLORDER_LSB2MSB) {
               for (bitmask = 0x01, bit = 0; bit < 8; bit++) {
-                if (col + bit == Gx && index == Gy) DiagBreak();
+                if (col + bit == (unsigned int)Gx && index == Gy) DiagBreak();
                 *IMAGEpix(I, col + bit, index) = ((byte_ & bitmask) > 0);
                 bitmask = bitmask << 1;
               }
@@ -986,7 +986,7 @@ static IMAGE *TiffReadImage(const char *fname, int frame0)
             else  // fillorder == FILLORDER_MSB2LSB
             {
               for (bitmask = 0x01 << 7, bit = 0; bit < 8; bit++) {
-                if (col + bit == Gx && index == Gy) DiagBreak();
+                if (col + bit == (unsigned int)Gx && index == Gy) DiagBreak();
                 *IMAGEpix(I, col + bit, index) = ((byte_ & bitmask) > 0);
                 bitmask = bitmask >> 1;
               }

--- a/utils/matfile.c
+++ b/utils/matfile.c
@@ -874,7 +874,7 @@ char *MatReadHeader(FILE *fp, MATFILE *mf, long32 *compressed)
   long32 dt;
   char ctmp[4];
   long32 tmp;
-  int fourbytes = 4;
+  unsigned int fourbytes = 4;
 
   if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON) DiagPrintf(DIAG_VERBOSE, "MatReadHeader: fp=%lx, mf=%lx\n", fp, mf);
 

--- a/utils/morph.c
+++ b/utils/morph.c
@@ -736,7 +736,7 @@ IMAGE *ImageMorph(IMAGE *Isrc, IMAGE *Idst, int which)
   IMAGE *Iin, *Itmp, *Iout, *Ifiltered;
   unsigned char *lut;
 
-  if (which < 0 || which >= NLUTS) ErrorReturn(NULL, (ERROR_BADPARM, "ImageMorph(%d): unknown operation code", which));
+  if (which < 0 || which >= (int)NLUTS) ErrorReturn(NULL, (ERROR_BADPARM, "ImageMorph(%d): unknown operation code", which));
 
   lut = lut_pointers[which];
 

--- a/utils/mri_identify.c
+++ b/utils/mri_identify.c
@@ -1132,7 +1132,7 @@ int is_nrrd(const char *fname)
   dot = strrchr(fname, '.');
 
   if (dot != NULL) {
-    if ((strcmp(dot, ".nrrd") == 0) && (strlen(fname) == dot - fname + 5)) {
+    if ((strcmp(dot, ".nrrd") == 0) && (strlen(fname) == (size_t)(dot - fname + 5))) {
       return (TRUE);
     }
   }

--- a/utils/mriclass.c
+++ b/utils/mriclass.c
@@ -141,7 +141,7 @@ MRIC *MRICalloc(int nrounds, int *types, int *features, void *parms)
 
   mric->nrounds = nrounds;
   for (round = 0; round < nrounds; round++) {
-    for (ninputs = 0, f = 0x001; f != MAX_FEATURE; f <<= 1)
+    for (ninputs = 0, f = 0x001; f != (int)MAX_FEATURE; f <<= 1)
       if (f & features[round]) ninputs++;
 
     if (ninputs < 1 || ninputs > MAX_INPUTS)
@@ -1182,7 +1182,7 @@ char *MRICfeatureName(MRIC *mric, int round, int feature_number)
   /* first ninputs-1 correspond to inputs #s, rest to frames in priors */
 
   /* find bit which corresponds to this # */
-  for (f = 0x001, fno = 0; f != MAX_FEATURE; f <<= 1)
+  for (f = 0x001, fno = 0; f != (int)MAX_FEATURE; f <<= 1)
     if ((f & mric->features[round]) && (fno++ == feature_number)) break;
 
   if (f & FEATURE_INTENSITY) return ("INTENSITY");
@@ -1220,7 +1220,7 @@ char *MRICfeatureNumberToName(int feature_number)
   int f, fno;
 
   /* find bit which corresponds to this # */
-  for (f = 0x001, fno = 0; f != MAX_FEATURE; f <<= 1)
+  for (f = 0x001, fno = 0; f != (int)MAX_FEATURE; f <<= 1)
     if (fno++ == feature_number) break;
 
   if (f & FEATURE_INTENSITY) return ("INTENSITY");
@@ -1267,7 +1267,7 @@ int MRICfeatureNumberCode(int feature_number)
   int f, fno;
 
   /* find bit which corresponds to this # */
-  for (f = 0x001, fno = 0; f != MAX_FEATURE; f <<= 1)
+  for (f = 0x001, fno = 0; f != (int)MAX_FEATURE; f <<= 1)
     if (fno++ == feature_number) break;
 
   if (f & FEATURE_POSITION) return (FEATURE_POSITION);
@@ -1289,7 +1289,7 @@ int MRICfeatureCode(MRIC *mric, int round, int feature_number)
   /* first ninputs-1 correspond to inputs #s, rest to frames in priors */
 
   /* find bit which corresponds to this # */
-  for (f = 0x001, fno = 0; f != MAX_FEATURE; f <<= 1)
+  for (f = 0x001, fno = 0; f != (int)MAX_FEATURE; f <<= 1)
     if ((f & mric->features[round]) && (fno++ == feature_number)) break;
 
   return (f);
@@ -1309,7 +1309,7 @@ int MRICfeatureNumber(MRIC *mric, int round, int feature_code)
   /* first ninputs-1 correspond to inputs #s, rest to frames in priors */
 
   /* find bit which corresponds to this # */
-  for (f = 0x001, fno = 0; f != MAX_FEATURE; f <<= 1) {
+  for (f = 0x001, fno = 0; f != (int)MAX_FEATURE; f <<= 1) {
     if (f & feature_code) return (fno);
     if (f & mric->features[round]) fno++;
   }

--- a/utils/mriio.c
+++ b/utils/mriio.c
@@ -2247,7 +2247,7 @@ static MRI *siemensRead(const char *fname, int read_volume_flag)
       fseek(fp, 6144, SEEK_SET);
 
       for (i = 0; i < rows; i++) {
-        if (fread(&MRISvox(mri_raw, 0, i, file_n - n_low), sizeof(short), cols, fp) != cols){
+        if (fread(&MRISvox(mri_raw, 0, i, file_n - n_low), sizeof(short), cols, fp) != (size_t)cols){
           ErrorPrintf(ERROR_BADFILE, "siemensRead(): could not read file");
         }
 #if (BYTE_ORDER == LITTLE_ENDIAN)
@@ -11440,10 +11440,13 @@ static MRI *mghRead(const char *fname, int read_volume, int frame)
     if (znzreadFloatEx(&fval, fp)) {
       mri->flip_angle = fval;
       // flip_angle is double. I cannot use the same trick.
-      if (znzreadFloatEx(&(mri->te), fp))
-        if (znzreadFloatEx(&(mri->ti), fp))
-          if (znzreadFloatEx(&(mri->fov), fp))
+      if (znzreadFloatEx(&(mri->te), fp)) {
+        if (znzreadFloatEx(&(mri->ti), fp)) {
+          if (znzreadFloatEx(&(mri->fov), fp)) {
             ;
+	  }
+	}
+      }
     }
   }
   // tag reading

--- a/utils/mrimorph.c
+++ b/utils/mrimorph.c
@@ -4564,7 +4564,7 @@ MORPH_3D *MRI3DreadSmall(char *fname)
   if (!fp) ErrorReturn(NULL, (ERROR_NOFILE, "MRI3DreadSmall: could not open file %s", fname));
 
   magic = freadInt(fp);
-  if (magic != M3D_MAGIC) {
+  if (magic != (int)M3D_MAGIC) {
     fclose(fp);
     ErrorReturn(NULL, (ERROR_BADFILE, "file %s not an old 3d morph file.\nTry a new 3d morph read routine.\n", fname));
   }

--- a/utils/mripolv.c
+++ b/utils/mripolv.c
@@ -4158,7 +4158,7 @@ float MRIcpolvMedianAtVoxel(MRI *mri_src, int vertex, float x, float y, float z,
 }
 int MRIvertexToVector(int vertex, float *pdx, float *pdy, float *pdz)
 {
-  if ((vertex < 0) || (vertex >= sizeof(ic_x_vertices) / sizeof(ic_x_vertices[0])))
+  if ((vertex < 0) || (vertex >= (int)(sizeof(ic_x_vertices) / sizeof(ic_x_vertices[0]))))
     ErrorReturn(ERROR_BADPARM, (ERROR_BADPARM, "MRIvertexToVector(%d): index out of range", vertex));
   *pdx = ic_x_vertices[vertex];
   *pdy = ic_y_vertices[vertex];

--- a/utils/mrisurf.c
+++ b/utils/mrisurf.c
@@ -131,7 +131,7 @@ static bool vertix_n_hash_add(size_t vectorSize, MRIS_HASH* hashVector, MRIS con
     #define ELTX(TYPE,   MBR) // don't hash excluded elements
 #ifdef SEPARATE_VERTEX_TOPOLOGY
     #define ELTT(TYPE,   MBR) \
-        for (i = 0; i < vectorSize; i++) {                                                              \
+      for (i = 0; i < (int)vectorSize; i++) {				\
             MRIS_HASH  * hash = &hashVector[i];                                                         \
             MRIS const * mris = mrisPVector[i];                                                         \
             VERTEX_TOPOLOGY const * vt = &mris->vertices_topology[vno];                                 \
@@ -149,7 +149,7 @@ static bool vertix_n_hash_add(size_t vectorSize, MRIS_HASH* hashVector, MRIS con
     #undef ELTT
 #endif
     #define ELTT(TYPE,   MBR) \
-        for (i = 0; i < vectorSize; i++) {                                                              \
+      for (i = 0; i < (int)vectorSize; i++) {				\
             MRIS_HASH  * hash = &hashVector[i];                                                         \
             MRIS const * mris = mrisPVector[i];                                                         \
             VERTEX const * v = &mris->vertices[vno];                                                    \
@@ -170,7 +170,7 @@ static bool vertix_n_hash_add(size_t vectorSize, MRIS_HASH* hashVector, MRIS con
     
     // Now include some of the pointer targets
     //
-    for (i = 0; i < vectorSize; i++) {
+      for (i = 0; i < (int)vectorSize; i++) {
         MRIS_HASH  * hash = &hashVector[i];
         MRIS const * mris = mrisPVector[i];
         VERTEX_TOPOLOGY const * vt = &mris->vertices_topology[vno];
@@ -217,7 +217,7 @@ static bool face_n_hash_add(size_t vectorSize, MRIS_HASH* hashVector, MRIS const
     #define SEP
     #define ELTP(TARGET,NAME) // don't hash pointers
     #define ELTT(TYPE,       MBR) \
-        for (i = 0; i < vectorSize; i++) {                                                              \
+      for (i = 0; i < (int)vectorSize; i++) {				\
             MRIS_HASH  * hash = &hashVector[i];                                                         \
             MRIS const * mris = mrisPVector[i];                                                         \
             FACE* face = &mris->faces[fno];                                                             \

--- a/utils/mrisurf_base.c
+++ b/utils/mrisurf_base.c
@@ -803,12 +803,12 @@ int MRISsetCurvatureName(int nth, char const *name)
 
 int MRISprintCurvatureNames(FILE *fp)
 {
-  int k;
+  size_t k;
   for (k = 0; k < sizeof(curvature_names) / sizeof(curvature_names[0]); k++) {
     if (curvature_names[k])
-      printf("%d %s\n", k, curvature_names[k]);
+      printf("%zd %s\n", k, curvature_names[k]);
     else if (mrisurf_surface_names[k])
-      printf("%d %s (computed)\n", k, mrisurf_surface_names[k]);
+      printf("%zd %s (computed)\n", k, mrisurf_surface_names[k]);
   }
   return (0);
 }

--- a/utils/mrisurf_defect.c
+++ b/utils/mrisurf_defect.c
@@ -2021,8 +2021,8 @@ static void cachedOrComputeVertexPseudoNormal(
       
       if (0) {
       	cheapAssert(0 <= index);
-      	cheapAssert(index       < PerThreadVertexPseudoNormalCacheSize);
-      	cheapAssert(initedIndex < PerThreadVertexPseudoNormalCacheInitedSize);
+      	cheapAssert(index       < (int)PerThreadVertexPseudoNormalCacheSize);
+      	cheapAssert(initedIndex < (int)PerThreadVertexPseudoNormalCacheInitedSize);
       }
       
       inited = p->inited[initedIndex] & initedMask;
@@ -4122,7 +4122,7 @@ MRI *mriInitDefectVolume(MRIS *mris, TOPOFIX_PARMS *parms)
 // used for fs_topo_fixer
 void MRISsaveLocal(MRIS *mris, TOPOFIX_PARMS *parms, char *name)
 {
-  int static n_br = 0;
+  static int n_br = 0;
   char fname[512];
   int n;
   double x, y, z, xv, yv, zv;

--- a/utils/mrisurf_deform.c
+++ b/utils/mrisurf_deform.c
@@ -9578,9 +9578,9 @@ int mrisRemoveNegativeArea(
       pnum = &parms->l_spring;
     }
 
-  for (total_steps = npasses = 0; npasses < MAX_PASSES; npasses++) {
+  for (total_steps = npasses = 0; npasses < (int)MAX_PASSES; npasses++) {
     *pnum = 1.0;
-    *pdenom = cmod * (npasses >= MAX_PASSES ? neg_area_ratios[MAX_PASSES - 1] : neg_area_ratios[npasses]);
+    *pdenom = cmod * (npasses >= (int)MAX_PASSES ? neg_area_ratios[MAX_PASSES - 1] : neg_area_ratios[npasses]);
 
     ratio = *pnum / *pdenom;
 

--- a/utils/mrisurf_integrate.c
+++ b/utils/mrisurf_integrate.c
@@ -2146,7 +2146,7 @@ int MRISminimizeThicknessFunctional(MRI_SURFACE *mris, INTEGRATION_PARMS *parms,
 static float area_coefs[] = {1.0f, 1.0f, 0.1f};
 static float dist_coefs[] = {0.1f, 1.0f, 1.0f};
 
-#define NCOEFS sizeof(area_coefs) / sizeof(area_coefs[0])
+#define NCOEFS ((int)(sizeof(area_coefs) / sizeof(area_coefs[0])))
 
 #define MAX_NBHD_SIZE 200
 #define NBR_COEF (M_PI * 1.0f)

--- a/utils/mrisurf_metricProperties.c
+++ b/utils/mrisurf_metricProperties.c
@@ -10151,7 +10151,7 @@ int MRISaverageGradients(MRIS *mris, int num_avgs)
       // Do all the iterations
       for (i = 0 ; i < num_avgs ; i++) {
         
-        int chunksIndex;
+        size_t chunksIndex;
         ROMP_PF_begin
 #ifdef HAVE_OPENMP
         #pragma omp parallel for if_ROMP(assume_reproducible)

--- a/utils/mrisurf_timeStep.c
+++ b/utils/mrisurf_timeStep.c
@@ -57,13 +57,13 @@ static int MRISAsynchronousTimeStep_optionalDxDyDzUpdate_svi(
   float x, float y, float z) 
 {
   const size_t numSubvolsPerEdge   = MRISAsynchronousTimeStep_optionalDxDyDzUpdate_numSubvolsPerEdge;
-  int const svxLo = MIN(numSubvolsPerEdge-1,(int)((x - ctx->xSubvolVerge - ctx->xLo)/ctx->xSubvolLen));
-  int const svyLo = MIN(numSubvolsPerEdge-1,(int)((y - ctx->ySubvolVerge - ctx->yLo)/ctx->ySubvolLen));
-  int const svzLo = MIN(numSubvolsPerEdge-1,(int)((z - ctx->zSubvolVerge - ctx->zLo)/ctx->zSubvolLen));
+  int const svxLo = MIN((int)numSubvolsPerEdge-1,(int)((x - ctx->xSubvolVerge - ctx->xLo)/ctx->xSubvolLen));
+  int const svyLo = MIN((int)numSubvolsPerEdge-1,(int)((y - ctx->ySubvolVerge - ctx->yLo)/ctx->ySubvolLen));
+  int const svzLo = MIN((int)numSubvolsPerEdge-1,(int)((z - ctx->zSubvolVerge - ctx->zLo)/ctx->zSubvolLen));
 
-  int const svxHi = MIN(numSubvolsPerEdge-1,(int)((x + ctx->xSubvolVerge - ctx->xLo)/ctx->xSubvolLen));
-  int const svyHi = MIN(numSubvolsPerEdge-1,(int)((y + ctx->ySubvolVerge - ctx->yLo)/ctx->ySubvolLen));
-  int const svzHi = MIN(numSubvolsPerEdge-1,(int)((z + ctx->zSubvolVerge - ctx->zLo)/ctx->zSubvolLen));
+  int const svxHi = MIN((int)numSubvolsPerEdge-1,(int)((x + ctx->xSubvolVerge - ctx->xLo)/ctx->xSubvolLen));
+  int const svyHi = MIN((int)numSubvolsPerEdge-1,(int)((y + ctx->ySubvolVerge - ctx->yLo)/ctx->ySubvolLen));
+  int const svzHi = MIN((int)numSubvolsPerEdge-1,(int)((z + ctx->zSubvolVerge - ctx->zLo)/ctx->zSubvolLen));
 
   if (svxLo != svxHi || svyLo != svyHi || svzLo != svzHi) 
     return MRISAsynchronousTimeStep_optionalDxDyDzUpdate_numSubvolsPerThread - 1;       // the svi for any items not deep inside a subvolume
@@ -625,7 +625,7 @@ static void mrisAsynchronousTimeStep_optionalDxDyDzUpdate( // BEVIN mris_make_su
       
       // Choose the subvolume to put this face into
       //
-      int const svi = (sviLo==sviHi) ? sviLo : numSubvolsPerThread-1;   // if not same subvol, into the shared subvol
+      int const svi = (sviLo==sviHi) ? sviLo : (int)numSubvolsPerThread-1;   // if not same subvol, into the shared subvol
 
       // Assign the face to the subvolume
       //
@@ -718,13 +718,13 @@ static void mrisAsynchronousTimeStep_optionalDxDyDzUpdate( // BEVIN mris_make_su
   { int * temp = (int*)malloc(sizeof(int)*mris->nvertices);
     
     int svi;
-    for (svi = 0; svi < numSubvolsPerThread; svi++) {
+    for (svi = 0; svi < (int)numSubvolsPerThread; svi++) {
     
       // build the list in the temp
       //
       int tempSize = 0;
       
-      int tid;
+      size_t tid;
       for (tid = 0; tid < numThreads; tid++) {
         SubvolInfo* subvol = subvols + tid*numSubvolsPerThread + svi;
         int vno = subvol->firstVnoPlus1 - 1;

--- a/utils/mrisurf_topology.c
+++ b/utils/mrisurf_topology.c
@@ -223,9 +223,9 @@ void MRIScheckIsPolyhedron(MRIS *mris, const char* file, int line) {
           hiVnos[hiVnosSize++] = vno2;
         } else {
           Edges const * const edgesForVno2 = &edges[vno2];
-          int count = 0;
+          unsigned int count = 0;
           int i;
-          for (i = 0; i < edgesForVno2->hiVnosCount; i++) {
+          for (i = 0; i < (int)edgesForVno2->hiVnosCount; i++) {
             if (hiVnos[edgesForVno2->hiVnosBegin + i] == vno) count++;
           }
           cheapAssert(count == 1);  // each should be entered exactly once
@@ -261,7 +261,7 @@ void MRIScheckIsPolyhedron(MRIS *mris, const char* file, int line) {
         if (vno1 > vno2) { vno1 = vno2; vno2 = face->v[n1]; } else cheapAssert(vno1 != vno2);
         Edges const * const edgesForVno = &edges[vno1];
         int i;
-        for (i = 0; i < edgesForVno->hiVnosCount; i++) {
+        for (i = 0; i < (int)edgesForVno->hiVnosCount; i++) {
           if (hiVnos   [edgesForVno->hiVnosBegin + i] != vno2) continue;
           // found the entry for an edge
           if (!badCount) {
@@ -285,7 +285,7 @@ void MRIScheckIsPolyhedron(MRIS *mris, const char* file, int line) {
     if (badCount) break;
     
     int edgeNo;
-    for (edgeNo = 0; edgeNo < hiVnosSize; edgeNo++) {
+    for (edgeNo = 0; edgeNo < (int)hiVnosSize; edgeNo++) {
       int count = nFacesPerEdge[edgeNo];
       if (count == 2) continue;
       if (count <  2 && tearsOk) continue;
@@ -920,13 +920,15 @@ void MRIS_VertexNeighbourInfo_check(
   cheapAssert(lhs->hops == rhs->hops);
   
   int i;
-  for (i = 0; i <= lhs->hops; i++)
+  for (i = 0; i <= (int)lhs->hops; i++) {
     cheapAssert(lhs->vnum[i] == rhs->vnum[i]); 
+  }
     
   // Even test the algorithms put them in the same order!
   //
-  for (i = 0; i < lhs->vnum[lhs->hops]; i++) 
+  for (i = 0; i < lhs->vnum[lhs->hops]; i++) {
     cheapAssert(lhs->v[i] == rhs->v[i]);
+  }
 }
 
 
@@ -941,16 +943,18 @@ void MRIS_VertexNeighbourInfo_load_from_VERTEX (MRIS_VertexNeighbourInfo* info, 
   case 0: info->vnum[0] = 1;
   }
   int i;
-  for (i = 0; i < info->vnum[info->hops]; i++) info->v[i] = vt->v[i];
+  for (i = 0; i < info->vnum[info->hops]; i++) {
+    info->v[i] = vt->v[i];
+  }
 }
 
 void MRIS_VertexNeighbourInfo_load_from_vlist (MRIS_VertexNeighbourInfo* info, MRIS* mris, int vno, size_t listSize, int* vlist, int* hops) {
   info->vnum[0] = 1;
   int i;
-  for (i = 0; i < listSize; i++) {
+  for (i = 0; i < (int)listSize; i++) {
     info->v[i] = vlist[i];
     info->hops = hops[i];
-    cheapAssert(info->hops >= 0);
+    // cheapAssert(info->hops >= 0); Unsigned must be greater than zero
     cheapAssert(info->hops <= 3);
     info->vnum[info->hops] = i+1;
   }
@@ -1109,7 +1113,7 @@ static int MRISfindNeighborsAtVertex_new(MRIS *mris, int vno, int nlinks, size_t
   static Temp tempForEachThread[_MAX_FS_THREADS];
   
   Temp* const temp = &tempForEachThread[omp_get_thread_num()];
-  if (temp->capacity < mris->nvertices) {
+  if ((int)temp->capacity < mris->nvertices) {
     temp->capacity = mris->nvertices;
     temp->status   = (unsigned char*)realloc(temp->status, temp->capacity*sizeof(unsigned char));
     bzero(temp->status, temp->capacity*sizeof(unsigned char));
@@ -1170,7 +1174,7 @@ static int MRISfindNeighborsAtVertex_new(MRIS *mris, int vno, int nlinks, size_t
       
       temp->status[vnoCandidate] = Status_inSet;
 
-      cheapAssert(neighborCount < listCapacity);
+      cheapAssert(neighborCount < (int)listCapacity);
       vlist[neighborCount] = vnoCandidate;
       hops [neighborCount] = ringLinks;
       neighborCount++;
@@ -1207,7 +1211,7 @@ static int MRISfindNeighborsAtVertex_new(MRIS *mris, int vno, int nlinks, size_t
 
         temp->status[vnoCandidate] = Status_inSet;
 
-        cheapAssert(neighborCount < listCapacity);
+        cheapAssert(neighborCount < (int)listCapacity);
         vlist[neighborCount] = vnoCandidate;
         hops [neighborCount] = ringLinks;
         neighborCount++;
@@ -1249,7 +1253,7 @@ static int MRISfindNeighborsAtVertex_new(MRIS *mris, int vno, int nlinks, size_t
         vt->nsizeMax = newPossibleNsizeMax; vt->nsizeMaxClock = mris->nsizeMaxClock; 
       }
 
-      cheapAssert(vt->nsizeCur >= 0);
+      // cheapAssert(vt->nsizeCur >= 0); Unsigned must be greater than zero
       cheapAssert(vt->nsizeCur <= vt->nsizeMax);
       vt->vtotal = vnums[vt->nsizeCur];
     }

--- a/utils/nifti1_io.c
+++ b/utils/nifti1_io.c
@@ -4117,7 +4117,7 @@ nifti_image *nifti_image_read(const char *hname, int read_data)
 
   /* keep file open so we can check for exts. after nifti_convert_nhdr2nim() */
 
-  if (ii < (unsigned int)sizeof(nhdr)) {
+  if ((size_t)ii < sizeof(nhdr)) {
     if (g_opts.debug > 0) {
       LNI_FERR(fname, "bad binary header read for file", hfile);
       fprintf(stderr, "  - read %d of %d bytes\n", ii, (int)sizeof(nhdr));

--- a/utils/realm.c
+++ b/utils/realm.c
@@ -1023,7 +1023,9 @@ static void insertFnoIntoRealmTreeNode(RealmTree* realmTree, RealmTreeNode* n, i
         realmTree->interestingRealmTreeNode = n;
     }
     
-    if (realmTree->interestingRealmTreeNode) costlyAssert(isFnoInRealmTreeNode(realmTree, interestingFno));
+    if (realmTree->interestingRealmTreeNode) {
+      costlyAssert(isFnoInRealmTreeNode(realmTree, interestingFno));
+    }
 }
 
 static void removeFnoFromRealmTree(RealmTree* realmTree, int fno) {
@@ -1066,7 +1068,9 @@ static void removeFnoFromRealmTree(RealmTree* realmTree, int fno) {
         }
     }
 
-    if (realmTree->interestingRealmTreeNode) costlyAssert(isFnoInRealmTreeNode(realmTree, interestingFno));
+    if (realmTree->interestingRealmTreeNode) {
+      costlyAssert(isFnoInRealmTreeNode(realmTree, interestingFno));
+    }
 }
 
 
@@ -1441,7 +1445,7 @@ static void moveToNext(RealmIterator* realmIterator, Realm* realm) {
 #endif
         unsigned long c = i & leafIndexMask;
         c++;
-        if (c < n->vnosSize) {
+        if (c < (unsigned long)n->vnosSize) {
             realmIterator->i++;
             return;
         }

--- a/utils/rfa.c
+++ b/utils/rfa.c
@@ -694,9 +694,11 @@ static int csf_labels[] = {CSF,
 
 int MRIcountCSFInNbhd(MRI *mri_seg, int wsize, int x, int y, int z)
 {
-  int total, n;
+  int total;
+  size_t n;
 
-  for (n = total = 0; n < NCSF_LABELS; n++) total += MRIcountValInNbhd(mri_seg, wsize, x, y, z, csf_labels[n]);
-
+  for (n = total = 0; n < NCSF_LABELS; n++) {
+    total += MRIcountValInNbhd(mri_seg, wsize, x, y, z, csf_labels[n]);
+  }
   return (total);
 }

--- a/utils/romp_support.c
+++ b/utils/romp_support.c
@@ -436,7 +436,7 @@ static void node_show_stats(FILE* file, PerThreadScopeTreeData* node, unsigned i
         inAllThreads.ns += node->in_child_threads[tid].ns;
     }
     
-    {   int d;
+    {   unsigned int d;
         for (d = 0; d < depth; d++) fprintf(file, "    ");
     }
     

--- a/utils/stats.c
+++ b/utils/stats.c
@@ -450,7 +450,7 @@ SV *StatReadVolume(const char *prefix)
     for (event = 0; event < sv->nevents; event++) {
       /* read slice of means for each time point */
       for (t = 0; t < sv->time_per_event; t++) {
-        if (fread(buf, sizeof(float), nitems, fp) != nitems)
+        if (fread(buf, sizeof(float), nitems, fp) != (size_t)nitems)
           ErrorReturn(NULL,
                       (ERROR_BADFILE,
                        "StatReadVolume: could not read "
@@ -470,7 +470,7 @@ SV *StatReadVolume(const char *prefix)
       /* read slice of standard deviations for each time point */
       if (sv->mri_stds[event])
         for (t = 0; t < sv->time_per_event; t++) {
-          if (fread(buf, sizeof(float), nitems, fp) != nitems)
+          if (fread(buf, sizeof(float), nitems, fp) != (size_t)nitems)
             ErrorReturn(NULL,
                         (ERROR_BADFILE,
                          "StatReadVolume: could not read "
@@ -500,7 +500,7 @@ SV *StatReadVolume(const char *prefix)
     for (event = 0; event < sv->nevents; event++) {
       /* read slice of mean dofs for each time point */
       for (t = 0; t < sv->time_per_event; t++) {
-        if (fread(buf, sizeof(float), nitems, fp) != nitems)
+        if (fread(buf, sizeof(float), nitems, fp) != (size_t)nitems)
           ErrorReturn(NULL,
                       (ERROR_BADFILE,
                        "StatReadVolume: could not read "
@@ -520,7 +520,7 @@ SV *StatReadVolume(const char *prefix)
       /* read slice of standard deviation dofs for each time point */
       if (sv->mri_stds[event])
         for (t = 0; t < sv->time_per_event; t++) {
-          if (fread(buf, sizeof(float), nitems, fp) != nitems)
+          if (fread(buf, sizeof(float), nitems, fp) != (size_t)nitems)
             ErrorReturn(NULL,
                         (ERROR_BADFILE,
                          "StatReadVolume: could not read "
@@ -1238,7 +1238,7 @@ int StatWriteVolume(SV *sv, const char *prefix)
             buf[y * width + x] = fval;
           }
         }
-        if (fwrite(buf, sizeof(float), nitems, fp) != nitems)
+        if (fwrite(buf, sizeof(float), nitems, fp) != (size_t)nitems)
           ErrorReturn(ERROR_BADFILE,
                       (ERROR_BADFILE,
                        "StatWriteVolume: could not write "
@@ -1258,7 +1258,7 @@ int StatWriteVolume(SV *sv, const char *prefix)
               buf[y * width + x] = fval;
             }
           }
-          if (fwrite(buf, sizeof(float), nitems, fp) != nitems)
+          if (fwrite(buf, sizeof(float), nitems, fp) != (size_t)nitems)
             ErrorReturn(ERROR_BADFILE,
                         (ERROR_BADFILE,
                          "StatWriteVolume: could not write "

--- a/utils/utils.c
+++ b/utils/utils.c
@@ -1097,7 +1097,7 @@ int ItemsInString(const char *str)
 char *deblank(const char *str)
 {
   char *dbstr;
-  int n, m;
+  size_t n, m;
 
   dbstr = (char *)calloc(strlen(str) + 1, sizeof(char));
 
@@ -1119,7 +1119,7 @@ char *deblank(const char *str)
 */
 char *str_toupper(char *str)
 {
-  int n;
+  size_t n;
   for (n = 0; n < strlen(str); n++) str[n] = toupper(str[n]);
   return (0);
 }

--- a/utils/vertexRotator.c
+++ b/utils/vertexRotator.c
@@ -47,7 +47,7 @@ static void rotateVertices1axis_wkr(
   float const sa = sin(alpha);
   float const ca = cos(alpha);
 
-  int vno;
+  size_t vno;
   
   for (vno = 0; vno < nvertices; vno++) {
     float x  = xv_inp[vno];
@@ -98,7 +98,7 @@ static inline void rotateVertices_wkr(
   float const cbcg = cb * cg;
   float const cbsg = cb * sg;
 
-  int vno;
+  size_t vno;
   
   for (vno = 0; vno < nvertices; vno++) {
 

--- a/utils/xUtilities.c
+++ b/utils/xUtilities.c
@@ -94,8 +94,8 @@ char *xUtil_GetErrorString(xUtil_tErr ieCode)
   return xUtil_ksaErrorString[eCode];
 }
 
-struct timeval sStartTime = {};
-struct timeval sEndTime = {};
+struct timeval sStartTime = {0, 0};
+struct timeval sEndTime = {0, 0};
 
 void xUtil_StartTimer() { gettimeofday(&sStartTime, NULL); }
 

--- a/utils/xmlToHtml.c
+++ b/utils/xmlToHtml.c
@@ -324,7 +324,7 @@ int tagNameIs(char *c, xmlNodePtr cur)
 int wrdLen(char *c)
 {
   int i;
-  for (i = 0; i < strlen(c); i++)
+  for (i = 0; i < (int)strlen(c); i++)
     if (*(c + i) == ' ' || *(c + i) == '_' || *(c + i) == '/') {
       return i;
     }


### PR DESCRIPTION
Enable -Wextra and fix many compiler warnings
- Mark ITK as "SYSTEM" in CMake to turn off warnings on those files
- Comment out unused typedefs
- Put braces around some empty blocks
- Coerce a lot of unsigned/signed integer comparisons