### PR TITLE
bf: revert surface behavior

### DIFF
--- a/utils/mrisurf_deform.cpp
+++ b/utils/mrisurf_deform.cpp
@@ -8189,8 +8189,13 @@ double mrisComputeDistanceError(MRI_SURFACE *mris, INTEGRATION_PARMS *parms)
 
   freeAndNULL(vertexRipflags);  
 
+  if (getenv("DISTANCE_ERROR_NEW_BEHAVIOR") != nullptr) {
+    // this is the correct way of doing things (because MRISComputeDistanceTerm does this normalization) 
+    sse_dist /= mris->avg_nbrs;
+  }
+
   /*fprintf(stdout, "max_del = %f at v %d, n %d\n", max_del, max_v, max_n) ;*/
-  return (sse_dist);
+  return sse_dist;
 }
 
 int MRISmarkedSpringTerm(MRI_SURFACE *mris, double l_spring)


### PR DESCRIPTION

This is a temporary modification to get `mris_resample` and `mris_sphere` to perform the way they did before https://github.com/freesurfer/freesurfer/pull/612 was merged. This resets `avg_nbrs` back to the previously incorrect values in `MRISregister` and `MRISunfold`, but the new (and correct) functionality can be turned on with these env vars:

`MRIS_SPHERE_NEW_BEHAVIOR` - uses the correct `avg_nbrs` in `MRISunfold`
`MRIS_REGISTER_NEW_BEHAVIOR` - uses the correct `avg_nbrs` in `MRISregister`
`DISTANCE_ERROR_NEW_BEHAVIOR` - normalizes the distance error by `avg_nbrs`
