### PR TITLE
Should store these even if not previously stored

### DIFF
--- a/include/mrisurf.h
+++ b/include/mrisurf.h
@@ -2949,10 +2949,15 @@ static bool mrisVerticesAreNeighbors(MRIS const * const mris, int const vno1, in
 
 // Vals
 //
-void MRISsetOriginalXYZwkr(MRIS *mris, int vno, float x, float y, float z, const char* file, int line, bool* laterTime);
 void MRISsetOriginalXYZfromXYZ(MRIS *mris);
+    //
+    // This includes copying the MRIS::status to the MRIS::origxyz_status
+    
+void MRISsetOriginalXYZwkr(MRIS *mris, int vno, float x, float y, float z, const char* file, int line, bool* laterTime);
 #define MRISsetOriginalXYZ(_MRIS,_VNO,_X,_Y,_Z) \
     { static bool laterTime; MRISsetOriginalXYZwkr((_MRIS),(_VNO),(_X),(_Y),(_Z),__FILE__,__LINE__, &laterTime); }
+    //
+    // The values being set need to match the MRIS::origxyz_status
 
 int mrisComputeOriginalVertexDistances(MRIS *mris);
 void mrisComputeOriginalVertexDistancesIfNecessaryWkr(MRIS *mris, bool* laterTime, const char* file, int line);

--- a/include/mrisurf.h
+++ b/include/mrisurf.h
@@ -539,34 +539,38 @@ typedef char    MRIS_subject_name_t[STRLEN] ;
 typedef char    MRIS_fname_t[STRLEN] ;
 
 
-#if 1
-enum MRIS_Status {
-  MRIS_SURFACE               = 0,
-  MRIS_PATCH                 = 1,
-  MRIS_CUT                   = MRIS_PATCH,
-  MRIS_PLANE                 = 2,
-  MRIS_ELLIPSOID             = 3,
-  MRIS_SPHERE                = 4,
-  MRIS_PARAMETERIZED_SPHERE  = 5,
-  MRIS_RIGID_BODY            = 6,
-  MRIS_SPHERICAL_PATCH       = 7,
-  MRIS_UNORIENTED_SPHERE     = 8,
-  MRIS_PIAL_SURFACE          = 9,
-  MRIS_Status__end           = 10
+enum MRIS_Status_DistanceFormula {
+  MRIS_Status_DistanceFormula_0,    // see utils/mrisComputeVertexDistancesWkr_extracted.h
+  MRIS_Status_DistanceFormula_1
 };
-#else
-  #define MRIS_SURFACE               0
-  #define MRIS_PATCH                 1
-  #define MRIS_CUT                   MRIS_PATCH
-  #define MRIS_PLANE                 2
-  #define MRIS_ELLIPSOID             3
-  #define MRIS_SPHERE                4
-  #define MRIS_PARAMETERIZED_SPHERE  5
-  #define MRIS_RIGID_BODY            6
-  #define MRIS_SPHERICAL_PATCH       7
-  #define MRIS_UNORIENTED_SPHERE     8
-  #define MRIS_PIAL_SURFACE          9
-#endif
+
+enum MRIS_Status {
+#define MRIS_Status_ELTS \
+  ELT(MRIS_SURFACE              ,0) SEP \
+  ELT(MRIS_PATCH                ,0) SEP \
+  ELT(MRIS_PLANE                ,0) SEP \
+  ELT(MRIS_ELLIPSOID            ,0) SEP \
+  ELT(MRIS_SPHERE               ,1) SEP \
+  ELT(MRIS_PARAMETERIZED_SPHERE ,1) SEP \
+  ELT(MRIS_RIGID_BODY           ,0) SEP \
+  ELT(MRIS_SPHERICAL_PATCH      ,0) SEP \
+  ELT(MRIS_UNORIENTED_SPHERE    ,0) SEP \
+  ELT(MRIS_PIAL_SURFACE         ,0)     \
+  // end of macro
+#define SEP ,
+#define ELT(E,D) E
+  MRIS_Status_ELTS,
+  MRIS_Status__end, 
+  MRIS_CUT = MRIS_PATCH
+#undef ELT
+#undef SEP
+};
+
+const char* MRIS_Status_text(MRIS_Status s1);
+MRIS_Status_DistanceFormula MRIS_Status_distanceFormula(MRIS_Status s1);
+bool areCompatible(MRIS_Status s1, MRIS_Status s2);
+void checkOrigXYZCompatibleWkr(MRIS_Status s1, MRIS_Status s2, const char* file, int line);
+#define checkOrigXYZCompatible(S1,S2) checkOrigXYZCompatibleWkr((S1),(S2),__FILE__,__LINE__);
 
 
 typedef struct MRIS

--- a/include/mrisurf.h
+++ b/include/mrisurf.h
@@ -287,7 +287,7 @@ typedef struct vertex_type_
   ELTT(/*CONST_EXCEPT_MRISURF_METRIC_PROPERTIES*/ float,y)          SEP             /* use MRISsetXYZ() to set */                   \
   ELTT(/*CONST_EXCEPT_MRISURF_METRIC_PROPERTIES*/ float,z)          SEP                                                             \
   \
-  ELTT(const float,origx)                                       SEP             /* original coordinates */                          \
+  ELTT(const float,origx)                                       SEP             /* original coordinates, see also MRIS::origxyz_status */   \
   ELTT(const float,origy)                                       SEP             /* use MRISsetOriginalXYZ() */                      \
   ELTT(const float,origz)                                       SEP             /* or MRISsetOriginalXYZfromXYZ to set */           \
   \
@@ -538,6 +538,37 @@ typedef char   *MRIS_cmdlines_t[MAX_CMDS] ;
 typedef char    MRIS_subject_name_t[STRLEN] ;
 typedef char    MRIS_fname_t[STRLEN] ;
 
+
+#if 1
+enum MRIS_Status {
+  MRIS_SURFACE               = 0,
+  MRIS_PATCH                 = 1,
+  MRIS_CUT                   = MRIS_PATCH,
+  MRIS_PLANE                 = 2,
+  MRIS_ELLIPSOID             = 3,
+  MRIS_SPHERE                = 4,
+  MRIS_PARAMETERIZED_SPHERE  = 5,
+  MRIS_RIGID_BODY            = 6,
+  MRIS_SPHERICAL_PATCH       = 7,
+  MRIS_UNORIENTED_SPHERE     = 8,
+  MRIS_PIAL_SURFACE          = 9,
+  MRIS_Status__end           = 10
+};
+#else
+  #define MRIS_SURFACE               0
+  #define MRIS_PATCH                 1
+  #define MRIS_CUT                   MRIS_PATCH
+  #define MRIS_PLANE                 2
+  #define MRIS_ELLIPSOID             3
+  #define MRIS_SPHERE                4
+  #define MRIS_PARAMETERIZED_SPHERE  5
+  #define MRIS_RIGID_BODY            6
+  #define MRIS_SPHERICAL_PATCH       7
+  #define MRIS_UNORIENTED_SPHERE     8
+  #define MRIS_PIAL_SURFACE          9
+#endif
+
+
 typedef struct MRIS
 {
 // The LIST_OF_MRIS_ELTS macro used here enables the the mris_hash
@@ -620,7 +651,8 @@ typedef struct MRIS
   ELTT(float,Kmin) SEP              /* min Gaussian curvature */    \
   ELTT(float,Kmax) SEP              /* max Gaussian curvature */    \
   ELTT(double,Ktotal) SEP           /* total Gaussian curvature */    \
-  ELTT(int,status) SEP              /* type of surface (e.g. sphere, plane) */    \
+  ELTT(MRIS_Status,status) SEP          /* type of surface (e.g. sphere, plane) */    \
+  ELTT(MRIS_Status,origxyz_status) SEP  /* type of surface (e.g. sphere, plane) that this origxyz were obtained from */    \
   ELTT(int,patch) SEP               /* if a patch of the surface */    \
   ELTT(int,nlabels) SEP    \
   ELTP(MRIS_AREA_LABEL,labels) SEP  /* nlabels of these (may be null) */    \
@@ -851,18 +883,6 @@ positive areas */
 #define INTEGRATE_MOMENTUM         1
 #define INTEGRATE_ADAPTIVE         2
 #define INTEGRATE_LM_SEARCH        3  /* binary search for minimum */
-
-#define MRIS_SURFACE               0
-#define MRIS_PATCH                 1
-#define MRIS_CUT                   MRIS_PATCH
-#define MRIS_PLANE                 2
-#define MRIS_ELLIPSOID             3
-#define MRIS_SPHERE                4
-#define MRIS_PARAMETERIZED_SPHERE  5
-#define MRIS_RIGID_BODY            6
-#define MRIS_SPHERICAL_PATCH       7
-#define MRIS_UNORIENTED_SPHERE     8
-#define MRIS_PIAL_SURFACE          9
 
 // different Hausdorff distance modes
 #define HDIST_MODE_SYMMETRIC_MEAN 0

--- a/mri_watershed/mri_watershed.cpp
+++ b/mri_watershed/mri_watershed.cpp
@@ -246,7 +246,7 @@ SPHERE_ELTS
         MRISfree(&mris);
     }
     MRIS* mris;
-    int   const status;
+    MRIS_Status const status;
     int   const nvertices;
     float radius;
     struct Vertex {
@@ -7858,8 +7858,8 @@ mrisRigidBodyAlignGlobal(MRIS *mris_curv,
 {
   double   alpha, beta, gamma, degrees, delta, mina, minb, ming,
            sse, min_sse ;
-  int      curv_old_status = mris_curv->status
-                             ,dist_old_status=mris_dist->status ;
+  auto const curv_old_status = mris_curv->status;
+  auto const dist_old_status = mris_dist->status;
 
   //to stop the compilator warnings !
   min_sse=0;

--- a/mris2rgb/mris2rgb.cpp
+++ b/mris2rgb/mris2rgb.cpp
@@ -208,7 +208,7 @@ int
 main(int argc, char *argv[]) {
   char            **av, *in_fname, *out_prefix, out_fname[100], name[100],
   path[100], *cp, hemi[100], fname[100], *surf_fname ;
-  int             ac, nargs, size, ino, old_status, i, drawn, is_flat ;
+  int             ac, nargs, size, ino, i, drawn, is_flat ;
   float           angle = 0.0f ;
   unsigned short  *red=NULL, *green=NULL, *blue=NULL;
   unsigned char   *rgb=NULL;
@@ -427,9 +427,9 @@ main(int argc, char *argv[]) {
       MRIScomputeSecondFundamentalForm(mris) ;
       MRISuseGaussianCurvature(mris) ;
       break ;
-    case AREA_ERRORS:
+    case AREA_ERRORS: {
       MRISstoreCurrentPositions(mris) ;
-      old_status = mris->status ;
+      auto const old_status = mris->status ;
       mris->status = MRIS_SURFACE ;
       MRISreadVertexPositions(mris, "smoothwm") ;
       MRIScomputeMetricProperties(mris) ;
@@ -438,7 +438,7 @@ main(int argc, char *argv[]) {
       mris->status = old_status ;
       MRIScomputeMetricProperties(mris) ;
       MRISuseAreaErrors(mris) ;
-      break ;
+    } break ;
     }
 
     if (normalize_flag)

--- a/mris_congeal/mris_congeal.cpp
+++ b/mris_congeal/mris_congeal.cpp
@@ -1193,9 +1193,9 @@ MRIScongealRigidBodyAlignGlobal(MRI_SURFACE *mris_ico, MRI_SURFACE *mris,
 {
   double   alpha, beta, gamma, degrees, delta, mina, minb, ming,
   sse, min_sse, ext_sse ;
-  int      old_status = mris->status, old_norm ;
-
-  old_norm = parms->abs_norm ;
+  auto const old_status = mris->status;
+  auto const old_norm   = parms->abs_norm ;
+  
   parms->abs_norm = 1 ;
   min_degrees = RADIANS(min_degrees) ;
   max_degrees = RADIANS(max_degrees) ;

--- a/mris_fix_topology/mris_fix_topology.cpp
+++ b/mris_fix_topology/mris_fix_topology.cpp
@@ -279,6 +279,7 @@ main(int argc, char *argv[])
   /* at this point : original vertices
      real solution in original vertices = corrected smoothed orig vertices */
   MRISfree(&mris) ;
+
   if (!mris_corrected || exit_after_diag)  /* for now */
     exit(0) ;
 

--- a/mris_resample/mris_resample.cpp
+++ b/mris_resample/mris_resample.cpp
@@ -235,6 +235,8 @@ resampleSurface( MRIS* mrisAtlasReg,
                  MRIS* mrisSubject,
                  bool passAnnotation )
 {
+  cheapAssert(mrisAtlasReg->origxyz_status == mrisSubject->origxyz_status);
+
   /* this function assumes the mapping function is stored
      as the "INFLATED vertex" of mris_template */
 

--- a/mris_topo_fixer/mris_topology.cpp
+++ b/mris_topo_fixer/mris_topology.cpp
@@ -482,6 +482,8 @@ MRIS *MRISduplicateOver(MRIS *mris,int mode)
   //clone the surface mris
   MRIS * mris_dst = MRISclone(mris);
   
+  cheapAssert(mris_dst->origxyz_status == mris->origxyz_status);
+  
   for (int n = 0 ; n < mris->nvertices ; n++) {
     VERTEX *vdst = &mris_dst->vertices[n];
     VERTEX *vsrc = &mris->vertices[n];
@@ -1132,6 +1134,9 @@ bool MRISaddMRIP(MRIS *mris_dst, MRIP *mrip)
   int newNumFaces     = currNumFaces    + mris->nfaces    - nfaces;
 
   MRISreallocVerticesAndFaces(mris_dst, newNumVertices, newNumFaces);
+
+  cheapAssert(mris_dst->origxyz_status == mris->origxyz_status);
+  
 
   //vertices
   for (int n = 0 ; n < mris->nvertices ; n++) {

--- a/utils/mrisComputeVertexDistancesWkr_extracted.h
+++ b/utils/mrisComputeVertexDistancesWkr_extracted.h
@@ -18,7 +18,10 @@ static bool FUNCTION_NAME(
 #endif
 
   if (mris->status != mris->INPUT_STATUS) {
+    auto oldStatusFormula = MRIS_Status_distanceFormula(mris->status);
+    auto newStatusFormula = MRIS_Status_distanceFormula(mris->INPUT_STATUS);
     fprintf(stdout, "%s:%d %s mris->status:%d != mris->INPUT_STATUS:%d ",__FILE__,__LINE__, __MYFUNCTION__, int(mris->status), int( mris->INPUT_STATUS));
+    if (oldStatusFormula != newStatusFormula) fprintf(stdout, "  executing formula_%d instead of _%d\n", newStatusFormula, oldStatusFormula);
   }
 
   int nonZeroInputXCount = 0;

--- a/utils/mrisComputeVertexDistancesWkr_extracted.h
+++ b/utils/mrisComputeVertexDistancesWkr_extracted.h
@@ -27,11 +27,12 @@ static bool FUNCTION_NAME(
   
   int vno;
 
-  switch (mris->INPUT_STATUS) {
-    default: /* don't really know what to do in other cases */
+  switch (MRIS_Status_distanceFormula(mris->INPUT_STATUS)) {
+    default: 
+      cheapAssert(false);
 
-    case MRIS_PLANE:
-
+    case MRIS_Status_DistanceFormula_0:
+    {
       ROMP_PF_begin		// mris_fix_topology
 #ifdef HAVE_OPENMP
       #pragma omp parallel for if_ROMP(shown_reproducible) reduction(+:errors)  reduction(+:nonZeroInputXCount)
@@ -88,12 +89,10 @@ static bool FUNCTION_NAME(
         ROMP_PFLB_end
       }
       ROMP_PF_end
-  
-      break;
+    } break;
 
-    case MRIS_PARAMETERIZED_SPHERE:
-    case MRIS_SPHERE: {
-
+    case MRIS_Status_DistanceFormula_1:
+    {
       // Sped up by computing the normalized vectors for all the vertices once rather than repeatedly
       // and storing them along with their ripflag in a structure!
       //

--- a/utils/mrisComputeVertexDistancesWkr_extracted.h
+++ b/utils/mrisComputeVertexDistancesWkr_extracted.h
@@ -12,10 +12,14 @@ static bool FUNCTION_NAME(
   
 #ifndef COMPILING_MRIS_MP
   if (debugNonDeterminism) {
-    fprintf(stdout, "%s:%d %s stdout ",__FILE__,__LINE__, __MYFUNCTION__);
+    fprintf(stdout, "%s:%d %s ",__FILE__,__LINE__, __MYFUNCTION__);
     mris_print_hash(stdout, mris, "mris ", "\n");
   }
 #endif
+
+  if (mris->status != mris->INPUT_STATUS) {
+    fprintf(stdout, "%s:%d %s mris->status:%d != mris->INPUT_STATUS:%d ",__FILE__,__LINE__, __MYFUNCTION__, int(mris->status), int( mris->INPUT_STATUS));
+  }
 
   int nonZeroInputXCount = 0;
   
@@ -23,7 +27,7 @@ static bool FUNCTION_NAME(
   
   int vno;
 
-  switch (mris->status) {
+  switch (mris->INPUT_STATUS) {
     default: /* don't really know what to do in other cases */
 
     case MRIS_PLANE:
@@ -217,6 +221,7 @@ static bool FUNCTION_NAME(
 }
 
 #undef FUNCTION_NAME 
+#undef INPUT_STATUS
 #undef INPUT_X 
 #undef INPUT_Y 
 #undef INPUT_Z

--- a/utils/mrisp.cpp
+++ b/utils/mrisp.cpp
@@ -1232,6 +1232,9 @@ MRIS *MRIScoordsFromParameterization(MRI_SP *mrisp, MRIS *mrisInit, int which_ve
 
   MRIS * const mris = (!mrisInit) ? MRISclone(mrisp->mris) : mrisInit;
 
+  if (which_vertices == ORIGINAL_VERTICES)
+    cheapAssert(mris->origxyz_status == mrisInit->origxyz_status);
+  
   for (vno = 0; vno < mris->nvertices; vno++) {
     VERTEX * const vertex = &mris->vertices[vno];
     if (vno == Gdiag_no) DiagBreak();

--- a/utils/mrisurf_base.cpp
+++ b/utils/mrisurf_base.cpp
@@ -39,6 +39,45 @@ int mris_sort_compare_float(const void *pc1, const void *pc2)
 }
 
 
+const char* MRIS_Status_text(MRIS_Status s1)
+{
+    switch (s1) {
+#define SEP
+#define ELT(S,D) case S : return #S;
+    MRIS_Status_ELTS
+#undef ELT
+#undef SEP
+    default: cheapAssert(false); return "<Bad MRIS_Status>";
+    }
+}
+
+
+MRIS_Status_DistanceFormula MRIS_Status_distanceFormula(MRIS_Status s1)
+{
+    switch (s1) {
+#define SEP
+#define ELT(S,D) case S : return MRIS_Status_DistanceFormula_##D;
+    MRIS_Status_ELTS
+#undef ELT
+#undef SEP
+    default: cheapAssert(false); return MRIS_Status_DistanceFormula_0;
+    }
+}
+
+
+bool areCompatible(MRIS_Status s1, MRIS_Status s2)
+{
+  return MRIS_Status_distanceFormula(s1) == MRIS_Status_distanceFormula(s2);
+}
+
+
+void checkOrigXYZCompatibleWkr(MRIS_Status s1, MRIS_Status s2, const char* file, int line) {
+  if (areCompatible(s1,s2)) return;
+  fprintf(stderr, "%s:%d using incompatible %s %s\n", file, line, 
+    MRIS_Status_text(s1), MRIS_Status_text(s2));
+}
+
+
 int  MRIS_acquireTemp(MRIS* mris, MRIS_TempAssigned temp) {
   int const bits = 1 << temp;
   int const * tc = &mris->tempsAssigned;

--- a/utils/mrisurf_defect.cpp
+++ b/utils/mrisurf_defect.cpp
@@ -8759,7 +8759,7 @@ MRI_SURFACE *MRIScorrectTopology(
   memset(face_trans,   -1, mris->nfaces       * sizeof(int));
   
   // create a new surface
-  MRI_SURFACE * mris_corrected = MRISoverAlloc(mris->nvertices + 10, 2 * mris->nfaces, kept_vertices, 2 * mris->nfaces);
+  MRIS * mris_corrected = MRISoverAlloc(mris->nvertices + 10, 2 * mris->nfaces, kept_vertices, 2 * mris->nfaces);
   
   // keep the extra info into the new one
   mris_corrected->useRealRAS = mris->useRealRAS;
@@ -8767,7 +8767,9 @@ MRI_SURFACE *MRIScorrectTopology(
   copyVolGeom(&mris->vg, &mris_corrected->vg);
 
   mris_corrected->type = MRIS_TRIANGULAR_SURFACE;
-  
+  mris_corrected->status         = mris->status;            // this should have been done
+  mris_corrected->origxyz_status = mris->origxyz_status;    // this is new 
+
 #if 0
   MRISrestoreVertexPositions(mris, ORIGINAL_VERTICES) ;
 #endif
@@ -12120,8 +12122,10 @@ static OPTIMAL_DEFECT_MAPPING *mrisFindOptimalDefectMapping(MRIS *mris_src, DEFE
 
   /* allocate temporary surface */
   mris_dst = MRISalloc(nvertices, nfaces);
+  mris_dst->type   = MRIS_TRIANGULAR_SURFACE;
   mris_dst->status = MRIS_SPHERICAL_PATCH;
-  mris_dst->type = MRIS_TRIANGULAR_SURFACE;
+  mris_dst->origxyz_status = mris_src->origxyz_status;
+  
   mris_dst->radius = DEFAULT_RADIUS;
 
   /* copy faces */

--- a/utils/mrisurf_deform.cpp
+++ b/utils/mrisurf_deform.cpp
@@ -12513,11 +12513,11 @@ MRI_SURFACE *MRISradialProjectOntoEllipsoid(MRI_SURFACE *mris_src, MRI_SURFACE *
 
 int MRISrigidBodyAlignLocal(MRI_SURFACE *mris, INTEGRATION_PARMS *old_parms)
 {
-  int old_status, steps;
+  int steps;
   INTEGRATION_PARMS parms;
 
   /* dx,dy,dz interpreted as rotations in applyGradient when status is rigid */
-  old_status = mris->status; /* okay, okay, this is a hack too... */
+  auto const old_status = mris->status; /* okay, okay, this is a hack too... */
   mris->status = MRIS_RIGID_BODY;
   memset(&parms, 0, sizeof(parms));
   parms.integration_type = INTEGRATE_LM_SEARCH;
@@ -12555,11 +12555,11 @@ int MRISrigidBodyAlignLocal(MRI_SURFACE *mris, INTEGRATION_PARMS *old_parms)
 
 int MRISrigidBodyAlignVectorLocal(MRI_SURFACE *mris, INTEGRATION_PARMS *old_parms)
 {
-  int n, old_status, steps;
+  int n, steps;
   INTEGRATION_PARMS parms;
 
   /* dx,dy,dz interpreted as rotations in applyGradient when status is rigid */
-  old_status = mris->status; /* okay, okay, this is a hack too... */
+  auto const old_status = mris->status; /* okay, okay, this is a hack too... */
   mris->status = MRIS_RIGID_BODY;
   memset(&parms, 0, sizeof(parms));
   parms.integration_type = INTEGRATE_LM_SEARCH;
@@ -12630,7 +12630,7 @@ int MRISrigidBodyAlignGlobal(
 
   mrisOrientSurface(mris);
 
-  int const old_status = mris->status;
+  auto const old_status = mris->status;
   mris->status = MRIS_RIGID_BODY;
 
   if (!parms->start_t) {
@@ -12857,7 +12857,7 @@ int MRISrigidBodyAlignVectorGlobal(
     MRI_SURFACE *mris, INTEGRATION_PARMS *parms, float min_degrees, float max_degrees, int nangles)
 {
   double alpha, beta, gamma, degrees, delta, mina, minb, ming, sse, min_sse;
-  int old_status = mris->status;
+  auto const old_status = mris->status;
 
   min_degrees = RADIANS(min_degrees);
   max_degrees = RADIANS(max_degrees);

--- a/utils/mrisurf_deform.cpp
+++ b/utils/mrisurf_deform.cpp
@@ -10382,7 +10382,6 @@ int MRISsoapBubbleTargetVertexPositions(MRI_SURFACE *mris, int navgs)
 /* extract the non-marked vertices from a surface */
 MRIS *MRISextractMarkedVertices(MRIS *mris)
 {
-  MRIS *mris_corrected;
   int *face_trans, *vertex_trans;
   FACE *f, *fdst;
   int vno, i, n, fno;
@@ -10392,13 +10391,15 @@ MRIS *MRISextractMarkedVertices(MRIS *mris)
   memset(vertex_trans, -1, mris->nvertices * sizeof(int));
   memset(face_trans, -1, mris->nfaces * sizeof(int));
   // create a new surface
-  mris_corrected = MRISalloc(mris->nvertices, mris->nfaces);
+  MRIS *mris_corrected = MRISalloc(mris->nvertices, mris->nfaces);
   // keep the extra info into the new one
   mris_corrected->useRealRAS = mris->useRealRAS;
   copyVolGeom(&mris->vg, &mris_corrected->vg);
 
   mris_corrected->type = MRIS_TRIANGULAR_SURFACE;
-
+  mris_corrected->status         = mris->status;            // this should have been done
+  mris_corrected->origxyz_status = mris->origxyz_status;    // this is new
+  
   int newNVertices;
   for (newNVertices = vno = 0; vno < mris->nvertices; vno++) {
     VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
@@ -10661,6 +10662,10 @@ MRIS *MRISextractMainComponent(MRI_SURFACE *mris, int do_not_extract, int verbos
 
 int MRIScombine(MRI_SURFACE *mris_src, MRI_SURFACE *mris_total, MRIS_HASH_TABLE *mht, int which)
 {
+  if (which == VERTEX_COORDS) {
+    cheapAssert(mris_src->origxyz_status == mris_total->origxyz_status);
+  }
+  
   int vno;
   VERTEX *v, *vdst;
   MHT *mht_src = NULL;
@@ -10805,6 +10810,12 @@ int MRIScombine(MRI_SURFACE *mris_src, MRI_SURFACE *mris_total, MRIS_HASH_TABLE 
 #if 1
 int MRISsphericalCopy(MRI_SURFACE *mris_src, MRI_SURFACE *mris_dst, MRIS_HASH_TABLE *mht, int which)
 {
+  switch (which) {
+    case VERTEX_COORDS:
+      cheapAssert(mris_dst->origxyz_status == mris_src->origxyz_status);
+      break;
+  }
+  
   int vno;
   MHT *mht_src = NULL;
   double max_len;
@@ -11039,7 +11050,6 @@ MRIS *MRISremoveRippedSurfaceElements(MRIS *mris)
 {
   int *vertex_trans, *face_trans;
   int vno, fno, i, n, nrippedfaces, nrippedvertices, kept_vertices, kept_faces;
-  MRIS *mris_corrected;
 
   FACE *f, *fdst;
 
@@ -11068,12 +11078,14 @@ MRIS *MRISremoveRippedSurfaceElements(MRIS *mris)
   }
 
   // create a new surface
-  mris_corrected = MRISalloc(kept_vertices, kept_faces);
+  MRIS *mris_corrected = MRISalloc(kept_vertices, kept_faces);
   // keep the extra info into the new one
   mris_corrected->useRealRAS = mris->useRealRAS;
   copyVolGeom(&mris->vg, &mris_corrected->vg);
 
-  mris_corrected->type = MRIS_TRIANGULAR_SURFACE;
+  mris_corrected->type           = MRIS_TRIANGULAR_SURFACE;
+  mris_corrected->status         = mris->status;                // this should have been set, but wasn't
+  mris_corrected->origxyz_status = mris->origxyz_status;        // this is new
 
   int newNVertices = 0;
   for (nrippedvertices = vno = 0; vno < mris->nvertices; vno++) {
@@ -11473,6 +11485,8 @@ int MRISupsampleIco(MRI_SURFACE *mris, MRI_SURFACE *mris_new)
 {
   MRISclearMarks(mris_new);
 
+  mris_new->origxyz_status = mris->origxyz_status;
+  
   int vno;
   for (vno = 0; vno < mris->nvertices; vno++) {
     VERTEX * const vold = &mris->vertices[vno];
@@ -13090,6 +13104,7 @@ static int mrisPlaceVertexInOrigFace(MRIS * const mris_vno, int const vno, MRIS 
   ADD(e1, e2, P);
   ADD(P, U0, P);
 
+  cheapAssert(mris->status == mris->origxyz_status);
   MRISsetOriginalXYZ(mris_vno, vno, P[0], P[1], P[2]);
 
   return (NO_ERROR);

--- a/utils/mrisurf_io.cpp
+++ b/utils/mrisurf_io.cpp
@@ -2465,15 +2465,13 @@ int MRISreadVertexPositions(MRI_SURFACE *mris, const char *name)
   ------------------------------------------------------*/
 int MRISreadOriginalProperties(MRI_SURFACE *mris, const char *sname)
 {
-  int old_status;
-
   if (!sname) {
     sname = "smoothwm";
   }
 
   MRISsaveVertexPositions(mris, TMP_VERTICES);
 
-  old_status = mris->status;
+  auto const old_status = mris->status;
   mris->status = MRIS_PATCH; /* so no orientating will be done */
   if (MRISreadVertexPositions(mris, sname) != NO_ERROR)
     ErrorReturn(ERROR_BADFILE, (ERROR_BADFILE, "MRISreadOriginalProperties: could not read surface file %s", sname));

--- a/utils/mrisurf_metricProperties.cpp
+++ b/utils/mrisurf_metricProperties.cpp
@@ -3008,7 +3008,11 @@ int MRISstoreMetricProperties(MRIS *mris)
     }
     v->origarea = v->area;
 #if 1
-    if (v->dist && v->dist_orig) {
+    if (v->dist) {
+      
+      if (!v->dist_orig)
+        MRISmakeDistOrig(mris, vno);
+       
       // Used to only go to vtotal, but that is v[nsizeCur]num, and the code can go to to v[nsizeMax]num
       int const vsize = mrisVertexVSize(mris,vno);
       for (n = 0; n < vsize; n++) {

--- a/utils/mrisurf_metricProperties.cpp
+++ b/utils/mrisurf_metricProperties.cpp
@@ -3129,172 +3129,99 @@ void MRISpopXYZ (MRIS *mris, MRISsavedXYZ ** ppMRISsavedXYZ) {
 }
 
 
+/*-----------------------------------------------------
+    These functions abuse the ORIGINAL_VERTICES and other fields
+    using them as temp storage.  This abuse is especially bad for the 
+    orig_xyz because these are input the two different dist_orig algorithms
+    so putting other values into there is especially bad.
+  ------------------------------------------------------*/
 int MRISsaveVertexPositions(MRIS *mris, int which)
 {
   if (which == ORIGINAL_VERTICES) {
-    cheapAssert(mris->status == mris->origxyz_status);
+
+    MRISsetOriginalXYZfromXYZ(mris);
+
+  } else {
+  
+    int const nvertices = mris->nvertices;
+
+    int vno;
+    for (vno = 0; vno < nvertices; vno++) {
+      VERTEX * const v = &mris->vertices[vno];
+  #if 0
+      if (v->ripflag)
+      {
+        continue ;
+      }
+  #endif
+      switch (which) {
+        case LAYERIV_VERTICES:
+          v->l4x = v->x;
+          v->l4y = v->y;
+          v->l4z = v->z;
+          break;
+        case TARGET_VERTICES:
+          v->targx = v->x;
+          v->targy = v->y;
+          v->targz = v->z;
+          break;
+        case WHITE_VERTICES:
+          v->whitex = v->x;
+          v->whitey = v->y;
+          v->whitez = v->z;
+          break;
+        case PIAL_VERTICES:
+          v->pialx = v->x;
+          v->pialy = v->y;
+          v->pialz = v->z;
+          break;
+        case INFLATED_VERTICES:
+          v->infx = v->x;
+          v->infy = v->y;
+          v->infz = v->z;
+          break;
+        case FLATTENED_VERTICES:
+          v->fx = v->x;
+          v->fy = v->y;
+          v->fz = v->z;
+          break;
+        case CANONICAL_VERTICES:
+          v->cx = v->x;
+          v->cy = v->y;
+          v->cz = v->z;
+          break;
+        case TMP2_VERTICES:
+          v->tx2 = v->x;
+          v->ty2 = v->y;
+          v->tz2 = v->z;
+          break;
+        case TMP_VERTICES:
+          v->tx = v->x;
+          v->ty = v->y;
+          v->tz = v->z;
+          break;
+        default:
+          cheapAssert(false);
+      }
+    }
   }
   
-  int const nvertices = mris->nvertices;
-
-  int vno;
-  for (vno = 0; vno < nvertices; vno++) {
-    VERTEX * const v = &mris->vertices[vno];
-#if 0
-    if (v->ripflag)
-    {
-      continue ;
-    }
-#endif
-    switch (which) {
-      case LAYERIV_VERTICES:
-        v->l4x = v->x;
-        v->l4y = v->y;
-        v->l4z = v->z;
-        break;
-      case TARGET_VERTICES:
-        v->targx = v->x;
-        v->targy = v->y;
-        v->targz = v->z;
-        break;
-      case WHITE_VERTICES:
-        v->whitex = v->x;
-        v->whitey = v->y;
-        v->whitez = v->z;
-        break;
-      case PIAL_VERTICES:
-        v->pialx = v->x;
-        v->pialy = v->y;
-        v->pialz = v->z;
-        break;
-      case INFLATED_VERTICES:
-        v->infx = v->x;
-        v->infy = v->y;
-        v->infz = v->z;
-        break;
-      case FLATTENED_VERTICES:
-        v->fx = v->x;
-        v->fy = v->y;
-        v->fz = v->z;
-        break;
-      case CANONICAL_VERTICES:
-        v->cx = v->x;
-        v->cy = v->y;
-        v->cz = v->z;
-        break;
-      case ORIGINAL_VERTICES:
-        MRISsetOriginalXYZ(mris, vno, v->x, v->y, v->z);
-        break;
-      case TMP2_VERTICES:
-        v->tx2 = v->x;
-        v->ty2 = v->y;
-        v->tz2 = v->z;
-        break;
-      default:
-      case TMP_VERTICES:
-        v->tx = v->x;
-        v->ty = v->y;
-        v->tz = v->z;
-        break;
-    }
-  }
   if (which == CANONICAL_VERTICES) {
     MRIScomputeCanonicalCoordinates(mris);
   }
+  
   return (NO_ERROR);
 }
 
 
-int MRISsaveNormals(MRIS *mris, int which)
-{
-  int vno, nvertices;
-  VERTEX *v;
-
-  nvertices = mris->nvertices;
-  for (vno = 0; vno < nvertices; vno++) {
-    v = &mris->vertices[vno];
-    switch (which) {
-      case TMP_VERTICES:
-        v->tx = v->nx;
-        v->ty = v->ny;
-        v->tz = v->nz;
-        break;
-      case TMP2_VERTICES:
-        v->tx2 = v->nx;
-        v->ty2 = v->ny;
-        v->tz2 = v->nz;
-        break;
-      case PIAL_VERTICES:
-        v->pnx = v->nx;
-        v->pny = v->ny;
-        v->pnz = v->nz;
-        break;
-      case WHITE_VERTICES:
-        v->wnx = v->nx;
-        v->wny = v->ny;
-        v->wnz = v->nz;
-        break;
-      case INFLATED_VERTICES:
-      case FLATTENED_VERTICES:
-      case CANONICAL_VERTICES:
-      case ORIGINAL_VERTICES:
-      default:
-        ErrorExit(ERROR_BADPARM, "MRISsaveNormals: unsupported which %d", which);
-        break;
-    }
-  }
-  return (NO_ERROR);
-}
-
-
-int MRISrestoreNormals(MRIS *mris, int which)
-{
-  int vno, nvertices;
-  VERTEX *v;
-
-  nvertices = mris->nvertices;
-  for (vno = 0; vno < nvertices; vno++) {
-    v = &mris->vertices[vno];
-    switch (which) {
-      case TMP_VERTICES:
-        v->nx = v->tx;
-        v->ny = v->ty;
-        v->nz = v->tz;
-        break;
-      case TMP2_VERTICES:
-        v->nx = v->tx2;
-        v->ny = v->ty2;
-        v->nz = v->tz2;
-        break;
-      case PIAL_VERTICES:
-        v->nx = v->pnx;
-        v->ny = v->pny;
-        v->nz = v->pnz;
-        break;
-      case WHITE_VERTICES:
-      case INFLATED_VERTICES:
-      case FLATTENED_VERTICES:
-      case CANONICAL_VERTICES:
-      case ORIGINAL_VERTICES:
-      default:
-        ErrorExit(ERROR_BADPARM, "MRISsaveNormals: unsupported which %d", which);
-        break;
-    }
-  }
-  return (NO_ERROR);
-}
-
-/*-----------------------------------------------------
-  Parameters:
-
-  Returns value:
-
-  Description
-  ------------------------------------------------------*/
 int MRISrestoreVertexPositions(MRIS *mris, int which)
 {
   if (which == ORIGINAL_VERTICES) {
-    cheapAssert(mris->status == mris->origxyz_status);
+    
+    // Verify it is plausible to copy these values into the MRIS vertices xyz 
+    // without changing the status
+    //
+    checkOrigXYZCompatible(mris->status,mris->origxyz_status);
   }
   
   int const nvertices = mris->nvertices;
@@ -3416,6 +3343,86 @@ int MRISrestoreVertexPositions(MRIS *mris, int which)
     }
   }
   mrisComputeSurfaceDimensions(mris);
+  return (NO_ERROR);
+}
+
+
+int MRISsaveNormals(MRIS *mris, int which)
+{
+  int vno, nvertices;
+  VERTEX *v;
+
+  nvertices = mris->nvertices;
+  for (vno = 0; vno < nvertices; vno++) {
+    v = &mris->vertices[vno];
+    switch (which) {
+      case TMP_VERTICES:
+        v->tx = v->nx;
+        v->ty = v->ny;
+        v->tz = v->nz;
+        break;
+      case TMP2_VERTICES:
+        v->tx2 = v->nx;
+        v->ty2 = v->ny;
+        v->tz2 = v->nz;
+        break;
+      case PIAL_VERTICES:
+        v->pnx = v->nx;
+        v->pny = v->ny;
+        v->pnz = v->nz;
+        break;
+      case WHITE_VERTICES:
+        v->wnx = v->nx;
+        v->wny = v->ny;
+        v->wnz = v->nz;
+        break;
+      case INFLATED_VERTICES:
+      case FLATTENED_VERTICES:
+      case CANONICAL_VERTICES:
+      case ORIGINAL_VERTICES:
+      default:
+        ErrorExit(ERROR_BADPARM, "MRISsaveNormals: unsupported which %d", which);
+        break;
+    }
+  }
+  return (NO_ERROR);
+}
+
+
+int MRISrestoreNormals(MRIS *mris, int which)
+{
+  int vno, nvertices;
+  VERTEX *v;
+
+  nvertices = mris->nvertices;
+  for (vno = 0; vno < nvertices; vno++) {
+    v = &mris->vertices[vno];
+    switch (which) {
+      case TMP_VERTICES:
+        v->nx = v->tx;
+        v->ny = v->ty;
+        v->nz = v->tz;
+        break;
+      case TMP2_VERTICES:
+        v->nx = v->tx2;
+        v->ny = v->ty2;
+        v->nz = v->tz2;
+        break;
+      case PIAL_VERTICES:
+        v->nx = v->pnx;
+        v->ny = v->pny;
+        v->nz = v->pnz;
+        break;
+      case WHITE_VERTICES:
+      case INFLATED_VERTICES:
+      case FLATTENED_VERTICES:
+      case CANONICAL_VERTICES:
+      case ORIGINAL_VERTICES:
+      default:
+        ErrorExit(ERROR_BADPARM, "MRISsaveNormals: unsupported which %d", which);
+        break;
+    }
+  }
   return (NO_ERROR);
 }
 

--- a/utils/mrisurf_metricProperties_fast.h
+++ b/utils/mrisurf_metricProperties_fast.h
@@ -18,7 +18,8 @@ typedef struct MRIS_MP {
 
   // ATH - temporarily adding this constructor to avoid the 'uninitialized const member' errors in g++ > 4
   MRIS_MP() :
-    status(0),
+    status(MRIS_Status__end),
+    origxyz_status(MRIS_Status__end),
     nvertices(0),
     nfaces(0),
     nsize(0),
@@ -39,11 +40,12 @@ typedef struct MRIS_MP {
 #define ELT(C,T,N) T C N;
 
   #define MRIS_MP__LIST_MRIS_IN \
-    ELT(const,  int,    status      ) SEP \
-    ELT(const,  int,    nvertices   ) SEP \
-    ELT(const,  int,    nfaces      ) SEP \
-    ELT(const,  int,    nsize       ) SEP \
-    ELT(const,  double, radius      ) SEP \
+    ELT(const,  MRIS_Status, status         ) SEP \
+    ELT(const,  MRIS_Status, origxyz_status ) SEP \
+    ELT(const,  int,         nvertices      ) SEP \
+    ELT(const,  int,         nfaces         ) SEP \
+    ELT(const,  int,         nsize          ) SEP \
+    ELT(const,  double,      radius         ) SEP \
     ELT(const,  VERTEX_TOPOLOGY const *, vertices_topology) \
     ELTX(const, FACE_TOPOLOGY   const *, faces_topology)
 
@@ -51,7 +53,7 @@ typedef struct MRIS_MP {
     
   // In out
   #define MRIS_MP__LIST_MRIS_IN_OUT \
-    ELT(,       int,    dist_nsize  ) \
+    ELT(,       int,     dist_nsize  ) \
 
     MRIS_MP__LIST_MRIS_IN_OUT
   
@@ -809,6 +811,7 @@ static void MRISMP_computeNormals(MRIS_MP* mris, bool check)
 
 
 #define FUNCTION_NAME MRISMP_computeVertexDistancesWkr
+#define INPUT_STATUS status
 #define INPUT_X v_x
 #define INPUT_Y v_y
 #define INPUT_Z v_z


### PR DESCRIPTION
Does not change test results or recon-all of bert

Found this while investigating the mris_register diff, but affect that either

These should have been saved regardless of whether the dist_orig had already been computed