### PR TITLE
Support writing a label file labelling the points of greatest rel xyz change

### DIFF
--- a/mris_diff/mris_diff.cpp
+++ b/mris_diff/mris_diff.cpp
@@ -67,12 +67,14 @@
   17. face vertex identities (3)
 
 
-  mris_diff --s1 subj1 --s2 subj2 --hemi lh --curv curv
-  SD/subj1/surf/hemi.curv SD/subj2/surf/hemi.curv
+    mris_diff --s1 subj1 --s2 subj2 --hemi lh --curv curv
+        SD/subj1/surf/hemi.curv SD/subj2/surf/hemi.curv
 
-  mris_diff --s1 subj1 --s2 subj2 --hemi lh --annot aparc
-  SD/subj1/label/hemi.aparc SD/subj2/label/hemi.aparc.annot
+    mris_diff --s1 subj1 --s2 subj2 --hemi lh --annot aparc
+        SD/subj1/label/hemi.aparc SD/subj2/label/hemi.aparc.annot
 
+    mris_diff --worst-bucket bucket_file --okayBucketMax int file1 file2
+    
   ENDHELP
 */
 
@@ -93,6 +95,7 @@ double round(double x);
 #include "mrisutils.h"
 #include "error.h"
 #include "diag.h"
+#include "label.h"
 #include "mri.h"
 #include "mrisurf.h"
 #include "mri2.h"
@@ -127,7 +130,8 @@ static char *out_fname ;
 static char tmpstr[2000];
 static char *xyzRMSFile=NULL;
 static char *angleRMSFile=NULL;
-
+static char *worstBucketFile=NULL;
+static int   okayBucketMax=1;
 static MRIS *surf1, *surf2;
 
 static int CheckSurf=0;
@@ -152,12 +156,16 @@ MRI *MRISminDist(MRIS *srcsurf, MRIS *trgsurf);
 // it is important to understand how well the whole surface fits, rather than just looking for the
 // few bad matches.  So histograms of the various properties are used...
 //
+static std::vector<char> vnoToWorstBucket;
+
 #define HistogramSize 20
-typedef struct {
+struct HistogramOfFit {
+  bool contributesToWorstBucket;
+  HistogramOfFit(bool contributesToWorstBucket = false) : contributesToWorstBucket(contributesToWorstBucket) {}
   double maxV;
   double maxDiff;
   unsigned int v[HistogramSize];
-} HistogramOfFit;
+};
 
 static void initHistogramOfFit(HistogramOfFit* histogramOfFit) {
   histogramOfFit->maxV = 0.0;
@@ -179,13 +187,17 @@ static int headHistogramOfFit(HistogramOfFit* histogramOfFit) {
   return 0;
 }
 
-static void insertHistogramOfFit(HistogramOfFit* histogramOfFit, double diff, double v) {
+static void insertHistogramOfFit(int vnoOrNegative, HistogramOfFit* histogramOfFit, double diff, double v) {
   if (histogramOfFit->maxV < v) histogramOfFit->maxV = v;
   if (histogramOfFit->maxDiff < diff) histogramOfFit->maxDiff = diff;
   double fit = 0.01; int i = 0;
   while (fit < diff) { fit *= 3; i++; }
   if (i >= HistogramSize) i = HistogramSize-1;
   histogramOfFit->v[i]++;
+  if (histogramOfFit->contributesToWorstBucket && vnoOrNegative >= 0) {
+    auto & e = vnoToWorstBucket[vnoOrNegative];
+    e = std::max(e,char(i));
+  }
 }
 
 static int printfHistogramOfFit(HistogramOfFit* histogramOfFit, double const* requiredFit) {
@@ -214,17 +226,17 @@ static int printfHistogramOfFit(HistogramOfFit* histogramOfFit, double const* re
 }
 
 static HistogramOfFit vertexXyzHistogram;
-static HistogramOfFit vertexRelativeXyzHistogram;
+static HistogramOfFit vertexRelativeXyzHistogram(true);
 static HistogramOfFit vertexNxnynzHistogram;
 static HistogramOfFit faceNxnynzHistogram;
 static HistogramOfFit faceAreaHistogram;
 static HistogramOfFit vertexCurvHistogram;
 
-static void compare(HistogramOfFit* histogramOfFit, double lhs, double rhs) {
+static void compare(int vnoOrNegative, HistogramOfFit* histogramOfFit, double lhs, double rhs) {
   double absLhs = fabs(lhs);
   double absRhs = fabs(rhs);
   double diffAbs = fabs(lhs - rhs);
-  insertHistogramOfFit(histogramOfFit, diffAbs, absLhs>absRhs?absLhs:absRhs);
+  insertHistogramOfFit(vnoOrNegative, histogramOfFit, diffAbs, absLhs>absRhs?absLhs:absRhs);
 }
 
 static void initHistograms() {
@@ -310,7 +322,8 @@ static bool compareVertexPositions(MRIS * const lhs, MRIS * const rhs, std::vect
   // 
   size_t rLo = 0, rHi = 0;
   for (size_t li = 0; li < lhsList.size(); li++) {
-      auto const & lv = lhs->vertices[lhsList[li]];
+      auto const lhsVno = lhsList[li];
+      auto const & lv = lhs->vertices[lhsVno];
       while (rLo < rhsList.size() && rhs->vertices[rhsList[rLo]].x < lv.x - maxDistortion) rLo++;
       while (rHi < rhsList.size() && rhs->vertices[rhsList[rHi]].x < lv.x + maxDistortion) rHi++;
       if (rLo == rhsList.size()) break;       // no more candidates
@@ -328,12 +341,12 @@ static bool compareVertexPositions(MRIS * const lhs, MRIS * const rhs, std::vect
       } else if (found != 1) {
         std::cout << "compareVertexPositions more than 1 candidate matched, in fact found: " << found << std::endl;
       } else {
-        lhsVno2rhsVno[lhsList[li]] = rv - rhs->vertices;
+        lhsVno2rhsVno[lhsVno] = rv - rhs->vertices;
         matched++;
         if (rv) {
-          compare(&vertexXyzHistogram, lv.x, rv->x);
-          compare(&vertexXyzHistogram, lv.y, rv->y);
-          compare(&vertexXyzHistogram, lv.z, rv->z);
+          compare(lhsVno,&vertexXyzHistogram, lv.x, rv->x);
+          compare(lhsVno,&vertexXyzHistogram, lv.y, rv->y);
+          compare(lhsVno,&vertexXyzHistogram, lv.z, rv->z);
         }
       }
   }
@@ -583,6 +596,9 @@ int main(int argc, char *argv[]) {
     exit(0);
   }
 
+  vnoToWorstBucket.resize(surf1->nvertices);
+  std::fill(vnoToWorstBucket.begin(),vnoToWorstBucket.end(),0);
+  
   maxdiff=0;
   //------------------------------------------------------------
   if (CheckSurf) {
@@ -612,9 +628,9 @@ int main(int argc, char *argv[]) {
       bool has_bad_neighbours = false;
       
       if (CheckXYZ) {
-        compare(&vertexXyzHistogram, vtx1->x, vtx2->x);
-        compare(&vertexXyzHistogram, vtx1->y, vtx2->y);
-        compare(&vertexXyzHistogram, vtx1->z, vtx2->z);
+        compare(nthvtx,&vertexXyzHistogram, vtx1->x, vtx2->x);
+        compare(nthvtx,&vertexXyzHistogram, vtx1->y, vtx2->y);
+        compare(nthvtx,&vertexXyzHistogram, vtx1->z, vtx2->z);
 
 	// The problem with comparing xyz is that a whole "continent" of
 	// faces can drift in the same internal shape and they all
@@ -646,15 +662,15 @@ int main(int argc, char *argv[]) {
               double dy2 = v2->y - vtx2->y ;
               double dz2 = v2->z - vtx2->z ;
               double dist2 = sqrt(dx2*dx2 + dy2*dy2 + dz2*dz2);
-	      compare(&vertexRelativeXyzHistogram, dist1, dist2);
+	      compare(f1->v[vn],&vertexRelativeXyzHistogram, dist1, dist2);
 	    }
 	  }
 	}
       }
       if (CheckNXYZ) {
-        compare(&vertexNxnynzHistogram, vtx1->nx, vtx2->nx);
-        compare(&vertexNxnynzHistogram, vtx1->ny, vtx2->ny);
-        compare(&vertexNxnynzHistogram, vtx1->nz, vtx2->nz);
+        compare(nthvtx,&vertexNxnynzHistogram, vtx1->nx, vtx2->nx);
+        compare(nthvtx,&vertexNxnynzHistogram, vtx1->ny, vtx2->ny);
+        compare(nthvtx,&vertexNxnynzHistogram, vtx1->nz, vtx2->nz);
       }
       
       nnbrs1 = vtx1t->vnum;
@@ -734,11 +750,11 @@ int main(int argc, char *argv[]) {
       face2 = &(surf2->faces[nthface2]); FaceNormCacheEntry const * fNorm2 = getFaceNorm(surf2, nthface2);
       
       if (CheckNXYZ) {
-        compare(&faceNxnynzHistogram, fNorm1->nx, fNorm2->nx);
-        compare(&faceNxnynzHistogram, fNorm1->ny, fNorm2->ny);
-        compare(&faceNxnynzHistogram, fNorm1->nz, fNorm2->nz);
+        compare(-1,&faceNxnynzHistogram, fNorm1->nx, fNorm2->nx);
+        compare(-1,&faceNxnynzHistogram, fNorm1->ny, fNorm2->ny);
+        compare(-1,&faceNxnynzHistogram, fNorm1->nz, fNorm2->nz);
       }
-      compare(&faceAreaHistogram, face1->area, face2->area);
+      compare(-1,&faceAreaHistogram, face1->area, face2->area);
       if (face1->ripflag != face2->ripflag) {
         printf("Face %d:%d differs in ripflag %c %c\n",
                nthface,nthface2,face1->ripflag,face2->ripflag);
@@ -777,6 +793,17 @@ int main(int argc, char *argv[]) {
       exit(103);
     }
 
+    if(worstBucketFile){
+      printf("Writing worstBucket\n");
+      for (nthvtx=0; nthvtx < surf1->nvertices; nthvtx++) {
+        auto & v = surf1->vertices[nthvtx];
+        v.stat = (vnoToWorstBucket[nthvtx] > okayBucketMax) ? -1 : 1;
+        if (v.stat > 0.0f) v.marked = 1;
+      }
+      LABEL* area = LabelFromMarkedSurface(surf1);
+      LabelWrite(area,worstBucketFile);
+    }
+
     exit(0);
   } // end check surf
 
@@ -802,7 +829,7 @@ int main(int argc, char *argv[]) {
       if (nthvtx2 < 0) continue;
       VERTEX const * const vtx1 = &(surf1->vertices[nthvtx ]);
       VERTEX const * const vtx2 = &(surf2->vertices[nthvtx2]);
-      compare(&vertexCurvHistogram, vtx1->curv, vtx2->curv);
+      compare(nthvtx,&vertexCurvHistogram, vtx1->curv, vtx2->curv);
     } // end loop over vertices
     if (maxdiff>0) printf("maxdiff=%g\n",maxdiff);
     if (error_count > 0) {
@@ -912,6 +939,18 @@ static int parse_commandline(int argc, char **argv) {
       angleRMSFile = pargv[0];
       nargsused = 1;
     } 
+    else if (!strcasecmp(option, "--worst-bucket")) {
+      if (nargc < 1) CMDargNErr(option,1);
+      worstBucketFile = pargv[0];
+      nargsused = 1;
+    } 
+    else if (!strcasecmp(option, "--okayBucketMax")) {
+      if (nargc < 1) CMDargNErr(option,1);
+      long int val;
+      sscanf(pargv[0],"%ld",&val);
+      okayBucketMax = int(val);
+      nargsused = 1;
+    }     
     else if (!strcasecmp(option, "--s1")) {
       if (nargc < 1) CMDargNErr(option,1);
       subject1 = pargv[0];
@@ -1025,6 +1064,7 @@ static void print_usage(void) {
   printf("   --maxerrs N   stop looping after N errors (default=%d)\n",
          MAX_NUM_ERRORS);
   printf("   --renumbered  the vertices or faces may have been renumbered and a few deleted\n");
+  printf("   --worst-bucket worstbucketfile : compute the worst histogram bucket each vertex is in\n");
   printf("\n");
   printf("   --no-check-xyz  : do not check vertex xyz\n");
   printf("   --no-check-nxyz : do not check vertex normals\n");


### PR DESCRIPTION
To help debug changes in mris_inflate and mris_sphere it is useful to easily visualize where on the MRIS the differences are happening.  This change adds the capability to generate a label file at various thresholds of change.  This label file can then be used by freeview.

e.g.

(
~/freesurfer_repo_newReg/freesurfer//mris_diff/mris_diff --worst-bucket worst-bucket --okayBucketMax 3 ./testdata/rh.qsphere.nofix.{oldReg,newReg}
export BEFOR=/home/rheticus/tmp/mir_root~restarted/freesurfer-bf_more_managed_xyz_and_dist-3-T4/subjects/bert
(        
    export FREESURFER_HOME=~/bin/freesurfer
    export MINC_BIN_DIR=~/freesurfer-packages/minc/1.5/bin
    export MINC_LIB_DIR=~/freesurfer-packages/minc/1.5/lib
    source $FREESURFER_HOME/SetUpFreeSurfer.sh
    ~/bin/freesurfer/bin/freeview -v $BEFOR/mri/brain.mgz -f ./testdata/rh.qsphere.nofix.oldReg:label=worst-bucket.label
    ~/bin/freesurfer/bin/freeview -v $BEFOR/mri/brain.mgz -f ./testdata/rh.smoothwm.nofix.inflated.oldReg:label=worst-bucket.label
)
)