### PR TITLE
Bf freesurfer replacement for creation time string

### DIFF
--- a/utils/mrisurf_io.cpp
+++ b/utils/mrisurf_io.cpp
@@ -5830,7 +5830,7 @@ int MRISwriteTriangularSurface(MRI_SURFACE *mris, const char *fname)
   if (!user)  user = "UNKNOWN";
 
   auto cdt = currentDateTime();
-  if (true) // HACK Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
+  if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
     fprintf(stdout, "writing surface file %s, created by %s on %s.\n", fname, user, cdt.c_str());
 
   FILE *fp = fopen(fname, "w");

--- a/utils/mrisurf_io.cpp
+++ b/utils/mrisurf_io.cpp
@@ -5825,33 +5825,29 @@ SMALL_SURFACE *MRISreadVerticesOnly(char *fname)
   ------------------------------------------------------*/
 int MRISwriteTriangularSurface(MRI_SURFACE *mris, const char *fname)
 {
-  int k, n;
-  FILE *fp;
-  const char *user, *time_str;
+  const char *user = getenv("USER");
+  if (!user)  user = getenv("LOGNAME");
+  if (!user)  user = "UNKNOWN";
 
-  user = getenv("USER");
-  if (!user) {
-    user = getenv("LOGNAME");
-  }
-  if (!user) {
-    user = "UNKNOWN";
-  }
-  time_str = currentDateTime().c_str();
-  if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
-    fprintf(stdout, "writing surface file %s, created by %s on %s.\n", fname, user, time_str);
-  fp = fopen(fname, "w");
+  auto cdt = currentDateTime();
+  if (true) // HACK Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
+    fprintf(stdout, "writing surface file %s, created by %s on %s.\n", fname, user, cdt.c_str());
+
+  FILE *fp = fopen(fname, "w");
   if (fp == NULL) ErrorReturn(ERROR_BADFILE, (ERROR_BADFILE, "MRISwrite(%s): can't create file\n", fname));
+  
   fwrite3(TRIANGLE_FILE_MAGIC_NUMBER, fp);
-  fprintf(fp, "created by %s on %s\n", user, time_str);
+  fprintf(fp, "created by %s on %s\n", user, cdt.c_str());
   fwriteInt(mris->nvertices, fp);
   fwriteInt(mris->nfaces, fp); /* # of triangles */
-  for (k = 0; k < mris->nvertices; k++) {
+
+  for (int k = 0; k < mris->nvertices; k++) {
     fwriteFloat(mris->vertices[k].x, fp);
     fwriteFloat(mris->vertices[k].y, fp);
     fwriteFloat(mris->vertices[k].z, fp);
   }
-  for (k = 0; k < mris->nfaces; k++) {
-    for (n = 0; n < VERTICES_PER_FACE; n++) {
+  for (int k = 0; k < mris->nfaces; k++) {
+    for (int n = 0; n < VERTICES_PER_FACE; n++) {
       fwriteInt(mris->faces[k].v[n], fp);
     }
   }
@@ -5872,13 +5868,13 @@ int MRISwriteTriangularSurface(MRI_SURFACE *mris, const char *fname)
     TAGwriteEnd(fp, here);
   }
   {
-    int i;
-
-    for (i = 0; i < mris->ncmds; i++) TAGwrite(fp, TAG_CMDLINE, mris->cmdlines[i], strlen(mris->cmdlines[i]) + 1);
+    for (int i = 0; i < mris->ncmds; i++) TAGwrite(fp, TAG_CMDLINE, mris->cmdlines[i], strlen(mris->cmdlines[i]) + 1);
   }
+  
   fclose(fp);
   return (NO_ERROR);
 }
+
 /*-----------------------------------------------------
   Parameters:
 


### PR DESCRIPTION
I am seeing bad text in the currentDate field in the triangle files under obscure circumstances. This was causing crashes when the triangle file was read.

The code has a function call returning a std::string and the caller then taking its c_str().  The function result is then destroyed, but a pointer to its c_str has been kept and is later used.

This fix eliminates the problem.

