### PR TITLE
Nf mht using surface face vertex abstraction 2

### DIFF
--- a/include/face_barycentric_coords.h
+++ b/include/face_barycentric_coords.h
@@ -42,64 +42,16 @@ int face_barycentric_coords_template(
   double *pl3)
 {
   auto face = surface.faces(fno);
-  auto v0   = face.v(0);
-  auto v1   = face.v(1);
-  auto v2   = face.v(2);
   
-  double V0[3], V1[3], V2[3];
+  double d[3][3];
 
-  // Done this way because might be faster than v0.which_coords(...) ...
-  // but should be pulled out of this specific function and used more widely
-  
-  switch (which_vertices) {
-    default:
-      ErrorExit(ERROR_BADPARM, "face_barycentric_coords: which %d not supported", which_vertices);
-      break;
-    case FLATTENED_VERTICES:
-      V0[0] = v0.fx();
-      V0[1] = v0.fy();
-      V0[2] = v0.fz();
-      V1[0] = v1.fx();
-      V1[1] = v1.fy();
-      V1[2] = v1.fz();
-      V2[0] = v2.fx();
-      V2[1] = v2.fy();
-      V2[2] = v2.fz();
-      break;
-    case CURRENT_VERTICES:
-      V0[0] = v0.x();
-      V0[1] = v0.y();
-      V0[2] = v0.z();
-      V1[0] = v1.x();
-      V1[1] = v1.y();
-      V1[2] = v1.z();
-      V2[0] = v2.x();
-      V2[1] = v2.y();
-      V2[2] = v2.z();
-      break;
-    case PIAL_VERTICES:
-      V0[0] = v0.pialx();
-      V0[1] = v0.pialy();
-      V0[2] = v0.pialz();
-      V1[0] = v1.pialx();
-      V1[1] = v1.pialy();
-      V1[2] = v1.pialz();
-      V2[0] = v2.pialx();
-      V2[1] = v2.pialy();
-      V2[2] = v2.pialz();
-      break;
-    case CANONICAL_VERTICES:
-      V0[0] = v0.cx();
-      V0[1] = v0.cy();
-      V0[2] = v0.cz();
-      V1[0] = v1.cx();
-      V1[1] = v1.cy();
-      V1[2] = v1.cz();
-      V2[0] = v2.cx();
-      V2[1] = v2.cy();
-      V2[2] = v2.cz();
-      break;
+  for (int i = 0; i < 3; i++) {
+    float x,y,z;
+    face.v(i).which_coords(which_vertices, &x,&y,&z);
+    d[i][0] = x;
+    d[i][1] = y;
+    d[i][2] = z;
   }
-
-  return face_barycentric_coords(V0, V1, V2, cx, cy, cz, pl1, pl2, pl3);
+  
+  return face_barycentric_coords(d[0], d[1], d[2], cx, cy, cz, pl1, pl2, pl3);
 }

--- a/include/face_barycentric_coords.h
+++ b/include/face_barycentric_coords.h
@@ -1,0 +1,105 @@
+#pragma once
+/**
+ * @file  face_barycentric_coords.h
+ * @brief MRI_SURFACE utilities.
+ *
+ * Utilities, constants and structure definitions for manipulation
+ * and i/o of surfaces derived from MRI volumes.
+ */
+/*
+ * Original Author: Bruce Fischl, extracted by Bevin Brett
+ * CVS Revision Info:
+ *    $Author: fischl $
+ *    $Date: 2017/02/16 19:42:54 $
+ *    $Revision: 1.391 $
+ *
+ * Copyright © 2011 The General Hospital Corporation (Boston, MA) "MGH"
+ *
+ * Terms and conditions for use, reproduction, distribution and contribution
+ * are found in the 'FreeSurfer Software License Agreement' contained
+ * in the file 'LICENSE' found in the FreeSurfer distribution, and here:
+ *
+ * https://surfer.nmr.mgh.harvard.edu/fswiki/FreeSurferSoftwareLicense
+ *
+ * Reporting: freesurfer@nmr.mgh.harvard.edu
+ *
+ */
+
+
+
+#include "mrisurf.h"
+
+template <class Surface>
+int face_barycentric_coords_template(
+  Surface surface,
+  int     fno,
+  int     which_vertices,
+  double  cx,
+  double  cy,
+  double  cz,
+  double *pl1,
+  double *pl2,
+  double *pl3)
+{
+  auto face = surface.faces(fno);
+  auto v0   = face.v(0);
+  auto v1   = face.v(1);
+  auto v2   = face.v(2);
+  
+  double V0[3], V1[3], V2[3];
+
+  // Done this way because might be faster than v0.which_coords(...) ...
+  // but should be pulled out of this specific function and used more widely
+  
+  switch (which_vertices) {
+    default:
+      ErrorExit(ERROR_BADPARM, "face_barycentric_coords: which %d not supported", which_vertices);
+      break;
+    case FLATTENED_VERTICES:
+      V0[0] = v0.fx();
+      V0[1] = v0.fy();
+      V0[2] = v0.fz();
+      V1[0] = v1.fx();
+      V1[1] = v1.fy();
+      V1[2] = v1.fz();
+      V2[0] = v2.fx();
+      V2[1] = v2.fy();
+      V2[2] = v2.fz();
+      break;
+    case CURRENT_VERTICES:
+      V0[0] = v0.x();
+      V0[1] = v0.y();
+      V0[2] = v0.z();
+      V1[0] = v1.x();
+      V1[1] = v1.y();
+      V1[2] = v1.z();
+      V2[0] = v2.x();
+      V2[1] = v2.y();
+      V2[2] = v2.z();
+      break;
+    case PIAL_VERTICES:
+      V0[0] = v0.pialx();
+      V0[1] = v0.pialy();
+      V0[2] = v0.pialz();
+      V1[0] = v1.pialx();
+      V1[1] = v1.pialy();
+      V1[2] = v1.pialz();
+      V2[0] = v2.pialx();
+      V2[1] = v2.pialy();
+      V2[2] = v2.pialz();
+      break;
+    case CANONICAL_VERTICES:
+      V0[0] = v0.cx();
+      V0[1] = v0.cy();
+      V0[2] = v0.cz();
+      V1[0] = v1.cx();
+      V1[1] = v1.cy();
+      V1[2] = v1.cz();
+      V2[0] = v2.cx();
+      V2[1] = v2.cy();
+      V2[2] = v2.cz();
+      break;
+  }
+
+  return face_barycentric_coords(V0, V1, V2, cx, cy, cz, pl1, pl2, pl3);
+}

--- a/include/mrishash.h
+++ b/include/mrishash.h
@@ -34,6 +34,77 @@
 //
 #define MRISHASH_VANILLA_FUNCS
 
+// this was a partially exposed c struct, but has been worked over
+// so that it is now a c++ interface with mostly virtual methods
+// that still has compatibility level c functions that should be eliminated
+//
+typedef enum {
+    MHTFNO_FACE   = 0,
+    MHTFNO_VERTEX = 1
+} MHTFNO_t;
+
+struct MRIS_HASH_TABLE_NoSurface;
+struct MRIS_HASH_TABLE {
+
+    int         which()     const { return m_which_vertices; }
+    MHTFNO_t    fno_usage() const { return m_fno_usage;      }      // To enforce consistent use of fno:  face number or vertex number
+    float       vres()      const { return m_vres;           }      // Resolution of discretization
+
+    MRIS_HASH_TABLE(MHTFNO_t fno_usage, float vres, int which_vertices) : m_fno_usage(fno_usage), m_vres(vres), m_which_vertices(which_vertices) {}
+    virtual ~MRIS_HASH_TABLE() {}
+    
+    MRIS_HASH_TABLE_NoSurface               * toMRIS_HASH_TABLE_NoSurface    ()       { return this ? toMRIS_HASH_TABLE_NoSurface_Wkr() : nullptr; }
+    MRIS_HASH_TABLE_NoSurface         const * toMRIS_HASH_TABLE_NoSurface    () const { return this ? toMRIS_HASH_TABLE_NoSurface_Wkr() : nullptr; }
+    virtual MRIS_HASH_TABLE_NoSurface       * toMRIS_HASH_TABLE_NoSurface_Wkr()       { return nullptr; }
+    virtual MRIS_HASH_TABLE_NoSurface const * toMRIS_HASH_TABLE_NoSurface_Wkr() const { return nullptr; }
+
+  // Implement the traditional functions as virtual or static member functions
+  // so they will all be appropriately changed once this
+  // becomes a template class
+  //
+#define MHT_ONLY_VIRTUAL
+#define MHT_VIRTUAL                 virtual
+#define MHT_ABSTRACT                = 0
+#define MHT_STATIC_MEMBER           static
+#define MHT_FUNCTION(NAME)          NAME
+#define MHT_FUNCTION(NAME)          NAME
+#define MHT_CONST_THIS_PARAMETER
+#define MHT_CONST_THIS              const
+#define MHT_THIS_PARAMETER_NOCOMMA
+#define MHT_THIS_PARAMETER
+#define MHT_MRIS_PARAMETER_NOCOMMA
+#define MHT_MRIS_PARAMETER
+#include "mrishash_traditional_functions.h"
+#undef MHT_ONLY_VIRTUAL
+
+#define MHT_ONLY_STATIC
+#define MHT_VIRTUAL                 virtual
+#define MHT_ABSTRACT                = 0
+#define MHT_STATIC_MEMBER           static
+#define MHT_FUNCTION(NAME)          NAME
+#define MHT_FUNCTION(NAME)          NAME
+#define MHT_CONST_THIS_PARAMETER
+#define MHT_CONST_THIS              const
+#define MHT_THIS_PARAMETER_NOCOMMA
+#define MHT_THIS_PARAMETER
+#define MHT_MRIS_PARAMETER_NOCOMMA  MRIS *mris
+#define MHT_MRIS_PARAMETER          MHT_MRIS_PARAMETER_NOCOMMA ,
+#include "mrishash_traditional_functions.h"
+#undef MHT_ONLY_STATIC
+
+protected:
+    MHTFNO_t const      m_fno_usage;                    // To enforce consistent use of fno:  face number or vertex number
+    float    const      m_vres ;                        // Resolution of discretization
+    int      const      m_which_vertices ;              // ORIGINAL, CANONICAL, CURRENT, etc.
+} ;
+
+
+// Construction, use either delete or MHTfree to destroy
+//
+MRIS_HASH_TABLE* MHTcreateFaceTable             (MRIS* mris);
+MRIS_HASH_TABLE* MHTcreateFaceTable_Resolution  (MRIS* mris, int which, float res);
+MRIS_HASH_TABLE* MHTcreateVertexTable           (MRIS* mris, int which);
+MRIS_HASH_TABLE* MHTcreateVertexTable_Resolution(MRIS* mris, int which, float res);
 
 // Version
 //
@@ -66,6 +137,7 @@ void MHTfree(MRIS_HASH_TABLE**mht);
 #define MHT_MRIS_PARAMETER_NOCOMMA  MRIS *mris
 #define MHT_MRIS_PARAMETER  MHT_MRIS_PARAMETER_NOCOMMA ,
 #define MHT_THIS_PARAMETER  MHT_THIS_PARAMETER_NOCOMMA ,
+
 #include "mrishash_traditional_functions.h"
 
 

--- a/include/mrishash.h
+++ b/include/mrishash.h
@@ -51,6 +51,8 @@ void MHTfindReportCounts(int * BucketsChecked,
 void MHT_maybeParallel_begin();     // Note: Can be nested!
 void MHT_maybeParallel_end();
 
+int  MHTwhich(MRIS_HASH_TABLE const * mht);
+void MHTfree(MRIS_HASH_TABLE**mht);
 
 // Support multiple representations
 //

--- a/include/mrishash_SurfaceFromMRIS.h
+++ b/include/mrishash_SurfaceFromMRIS.h
@@ -1,0 +1,26 @@
+#pragma once
+
+/*
+ * Original Author: Bevin R. Brett
+ * CVS Revision Info:
+ *
+ * Copyright © 2019 The General Hospital Corporation (Boston, MA) "MGH"
+ *
+ * Terms and conditions for use, reproduction, distribution and contribution
+ * are found in the 'FreeSurfer Software License Agreement' contained
+ * in the file 'LICENSE' found in the FreeSurfer distribution, and here:
+ *
+ * https://surfer.nmr.mgh.harvard.edu/fswiki/FreeSurferSoftwareLicense
+ *
+ * Reporting: freesurfer@nmr.mgh.harvard.edu
+ *
+ */
+
+#include "mrishash.h"
+#include "mrisurf_SurfaceFromMRIS_generated.h"
+
+MRIS_HASH_TABLE* MHTcreateFaceTable             (SurfaceFromMRIS::Analysis::Surface surface);
+MRIS_HASH_TABLE* MHTcreateFaceTable_Resolution  (SurfaceFromMRIS::Analysis::Surface surface, int which, float res);
+MRIS_HASH_TABLE* MHTcreateVertexTable           (SurfaceFromMRIS::Analysis::Surface surface, int which);
+MRIS_HASH_TABLE* MHTcreateVertexTable_Resolution(SurfaceFromMRIS::Analysis::Surface surface, int which, float res);
+

--- a/include/mrishash_SurfaceFromMRISPV.h
+++ b/include/mrishash_SurfaceFromMRISPV.h
@@ -1,0 +1,26 @@
+#pragma once
+
+/*
+ * Original Author: Bevin R. Brett
+ * CVS Revision Info:
+ *
+ * Copyright © 2019 The General Hospital Corporation (Boston, MA) "MGH"
+ *
+ * Terms and conditions for use, reproduction, distribution and contribution
+ * are found in the 'FreeSurfer Software License Agreement' contained
+ * in the file 'LICENSE' found in the FreeSurfer distribution, and here:
+ *
+ * https://surfer.nmr.mgh.harvard.edu/fswiki/FreeSurferSoftwareLicense
+ *
+ * Reporting: freesurfer@nmr.mgh.harvard.edu
+ *
+ */
+
+#include "mrishash.h"
+#include "mrisurf_SurfaceFromMRISPV_generated.h"
+
+MRIS_HASH_TABLE* MHTcreateFaceTable             (SurfaceFromMRISPV::XYZPositionConsequences::Surface surface);
+MRIS_HASH_TABLE* MHTcreateFaceTable_Resolution  (SurfaceFromMRISPV::XYZPositionConsequences::Surface surface, int which, float res);
+MRIS_HASH_TABLE* MHTcreateVertexTable           (SurfaceFromMRISPV::XYZPositionConsequences::Surface surface, int which);
+MRIS_HASH_TABLE* MHTcreateVertexTable_Resolution(SurfaceFromMRISPV::XYZPositionConsequences::Surface surface, int which, float res);
+

--- a/include/mrishash_internals.h
+++ b/include/mrishash_internals.h
@@ -118,7 +118,6 @@ struct _mht
 };
 
 struct MRIS_HASH_TABLE_NoSurface;
-struct MRIS_HASH_TABLE_IMPL;
 struct MRIS_HASH_TABLE : public _mht {                      // Later we may make this private inheritance...
 
     MRIS_HASH_TABLE(MHTFNO_t fno_usage, float vres, int which_vertices) : _mht(fno_usage, vres, which_vertices) {}

--- a/include/mrishash_internals.h
+++ b/include/mrishash_internals.h
@@ -132,6 +132,22 @@ struct MRIS_HASH_TABLE : public _mht {                      // Later we may make
   // so they will all be appropriately changed once this
   // becomes a template class
   //
+#define MHT_ONLY_VIRTUAL
+#define MHT_VIRTUAL                 virtual
+#define MHT_ABSTRACT                = 0
+#define MHT_STATIC_MEMBER           static
+#define MHT_FUNCTION(NAME)          NAME
+#define MHT_FUNCTION(NAME)          NAME
+#define MHT_CONST_THIS_PARAMETER
+#define MHT_CONST_THIS              const
+#define MHT_THIS_PARAMETER_NOCOMMA
+#define MHT_THIS_PARAMETER
+#define MHT_MRIS_PARAMETER_NOCOMMA
+#define MHT_MRIS_PARAMETER
+#include "mrishash_traditional_functions.h"
+#undef MHT_ONLY_VIRTUAL
+
+#define MHT_ONLY_STATIC
 #define MHT_VIRTUAL                 virtual
 #define MHT_ABSTRACT                = 0
 #define MHT_STATIC_MEMBER           static
@@ -144,5 +160,6 @@ struct MRIS_HASH_TABLE : public _mht {                      // Later we may make
 #define MHT_MRIS_PARAMETER_NOCOMMA  MRIS *mris
 #define MHT_MRIS_PARAMETER          MHT_MRIS_PARAMETER_NOCOMMA ,
 #include "mrishash_traditional_functions.h"
+#undef MHT_ONLY_STATIC
 
 } ;

--- a/include/mrishash_internals.h
+++ b/include/mrishash_internals.h
@@ -117,16 +117,17 @@ struct _mht
 
 };
 
+struct MRIS_HASH_TABLE_NoSurface;
 struct MRIS_HASH_TABLE_IMPL;
 struct MRIS_HASH_TABLE : public _mht {                      // Later we may make this private inheritance...
 
     MRIS_HASH_TABLE(MHTFNO_t fno_usage, float vres, int which_vertices) : _mht(fno_usage, vres, which_vertices) {}
     
-    MRIS_HASH_TABLE_IMPL               * toMRIS_HASH_TABLE_IMPL    ()       { return this ? toMRIS_HASH_TABLE_IMPL_Wkr() : nullptr; }
-    MRIS_HASH_TABLE_IMPL         const * toMRIS_HASH_TABLE_IMPL    () const { return this ? toMRIS_HASH_TABLE_IMPL_Wkr() : nullptr; }
-    virtual MRIS_HASH_TABLE_IMPL       * toMRIS_HASH_TABLE_IMPL_Wkr()       { return nullptr; }
-    virtual MRIS_HASH_TABLE_IMPL const * toMRIS_HASH_TABLE_IMPL_Wkr() const { return nullptr; }
-    
+    MRIS_HASH_TABLE_NoSurface               * toMRIS_HASH_TABLE_NoSurface    ()       { return this ? toMRIS_HASH_TABLE_NoSurface_Wkr() : nullptr; }
+    MRIS_HASH_TABLE_NoSurface         const * toMRIS_HASH_TABLE_NoSurface    () const { return this ? toMRIS_HASH_TABLE_NoSurface_Wkr() : nullptr; }
+    virtual MRIS_HASH_TABLE_NoSurface       * toMRIS_HASH_TABLE_NoSurface_Wkr()       { return nullptr; }
+    virtual MRIS_HASH_TABLE_NoSurface const * toMRIS_HASH_TABLE_NoSurface_Wkr() const { return nullptr; }
+
   // Implement the traditional functions as virtual or static member functions
   // so they will all be appropriately changed once this
   // becomes a template class

--- a/include/mrishash_internals.h
+++ b/include/mrishash_internals.h
@@ -78,11 +78,6 @@ typedef struct MRIS_HASH_BUCKET
 //#define TABLE_SIZE     ((int)(FIELD_OF_VIEW / VOXEL_RES))
 #define TABLE_SIZE     2000
 
-typedef enum {
-    MHTFNO_FACE   = 0,
-    MHTFNO_VERTEX = 1
-} MHTFNO_t;
-
 
 typedef struct mht_face_t {
     // for per-vertex information that should not be stored in the MRIS FACE
@@ -97,71 +92,3 @@ void MHTrelBucket(MHBT**);
 void MHTrelBucketC(MHBT const **);
 
 
-struct _mht {
-    MHTFNO_t const      fno_usage;                      // To enforce consistent use of fno:  face number or vertex number
-    float    const      vres ;                          // Resolution of discretization
-    int      const      which_vertices ;                       // ORIGINAL, CANONICAL, CURRENT, etc.
-
-    _mht(MHTFNO_t fno_usage, float vres, int which_vertices);
-    virtual ~_mht();
-
-#ifdef HAVE_OPENMP
-    omp_lock_t mutable buckets_lock;
-#endif
-    int                 nbuckets ;                      // Total # of buckets
-    MRIS_HASH_BUCKET **buckets_mustUseAcqRel[TABLE_SIZE][TABLE_SIZE] ;
-
-    int                nfaces;
-    MHT_FACE*          f;
-
-    int which() const { return which_vertices; }
-};
-
-
-
-
-struct MRIS_HASH_TABLE_NoSurface;
-struct MRIS_HASH_TABLE : public _mht {                      // Later we may make this private inheritance...
-
-    MRIS_HASH_TABLE(MHTFNO_t fno_usage, float vres, int which_vertices) : _mht(fno_usage, vres, which_vertices) {}
-    
-    MRIS_HASH_TABLE_NoSurface               * toMRIS_HASH_TABLE_NoSurface    ()       { return this ? toMRIS_HASH_TABLE_NoSurface_Wkr() : nullptr; }
-    MRIS_HASH_TABLE_NoSurface         const * toMRIS_HASH_TABLE_NoSurface    () const { return this ? toMRIS_HASH_TABLE_NoSurface_Wkr() : nullptr; }
-    virtual MRIS_HASH_TABLE_NoSurface       * toMRIS_HASH_TABLE_NoSurface_Wkr()       { return nullptr; }
-    virtual MRIS_HASH_TABLE_NoSurface const * toMRIS_HASH_TABLE_NoSurface_Wkr() const { return nullptr; }
-
-  // Implement the traditional functions as virtual or static member functions
-  // so they will all be appropriately changed once this
-  // becomes a template class
-  //
-#define MHT_ONLY_VIRTUAL
-#define MHT_VIRTUAL                 virtual
-#define MHT_ABSTRACT                = 0
-#define MHT_STATIC_MEMBER           static
-#define MHT_FUNCTION(NAME)          NAME
-#define MHT_FUNCTION(NAME)          NAME
-#define MHT_CONST_THIS_PARAMETER
-#define MHT_CONST_THIS              const
-#define MHT_THIS_PARAMETER_NOCOMMA
-#define MHT_THIS_PARAMETER
-#define MHT_MRIS_PARAMETER_NOCOMMA
-#define MHT_MRIS_PARAMETER
-#include "mrishash_traditional_functions.h"
-#undef MHT_ONLY_VIRTUAL
-
-#define MHT_ONLY_STATIC
-#define MHT_VIRTUAL                 virtual
-#define MHT_ABSTRACT                = 0
-#define MHT_STATIC_MEMBER           static
-#define MHT_FUNCTION(NAME)          NAME
-#define MHT_FUNCTION(NAME)          NAME
-#define MHT_CONST_THIS_PARAMETER
-#define MHT_CONST_THIS              const
-#define MHT_THIS_PARAMETER_NOCOMMA
-#define MHT_THIS_PARAMETER
-#define MHT_MRIS_PARAMETER_NOCOMMA  MRIS *mris
-#define MHT_MRIS_PARAMETER          MHT_MRIS_PARAMETER_NOCOMMA ,
-#include "mrishash_traditional_functions.h"
-#undef MHT_ONLY_STATIC
-
-} ;

--- a/include/mrishash_internals.h
+++ b/include/mrishash_internals.h
@@ -97,8 +97,7 @@ void MHTrelBucket(MHBT**);
 void MHTrelBucketC(MHBT const **);
 
 
-struct _mht 
-{
+struct _mht {
     MHTFNO_t const      fno_usage;                      // To enforce consistent use of fno:  face number or vertex number
     float    const      vres ;                          // Resolution of discretization
     int      const      which_vertices ;                       // ORIGINAL, CANONICAL, CURRENT, etc.
@@ -115,7 +114,11 @@ struct _mht
     int                nfaces;
     MHT_FACE*          f;
 
+    int which() const { return which_vertices; }
 };
+
+
+
 
 struct MRIS_HASH_TABLE_NoSurface;
 struct MRIS_HASH_TABLE : public _mht {                      // Later we may make this private inheritance...

--- a/include/mrishash_internals.h
+++ b/include/mrishash_internals.h
@@ -122,8 +122,8 @@ struct MRIS_HASH_TABLE : public _mht {                      // Later we may make
 
     MRIS_HASH_TABLE(MHTFNO_t fno_usage, float vres, int which_vertices) : _mht(fno_usage, vres, which_vertices) {}
     
-    MRIS_HASH_TABLE_IMPL               * toMRIS_HASH_TABLE_IMPL    ()       { return toMRIS_HASH_TABLE_IMPL_Wkr(); }
-    MRIS_HASH_TABLE_IMPL         const * toMRIS_HASH_TABLE_IMPL    () const { return toMRIS_HASH_TABLE_IMPL_Wkr(); }
+    MRIS_HASH_TABLE_IMPL               * toMRIS_HASH_TABLE_IMPL    ()       { return this ? toMRIS_HASH_TABLE_IMPL_Wkr() : nullptr; }
+    MRIS_HASH_TABLE_IMPL         const * toMRIS_HASH_TABLE_IMPL    () const { return this ? toMRIS_HASH_TABLE_IMPL_Wkr() : nullptr; }
     virtual MRIS_HASH_TABLE_IMPL       * toMRIS_HASH_TABLE_IMPL_Wkr()       { return nullptr; }
     virtual MRIS_HASH_TABLE_IMPL const * toMRIS_HASH_TABLE_IMPL_Wkr() const { return nullptr; }
     

--- a/include/mrishash_traditional_functions.h
+++ b/include/mrishash_traditional_functions.h
@@ -134,7 +134,6 @@ MHT_VIRTUAL int MHT_FUNCTION(isVectorFilled)(MHT_CONST_THIS_PARAMETER  int vno,
 // Find nearest vertex/vertices (Uses MHT_FUNCTION() initialized with VERTICES)
 //
 MHT_VIRTUAL int MHT_FUNCTION(findClosestVertexGeneric)(MHT_THIS_PARAMETER
-                                MHT_MRIS_PARAMETER 
                                 double probex, double probey, double probez,
                                 double in_max_distance_mm, 
                                 int in_max_halfmhts,
@@ -143,7 +142,8 @@ MHT_VIRTUAL int MHT_FUNCTION(findClosestVertexGeneric)(MHT_THIS_PARAMETER
 #ifndef MHT_TRADITIONAL_IMPL
     ;
 #else
-{ return mht->findClosestVertexGeneric(mris, probex, probey, probez,
+{ return mht->findClosestVertexGeneric(
+                                probex, probey, probez,
                                 in_max_distance_mm, 
                                 in_max_halfmhts,
                                 vtxnum, 

--- a/include/mrishash_traditional_functions.h
+++ b/include/mrishash_traditional_functions.h
@@ -142,7 +142,7 @@ MHT_STATIC_MEMBER int MHT_FUNCTION(BruteForceClosestFace)(MHT_MRIS_PARAMETER
 #ifndef MHT_TRADITIONAL_IMPL
     ;
 #else
-{ return MRIS_HASH_TABLE_IMPL::BruteForceClosestFace(mris,x,y,z,which,dmin); }
+{ return MRIS_HASH_TABLE_IMPL<Surface,Face,Vertex>::BruteForceClosestFace(mris,x,y,z,which,dmin); }
 #endif
 
 
@@ -161,7 +161,7 @@ MHT_STATIC_MEMBER MRIS_HASH_TABLE* MHT_FUNCTION(createFaceTable)(
 #ifndef MHT_TRADITIONAL_IMPL
     ;
 #else
-{ return MRIS_HASH_TABLE_IMPL::createFaceTable(mris); }
+{ return MRIS_HASH_TABLE_IMPL<Surface,Face,Vertex>::createFaceTable(mris); }
 #endif
 
 
@@ -172,7 +172,7 @@ MHT_STATIC_MEMBER MRIS_HASH_TABLE* MHT_FUNCTION(createFaceTable_Resolution)(
 #ifndef MHT_TRADITIONAL_IMPL
     ;
 #else
-{ return MRIS_HASH_TABLE_IMPL::createFaceTable_Resolution(mris,which,res); }
+{ return MRIS_HASH_TABLE_IMPL<Surface,Face,Vertex>::createFaceTable_Resolution(mris,which,res); }
 #endif
 
 
@@ -182,7 +182,7 @@ MHT_STATIC_MEMBER MRIS_HASH_TABLE* MHT_FUNCTION(createVertexTable)(
 #ifndef MHT_TRADITIONAL_IMPL
     ;
 #else
-{ return MRIS_HASH_TABLE_IMPL::createVertexTable(mris,which); }
+{ return MRIS_HASH_TABLE_IMPL<Surface,Face,Vertex>::createVertexTable(mris,which); }
 #endif
 
                                     
@@ -193,14 +193,14 @@ MHT_STATIC_MEMBER MRIS_HASH_TABLE* MHT_FUNCTION(createVertexTable_Resolution)(
 #ifndef MHT_TRADITIONAL_IMPL
     ;
 #else
-{ return MRIS_HASH_TABLE_IMPL::createVertexTable_Resolution(mris,which,res); }
+{ return MRIS_HASH_TABLE_IMPL<Surface,Face,Vertex>::createVertexTable_Resolution(mris,which,res); }
 #endif
 
 MHT_STATIC_MEMBER void MHT_FUNCTION(free)(MRIS_HASH_TABLE**mht)
 #ifndef MHT_TRADITIONAL_IMPL
     ;
 #else
-{ MRIS_HASH_TABLE_IMPL::free(mht); }
+{ MRIS_HASH_TABLE_IMPL<Surface,Face,Vertex>::free(mht); }
 #endif
 
 int MHT_FUNCTION(which)(MHT_THIS_PARAMETER_NOCOMMA)     // Whether uses the ORIGINAL, CANONICAL, CURRENT, ... ###xyz values

--- a/include/mrishash_traditional_functions.h
+++ b/include/mrishash_traditional_functions.h
@@ -1,29 +1,150 @@
-// Test functions
+#ifndef MHT_ONLY_STATIC
+
+
+// Add/remove the faces of which vertex vno is a part
 //
-MHT_VIRTUAL int MHT_FUNCTION(checkFace)     (MHT_THIS_PARAMETER MHT_MRIS_PARAMETER int fno1) MHT_ABSTRACT
+MHT_VIRTUAL int  MHT_FUNCTION(addAllFaces)   (MHT_THIS_PARAMETER MHT_MRIS_PARAMETER int vno) MHT_ABSTRACT
 #ifndef MHT_TRADITIONAL_IMPL
     ;
 #else
-{ return mht->checkFace(mris,fno1); }
+{ mht->toMRIS_HASH_TABLE_NoSurface()->checkConstructedWithFaces();
+  return mht->addAllFaces(vno); }
 #endif
 
-MHT_VIRTUAL int MHT_FUNCTION(checkFaces)    (MHT_THIS_PARAMETER MHT_MRIS_PARAMETER_NOCOMMA) MHT_ABSTRACT
+MHT_VIRTUAL int  MHT_FUNCTION(removeAllFaces)(MHT_THIS_PARAMETER MHT_MRIS_PARAMETER int vno) MHT_ABSTRACT
 #ifndef MHT_TRADITIONAL_IMPL
     ;
 #else
-{ return mht->checkFaces(mris); }
-#endif
-
-MHT_VIRTUAL int MHT_FUNCTION(checkSurface)  (MHT_THIS_PARAMETER MHT_MRIS_PARAMETER_NOCOMMA) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return mht->checkSurface(mris); }
+{ mht->toMRIS_HASH_TABLE_NoSurface()->checkConstructedWithFaces();
+  return mht->removeAllFaces(vno); }
 #endif
 
 
 
+// Surface self-intersection (Uses MHT_FUNCTION() initialized with FACES)
+//
+MHT_VIRTUAL int MHT_FUNCTION(doesFaceIntersect)(MHT_THIS_PARAMETER MHT_MRIS_PARAMETER int fno) MHT_ABSTRACT
+#ifndef MHT_TRADITIONAL_IMPL
+    ;
+#else
+{ mht->toMRIS_HASH_TABLE_NoSurface()->checkConstructedWithFaces();
+  return mht->doesFaceIntersect(fno); }
+#endif
+
+
+
+MHT_VIRTUAL int MHT_FUNCTION(isVectorFilled)(MHT_CONST_THIS_PARAMETER  int vno, 
+                                                float dx, float dy, float dz) MHT_CONST_THIS MHT_ABSTRACT
+#ifndef MHT_TRADITIONAL_IMPL
+    ;
+#else
+{ return mht->isVectorFilled(vno,dx,dy,dz); }
+#endif
+
+
+// Find nearest vertex/vertices (Uses MHT_FUNCTION() initialized with VERTICES)
+//
+MHT_VIRTUAL int MHT_FUNCTION(findClosestVertexGeneric)(MHT_THIS_PARAMETER
+                                double probex, double probey, double probez,
+                                double in_max_distance_mm, 
+                                int in_max_halfmhts,
+                                int *vtxnum, 
+                                double *vtx_distance) MHT_ABSTRACT
+#ifndef MHT_TRADITIONAL_IMPL
+    ;
+#else
+{ return mht->findClosestVertexGeneric(
+                                probex, probey, probez,
+                                in_max_distance_mm, 
+                                in_max_halfmhts,
+                                vtxnum, 
+                                vtx_distance); }
+#endif
+
+
+MHT_VIRTUAL int     MHT_FUNCTION(findClosestVertexNoXYZ)(MHT_THIS_PARAMETER
+                               MHT_MRIS_PARAMETER  
+                               float x, float y, float z, 
+                               float *min_dist) MHT_ABSTRACT
+#ifndef MHT_TRADITIONAL_IMPL
+    ;
+#else
+{ mht->toMRIS_HASH_TABLE_NoSurface()->checkConstructedWithVertices();
+  return mht->findClosestVertexNoXYZ(x,y,z,min_dist); }
+#endif
+
+
+                             
+MHT_VIRTUAL int     MHT_FUNCTION(findClosestSetVertexNo)(MHT_THIS_PARAMETER
+                                MHT_MRIS_PARAMETER  
+                                float x, float y, float z) MHT_ABSTRACT
+#ifndef MHT_TRADITIONAL_IMPL
+    ;
+#else
+{ mht->toMRIS_HASH_TABLE_NoSurface()->checkConstructedWithVertices();
+  return mht->findClosestSetVertexNo(x,y,z); }
+#endif
+
+
+                                            
+MHT_VIRTUAL int MHT_FUNCTION(findVnoOfClosestVertexInTable)(MHT_THIS_PARAMETER
+                                MHT_MRIS_PARAMETER
+                                float x, float y, float z, int do_global_search) MHT_ABSTRACT
+#ifndef MHT_TRADITIONAL_IMPL
+    ;
+#else
+{ mht->toMRIS_HASH_TABLE_NoSurface()->checkConstructedWithVertices();
+  return mht->findVnoOfClosestVertexInTable(x,y,z,do_global_search); }
+#endif
+
+
+
+// utilities for finding closest face
+//
+MHT_VIRTUAL void MHT_FUNCTION(findClosestFaceNoGeneric)(MHT_THIS_PARAMETER
+                              MHT_MRIS_PARAMETER 
+                              //---------- inputs --------------
+                              double probex, double probey, double probez,
+                              // How far to search: set one or both
+                              double in_max_distance_mm, /* Use large number 
+                                                            to ignore */
+                              int    in_max_mhts,  /* Use -1 to ignore */
+                              // only faces that projection is interior to (Use -1 to ignore )
+                              int    project_into_face, 
+                              //---------- outputs -------------
+                              int *pfno, 
+                              double *pface_distance) MHT_ABSTRACT
+#ifndef MHT_TRADITIONAL_IMPL
+    ;
+#else
+{ mht->toMRIS_HASH_TABLE_NoSurface()->checkConstructedWithFaces();    // seen to fail when Vertices
+  mht->findClosestFaceNoGeneric(probex, probey, probez,
+                              in_max_distance_mm,
+                              in_max_mhts,
+                              project_into_face,
+                              pfno, 
+                              pface_distance); }
+#endif
+
+
+#endif  // not MHT_STATIC_ONLY
+                     
+
+// The static functions that need to be given an MRIS or other Surface as a parameter
+//
 #ifndef MHT_ONLY_VIRTUAL
+
+        
+MHT_STATIC_MEMBER int MHT_FUNCTION(BruteForceClosestFace)(MHT_MRIS_PARAMETER  
+                             float x, float y, float z, 
+                             int which,                  // which surface within mris to search
+                             float *dmin)
+#ifndef MHT_TRADITIONAL_IMPL
+    ;
+#else
+{ return MRIS_HASH_TABLE_IMPL::BruteForceClosestFace(mris,x,y,z,which,dmin); }
+#endif
+
 
 MHT_STATIC_MEMBER int MHT_FUNCTION(testIsMRISselfIntersecting)(MHT_MRIS_PARAMETER  float res)
 #ifndef MHT_TRADITIONAL_IMPL
@@ -93,152 +214,8 @@ int MHT_FUNCTION(which)(MHT_THIS_PARAMETER_NOCOMMA)     // Whether uses the ORIG
 #endif  // non virtual
 
 
-// Add/remove the faces of which vertex vno is a part
-//
-MHT_VIRTUAL int  MHT_FUNCTION(addAllFaces)   (MHT_THIS_PARAMETER MHT_MRIS_PARAMETER int vno) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return mht->addAllFaces(mris, vno); }
-#endif
-
-MHT_VIRTUAL int  MHT_FUNCTION(removeAllFaces)(MHT_THIS_PARAMETER MHT_MRIS_PARAMETER int vno) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return mht->removeAllFaces(mris, vno); }
-#endif
 
 
-
-// Surface self-intersection (Uses MHT_FUNCTION() initialized with FACES)
-//
-MHT_VIRTUAL int MHT_FUNCTION(doesFaceIntersect)(MHT_THIS_PARAMETER MHT_MRIS_PARAMETER int fno) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return mht->doesFaceIntersect(mris, fno); }
-#endif
-
-
-
-MHT_VIRTUAL int MHT_FUNCTION(isVectorFilled)(MHT_CONST_THIS_PARAMETER  int vno, 
-                                                float dx, float dy, float dz) MHT_CONST_THIS MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return mht->isVectorFilled(vno,dx,dy,dz); }
-#endif
-
-
-// Find nearest vertex/vertices (Uses MHT_FUNCTION() initialized with VERTICES)
-//
-MHT_VIRTUAL int MHT_FUNCTION(findClosestVertexGeneric)(MHT_THIS_PARAMETER
-                                double probex, double probey, double probez,
-                                double in_max_distance_mm, 
-                                int in_max_halfmhts,
-                                int *vtxnum, 
-                                double *vtx_distance) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return mht->findClosestVertexGeneric(
-                                probex, probey, probez,
-                                in_max_distance_mm, 
-                                in_max_halfmhts,
-                                vtxnum, 
-                                vtx_distance); }
-#endif
-
-
-MHT_VIRTUAL int     MHT_FUNCTION(findClosestVertexNoXYZ)(MHT_THIS_PARAMETER
-                               MHT_MRIS_PARAMETER  
-                               float x, float y, float z, 
-                               float *min_dist) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return mht->findClosestVertexNoXYZ(mris,x,y,z,min_dist); }
-#endif
-
-
-                             
-MHT_VIRTUAL int     MHT_FUNCTION(findClosestSetVertexNo)(MHT_THIS_PARAMETER
-                                MHT_MRIS_PARAMETER  
-                                float x, float y, float z) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return mht->findClosestSetVertexNo(mris,x,y,z); }
-#endif
-
-
-                                            
-MHT_VIRTUAL int    *MHT_FUNCTION(getAllVerticesWithinDistance)(MHT_THIS_PARAMETER
-                                MHT_MRIS_PARAMETER 
-                                int vno, 
-                                float max_dist, 
-                                int *pvnum) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return mht->getAllVerticesWithinDistance(mris,vno,max_dist,pvnum); }
-#endif
-
-                                        
-MHT_VIRTUAL int MHT_FUNCTION(findVnoOfClosestVertexInTable)(MHT_THIS_PARAMETER
-                                MHT_MRIS_PARAMETER
-                                float x, float y, float z, int do_global_search) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return mht->findVnoOfClosestVertexInTable(mris,x,y,z,do_global_search); }
-#endif
-
-
-
-// utilities for finding closest face
-//
-MHT_VIRTUAL void MHT_FUNCTION(findClosestFaceNoGeneric)(MHT_THIS_PARAMETER
-                              MHT_MRIS_PARAMETER 
-                              //---------- inputs --------------
-                              double probex, double probey, double probez,
-                              // How far to search: set one or both
-                              double in_max_distance_mm, /* Use large number 
-                                                            to ignore */
-                              int    in_max_mhts,  /* Use -1 to ignore */
-                              // only faces that projection is interior to (Use -1 to ignore )
-                              int    project_into_face, 
-                              //---------- outputs -------------
-                              int *pfno, 
-                              double *pface_distance) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ mht->findClosestFaceNoGeneric(mris,probex, probey, probez,
-                              in_max_distance_mm,
-                              in_max_mhts,
-                              project_into_face,
-                              pfno, 
-                              pface_distance); }
-#endif
-
-                      
-
-#ifndef MHT_ONLY_VIRTUAL
-
-        
-MHT_STATIC_MEMBER int MHT_FUNCTION(BruteForceClosestFace)(MHT_MRIS_PARAMETER  
-                             float x, float y, float z, 
-                             int which,                  // which surface within mris to search
-                             float *dmin)
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return MRIS_HASH_TABLE_IMPL::BruteForceClosestFace(mris,x,y,z,which,dmin); }
-#endif
-
-#endif
 
 
 #undef MHT_MRIS_PARAMETER

--- a/include/mrishash_traditional_functions.h
+++ b/include/mrishash_traditional_functions.h
@@ -54,26 +54,6 @@ MHT_STATIC_MEMBER int MHT_FUNCTION(BruteForceClosestFace)(MHT_MRIS_PARAMETER
 MHT_STATIC_MEMBER int MHT_FUNCTION(testIsMRISselfIntersecting)(MHT_MRIS_PARAMETER  float res);
 
 
-// Construction and destruction
-// Given that the mris is stored in the MHT_FUNCTION(), it is very unclear why the following functions require it to be passed in again!
-//
-MHT_STATIC_MEMBER MRIS_HASH_TABLE* MHT_FUNCTION(createFaceTable)(
-    MHT_MRIS_PARAMETER_NOCOMMA);
-
-MHT_STATIC_MEMBER MRIS_HASH_TABLE* MHT_FUNCTION(createFaceTable_Resolution)(
-    MHT_MRIS_PARAMETER  
-    int   which, 
-    float res);
-    
-MHT_STATIC_MEMBER MRIS_HASH_TABLE* MHT_FUNCTION(createVertexTable)(
-    MHT_MRIS_PARAMETER  
-    int which);
-                                    
-MHT_STATIC_MEMBER MRIS_HASH_TABLE* MHT_FUNCTION(createVertexTable_Resolution)(
-    MHT_MRIS_PARAMETER 
-    int which,
-    float res);
-    
 #endif  // non virtual
 
 

--- a/include/mrishash_traditional_functions.h
+++ b/include/mrishash_traditional_functions.h
@@ -1,108 +1,33 @@
 #ifndef MHT_ONLY_STATIC
-
+    
+// The specifications of the virtual functions.
+// In the traditional c-style code, they are called passing the MHT as the first argument,
+// and they often passed the MRIS as the second parameter, even though that should have been captured in the MHT
+//
+// They should be called c++-style,   p->foo(...) rather than MHTfoo(p,...)
 
 // Add/remove the faces of which vertex vno is a part
 //
-MHT_VIRTUAL int  MHT_FUNCTION(addAllFaces)   (MHT_THIS_PARAMETER MHT_MRIS_PARAMETER int vno) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ mht->toMRIS_HASH_TABLE_NoSurface()->checkConstructedWithFaces();
-  return mht->addAllFaces(vno); }
-#endif
+MHT_VIRTUAL int  MHT_FUNCTION(addAllFaces)                  (MHT_THIS_PARAMETER MHT_MRIS_PARAMETER  int vno) MHT_ABSTRACT;
+MHT_VIRTUAL int  MHT_FUNCTION(removeAllFaces)               (MHT_THIS_PARAMETER MHT_MRIS_PARAMETER  int vno) MHT_ABSTRACT;
 
-MHT_VIRTUAL int  MHT_FUNCTION(removeAllFaces)(MHT_THIS_PARAMETER MHT_MRIS_PARAMETER int vno) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ mht->toMRIS_HASH_TABLE_NoSurface()->checkConstructedWithFaces();
-  return mht->removeAllFaces(vno); }
-#endif
-
-
-
-// Surface self-intersection (Uses MHT_FUNCTION() initialized with FACES)
+// Surface self-intersection (Uses MHT initialized with FACES)
 //
-MHT_VIRTUAL int MHT_FUNCTION(doesFaceIntersect)(MHT_THIS_PARAMETER MHT_MRIS_PARAMETER int fno) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ mht->toMRIS_HASH_TABLE_NoSurface()->checkConstructedWithFaces();
-  return mht->doesFaceIntersect(fno); }
-#endif
+MHT_VIRTUAL int MHT_FUNCTION(doesFaceIntersect)             (MHT_THIS_PARAMETER MHT_MRIS_PARAMETER  int fno                                 )                MHT_ABSTRACT;
+MHT_VIRTUAL int MHT_FUNCTION(isVectorFilled)                (MHT_CONST_THIS_PARAMETER               int vno, float dx, float dy, float dz   ) MHT_CONST_THIS MHT_ABSTRACT;
 
-
-
-MHT_VIRTUAL int MHT_FUNCTION(isVectorFilled)(MHT_CONST_THIS_PARAMETER  int vno, 
-                                                float dx, float dy, float dz) MHT_CONST_THIS MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return mht->isVectorFilled(vno,dx,dy,dz); }
-#endif
-
-
-// Find nearest vertex/vertices (Uses MHT_FUNCTION() initialized with VERTICES)
+// Find nearest vertex/vertices (Uses MHT initialized with VERTICES)
 //
-MHT_VIRTUAL int MHT_FUNCTION(findClosestVertexGeneric)(MHT_THIS_PARAMETER
-                                double probex, double probey, double probez,
-                                double in_max_distance_mm, 
-                                int in_max_halfmhts,
-                                int *vtxnum, 
-                                double *vtx_distance) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return mht->findClosestVertexGeneric(
-                                probex, probey, probez,
-                                in_max_distance_mm, 
-                                in_max_halfmhts,
-                                vtxnum, 
-                                vtx_distance); }
-#endif
+MHT_VIRTUAL int MHT_FUNCTION(findClosestVertexNoXYZ)        (MHT_THIS_PARAMETER MHT_MRIS_PARAMETER float x, float y, float z, float *min_dist       ) MHT_ABSTRACT;
+MHT_VIRTUAL int MHT_FUNCTION(findClosestSetVertexNo)        (MHT_THIS_PARAMETER MHT_MRIS_PARAMETER float x, float y, float z                        ) MHT_ABSTRACT;
+MHT_VIRTUAL int MHT_FUNCTION(findVnoOfClosestVertexInTable) (MHT_THIS_PARAMETER MHT_MRIS_PARAMETER float x, float y, float z, int do_global_search  ) MHT_ABSTRACT;
+MHT_VIRTUAL int MHT_FUNCTION(findClosestVertexGeneric)      (MHT_THIS_PARAMETER                    double probex, double probey, double probez, 
+                                                                                                   double in_max_distance_mm, int in_max_halfmhts, 
+                                                                                                   int *vtxnum,  double *vtx_distance               ) MHT_ABSTRACT;
 
-
-MHT_VIRTUAL int     MHT_FUNCTION(findClosestVertexNoXYZ)(MHT_THIS_PARAMETER
-                               MHT_MRIS_PARAMETER  
-                               float x, float y, float z, 
-                               float *min_dist) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ mht->toMRIS_HASH_TABLE_NoSurface()->checkConstructedWithVertices();
-  return mht->findClosestVertexNoXYZ(x,y,z,min_dist); }
-#endif
-
-
-                             
-MHT_VIRTUAL int     MHT_FUNCTION(findClosestSetVertexNo)(MHT_THIS_PARAMETER
-                                MHT_MRIS_PARAMETER  
-                                float x, float y, float z) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ mht->toMRIS_HASH_TABLE_NoSurface()->checkConstructedWithVertices();
-  return mht->findClosestSetVertexNo(x,y,z); }
-#endif
-
-
-                                            
-MHT_VIRTUAL int MHT_FUNCTION(findVnoOfClosestVertexInTable)(MHT_THIS_PARAMETER
-                                MHT_MRIS_PARAMETER
-                                float x, float y, float z, int do_global_search) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ mht->toMRIS_HASH_TABLE_NoSurface()->checkConstructedWithVertices();
-  return mht->findVnoOfClosestVertexInTable(x,y,z,do_global_search); }
-#endif
-
-
-
-// utilities for finding closest face
+// Find closest face
 //
-MHT_VIRTUAL void MHT_FUNCTION(findClosestFaceNoGeneric)(MHT_THIS_PARAMETER
-                              MHT_MRIS_PARAMETER 
+MHT_VIRTUAL void MHT_FUNCTION(findClosestFaceNoGeneric)(MHT_THIS_PARAMETER MHT_MRIS_PARAMETER 
                               //---------- inputs --------------
                               double probex, double probey, double probez,
                               // How far to search: set one or both
@@ -113,104 +38,42 @@ MHT_VIRTUAL void MHT_FUNCTION(findClosestFaceNoGeneric)(MHT_THIS_PARAMETER
                               int    project_into_face, 
                               //---------- outputs -------------
                               int *pfno, 
-                              double *pface_distance) MHT_ABSTRACT
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ mht->toMRIS_HASH_TABLE_NoSurface()->checkConstructedWithFaces();    // seen to fail when Vertices
-  mht->findClosestFaceNoGeneric(probex, probey, probez,
-                              in_max_distance_mm,
-                              in_max_mhts,
-                              project_into_face,
-                              pfno, 
-                              pface_distance); }
+                              double *pface_distance) MHT_ABSTRACT;
+
 #endif
 
-
-#endif  // not MHT_STATIC_ONLY
-                     
+#ifndef MHT_ONLY_VIRTUAL
 
 // The static functions that need to be given an MRIS or other Surface as a parameter
 //
-#ifndef MHT_ONLY_VIRTUAL
-
-        
 MHT_STATIC_MEMBER int MHT_FUNCTION(BruteForceClosestFace)(MHT_MRIS_PARAMETER  
                              float x, float y, float z, 
                              int which,                  // which surface within mris to search
-                             float *dmin)
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return MRIS_HASH_TABLE_IMPL<Surface,Face,Vertex>::BruteForceClosestFace(mris,x,y,z,which,dmin); }
-#endif
+                             float *dmin);
 
+MHT_STATIC_MEMBER int MHT_FUNCTION(testIsMRISselfIntersecting)(MHT_MRIS_PARAMETER  float res);
 
-MHT_STATIC_MEMBER int MHT_FUNCTION(testIsMRISselfIntersecting)(MHT_MRIS_PARAMETER  float res)
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return MRIS_HASH_TABLE::testIsMRISselfIntersecting(mris, res); }
-#endif
 
 // Construction and destruction
 // Given that the mris is stored in the MHT_FUNCTION(), it is very unclear why the following functions require it to be passed in again!
 //
 MHT_STATIC_MEMBER MRIS_HASH_TABLE* MHT_FUNCTION(createFaceTable)(
-    MHT_MRIS_PARAMETER_NOCOMMA)
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return MRIS_HASH_TABLE_IMPL<Surface,Face,Vertex>::createFaceTable(mris); }
-#endif
-
+    MHT_MRIS_PARAMETER_NOCOMMA);
 
 MHT_STATIC_MEMBER MRIS_HASH_TABLE* MHT_FUNCTION(createFaceTable_Resolution)(
     MHT_MRIS_PARAMETER  
     int   which, 
-    float res)
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return MRIS_HASH_TABLE_IMPL<Surface,Face,Vertex>::createFaceTable_Resolution(mris,which,res); }
-#endif
-
-
+    float res);
+    
 MHT_STATIC_MEMBER MRIS_HASH_TABLE* MHT_FUNCTION(createVertexTable)(
     MHT_MRIS_PARAMETER  
-    int which)
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return MRIS_HASH_TABLE_IMPL<Surface,Face,Vertex>::createVertexTable(mris,which); }
-#endif
-
+    int which);
                                     
 MHT_STATIC_MEMBER MRIS_HASH_TABLE* MHT_FUNCTION(createVertexTable_Resolution)(
     MHT_MRIS_PARAMETER 
     int which,
-    float res)
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return MRIS_HASH_TABLE_IMPL<Surface,Face,Vertex>::createVertexTable_Resolution(mris,which,res); }
-#endif
-
-MHT_STATIC_MEMBER void MHT_FUNCTION(free)(MRIS_HASH_TABLE**mht)
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ MRIS_HASH_TABLE_IMPL<Surface,Face,Vertex>::free(mht); }
-#endif
-
-int MHT_FUNCTION(which)(MHT_THIS_PARAMETER_NOCOMMA)     // Whether uses the ORIGINAL, CANONICAL, CURRENT, ... ###xyz values
-#ifndef MHT_TRADITIONAL_IMPL
-    ;
-#else
-{ return mht->which(); }
-#endif
-
-
+    float res);
+    
 #endif  // non virtual
 
 

--- a/include/mrisurf.h
+++ b/include/mrisurf.h
@@ -1967,6 +1967,15 @@ int MRISwriteCoordsToIco(MRI_SURFACE *mris,
 int MRISvertexCoord2XYZ (VERTEX const * v, int which, float  *x, float  *y, float  *z);
 int MRISvertexCoord2XYZ (VERTEX const * v, int which, double *x, double *y, double *z);
 
+int face_barycentric_coords(
+  double V0[3], double V1[3], double V2[3],
+  double  cx,
+  double  cy,
+  double  cz,
+  double *pl1,
+  double *pl2,
+  double *pl3);
+
 int face_barycentric_coords(MRIS const * mris, int fno, int which_vertices,
                             double cx, double cy, double cz, double *pl1, double *pl2, double *pl3) ;
 

--- a/include/mrisurf.h
+++ b/include/mrisurf.h
@@ -1687,19 +1687,22 @@ int MRISvertexNormalInVoxelCoords(MRI_SURFACE *mris,
                                   double *pnx, double *pny, double *pnz) ;
 
 #define MRISgetCoords(v,c,vx,vy,vz) \
+ MRISvertexCoord2XYZ_float(v,c,vx,vy,vz)
+#if 0 
  switch(c) { \
    case ORIGINAL_VERTICES:  (*vx) = (v)->origx;  (*vy) = (v)->origy;  (*vz) = (v)->origz; break; \
    case TMP_VERTICES:       (*vx) = (v)->tx;     (*vy) = (v)->ty;     (*vz) = (v)->tz; break; \
    case CANONICAL_VERTICES: (*vx) = (v)->cx;     (*vy) = (v)->cy;     (*vz) = (v)->cz; break; \
    case CURRENT_VERTICES:   (*vx) = (v)->x;      (*vy) = (v)->y;      (*vz) = (v)->z; break; \
-   case TARGET_VERTICES:   (*vx) = (v)->targx;   (*vy) = (v)->targy;  (*vz) = (v)->targz; break; \
+   case TARGET_VERTICES:    (*vx) = (v)->targx;  (*vy) = (v)->targy;  (*vz) = (v)->targz; break; \
    case INFLATED_VERTICES:  (*vx) = (v)->infx;   (*vy) = (v)->infy;   (*vz) = (v)->infz; break; \
    case FLATTENED_VERTICES: (*vx) = (v)->fx;     (*vy) = (v)->fy;     (*vz) = (v)->fz; break; \
    case PIAL_VERTICES:      (*vx) = (v)->pialx;  (*vy) = (v)->pialy;  (*vz) = (v)->pialz; break; \
-   case TMP2_VERTICES:      (*vx) = (v)->tx2;    (*vy) = (v)->ty2;    (*vz) = (v)->tz2; break; \
+   case TMP2_VERTICES:      (*vx) = (v)->t2x;    (*vy) = (v)->t2y;    (*vz) = (v)->t2z; break; \
    case WHITE_VERTICES:     (*vx) = (v)->whitex; (*vy) = (v)->whitey; (*vz) = (v)->whitez; break; \
    default: break; \
  }
+#endif
 
 int MRISlogOdds(MRI_SURFACE *mris, LABEL *area, double slope)  ;
 MRI_SP  *MRISPorLabel(MRI_SP *mrisp, MRI_SURFACE *mris, LABEL *area) ;
@@ -1958,13 +1961,12 @@ int MRISmeasureDistanceBetweenSurfaces(MRI_SURFACE *mris,
 int MRISwriteCoordsToIco(MRI_SURFACE *mris,
                          MRI_SURFACE *mris_ico,
                          int which_vertices);
-                         
-int MRISvertexCoord2XYZ_float (VERTEX const * v,
-                               int which,
-                               float  *x, float  *y, float  *z);
-int MRISvertexCoord2XYZ_double (VERTEX const * v,
-                               int which,
-                               double  *x, double  *y, double  *z);
+                  
+#define MRISvertexCoord2XYZ_float  MRISvertexCoord2XYZ
+#define MRISvertexCoord2XYZ_double MRISvertexCoord2XYZ
+int MRISvertexCoord2XYZ (VERTEX const * v, int which, float  *x, float  *y, float  *z);
+int MRISvertexCoord2XYZ (VERTEX const * v, int which, double *x, double *y, double *z);
+
 int face_barycentric_coords(MRIS const * mris, int fno, int which_vertices,
                             double cx, double cy, double cz, double *pl1, double *pl2, double *pl3) ;
 
@@ -2336,6 +2338,8 @@ struct face_topology_type_ {    // not used much yet
 //              fields that it should currently have access to
 //
 //  This is mrisurf_FACE_VERTEX_MRIS*.h
+//
+//  Most of the code uses this representation directly
 
 #include "mrisurf_FACE_VERTEX_MRIS_generated.h"
 
@@ -2365,6 +2369,30 @@ struct face_topology_type_ {    // not used much yet
 //      v2->marked = true;
 //
 #include "mrisurf_SurfaceFromMRIS_generated.h"
+
+
+// An alternative representation has the various fields of the VERTEX and FACE above
+// spread out into one array per field.
+//
+// This representation exploits the two facts that (a) we almost never want to
+// deal with all the fields of a VERTEX as a whole, and (b) that we tend to use
+// the vertices and faces with nearby indexs are about the same time, so that
+// the cachelines brought into and written out of the cache will now be fully
+// used.
+//
+// Almost none of the code uses this representation directly,
+// but obviously the constructors and destructors must.
+//
+//  class MRISPV is the MRIS with its Properties stored in Vectors
+//
+#include "mrisurf_MRIS_PropertiesInVectors.h"
+
+// Similar Surface Face Vertex classes and namespaces are generated to access
+// this representation, so that template classes and functions can be created
+// which can be instantiated to get high speed access to this representation
+// also, yet having common source.
+//
+#include "mrisurf_SurfaceFromMRISPV_generated.h"
 
 
 // Static function implementations

--- a/include/mrisurf_FACE_VERTEX_MRIS_generated.h
+++ b/include/mrisurf_FACE_VERTEX_MRIS_generated.h
@@ -27,9 +27,9 @@ struct VERTEX_TOPOLOGY {
     short         v3num         ;  //  number of 1,2,or 3-hop neighbors                         
     short         vtotal        ;  //  total # of neighbors. copy of vnum.nsizeCur              
     short         nsizeMaxClock ;  //  copy of mris->nsizeMaxClock when v#num                   
-    unsigned char nsizeMax      ;  //  the max nsize that was used to fill in vnum etc          
-    unsigned char nsizeCur      ;  //  index of the current v#num in vtotal                     
-    unsigned char num           ;  //  number of neighboring faces                              
+    uchar         nsizeMax      ;  //  the max nsize that was used to fill in vnum etc          
+    uchar         nsizeCur      ;  //  index of the current v#num in vtotal                     
+    uchar         num           ;  //  number of neighboring faces                              
 };		// VERTEX_TOPOLOGY
 
 struct vertex_type_ {
@@ -75,9 +75,9 @@ struct vertex_type_ {
     float         tx                 ;
     float         ty                 ;
     float         tz                 ;  //  tmp coordinate storage
-    float         tx2                ;
-    float         ty2                ;
-    float         tz2                ;  //  tmp coordinate storage
+    float         t2x                ;
+    float         t2y                ;
+    float         t2z                ;  //  another tmp coordinate storage
     float         targx              ;
     float         targy              ;
     float         targz              ;  //  target coordinates
@@ -141,7 +141,7 @@ struct vertex_type_ {
     float         mean               ;
     float         mean_imag          ;  //  imaginary part of complex statistic 
     float         std_error          ;
-    unsigned int  flags              ;
+    uint          flags              ;
     int           fno                ;  //  face that this vertex is in 
     int           cropped            ;
     short         marked             ;  //  for a variety of uses 
@@ -217,7 +217,7 @@ struct MRIS {
     int                           nlabels                  ;
     PMRIS_AREA_LABEL              labels                   ;  //  nlabels of these (may be null)
     char                          nsize                    ;  //  size of neighborhoods or -1
-    unsigned char                 vtotalsMightBeTooBig     ;  //  MRISsampleDistances sets this
+    uchar                         vtotalsMightBeTooBig     ;  //  MRISsampleDistances sets this
     short                         nsizeMaxClock            ;  //  changed whenever an edge is added or removed, which invalidates the vertex v#num values
     char                          max_nsize                ;  //  max the neighborhood size has been set to (typically 3)
     char                          dist_nsize               ;  //  max mrisComputeVertexDistances has computed distances out to
@@ -233,7 +233,7 @@ struct MRIS {
     float                         dg                       ;  //  old deltas
     int                           type                     ;  //  what type of surface was this initially
     int                           max_vertices             ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
-    int                           max_faces                ;  //  may be bigger than nfaces, set by calling MRISreallocVerticesAndFaces
+    int                           max_faces                ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
     MRIS_subject_name_t           subject_name             ;  //  name of the subject
     float                         canon_area               ;
     int                           noscale                  ;  //  don't scale by surface area if true
@@ -269,7 +269,7 @@ struct MRIS {
 
 #define LIST_OF_VERTEX_TOPOLOGY_ELTS \
     ELTP(int,f)  SEP \
-    ELTP(unsigned char,n)  SEP \
+    ELTP(uchar,n)  SEP \
     ELTP(int,e)  SEP \
     ELTP(int,v)  SEP \
     ELTT(short,vnum)  SEP \
@@ -277,9 +277,9 @@ struct MRIS {
     ELTT(short,v3num)  SEP \
     ELTT(short,vtotal)  SEP \
     ELTX(short,nsizeMaxClock)  SEP \
-    ELTT(unsigned char,nsizeMax)  SEP \
-    ELTT(unsigned char,nsizeCur)  SEP \
-    ELTT(unsigned char,num)  SEP \
+    ELTT(uchar,nsizeMax)  SEP \
+    ELTT(uchar,nsizeCur)  SEP \
+    ELTT(uchar,num)  SEP \
 // end of macro
 
 #define LIST_OF_VERTEX_ELTS_1 \
@@ -324,9 +324,9 @@ struct MRIS {
     ELTT(float,tx)  SEP \
     ELTT(float,ty)  SEP \
     ELTT(float,tz)  SEP \
-    ELTT(float,tx2)  SEP \
-    ELTT(float,ty2)  SEP \
-    ELTT(float,tz2)  SEP \
+    ELTT(float,t2x)  SEP \
+    ELTT(float,t2y)  SEP \
+    ELTT(float,t2z)  SEP \
     ELTT(float,targx)  SEP \
     ELTT(float,targy)  SEP \
     ELTT(float,targz)  SEP \
@@ -399,7 +399,7 @@ struct MRIS {
     ELTT(float,mean)  SEP \
     ELTT(float,mean_imag)  SEP \
     ELTT(float,std_error)  SEP \
-    ELTT(unsigned int,flags)  SEP \
+    ELTT(uint,flags)  SEP \
     ELTT(int,fno)  SEP \
     ELTT(int,cropped)  SEP \
     ELTT(short,marked)  SEP \
@@ -484,7 +484,7 @@ struct MRIS {
     ELTT(int,nlabels)  SEP \
     ELTP(MRIS_AREA_LABEL,labels)  SEP \
     ELTT(char,nsize)  SEP \
-    ELTT(unsigned char,vtotalsMightBeTooBig)  SEP \
+    ELTT(uchar,vtotalsMightBeTooBig)  SEP \
     ELTX(short,nsizeMaxClock)  SEP \
     ELTT(char,max_nsize)  SEP \
     ELTT(char,dist_nsize)  SEP \
@@ -518,8 +518,8 @@ struct MRIS {
     ELTX(p_void,user_parms)  SEP \
     ELTP(MATRIX,m_sras2vox)  SEP \
     ELTP(MRI,mri_sras2vox)  SEP \
-    ELTT(p_void,mht)  SEP \
-    ELTT(p_void,temps)  SEP \
+    ELTX(p_void,mht)  SEP \
+    ELTX(p_void,temps)  SEP \
 // end of macro
 
 #define LIST_OF_MRIS_ELTS \

--- a/include/mrisurf_MRIS_PropertiesInVectors.h
+++ b/include/mrisurf_MRIS_PropertiesInVectors.h
@@ -3,12 +3,15 @@
 // 
 // =======================================
 struct MRISPV {
-                    float * f_area    ;
+      vertices_per_face_t * f_v       ;
+    float                 * f_area    ;
     angles_per_triangle_t * f_angle   ;
     char                  * f_ripflag ;
     PDMATRIX              * f_norm    ;
     //  put the pointers before the ints, before the shorts, before uchars, to reduce size
     //  the whole fits in much less than one cache line, so further ordering is no use
+    pSeveralInt   * v_f             ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+    uchar         * v_num           ;  //  number of neighboring faces                              
     //  managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
     pSeveralFloat * v_dist          ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
     int           * v_dist_capacity ;  //  -- should contain at least vtx_vtotal elements   
@@ -24,26 +27,26 @@ struct MRISPV {
     char          * v_border        ;  //  flag 
     char          * v_ripflag       ;  //  vertex no longer exists - placed last to load the next vertex into cache
     //  Fields being maintained by specialist functions
-    int         nvertices       ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-    int         nfaces          ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-    float       xctr            ;
-    float       yctr            ;
-    float       zctr            ;
-    float       xlo             ;
-    float       ylo             ;
-    float       zlo             ;
-    float       xhi             ;
-    float       yhi             ;
-    float       zhi             ;
-    float       total_area      ;
-    double      avg_vertex_area ;
-    double      avg_vertex_dist ;  //  set by MRIScomputeAvgInterVertexDist
-    double      std_vertex_dist ;
-    float       neg_area        ;
-    float       neg_orig_area   ;  //  amount of original surface in folds
-    double      radius          ;  //  radius (if status==MRIS_SPHERE)
-    MRIS_Status status          ;  //  type of surface (e.g. sphere, plane)
-    MRIS_Status origxyz_status  ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-    char        nsize           ;  //  size of neighborhoods or -1
-    char        dist_nsize      ;  //  max mrisComputeVertexDistances has computed distances out to
+    int            nvertices       ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+    int            nfaces          ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+    float          xctr            ;
+    float          yctr            ;
+    float          zctr            ;
+    float          xlo             ;
+    float          ylo             ;
+    float          zlo             ;
+    float          xhi             ;
+    float          yhi             ;
+    float          zhi             ;
+    float          total_area      ;
+    double         avg_vertex_area ;
+    double         avg_vertex_dist ;  //  set by MRIScomputeAvgInterVertexDist
+    double         std_vertex_dist ;
+    float          neg_area        ;
+    float          neg_orig_area   ;  //  amount of original surface in folds
+    double         radius          ;  //  radius (if status==MRIS_SPHERE)
+    MRIS_Status    status          ;  //  type of surface (e.g. sphere, plane)
+    MRIS_Status    origxyz_status  ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+    char           nsize           ;  //  size of neighborhoods or -1
+    char           dist_nsize      ;  //  max mrisComputeVertexDistances has computed distances out to
 };

--- a/include/mrisurf_MRIS_PropertiesInVectors.h
+++ b/include/mrisurf_MRIS_PropertiesInVectors.h
@@ -1,0 +1,49 @@
+
+// GENERATED SOURCE - DO NOT DIRECTLY EDIT
+// 
+// =======================================
+struct MRISPV {
+                    float * f_area    ;
+    angles_per_triangle_t * f_angle   ;
+    char                  * f_ripflag ;
+    PDMATRIX              * f_norm    ;
+    //  put the pointers before the ints, before the shorts, before uchars, to reduce size
+    //  the whole fits in much less than one cache line, so further ordering is no use
+    //  managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
+    pSeveralFloat * v_dist          ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+    int           * v_dist_capacity ;  //  -- should contain at least vtx_vtotal elements   
+    float         * v_x             ;  //  current coordinates	
+    float         * v_y             ;  //  use MRISsetXYZ() to set
+    float         * v_z             ;
+    float         * v_nx            ;
+    float         * v_ny            ;
+    float         * v_nz            ;  //  curr normal
+    float         * v_area          ;
+    float         * v_origarea      ;
+    char          * v_neg           ;  //  1 if the normal vector is inverted 
+    char          * v_border        ;  //  flag 
+    char          * v_ripflag       ;  //  vertex no longer exists - placed last to load the next vertex into cache
+    //  Fields being maintained by specialist functions
+    int         nvertices       ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+    int         nfaces          ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+    float       xctr            ;
+    float       yctr            ;
+    float       zctr            ;
+    float       xlo             ;
+    float       ylo             ;
+    float       zlo             ;
+    float       xhi             ;
+    float       yhi             ;
+    float       zhi             ;
+    float       total_area      ;
+    double      avg_vertex_area ;
+    double      avg_vertex_dist ;  //  set by MRIScomputeAvgInterVertexDist
+    double      std_vertex_dist ;
+    float       neg_area        ;
+    float       neg_orig_area   ;  //  amount of original surface in folds
+    double      radius          ;  //  radius (if status==MRIS_SPHERE)
+    MRIS_Status status          ;  //  type of surface (e.g. sphere, plane)
+    MRIS_Status origxyz_status  ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+    char        nsize           ;  //  size of neighborhoods or -1
+    char        dist_nsize      ;  //  max mrisComputeVertexDistances has computed distances out to
+};

--- a/include/mrisurf_SurfaceFromMRISPV_generated.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "./mrisurf_SurfaceFromMRISPV_generated_prefix.h"
 
 // GENERATED SOURCE - DO NOT DIRECTLY EDIT

--- a/include/mrisurf_SurfaceFromMRISPV_generated.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated.h
@@ -1,0 +1,22 @@
+#include "./mrisurf_SurfaceFromMRISPV_generated_prefix.h"
+
+// GENERATED SOURCE - DO NOT DIRECTLY EDIT
+// 
+// =======================================
+namespace SurfaceFromMRISPV {
+    typedef MRISPV Representation;
+    #include "mrisurf_SurfaceFromMRISPV_generated_Existence.h"
+    #include "mrisurf_SurfaceFromMRISPV_generated_Topology.h"
+    #include "mrisurf_SurfaceFromMRISPV_generated_XYZPosition.h"
+    #include "mrisurf_SurfaceFromMRISPV_generated_XYZPositionConsequences.h"
+    #include "mrisurf_SurfaceFromMRISPV_generated_Distort.h"
+    #include "mrisurf_SurfaceFromMRISPV_generated_Analysis.h"
+    #include "mrisurf_SurfaceFromMRISPV_generated_ExistenceM.h"
+    #include "mrisurf_SurfaceFromMRISPV_generated_TopologyM.h"
+    #include "mrisurf_SurfaceFromMRISPV_generated_XYZPositionM.h"
+    #include "mrisurf_SurfaceFromMRISPV_generated_XYZPositionConsequencesM.h"
+    #include "mrisurf_SurfaceFromMRISPV_generated_DistortM.h"
+    #include "mrisurf_SurfaceFromMRISPV_generated_AnalysisM.h"
+    #include "mrisurf_SurfaceFromMRISPV_generated_AllM.h"
+} // SurfaceFromMRISPV
+#include "./mrisurf_SurfaceFromMRISPV_generated_suffix.h"

--- a/include/mrisurf_SurfaceFromMRISPV_generated_AllM.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_AllM.h
@@ -5,15 +5,17 @@
         inline Face (                        Representation* representation, size_t idx );
         int fno     () const { return idx; }
 
-        inline float                 area    (   ) const ;
-        inline angles_per_triangle_t angle   (   ) const ;
-        inline char                  ripflag (   ) const ;
-        inline PDMATRIX              norm    (   ) const ;
+        inline Vertex                v       ( size_t i  ) const ;
+        inline float                 area    (           ) const ;
+        inline angles_per_triangle_t angle   (           ) const ;
+        inline char                  ripflag (           ) const ;
+        inline PDMATRIX              norm    (           ) const ;
         
-        inline void set_area    (                  float to ) ;
-        inline void set_angle   (  angles_per_triangle_t to ) ;
-        inline void set_ripflag (                   char to ) ;
-        inline void set_norm    (               PDMATRIX to ) ;
+        inline void set_v       ( size_t i,                Vertex to ) ;
+        inline void set_area    (                           float to ) ;
+        inline void set_angle   (           angles_per_triangle_t to ) ;
+        inline void set_ripflag (                            char to ) ;
+        inline void set_norm    (                        PDMATRIX to ) ;
     };
 
     struct Vertex : public Repr_Elt {
@@ -24,6 +26,8 @@
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
+        inline Face  f             ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline uchar num           (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
         inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
@@ -45,24 +49,28 @@
         inline char  border        (           ) const ;  //  flag 
         inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
         inline void  which_coords  (int which, float *x, float *y, float *z) const ;
-        // 
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
         
-        inline void set_x        (  float to ) ;  //  current coordinates	
-        inline void set_y        (  float to ) ;  //  use MRISsetXYZ() to set
-        inline void set_z        (  float to ) ;
+        inline void set_f        ( size_t i,  Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline void set_num      (           uchar to ) ;  //  number of neighboring faces                              
+        // 
+        inline void set_x        (           float to ) ;  //  current coordinates	
+        inline void set_y        (           float to ) ;  //  use MRISsetXYZ() to set
+        inline void set_z        (           float to ) ;
         // 
         // 
-        inline void set_nx       (  float to ) ;
-        inline void set_ny       (  float to ) ;
-        inline void set_nz       (  float to ) ;  //  curr normal
+        inline void set_nx       (           float to ) ;
+        inline void set_ny       (           float to ) ;
+        inline void set_nz       (           float to ) ;  //  curr normal
         // 
         // 
         // 
-        inline void set_area     (  float to ) ;
-        inline void set_origarea (  float to ) ;
-        inline void set_neg      (   char to ) ;  //  1 if the normal vector is inverted 
-        inline void set_border   (   char to ) ;  //  flag 
-        inline void set_ripflag  (   char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_area     (           float to ) ;
+        inline void set_origarea (           float to ) ;
+        inline void set_neg      (            char to ) ;  //  1 if the normal vector is inverted 
+        inline void set_border   (            char to ) ;  //  flag 
+        inline void set_ripflag  (            char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
     struct Surface : public Repr_Elt {
@@ -71,26 +79,28 @@
         inline Surface ( Representation* representation );
 
         // Fields being maintained by specialist functions
-        inline int         nvertices       (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline int         nfaces          (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline float       xctr            (   ) const ;
-        inline float       yctr            (   ) const ;
-        inline float       zctr            (   ) const ;
-        inline float       xlo             (   ) const ;
-        inline float       ylo             (   ) const ;
-        inline float       zlo             (   ) const ;
-        inline float       xhi             (   ) const ;
-        inline float       yhi             (   ) const ;
-        inline float       zhi             (   ) const ;
-        inline float       total_area      (   ) const ;
-        inline double      avg_vertex_area (   ) const ;
-        inline double      avg_vertex_dist (   ) const ;  //  set by MRIScomputeAvgInterVertexDist
-        inline double      std_vertex_dist (   ) const ;
-        inline float       neg_area        (   ) const ;
-        inline float       neg_orig_area   (   ) const ;  //  amount of original surface in folds
-        inline double      radius          (   ) const ;  //  radius (if status==MRIS_SPHERE)
-        inline MRIS_Status status          (   ) const ;  //  type of surface (e.g. sphere, plane)
-        inline MRIS_Status origxyz_status  (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int         nvertices       (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces          (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline Vertex      vertices        ( size_t i  ) const ;
+        inline Face        faces           ( size_t i  ) const ;
+        inline float       xctr            (           ) const ;
+        inline float       yctr            (           ) const ;
+        inline float       zctr            (           ) const ;
+        inline float       xlo             (           ) const ;
+        inline float       ylo             (           ) const ;
+        inline float       zlo             (           ) const ;
+        inline float       xhi             (           ) const ;
+        inline float       yhi             (           ) const ;
+        inline float       zhi             (           ) const ;
+        inline float       total_area      (           ) const ;
+        inline double      avg_vertex_area (           ) const ;
+        inline double      avg_vertex_dist (           ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double      std_vertex_dist (           ) const ;
+        inline float       neg_area        (           ) const ;
+        inline float       neg_orig_area   (           ) const ;  //  amount of original surface in folds
+        inline double      radius          (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status          (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status  (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
         
         inline void set_xctr            (        float to ) ;
         inline void set_yctr            (        float to ) ;

--- a/include/mrisurf_SurfaceFromMRISPV_generated_AllM.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_AllM.h
@@ -1,0 +1,114 @@
+    namespace AllM {
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        int fno     () const { return idx; }
+
+        inline float                 area    (   ) const ;
+        inline angles_per_triangle_t angle   (   ) const ;
+        inline char                  ripflag (   ) const ;
+        inline PDMATRIX              norm    (   ) const ;
+        
+        inline void set_area    (                  float to ) ;
+        inline void set_angle   (  angles_per_triangle_t to ) ;
+        inline void set_ripflag (                   char to ) ;
+        inline void set_norm    (               PDMATRIX to ) ;
+    };
+
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        int vno       () const { return idx; }
+
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
+        // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
+        inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float x             (           ) const ;  //  current coordinates	
+        inline float y             (           ) const ;  //  use MRISsetXYZ() to set
+        inline float z             (           ) const ;
+        // 
+        // 
+        inline float nx            (           ) const ;
+        inline float ny            (           ) const ;
+        inline float nz            (           ) const ;  //  curr normal
+        // 
+        // 
+        // 
+        inline float area          (           ) const ;
+        inline float origarea      (           ) const ;
+        inline char  neg           (           ) const ;  //  1 if the normal vector is inverted 
+        inline char  border        (           ) const ;  //  flag 
+        inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void  which_coords  (int which, float *x, float *y, float *z) const ;
+        // 
+        
+        inline void set_x        (  float to ) ;  //  current coordinates	
+        inline void set_y        (  float to ) ;  //  use MRISsetXYZ() to set
+        inline void set_z        (  float to ) ;
+        // 
+        // 
+        inline void set_nx       (  float to ) ;
+        inline void set_ny       (  float to ) ;
+        inline void set_nz       (  float to ) ;  //  curr normal
+        // 
+        // 
+        // 
+        inline void set_area     (  float to ) ;
+        inline void set_origarea (  float to ) ;
+        inline void set_neg      (   char to ) ;  //  1 if the normal vector is inverted 
+        inline void set_border   (   char to ) ;  //  flag 
+        inline void set_ripflag  (   char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+    };
+
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
+
+        // Fields being maintained by specialist functions
+        inline int         nvertices       (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces          (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline float       xctr            (   ) const ;
+        inline float       yctr            (   ) const ;
+        inline float       zctr            (   ) const ;
+        inline float       xlo             (   ) const ;
+        inline float       ylo             (   ) const ;
+        inline float       zlo             (   ) const ;
+        inline float       xhi             (   ) const ;
+        inline float       yhi             (   ) const ;
+        inline float       zhi             (   ) const ;
+        inline float       total_area      (   ) const ;
+        inline double      avg_vertex_area (   ) const ;
+        inline double      avg_vertex_dist (   ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double      std_vertex_dist (   ) const ;
+        inline float       neg_area        (   ) const ;
+        inline float       neg_orig_area   (   ) const ;  //  amount of original surface in folds
+        inline double      radius          (   ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status          (   ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status  (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        
+        inline void set_xctr            (        float to ) ;
+        inline void set_yctr            (        float to ) ;
+        inline void set_zctr            (        float to ) ;
+        inline void set_xlo             (        float to ) ;
+        inline void set_ylo             (        float to ) ;
+        inline void set_zlo             (        float to ) ;
+        inline void set_xhi             (        float to ) ;
+        inline void set_yhi             (        float to ) ;
+        inline void set_zhi             (        float to ) ;
+        inline void set_total_area      (        float to ) ;
+        inline void set_avg_vertex_area (       double to ) ;
+        inline void set_avg_vertex_dist (       double to ) ;  //  set by MRIScomputeAvgInterVertexDist
+        inline void set_std_vertex_dist (       double to ) ;
+        inline void set_neg_area        (        float to ) ;
+        inline void set_neg_orig_area   (        float to ) ;  //  amount of original surface in folds
+        inline void set_status          (  MRIS_Status to ) ;  //  type of surface (e.g. sphere, plane)
+        inline void set_origxyz_status  (  MRIS_Status to ) ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+    };
+
+    } // namespace AllM

--- a/include/mrisurf_SurfaceFromMRISPV_generated_Analysis.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_Analysis.h
@@ -1,0 +1,100 @@
+    namespace Analysis {
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        AllM::Face const & src                     );
+        int fno     () const { return idx; }
+
+        inline float                 area    (   ) const ;
+        inline angles_per_triangle_t angle   (   ) const ;
+        inline char                  ripflag (   ) const ;
+        inline PDMATRIX              norm    (   ) const ;
+        
+        inline void set_ripflag (  char to ) ;
+    };
+
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        AllM::Vertex const & src                   );
+        int vno       () const { return idx; }
+
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
+        // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
+        inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float x             (           ) const ;  //  current coordinates	
+        inline float y             (           ) const ;  //  use MRISsetXYZ() to set
+        inline float z             (           ) const ;
+        // 
+        // 
+        inline float nx            (           ) const ;
+        inline float ny            (           ) const ;
+        inline float nz            (           ) const ;  //  curr normal
+        // 
+        // 
+        // 
+        inline float area          (           ) const ;
+        inline float origarea      (           ) const ;
+        inline char  neg           (           ) const ;  //  1 if the normal vector is inverted 
+        inline char  border        (           ) const ;  //  flag 
+        inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void  which_coords  (int which, float *x, float *y, float *z) const ;
+        // 
+        // 
+        
+        inline void set_nx       (  float to ) ;
+        inline void set_ny       (  float to ) ;
+        inline void set_nz       (  float to ) ;  //  curr normal
+        inline void set_origarea (  float to ) ;
+        inline void set_neg      (   char to ) ;  //  1 if the normal vector is inverted 
+        inline void set_border   (   char to ) ;  //  flag 
+        inline void set_ripflag  (   char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+    };
+
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
+        inline Surface ( AllM::Surface const & src      );
+
+        // Fields being maintained by specialist functions
+        inline int         nvertices       (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces          (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline float       xctr            (   ) const ;
+        inline float       yctr            (   ) const ;
+        inline float       zctr            (   ) const ;
+        inline float       xlo             (   ) const ;
+        inline float       ylo             (   ) const ;
+        inline float       zlo             (   ) const ;
+        inline float       xhi             (   ) const ;
+        inline float       yhi             (   ) const ;
+        inline float       zhi             (   ) const ;
+        inline float       total_area      (   ) const ;
+        inline double      avg_vertex_area (   ) const ;
+        inline double      avg_vertex_dist (   ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double      std_vertex_dist (   ) const ;
+        inline float       neg_area        (   ) const ;
+        inline float       neg_orig_area   (   ) const ;  //  amount of original surface in folds
+        inline double      radius          (   ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status          (   ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status  (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        
+        inline void set_xctr            (   float to ) ;
+        inline void set_yctr            (   float to ) ;
+        inline void set_zctr            (   float to ) ;
+        inline void set_xlo             (   float to ) ;
+        inline void set_ylo             (   float to ) ;
+        inline void set_zlo             (   float to ) ;
+        inline void set_xhi             (   float to ) ;
+        inline void set_yhi             (   float to ) ;
+        inline void set_zhi             (   float to ) ;
+        inline void set_total_area      (   float to ) ;
+        inline void set_avg_vertex_area (  double to ) ;
+    };
+
+    } // namespace Analysis

--- a/include/mrisurf_SurfaceFromMRISPV_generated_Analysis.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_Analysis.h
@@ -6,10 +6,11 @@
         inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
-        inline float                 area    (   ) const ;
-        inline angles_per_triangle_t angle   (   ) const ;
-        inline char                  ripflag (   ) const ;
-        inline PDMATRIX              norm    (   ) const ;
+        inline Vertex                v       ( size_t i  ) const ;
+        inline float                 area    (           ) const ;
+        inline angles_per_triangle_t angle   (           ) const ;
+        inline char                  ripflag (           ) const ;
+        inline PDMATRIX              norm    (           ) const ;
         
         inline void set_ripflag (  char to ) ;
     };
@@ -23,6 +24,8 @@
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
+        inline Face  f             ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline uchar num           (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
         inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
@@ -44,16 +47,19 @@
         inline char  border        (           ) const ;  //  flag 
         inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
         inline void  which_coords  (int which, float *x, float *y, float *z) const ;
-        // 
-        // 
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
         
-        inline void set_nx       (  float to ) ;
-        inline void set_ny       (  float to ) ;
-        inline void set_nz       (  float to ) ;  //  curr normal
-        inline void set_origarea (  float to ) ;
-        inline void set_neg      (   char to ) ;  //  1 if the normal vector is inverted 
-        inline void set_border   (   char to ) ;  //  flag 
-        inline void set_ripflag  (   char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_f        ( size_t i,  Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        // 
+        // 
+        inline void set_nx       (           float to ) ;
+        inline void set_ny       (           float to ) ;
+        inline void set_nz       (           float to ) ;  //  curr normal
+        inline void set_origarea (           float to ) ;
+        inline void set_neg      (            char to ) ;  //  1 if the normal vector is inverted 
+        inline void set_border   (            char to ) ;  //  flag 
+        inline void set_ripflag  (            char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
     struct Surface : public Repr_Elt {
@@ -63,26 +69,28 @@
         inline Surface ( AllM::Surface const & src      );
 
         // Fields being maintained by specialist functions
-        inline int         nvertices       (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline int         nfaces          (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline float       xctr            (   ) const ;
-        inline float       yctr            (   ) const ;
-        inline float       zctr            (   ) const ;
-        inline float       xlo             (   ) const ;
-        inline float       ylo             (   ) const ;
-        inline float       zlo             (   ) const ;
-        inline float       xhi             (   ) const ;
-        inline float       yhi             (   ) const ;
-        inline float       zhi             (   ) const ;
-        inline float       total_area      (   ) const ;
-        inline double      avg_vertex_area (   ) const ;
-        inline double      avg_vertex_dist (   ) const ;  //  set by MRIScomputeAvgInterVertexDist
-        inline double      std_vertex_dist (   ) const ;
-        inline float       neg_area        (   ) const ;
-        inline float       neg_orig_area   (   ) const ;  //  amount of original surface in folds
-        inline double      radius          (   ) const ;  //  radius (if status==MRIS_SPHERE)
-        inline MRIS_Status status          (   ) const ;  //  type of surface (e.g. sphere, plane)
-        inline MRIS_Status origxyz_status  (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int         nvertices       (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces          (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline Vertex      vertices        ( size_t i  ) const ;
+        inline Face        faces           ( size_t i  ) const ;
+        inline float       xctr            (           ) const ;
+        inline float       yctr            (           ) const ;
+        inline float       zctr            (           ) const ;
+        inline float       xlo             (           ) const ;
+        inline float       ylo             (           ) const ;
+        inline float       zlo             (           ) const ;
+        inline float       xhi             (           ) const ;
+        inline float       yhi             (           ) const ;
+        inline float       zhi             (           ) const ;
+        inline float       total_area      (           ) const ;
+        inline double      avg_vertex_area (           ) const ;
+        inline double      avg_vertex_dist (           ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double      std_vertex_dist (           ) const ;
+        inline float       neg_area        (           ) const ;
+        inline float       neg_orig_area   (           ) const ;  //  amount of original surface in folds
+        inline double      radius          (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status          (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status  (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
         
         inline void set_xctr            (   float to ) ;
         inline void set_yctr            (   float to ) ;

--- a/include/mrisurf_SurfaceFromMRISPV_generated_AnalysisM.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_AnalysisM.h
@@ -1,0 +1,100 @@
+    namespace AnalysisM {
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        AllM::Face const & src                     );
+        int fno     () const { return idx; }
+
+        inline float                 area    (   ) const ;
+        inline angles_per_triangle_t angle   (   ) const ;
+        inline char                  ripflag (   ) const ;
+        inline PDMATRIX              norm    (   ) const ;
+        
+        inline void set_ripflag (  char to ) ;
+    };
+
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        AllM::Vertex const & src                   );
+        int vno       () const { return idx; }
+
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
+        // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
+        inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float x             (           ) const ;  //  current coordinates	
+        inline float y             (           ) const ;  //  use MRISsetXYZ() to set
+        inline float z             (           ) const ;
+        // 
+        // 
+        inline float nx            (           ) const ;
+        inline float ny            (           ) const ;
+        inline float nz            (           ) const ;  //  curr normal
+        // 
+        // 
+        // 
+        inline float area          (           ) const ;
+        inline float origarea      (           ) const ;
+        inline char  neg           (           ) const ;  //  1 if the normal vector is inverted 
+        inline char  border        (           ) const ;  //  flag 
+        inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void  which_coords  (int which, float *x, float *y, float *z) const ;
+        // 
+        // 
+        
+        inline void set_nx       (  float to ) ;
+        inline void set_ny       (  float to ) ;
+        inline void set_nz       (  float to ) ;  //  curr normal
+        inline void set_origarea (  float to ) ;
+        inline void set_neg      (   char to ) ;  //  1 if the normal vector is inverted 
+        inline void set_border   (   char to ) ;  //  flag 
+        inline void set_ripflag  (   char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+    };
+
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
+        inline Surface ( AllM::Surface const & src      );
+
+        // Fields being maintained by specialist functions
+        inline int         nvertices       (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces          (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline float       xctr            (   ) const ;
+        inline float       yctr            (   ) const ;
+        inline float       zctr            (   ) const ;
+        inline float       xlo             (   ) const ;
+        inline float       ylo             (   ) const ;
+        inline float       zlo             (   ) const ;
+        inline float       xhi             (   ) const ;
+        inline float       yhi             (   ) const ;
+        inline float       zhi             (   ) const ;
+        inline float       total_area      (   ) const ;
+        inline double      avg_vertex_area (   ) const ;
+        inline double      avg_vertex_dist (   ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double      std_vertex_dist (   ) const ;
+        inline float       neg_area        (   ) const ;
+        inline float       neg_orig_area   (   ) const ;  //  amount of original surface in folds
+        inline double      radius          (   ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status          (   ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status  (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        
+        inline void set_xctr            (   float to ) ;
+        inline void set_yctr            (   float to ) ;
+        inline void set_zctr            (   float to ) ;
+        inline void set_xlo             (   float to ) ;
+        inline void set_ylo             (   float to ) ;
+        inline void set_zlo             (   float to ) ;
+        inline void set_xhi             (   float to ) ;
+        inline void set_yhi             (   float to ) ;
+        inline void set_zhi             (   float to ) ;
+        inline void set_total_area      (   float to ) ;
+        inline void set_avg_vertex_area (  double to ) ;
+    };
+
+    } // namespace AnalysisM

--- a/include/mrisurf_SurfaceFromMRISPV_generated_AnalysisM.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_AnalysisM.h
@@ -6,10 +6,11 @@
         inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
-        inline float                 area    (   ) const ;
-        inline angles_per_triangle_t angle   (   ) const ;
-        inline char                  ripflag (   ) const ;
-        inline PDMATRIX              norm    (   ) const ;
+        inline Vertex                v       ( size_t i  ) const ;
+        inline float                 area    (           ) const ;
+        inline angles_per_triangle_t angle   (           ) const ;
+        inline char                  ripflag (           ) const ;
+        inline PDMATRIX              norm    (           ) const ;
         
         inline void set_ripflag (  char to ) ;
     };
@@ -23,6 +24,8 @@
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
+        inline Face  f             ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline uchar num           (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
         inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
@@ -44,16 +47,19 @@
         inline char  border        (           ) const ;  //  flag 
         inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
         inline void  which_coords  (int which, float *x, float *y, float *z) const ;
-        // 
-        // 
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
         
-        inline void set_nx       (  float to ) ;
-        inline void set_ny       (  float to ) ;
-        inline void set_nz       (  float to ) ;  //  curr normal
-        inline void set_origarea (  float to ) ;
-        inline void set_neg      (   char to ) ;  //  1 if the normal vector is inverted 
-        inline void set_border   (   char to ) ;  //  flag 
-        inline void set_ripflag  (   char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_f        ( size_t i,  Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        // 
+        // 
+        inline void set_nx       (           float to ) ;
+        inline void set_ny       (           float to ) ;
+        inline void set_nz       (           float to ) ;  //  curr normal
+        inline void set_origarea (           float to ) ;
+        inline void set_neg      (            char to ) ;  //  1 if the normal vector is inverted 
+        inline void set_border   (            char to ) ;  //  flag 
+        inline void set_ripflag  (            char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
     struct Surface : public Repr_Elt {
@@ -63,26 +69,28 @@
         inline Surface ( AllM::Surface const & src      );
 
         // Fields being maintained by specialist functions
-        inline int         nvertices       (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline int         nfaces          (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline float       xctr            (   ) const ;
-        inline float       yctr            (   ) const ;
-        inline float       zctr            (   ) const ;
-        inline float       xlo             (   ) const ;
-        inline float       ylo             (   ) const ;
-        inline float       zlo             (   ) const ;
-        inline float       xhi             (   ) const ;
-        inline float       yhi             (   ) const ;
-        inline float       zhi             (   ) const ;
-        inline float       total_area      (   ) const ;
-        inline double      avg_vertex_area (   ) const ;
-        inline double      avg_vertex_dist (   ) const ;  //  set by MRIScomputeAvgInterVertexDist
-        inline double      std_vertex_dist (   ) const ;
-        inline float       neg_area        (   ) const ;
-        inline float       neg_orig_area   (   ) const ;  //  amount of original surface in folds
-        inline double      radius          (   ) const ;  //  radius (if status==MRIS_SPHERE)
-        inline MRIS_Status status          (   ) const ;  //  type of surface (e.g. sphere, plane)
-        inline MRIS_Status origxyz_status  (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int         nvertices       (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces          (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline Vertex      vertices        ( size_t i  ) const ;
+        inline Face        faces           ( size_t i  ) const ;
+        inline float       xctr            (           ) const ;
+        inline float       yctr            (           ) const ;
+        inline float       zctr            (           ) const ;
+        inline float       xlo             (           ) const ;
+        inline float       ylo             (           ) const ;
+        inline float       zlo             (           ) const ;
+        inline float       xhi             (           ) const ;
+        inline float       yhi             (           ) const ;
+        inline float       zhi             (           ) const ;
+        inline float       total_area      (           ) const ;
+        inline double      avg_vertex_area (           ) const ;
+        inline double      avg_vertex_dist (           ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double      std_vertex_dist (           ) const ;
+        inline float       neg_area        (           ) const ;
+        inline float       neg_orig_area   (           ) const ;  //  amount of original surface in folds
+        inline double      radius          (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status          (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status  (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
         
         inline void set_xctr            (   float to ) ;
         inline void set_yctr            (   float to ) ;

--- a/include/mrisurf_SurfaceFromMRISPV_generated_Distort.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_Distort.h
@@ -1,0 +1,106 @@
+    namespace Distort {
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        AnalysisM::Face const & src                );
+        inline Face (                        Analysis::Face const & src                 );
+        inline Face (                        AllM::Face const & src                     );
+        int fno     () const { return idx; }
+
+        inline float                 area    (   ) const ;
+        inline angles_per_triangle_t angle   (   ) const ;
+        inline char                  ripflag (   ) const ;
+        inline PDMATRIX              norm    (   ) const ;
+        
+        inline void set_ripflag (  char to ) ;
+    };
+
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        AnalysisM::Vertex const & src              );
+        inline Vertex (                        Analysis::Vertex const & src               );
+        inline Vertex (                        AllM::Vertex const & src                   );
+        int vno       () const { return idx; }
+
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
+        // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
+        inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float x             (           ) const ;  //  current coordinates	
+        inline float y             (           ) const ;  //  use MRISsetXYZ() to set
+        inline float z             (           ) const ;
+        // 
+        // 
+        inline float nx            (           ) const ;
+        inline float ny            (           ) const ;
+        inline float nz            (           ) const ;  //  curr normal
+        // 
+        // 
+        // 
+        inline float area          (           ) const ;
+        inline float origarea      (           ) const ;
+        inline char  neg           (           ) const ;  //  1 if the normal vector is inverted 
+        inline char  border        (           ) const ;  //  flag 
+        inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void  which_coords  (int which, float *x, float *y, float *z) const ;
+        // 
+        // 
+        
+        inline void set_nx       (  float to ) ;
+        inline void set_ny       (  float to ) ;
+        inline void set_nz       (  float to ) ;  //  curr normal
+        inline void set_origarea (  float to ) ;
+        inline void set_neg      (   char to ) ;  //  1 if the normal vector is inverted 
+        inline void set_border   (   char to ) ;  //  flag 
+        inline void set_ripflag  (   char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+    };
+
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
+        inline Surface ( AnalysisM::Surface const & src );
+        inline Surface ( Analysis::Surface const & src  );
+        inline Surface ( AllM::Surface const & src      );
+
+        // Fields being maintained by specialist functions
+        inline int         nvertices       (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces          (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline float       xctr            (   ) const ;
+        inline float       yctr            (   ) const ;
+        inline float       zctr            (   ) const ;
+        inline float       xlo             (   ) const ;
+        inline float       ylo             (   ) const ;
+        inline float       zlo             (   ) const ;
+        inline float       xhi             (   ) const ;
+        inline float       yhi             (   ) const ;
+        inline float       zhi             (   ) const ;
+        inline float       total_area      (   ) const ;
+        inline double      avg_vertex_area (   ) const ;
+        inline double      avg_vertex_dist (   ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double      std_vertex_dist (   ) const ;
+        inline float       neg_area        (   ) const ;
+        inline float       neg_orig_area   (   ) const ;  //  amount of original surface in folds
+        inline double      radius          (   ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status          (   ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status  (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        
+        inline void set_xctr            (   float to ) ;
+        inline void set_yctr            (   float to ) ;
+        inline void set_zctr            (   float to ) ;
+        inline void set_xlo             (   float to ) ;
+        inline void set_ylo             (   float to ) ;
+        inline void set_zlo             (   float to ) ;
+        inline void set_xhi             (   float to ) ;
+        inline void set_yhi             (   float to ) ;
+        inline void set_zhi             (   float to ) ;
+        inline void set_total_area      (   float to ) ;
+        inline void set_avg_vertex_area (  double to ) ;
+    };
+
+    } // namespace Distort

--- a/include/mrisurf_SurfaceFromMRISPV_generated_Distort.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_Distort.h
@@ -8,10 +8,11 @@
         inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
-        inline float                 area    (   ) const ;
-        inline angles_per_triangle_t angle   (   ) const ;
-        inline char                  ripflag (   ) const ;
-        inline PDMATRIX              norm    (   ) const ;
+        inline Vertex                v       ( size_t i  ) const ;
+        inline float                 area    (           ) const ;
+        inline angles_per_triangle_t angle   (           ) const ;
+        inline char                  ripflag (           ) const ;
+        inline PDMATRIX              norm    (           ) const ;
         
         inline void set_ripflag (  char to ) ;
     };
@@ -27,6 +28,8 @@
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
+        inline Face  f             ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline uchar num           (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
         inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
@@ -48,16 +51,19 @@
         inline char  border        (           ) const ;  //  flag 
         inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
         inline void  which_coords  (int which, float *x, float *y, float *z) const ;
-        // 
-        // 
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
         
-        inline void set_nx       (  float to ) ;
-        inline void set_ny       (  float to ) ;
-        inline void set_nz       (  float to ) ;  //  curr normal
-        inline void set_origarea (  float to ) ;
-        inline void set_neg      (   char to ) ;  //  1 if the normal vector is inverted 
-        inline void set_border   (   char to ) ;  //  flag 
-        inline void set_ripflag  (   char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_f        ( size_t i,  Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        // 
+        // 
+        inline void set_nx       (           float to ) ;
+        inline void set_ny       (           float to ) ;
+        inline void set_nz       (           float to ) ;  //  curr normal
+        inline void set_origarea (           float to ) ;
+        inline void set_neg      (            char to ) ;  //  1 if the normal vector is inverted 
+        inline void set_border   (            char to ) ;  //  flag 
+        inline void set_ripflag  (            char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
     struct Surface : public Repr_Elt {
@@ -69,26 +75,28 @@
         inline Surface ( AllM::Surface const & src      );
 
         // Fields being maintained by specialist functions
-        inline int         nvertices       (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline int         nfaces          (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline float       xctr            (   ) const ;
-        inline float       yctr            (   ) const ;
-        inline float       zctr            (   ) const ;
-        inline float       xlo             (   ) const ;
-        inline float       ylo             (   ) const ;
-        inline float       zlo             (   ) const ;
-        inline float       xhi             (   ) const ;
-        inline float       yhi             (   ) const ;
-        inline float       zhi             (   ) const ;
-        inline float       total_area      (   ) const ;
-        inline double      avg_vertex_area (   ) const ;
-        inline double      avg_vertex_dist (   ) const ;  //  set by MRIScomputeAvgInterVertexDist
-        inline double      std_vertex_dist (   ) const ;
-        inline float       neg_area        (   ) const ;
-        inline float       neg_orig_area   (   ) const ;  //  amount of original surface in folds
-        inline double      radius          (   ) const ;  //  radius (if status==MRIS_SPHERE)
-        inline MRIS_Status status          (   ) const ;  //  type of surface (e.g. sphere, plane)
-        inline MRIS_Status origxyz_status  (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int         nvertices       (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces          (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline Vertex      vertices        ( size_t i  ) const ;
+        inline Face        faces           ( size_t i  ) const ;
+        inline float       xctr            (           ) const ;
+        inline float       yctr            (           ) const ;
+        inline float       zctr            (           ) const ;
+        inline float       xlo             (           ) const ;
+        inline float       ylo             (           ) const ;
+        inline float       zlo             (           ) const ;
+        inline float       xhi             (           ) const ;
+        inline float       yhi             (           ) const ;
+        inline float       zhi             (           ) const ;
+        inline float       total_area      (           ) const ;
+        inline double      avg_vertex_area (           ) const ;
+        inline double      avg_vertex_dist (           ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double      std_vertex_dist (           ) const ;
+        inline float       neg_area        (           ) const ;
+        inline float       neg_orig_area   (           ) const ;  //  amount of original surface in folds
+        inline double      radius          (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status          (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status  (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
         
         inline void set_xctr            (   float to ) ;
         inline void set_yctr            (   float to ) ;

--- a/include/mrisurf_SurfaceFromMRISPV_generated_DistortM.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_DistortM.h
@@ -6,10 +6,11 @@
         inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
-        inline float                 area    (   ) const ;
-        inline angles_per_triangle_t angle   (   ) const ;
-        inline char                  ripflag (   ) const ;
-        inline PDMATRIX              norm    (   ) const ;
+        inline Vertex                v       ( size_t i  ) const ;
+        inline float                 area    (           ) const ;
+        inline angles_per_triangle_t angle   (           ) const ;
+        inline char                  ripflag (           ) const ;
+        inline PDMATRIX              norm    (           ) const ;
         
         inline void set_ripflag (  char to ) ;
     };
@@ -23,6 +24,8 @@
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
+        inline Face  f             ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline uchar num           (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
         inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
@@ -44,16 +47,19 @@
         inline char  border        (           ) const ;  //  flag 
         inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
         inline void  which_coords  (int which, float *x, float *y, float *z) const ;
-        // 
-        // 
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
         
-        inline void set_nx       (  float to ) ;
-        inline void set_ny       (  float to ) ;
-        inline void set_nz       (  float to ) ;  //  curr normal
-        inline void set_origarea (  float to ) ;
-        inline void set_neg      (   char to ) ;  //  1 if the normal vector is inverted 
-        inline void set_border   (   char to ) ;  //  flag 
-        inline void set_ripflag  (   char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_f        ( size_t i,  Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        // 
+        // 
+        inline void set_nx       (           float to ) ;
+        inline void set_ny       (           float to ) ;
+        inline void set_nz       (           float to ) ;  //  curr normal
+        inline void set_origarea (           float to ) ;
+        inline void set_neg      (            char to ) ;  //  1 if the normal vector is inverted 
+        inline void set_border   (            char to ) ;  //  flag 
+        inline void set_ripflag  (            char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
     struct Surface : public Repr_Elt {
@@ -63,26 +69,28 @@
         inline Surface ( AllM::Surface const & src      );
 
         // Fields being maintained by specialist functions
-        inline int         nvertices       (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline int         nfaces          (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline float       xctr            (   ) const ;
-        inline float       yctr            (   ) const ;
-        inline float       zctr            (   ) const ;
-        inline float       xlo             (   ) const ;
-        inline float       ylo             (   ) const ;
-        inline float       zlo             (   ) const ;
-        inline float       xhi             (   ) const ;
-        inline float       yhi             (   ) const ;
-        inline float       zhi             (   ) const ;
-        inline float       total_area      (   ) const ;
-        inline double      avg_vertex_area (   ) const ;
-        inline double      avg_vertex_dist (   ) const ;  //  set by MRIScomputeAvgInterVertexDist
-        inline double      std_vertex_dist (   ) const ;
-        inline float       neg_area        (   ) const ;
-        inline float       neg_orig_area   (   ) const ;  //  amount of original surface in folds
-        inline double      radius          (   ) const ;  //  radius (if status==MRIS_SPHERE)
-        inline MRIS_Status status          (   ) const ;  //  type of surface (e.g. sphere, plane)
-        inline MRIS_Status origxyz_status  (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int         nvertices       (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces          (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline Vertex      vertices        ( size_t i  ) const ;
+        inline Face        faces           ( size_t i  ) const ;
+        inline float       xctr            (           ) const ;
+        inline float       yctr            (           ) const ;
+        inline float       zctr            (           ) const ;
+        inline float       xlo             (           ) const ;
+        inline float       ylo             (           ) const ;
+        inline float       zlo             (           ) const ;
+        inline float       xhi             (           ) const ;
+        inline float       yhi             (           ) const ;
+        inline float       zhi             (           ) const ;
+        inline float       total_area      (           ) const ;
+        inline double      avg_vertex_area (           ) const ;
+        inline double      avg_vertex_dist (           ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double      std_vertex_dist (           ) const ;
+        inline float       neg_area        (           ) const ;
+        inline float       neg_orig_area   (           ) const ;  //  amount of original surface in folds
+        inline double      radius          (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status          (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status  (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
         
         inline void set_xctr            (   float to ) ;
         inline void set_yctr            (   float to ) ;

--- a/include/mrisurf_SurfaceFromMRISPV_generated_DistortM.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_DistortM.h
@@ -1,0 +1,100 @@
+    namespace DistortM {
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        AllM::Face const & src                     );
+        int fno     () const { return idx; }
+
+        inline float                 area    (   ) const ;
+        inline angles_per_triangle_t angle   (   ) const ;
+        inline char                  ripflag (   ) const ;
+        inline PDMATRIX              norm    (   ) const ;
+        
+        inline void set_ripflag (  char to ) ;
+    };
+
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        AllM::Vertex const & src                   );
+        int vno       () const { return idx; }
+
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
+        // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
+        inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float x             (           ) const ;  //  current coordinates	
+        inline float y             (           ) const ;  //  use MRISsetXYZ() to set
+        inline float z             (           ) const ;
+        // 
+        // 
+        inline float nx            (           ) const ;
+        inline float ny            (           ) const ;
+        inline float nz            (           ) const ;  //  curr normal
+        // 
+        // 
+        // 
+        inline float area          (           ) const ;
+        inline float origarea      (           ) const ;
+        inline char  neg           (           ) const ;  //  1 if the normal vector is inverted 
+        inline char  border        (           ) const ;  //  flag 
+        inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void  which_coords  (int which, float *x, float *y, float *z) const ;
+        // 
+        // 
+        
+        inline void set_nx       (  float to ) ;
+        inline void set_ny       (  float to ) ;
+        inline void set_nz       (  float to ) ;  //  curr normal
+        inline void set_origarea (  float to ) ;
+        inline void set_neg      (   char to ) ;  //  1 if the normal vector is inverted 
+        inline void set_border   (   char to ) ;  //  flag 
+        inline void set_ripflag  (   char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+    };
+
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
+        inline Surface ( AllM::Surface const & src      );
+
+        // Fields being maintained by specialist functions
+        inline int         nvertices       (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces          (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline float       xctr            (   ) const ;
+        inline float       yctr            (   ) const ;
+        inline float       zctr            (   ) const ;
+        inline float       xlo             (   ) const ;
+        inline float       ylo             (   ) const ;
+        inline float       zlo             (   ) const ;
+        inline float       xhi             (   ) const ;
+        inline float       yhi             (   ) const ;
+        inline float       zhi             (   ) const ;
+        inline float       total_area      (   ) const ;
+        inline double      avg_vertex_area (   ) const ;
+        inline double      avg_vertex_dist (   ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double      std_vertex_dist (   ) const ;
+        inline float       neg_area        (   ) const ;
+        inline float       neg_orig_area   (   ) const ;  //  amount of original surface in folds
+        inline double      radius          (   ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status          (   ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status  (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        
+        inline void set_xctr            (   float to ) ;
+        inline void set_yctr            (   float to ) ;
+        inline void set_zctr            (   float to ) ;
+        inline void set_xlo             (   float to ) ;
+        inline void set_ylo             (   float to ) ;
+        inline void set_zlo             (   float to ) ;
+        inline void set_xhi             (   float to ) ;
+        inline void set_yhi             (   float to ) ;
+        inline void set_zhi             (   float to ) ;
+        inline void set_total_area      (   float to ) ;
+        inline void set_avg_vertex_area (  double to ) ;
+    };
+
+    } // namespace DistortM

--- a/include/mrisurf_SurfaceFromMRISPV_generated_Existence.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_Existence.h
@@ -1,0 +1,68 @@
+    namespace Existence {
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        TopologyM::Face const & src                );
+        inline Face (                        Topology::Face const & src                 );
+        inline Face (                        XYZPositionM::Face const & src             );
+        inline Face (                        XYZPosition::Face const & src              );
+        inline Face (                        XYZPositionConsequencesM::Face const & src );
+        inline Face (                        XYZPositionConsequences::Face const & src  );
+        inline Face (                        DistortM::Face const & src                 );
+        inline Face (                        Distort::Face const & src                  );
+        inline Face (                        AnalysisM::Face const & src                );
+        inline Face (                        Analysis::Face const & src                 );
+        inline Face (                        AllM::Face const & src                     );
+        int fno     () const { return idx; }
+
+        inline char ripflag (   ) const ;
+        
+        inline void set_ripflag (  char to ) ;
+    };
+
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                     );
+        inline Vertex (                        Vertex const & src                           );
+        inline Vertex (                        Representation* representation, size_t idx   );
+        inline Vertex (                        TopologyM::Vertex const & src                );
+        inline Vertex (                        Topology::Vertex const & src                 );
+        inline Vertex (                        XYZPositionM::Vertex const & src             );
+        inline Vertex (                        XYZPosition::Vertex const & src              );
+        inline Vertex (                        XYZPositionConsequencesM::Vertex const & src );
+        inline Vertex (                        XYZPositionConsequences::Vertex const & src  );
+        inline Vertex (                        DistortM::Vertex const & src                 );
+        inline Vertex (                        Distort::Vertex const & src                  );
+        inline Vertex (                        AnalysisM::Vertex const & src                );
+        inline Vertex (                        Analysis::Vertex const & src                 );
+        inline Vertex (                        AllM::Vertex const & src                     );
+        int vno       () const { return idx; }
+
+        inline char ripflag      (    ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void which_coords (int which, float *x, float *y, float *z) const ;
+        
+        inline void set_ripflag (  char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+    };
+
+    struct Surface : public Repr_Elt {
+        inline Surface (                                               );
+        inline Surface ( Surface const & src                           );
+        inline Surface ( Representation* representation                );
+        inline Surface ( TopologyM::Surface const & src                );
+        inline Surface ( Topology::Surface const & src                 );
+        inline Surface ( XYZPositionM::Surface const & src             );
+        inline Surface ( XYZPosition::Surface const & src              );
+        inline Surface ( XYZPositionConsequencesM::Surface const & src );
+        inline Surface ( XYZPositionConsequences::Surface const & src  );
+        inline Surface ( DistortM::Surface const & src                 );
+        inline Surface ( Distort::Surface const & src                  );
+        inline Surface ( AnalysisM::Surface const & src                );
+        inline Surface ( Analysis::Surface const & src                 );
+        inline Surface ( AllM::Surface const & src                     );
+
+        inline double      radius         (   ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status         (   ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+    };
+
+    } // namespace Existence

--- a/include/mrisurf_SurfaceFromMRISPV_generated_ExistenceM.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_ExistenceM.h
@@ -1,0 +1,41 @@
+    namespace ExistenceM {
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        AllM::Face const & src                     );
+        int fno     () const { return idx; }
+
+        inline char ripflag (   ) const ;
+        
+        inline void set_ripflag (  char to ) ;
+    };
+
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        AllM::Vertex const & src                   );
+        int vno       () const { return idx; }
+
+        inline char ripflag      (    ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void which_coords (int which, float *x, float *y, float *z) const ;
+        
+        inline void set_ripflag (  char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+    };
+
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
+        inline Surface ( AllM::Surface const & src      );
+
+        inline double      radius         (   ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status         (   ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        
+        inline void set_status         (  MRIS_Status to ) ;  //  type of surface (e.g. sphere, plane)
+        inline void set_origxyz_status (  MRIS_Status to ) ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+    };
+
+    } // namespace ExistenceM

--- a/include/mrisurf_SurfaceFromMRISPV_generated_Topology.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_Topology.h
@@ -14,7 +14,8 @@
         inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
-        inline char ripflag (   ) const ;
+        inline Vertex v       ( size_t i  ) const ;
+        inline char   ripflag (           ) const ;
         
         inline void set_ripflag (  char to ) ;
     };
@@ -34,10 +35,17 @@
         inline Vertex (                        AllM::Vertex const & src                     );
         int vno       () const { return idx; }
 
-        inline char ripflag      (    ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
-        inline void which_coords (int which, float *x, float *y, float *z) const ;
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
+        inline Face  f            ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline uchar num          (           ) const ;  //  number of neighboring faces                              
+        inline char  ripflag      (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void  which_coords (int which, float *x, float *y, float *z) const ;
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
         
-        inline void set_ripflag (  char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_f       ( size_t i, Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline void set_ripflag (           char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
     struct Surface : public Repr_Elt {
@@ -55,11 +63,13 @@
         inline Surface ( AllM::Surface const & src                     );
 
         // Fields being maintained by specialist functions
-        inline int         nvertices      (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline int         nfaces         (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline double      radius         (   ) const ;  //  radius (if status==MRIS_SPHERE)
-        inline MRIS_Status status         (   ) const ;  //  type of surface (e.g. sphere, plane)
-        inline MRIS_Status origxyz_status (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int         nvertices      (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces         (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline Vertex      vertices       ( size_t i  ) const ;
+        inline Face        faces          ( size_t i  ) const ;
+        inline double      radius         (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status         (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
     };
 
     } // namespace Topology

--- a/include/mrisurf_SurfaceFromMRISPV_generated_Topology.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_Topology.h
@@ -1,0 +1,65 @@
+    namespace Topology {
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        XYZPositionM::Face const & src             );
+        inline Face (                        XYZPosition::Face const & src              );
+        inline Face (                        XYZPositionConsequencesM::Face const & src );
+        inline Face (                        XYZPositionConsequences::Face const & src  );
+        inline Face (                        DistortM::Face const & src                 );
+        inline Face (                        Distort::Face const & src                  );
+        inline Face (                        AnalysisM::Face const & src                );
+        inline Face (                        Analysis::Face const & src                 );
+        inline Face (                        AllM::Face const & src                     );
+        int fno     () const { return idx; }
+
+        inline char ripflag (   ) const ;
+        
+        inline void set_ripflag (  char to ) ;
+    };
+
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                     );
+        inline Vertex (                        Vertex const & src                           );
+        inline Vertex (                        Representation* representation, size_t idx   );
+        inline Vertex (                        XYZPositionM::Vertex const & src             );
+        inline Vertex (                        XYZPosition::Vertex const & src              );
+        inline Vertex (                        XYZPositionConsequencesM::Vertex const & src );
+        inline Vertex (                        XYZPositionConsequences::Vertex const & src  );
+        inline Vertex (                        DistortM::Vertex const & src                 );
+        inline Vertex (                        Distort::Vertex const & src                  );
+        inline Vertex (                        AnalysisM::Vertex const & src                );
+        inline Vertex (                        Analysis::Vertex const & src                 );
+        inline Vertex (                        AllM::Vertex const & src                     );
+        int vno       () const { return idx; }
+
+        inline char ripflag      (    ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void which_coords (int which, float *x, float *y, float *z) const ;
+        
+        inline void set_ripflag (  char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+    };
+
+    struct Surface : public Repr_Elt {
+        inline Surface (                                               );
+        inline Surface ( Surface const & src                           );
+        inline Surface ( Representation* representation                );
+        inline Surface ( XYZPositionM::Surface const & src             );
+        inline Surface ( XYZPosition::Surface const & src              );
+        inline Surface ( XYZPositionConsequencesM::Surface const & src );
+        inline Surface ( XYZPositionConsequences::Surface const & src  );
+        inline Surface ( DistortM::Surface const & src                 );
+        inline Surface ( Distort::Surface const & src                  );
+        inline Surface ( AnalysisM::Surface const & src                );
+        inline Surface ( Analysis::Surface const & src                 );
+        inline Surface ( AllM::Surface const & src                     );
+
+        // Fields being maintained by specialist functions
+        inline int         nvertices      (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces         (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline double      radius         (   ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status         (   ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+    };
+
+    } // namespace Topology

--- a/include/mrisurf_SurfaceFromMRISPV_generated_TopologyM.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_TopologyM.h
@@ -6,9 +6,11 @@
         inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
-        inline char ripflag (   ) const ;
+        inline Vertex v       ( size_t i  ) const ;
+        inline char   ripflag (           ) const ;
         
-        inline void set_ripflag (  char to ) ;
+        inline void set_v       ( size_t i, Vertex to ) ;
+        inline void set_ripflag (             char to ) ;
     };
 
     struct Vertex : public Repr_Elt {
@@ -18,10 +20,18 @@
         inline Vertex (                        AllM::Vertex const & src                   );
         int vno       () const { return idx; }
 
-        inline char ripflag      (    ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
-        inline void which_coords (int which, float *x, float *y, float *z) const ;
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
+        inline Face  f            ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline uchar num          (           ) const ;  //  number of neighboring faces                              
+        inline char  ripflag      (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void  which_coords (int which, float *x, float *y, float *z) const ;
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
         
-        inline void set_ripflag (  char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_f       ( size_t i,  Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline void set_num     (           uchar to ) ;  //  number of neighboring faces                              
+        inline void set_ripflag (            char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
     struct Surface : public Repr_Elt {
@@ -31,11 +41,13 @@
         inline Surface ( AllM::Surface const & src      );
 
         // Fields being maintained by specialist functions
-        inline int         nvertices      (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline int         nfaces         (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline double      radius         (   ) const ;  //  radius (if status==MRIS_SPHERE)
-        inline MRIS_Status status         (   ) const ;  //  type of surface (e.g. sphere, plane)
-        inline MRIS_Status origxyz_status (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int         nvertices      (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces         (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline Vertex      vertices       ( size_t i  ) const ;
+        inline Face        faces          ( size_t i  ) const ;
+        inline double      radius         (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status         (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
     };
 
     } // namespace TopologyM

--- a/include/mrisurf_SurfaceFromMRISPV_generated_TopologyM.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_TopologyM.h
@@ -1,0 +1,41 @@
+    namespace TopologyM {
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        AllM::Face const & src                     );
+        int fno     () const { return idx; }
+
+        inline char ripflag (   ) const ;
+        
+        inline void set_ripflag (  char to ) ;
+    };
+
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        AllM::Vertex const & src                   );
+        int vno       () const { return idx; }
+
+        inline char ripflag      (    ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void which_coords (int which, float *x, float *y, float *z) const ;
+        
+        inline void set_ripflag (  char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+    };
+
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
+        inline Surface ( AllM::Surface const & src      );
+
+        // Fields being maintained by specialist functions
+        inline int         nvertices      (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces         (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline double      radius         (   ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status         (   ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+    };
+
+    } // namespace TopologyM

--- a/include/mrisurf_SurfaceFromMRISPV_generated_XYZPosition.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_XYZPosition.h
@@ -1,0 +1,68 @@
+    namespace XYZPosition {
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        XYZPositionConsequencesM::Face const & src );
+        inline Face (                        XYZPositionConsequences::Face const & src  );
+        inline Face (                        DistortM::Face const & src                 );
+        inline Face (                        Distort::Face const & src                  );
+        inline Face (                        AnalysisM::Face const & src                );
+        inline Face (                        Analysis::Face const & src                 );
+        inline Face (                        AllM::Face const & src                     );
+        int fno     () const { return idx; }
+
+        inline char ripflag (   ) const ;
+        
+        inline void set_ripflag (  char to ) ;
+    };
+
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                     );
+        inline Vertex (                        Vertex const & src                           );
+        inline Vertex (                        Representation* representation, size_t idx   );
+        inline Vertex (                        XYZPositionConsequencesM::Vertex const & src );
+        inline Vertex (                        XYZPositionConsequences::Vertex const & src  );
+        inline Vertex (                        DistortM::Vertex const & src                 );
+        inline Vertex (                        Distort::Vertex const & src                  );
+        inline Vertex (                        AnalysisM::Vertex const & src                );
+        inline Vertex (                        Analysis::Vertex const & src                 );
+        inline Vertex (                        AllM::Vertex const & src                     );
+        int vno       () const { return idx; }
+
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
+        // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
+        inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float x             (           ) const ;  //  current coordinates	
+        inline float y             (           ) const ;  //  use MRISsetXYZ() to set
+        inline float z             (           ) const ;
+        inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void  which_coords  (int which, float *x, float *y, float *z) const ;
+        
+        inline void set_ripflag (  char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+    };
+
+    struct Surface : public Repr_Elt {
+        inline Surface (                                               );
+        inline Surface ( Surface const & src                           );
+        inline Surface ( Representation* representation                );
+        inline Surface ( XYZPositionConsequencesM::Surface const & src );
+        inline Surface ( XYZPositionConsequences::Surface const & src  );
+        inline Surface ( DistortM::Surface const & src                 );
+        inline Surface ( Distort::Surface const & src                  );
+        inline Surface ( AnalysisM::Surface const & src                );
+        inline Surface ( Analysis::Surface const & src                 );
+        inline Surface ( AllM::Surface const & src                     );
+
+        // Fields being maintained by specialist functions
+        inline int         nvertices      (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces         (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline double      radius         (   ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status         (   ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+    };
+
+    } // namespace XYZPosition

--- a/include/mrisurf_SurfaceFromMRISPV_generated_XYZPosition.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_XYZPosition.h
@@ -12,7 +12,8 @@
         inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
-        inline char ripflag (   ) const ;
+        inline Vertex v       ( size_t i  ) const ;
+        inline char   ripflag (           ) const ;
         
         inline void set_ripflag (  char to ) ;
     };
@@ -32,6 +33,8 @@
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
+        inline Face  f             ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline uchar num           (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
         inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
@@ -41,8 +44,11 @@
         inline float z             (           ) const ;
         inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
         inline void  which_coords  (int which, float *x, float *y, float *z) const ;
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
         
-        inline void set_ripflag (  char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_f       ( size_t i, Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline void set_ripflag (           char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
     struct Surface : public Repr_Elt {
@@ -58,11 +64,13 @@
         inline Surface ( AllM::Surface const & src                     );
 
         // Fields being maintained by specialist functions
-        inline int         nvertices      (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline int         nfaces         (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline double      radius         (   ) const ;  //  radius (if status==MRIS_SPHERE)
-        inline MRIS_Status status         (   ) const ;  //  type of surface (e.g. sphere, plane)
-        inline MRIS_Status origxyz_status (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int         nvertices      (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces         (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline Vertex      vertices       ( size_t i  ) const ;
+        inline Face        faces          ( size_t i  ) const ;
+        inline double      radius         (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status         (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
     };
 
     } // namespace XYZPosition

--- a/include/mrisurf_SurfaceFromMRISPV_generated_XYZPositionConsequences.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_XYZPositionConsequences.h
@@ -1,0 +1,106 @@
+    namespace XYZPositionConsequences {
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        DistortM::Face const & src                 );
+        inline Face (                        Distort::Face const & src                  );
+        inline Face (                        AnalysisM::Face const & src                );
+        inline Face (                        Analysis::Face const & src                 );
+        inline Face (                        AllM::Face const & src                     );
+        int fno     () const { return idx; }
+
+        inline float                 area    (   ) const ;
+        inline angles_per_triangle_t angle   (   ) const ;
+        inline char                  ripflag (   ) const ;
+        inline PDMATRIX              norm    (   ) const ;
+        
+        inline void set_ripflag (  char to ) ;
+    };
+
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        DistortM::Vertex const & src               );
+        inline Vertex (                        Distort::Vertex const & src                );
+        inline Vertex (                        AnalysisM::Vertex const & src              );
+        inline Vertex (                        Analysis::Vertex const & src               );
+        inline Vertex (                        AllM::Vertex const & src                   );
+        int vno       () const { return idx; }
+
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
+        // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
+        inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float x             (           ) const ;  //  current coordinates	
+        inline float y             (           ) const ;  //  use MRISsetXYZ() to set
+        inline float z             (           ) const ;
+        // 
+        // 
+        inline float nx            (           ) const ;
+        inline float ny            (           ) const ;
+        inline float nz            (           ) const ;  //  curr normal
+        // 
+        // 
+        // 
+        inline float area          (           ) const ;
+        inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void  which_coords  (int which, float *x, float *y, float *z) const ;
+        // 
+        // 
+        
+        inline void set_nx      (  float to ) ;
+        inline void set_ny      (  float to ) ;
+        inline void set_nz      (  float to ) ;  //  curr normal
+        inline void set_ripflag (   char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+    };
+
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
+        inline Surface ( DistortM::Surface const & src  );
+        inline Surface ( Distort::Surface const & src   );
+        inline Surface ( AnalysisM::Surface const & src );
+        inline Surface ( Analysis::Surface const & src  );
+        inline Surface ( AllM::Surface const & src      );
+
+        // Fields being maintained by specialist functions
+        inline int         nvertices       (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces          (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline float       xctr            (   ) const ;
+        inline float       yctr            (   ) const ;
+        inline float       zctr            (   ) const ;
+        inline float       xlo             (   ) const ;
+        inline float       ylo             (   ) const ;
+        inline float       zlo             (   ) const ;
+        inline float       xhi             (   ) const ;
+        inline float       yhi             (   ) const ;
+        inline float       zhi             (   ) const ;
+        inline float       total_area      (   ) const ;
+        inline double      avg_vertex_area (   ) const ;
+        inline double      avg_vertex_dist (   ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double      std_vertex_dist (   ) const ;
+        inline float       neg_area        (   ) const ;
+        inline float       neg_orig_area   (   ) const ;  //  amount of original surface in folds
+        inline double      radius          (   ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status          (   ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status  (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        
+        inline void set_xctr            (   float to ) ;
+        inline void set_yctr            (   float to ) ;
+        inline void set_zctr            (   float to ) ;
+        inline void set_xlo             (   float to ) ;
+        inline void set_ylo             (   float to ) ;
+        inline void set_zlo             (   float to ) ;
+        inline void set_xhi             (   float to ) ;
+        inline void set_yhi             (   float to ) ;
+        inline void set_zhi             (   float to ) ;
+        inline void set_total_area      (   float to ) ;
+        inline void set_avg_vertex_area (  double to ) ;
+    };
+
+    } // namespace XYZPositionConsequences

--- a/include/mrisurf_SurfaceFromMRISPV_generated_XYZPositionConsequences.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_XYZPositionConsequences.h
@@ -10,10 +10,11 @@
         inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
-        inline float                 area    (   ) const ;
-        inline angles_per_triangle_t angle   (   ) const ;
-        inline char                  ripflag (   ) const ;
-        inline PDMATRIX              norm    (   ) const ;
+        inline Vertex                v       ( size_t i  ) const ;
+        inline float                 area    (           ) const ;
+        inline angles_per_triangle_t angle   (           ) const ;
+        inline char                  ripflag (           ) const ;
+        inline PDMATRIX              norm    (           ) const ;
         
         inline void set_ripflag (  char to ) ;
     };
@@ -31,6 +32,8 @@
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
+        inline Face  f             ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline uchar num           (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
         inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
@@ -49,13 +52,16 @@
         inline float area          (           ) const ;
         inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
         inline void  which_coords  (int which, float *x, float *y, float *z) const ;
-        // 
-        // 
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
         
-        inline void set_nx      (  float to ) ;
-        inline void set_ny      (  float to ) ;
-        inline void set_nz      (  float to ) ;  //  curr normal
-        inline void set_ripflag (   char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_f       ( size_t i,  Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        // 
+        // 
+        inline void set_nx      (           float to ) ;
+        inline void set_ny      (           float to ) ;
+        inline void set_nz      (           float to ) ;  //  curr normal
+        inline void set_ripflag (            char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
     struct Surface : public Repr_Elt {
@@ -69,26 +75,28 @@
         inline Surface ( AllM::Surface const & src      );
 
         // Fields being maintained by specialist functions
-        inline int         nvertices       (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline int         nfaces          (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline float       xctr            (   ) const ;
-        inline float       yctr            (   ) const ;
-        inline float       zctr            (   ) const ;
-        inline float       xlo             (   ) const ;
-        inline float       ylo             (   ) const ;
-        inline float       zlo             (   ) const ;
-        inline float       xhi             (   ) const ;
-        inline float       yhi             (   ) const ;
-        inline float       zhi             (   ) const ;
-        inline float       total_area      (   ) const ;
-        inline double      avg_vertex_area (   ) const ;
-        inline double      avg_vertex_dist (   ) const ;  //  set by MRIScomputeAvgInterVertexDist
-        inline double      std_vertex_dist (   ) const ;
-        inline float       neg_area        (   ) const ;
-        inline float       neg_orig_area   (   ) const ;  //  amount of original surface in folds
-        inline double      radius          (   ) const ;  //  radius (if status==MRIS_SPHERE)
-        inline MRIS_Status status          (   ) const ;  //  type of surface (e.g. sphere, plane)
-        inline MRIS_Status origxyz_status  (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int         nvertices       (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces          (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline Vertex      vertices        ( size_t i  ) const ;
+        inline Face        faces           ( size_t i  ) const ;
+        inline float       xctr            (           ) const ;
+        inline float       yctr            (           ) const ;
+        inline float       zctr            (           ) const ;
+        inline float       xlo             (           ) const ;
+        inline float       ylo             (           ) const ;
+        inline float       zlo             (           ) const ;
+        inline float       xhi             (           ) const ;
+        inline float       yhi             (           ) const ;
+        inline float       zhi             (           ) const ;
+        inline float       total_area      (           ) const ;
+        inline double      avg_vertex_area (           ) const ;
+        inline double      avg_vertex_dist (           ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double      std_vertex_dist (           ) const ;
+        inline float       neg_area        (           ) const ;
+        inline float       neg_orig_area   (           ) const ;  //  amount of original surface in folds
+        inline double      radius          (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status          (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status  (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
         
         inline void set_xctr            (   float to ) ;
         inline void set_yctr            (   float to ) ;

--- a/include/mrisurf_SurfaceFromMRISPV_generated_XYZPositionConsequencesM.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_XYZPositionConsequencesM.h
@@ -1,0 +1,105 @@
+    namespace XYZPositionConsequencesM {
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        AllM::Face const & src                     );
+        int fno     () const { return idx; }
+
+        inline float                 area    (   ) const ;
+        inline angles_per_triangle_t angle   (   ) const ;
+        inline char                  ripflag (   ) const ;
+        inline PDMATRIX              norm    (   ) const ;
+        
+        inline void set_area    (                  float to ) ;
+        inline void set_angle   (  angles_per_triangle_t to ) ;
+        inline void set_ripflag (                   char to ) ;
+        inline void set_norm    (               PDMATRIX to ) ;
+    };
+
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        AllM::Vertex const & src                   );
+        int vno       () const { return idx; }
+
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
+        // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
+        inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float x             (           ) const ;  //  current coordinates	
+        inline float y             (           ) const ;  //  use MRISsetXYZ() to set
+        inline float z             (           ) const ;
+        // 
+        // 
+        inline float nx            (           ) const ;
+        inline float ny            (           ) const ;
+        inline float nz            (           ) const ;  //  curr normal
+        // 
+        // 
+        // 
+        inline float area          (           ) const ;
+        inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void  which_coords  (int which, float *x, float *y, float *z) const ;
+        // 
+        // 
+        
+        inline void set_nx      (  float to ) ;
+        inline void set_ny      (  float to ) ;
+        inline void set_nz      (  float to ) ;  //  curr normal
+        // 
+        // 
+        // 
+        inline void set_area    (  float to ) ;
+        inline void set_ripflag (   char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+    };
+
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
+        inline Surface ( AllM::Surface const & src      );
+
+        // Fields being maintained by specialist functions
+        inline int         nvertices       (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces          (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline float       xctr            (   ) const ;
+        inline float       yctr            (   ) const ;
+        inline float       zctr            (   ) const ;
+        inline float       xlo             (   ) const ;
+        inline float       ylo             (   ) const ;
+        inline float       zlo             (   ) const ;
+        inline float       xhi             (   ) const ;
+        inline float       yhi             (   ) const ;
+        inline float       zhi             (   ) const ;
+        inline float       total_area      (   ) const ;
+        inline double      avg_vertex_area (   ) const ;
+        inline double      avg_vertex_dist (   ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double      std_vertex_dist (   ) const ;
+        inline float       neg_area        (   ) const ;
+        inline float       neg_orig_area   (   ) const ;  //  amount of original surface in folds
+        inline double      radius          (   ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status          (   ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status  (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        
+        inline void set_xctr            (   float to ) ;
+        inline void set_yctr            (   float to ) ;
+        inline void set_zctr            (   float to ) ;
+        inline void set_xlo             (   float to ) ;
+        inline void set_ylo             (   float to ) ;
+        inline void set_zlo             (   float to ) ;
+        inline void set_xhi             (   float to ) ;
+        inline void set_yhi             (   float to ) ;
+        inline void set_zhi             (   float to ) ;
+        inline void set_total_area      (   float to ) ;
+        inline void set_avg_vertex_area (  double to ) ;
+        inline void set_avg_vertex_dist (  double to ) ;  //  set by MRIScomputeAvgInterVertexDist
+        inline void set_std_vertex_dist (  double to ) ;
+        inline void set_neg_area        (   float to ) ;
+        inline void set_neg_orig_area   (   float to ) ;  //  amount of original surface in folds
+    };
+
+    } // namespace XYZPositionConsequencesM

--- a/include/mrisurf_SurfaceFromMRISPV_generated_XYZPositionConsequencesM.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_XYZPositionConsequencesM.h
@@ -6,10 +6,11 @@
         inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
-        inline float                 area    (   ) const ;
-        inline angles_per_triangle_t angle   (   ) const ;
-        inline char                  ripflag (   ) const ;
-        inline PDMATRIX              norm    (   ) const ;
+        inline Vertex                v       ( size_t i  ) const ;
+        inline float                 area    (           ) const ;
+        inline angles_per_triangle_t angle   (           ) const ;
+        inline char                  ripflag (           ) const ;
+        inline PDMATRIX              norm    (           ) const ;
         
         inline void set_area    (                  float to ) ;
         inline void set_angle   (  angles_per_triangle_t to ) ;
@@ -26,6 +27,8 @@
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
+        inline Face  f             ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline uchar num           (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
         inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
@@ -44,17 +47,20 @@
         inline float area          (           ) const ;
         inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
         inline void  which_coords  (int which, float *x, float *y, float *z) const ;
-        // 
-        // 
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
         
-        inline void set_nx      (  float to ) ;
-        inline void set_ny      (  float to ) ;
-        inline void set_nz      (  float to ) ;  //  curr normal
+        inline void set_f       ( size_t i,  Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        // 
+        // 
+        inline void set_nx      (           float to ) ;
+        inline void set_ny      (           float to ) ;
+        inline void set_nz      (           float to ) ;  //  curr normal
         // 
         // 
         // 
-        inline void set_area    (  float to ) ;
-        inline void set_ripflag (   char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_area    (           float to ) ;
+        inline void set_ripflag (            char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
     struct Surface : public Repr_Elt {
@@ -64,26 +70,28 @@
         inline Surface ( AllM::Surface const & src      );
 
         // Fields being maintained by specialist functions
-        inline int         nvertices       (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline int         nfaces          (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline float       xctr            (   ) const ;
-        inline float       yctr            (   ) const ;
-        inline float       zctr            (   ) const ;
-        inline float       xlo             (   ) const ;
-        inline float       ylo             (   ) const ;
-        inline float       zlo             (   ) const ;
-        inline float       xhi             (   ) const ;
-        inline float       yhi             (   ) const ;
-        inline float       zhi             (   ) const ;
-        inline float       total_area      (   ) const ;
-        inline double      avg_vertex_area (   ) const ;
-        inline double      avg_vertex_dist (   ) const ;  //  set by MRIScomputeAvgInterVertexDist
-        inline double      std_vertex_dist (   ) const ;
-        inline float       neg_area        (   ) const ;
-        inline float       neg_orig_area   (   ) const ;  //  amount of original surface in folds
-        inline double      radius          (   ) const ;  //  radius (if status==MRIS_SPHERE)
-        inline MRIS_Status status          (   ) const ;  //  type of surface (e.g. sphere, plane)
-        inline MRIS_Status origxyz_status  (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int         nvertices       (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces          (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline Vertex      vertices        ( size_t i  ) const ;
+        inline Face        faces           ( size_t i  ) const ;
+        inline float       xctr            (           ) const ;
+        inline float       yctr            (           ) const ;
+        inline float       zctr            (           ) const ;
+        inline float       xlo             (           ) const ;
+        inline float       ylo             (           ) const ;
+        inline float       zlo             (           ) const ;
+        inline float       xhi             (           ) const ;
+        inline float       yhi             (           ) const ;
+        inline float       zhi             (           ) const ;
+        inline float       total_area      (           ) const ;
+        inline double      avg_vertex_area (           ) const ;
+        inline double      avg_vertex_dist (           ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double      std_vertex_dist (           ) const ;
+        inline float       neg_area        (           ) const ;
+        inline float       neg_orig_area   (           ) const ;  //  amount of original surface in folds
+        inline double      radius          (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status          (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status  (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
         
         inline void set_xctr            (   float to ) ;
         inline void set_yctr            (   float to ) ;

--- a/include/mrisurf_SurfaceFromMRISPV_generated_XYZPositionM.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_XYZPositionM.h
@@ -1,0 +1,54 @@
+    namespace XYZPositionM {
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        AllM::Face const & src                     );
+        int fno     () const { return idx; }
+
+        inline char ripflag (   ) const ;
+        
+        inline void set_ripflag (  char to ) ;
+    };
+
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        AllM::Vertex const & src                   );
+        int vno       () const { return idx; }
+
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
+        // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
+        inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float x             (           ) const ;  //  current coordinates	
+        inline float y             (           ) const ;  //  use MRISsetXYZ() to set
+        inline float z             (           ) const ;
+        inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void  which_coords  (int which, float *x, float *y, float *z) const ;
+        // 
+        
+        inline void set_x       (  float to ) ;  //  current coordinates	
+        inline void set_y       (  float to ) ;  //  use MRISsetXYZ() to set
+        inline void set_z       (  float to ) ;
+        inline void set_ripflag (   char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+    };
+
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
+        inline Surface ( AllM::Surface const & src      );
+
+        // Fields being maintained by specialist functions
+        inline int         nvertices      (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces         (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline double      radius         (   ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status         (   ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+    };
+
+    } // namespace XYZPositionM

--- a/include/mrisurf_SurfaceFromMRISPV_generated_XYZPositionM.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_XYZPositionM.h
@@ -6,7 +6,8 @@
         inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
-        inline char ripflag (   ) const ;
+        inline Vertex v       ( size_t i  ) const ;
+        inline char   ripflag (           ) const ;
         
         inline void set_ripflag (  char to ) ;
     };
@@ -20,6 +21,8 @@
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
+        inline Face  f             ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline uchar num           (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
         inline float dist          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         inline int   dist_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
@@ -29,12 +32,15 @@
         inline float z             (           ) const ;
         inline char  ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
         inline void  which_coords  (int which, float *x, float *y, float *z) const ;
-        // 
+        // put the pointers before the ints, before the shorts, before uchars, to reduce size
+        // the whole fits in much less than one cache line, so further ordering is no use
         
-        inline void set_x       (  float to ) ;  //  current coordinates	
-        inline void set_y       (  float to ) ;  //  use MRISsetXYZ() to set
-        inline void set_z       (  float to ) ;
-        inline void set_ripflag (   char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_f       ( size_t i,  Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        // 
+        inline void set_x       (           float to ) ;  //  current coordinates	
+        inline void set_y       (           float to ) ;  //  use MRISsetXYZ() to set
+        inline void set_z       (           float to ) ;
+        inline void set_ripflag (            char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
     struct Surface : public Repr_Elt {
@@ -44,11 +50,13 @@
         inline Surface ( AllM::Surface const & src      );
 
         // Fields being maintained by specialist functions
-        inline int         nvertices      (   ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline int         nfaces         (   ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        inline double      radius         (   ) const ;  //  radius (if status==MRIS_SPHERE)
-        inline MRIS_Status status         (   ) const ;  //  type of surface (e.g. sphere, plane)
-        inline MRIS_Status origxyz_status (   ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int         nvertices      (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int         nfaces         (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline Vertex      vertices       ( size_t i  ) const ;
+        inline Face        faces          ( size_t i  ) const ;
+        inline double      radius         (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline MRIS_Status status         (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status origxyz_status (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
     };
 
     } // namespace XYZPositionM

--- a/include/mrisurf_SurfaceFromMRISPV_generated_prefix.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_prefix.h
@@ -1,0 +1,148 @@
+
+// GENERATED SOURCE - DO NOT DIRECTLY EDIT
+// 
+// =======================================
+namespace SurfaceFromMRISPV {
+    typedef MRISPV Representation;
+
+
+    namespace Existence {
+        struct Face;
+        struct Vertex;
+        struct Surface;
+    } // namespace Existence
+
+
+    namespace Topology {
+        struct Face;
+        struct Vertex;
+        struct Surface;
+    } // namespace Topology
+
+
+    namespace XYZPosition {
+        struct Face;
+        struct Vertex;
+        struct Surface;
+    } // namespace XYZPosition
+
+
+    namespace XYZPositionConsequences {
+        struct Face;
+        struct Vertex;
+        struct Surface;
+    } // namespace XYZPositionConsequences
+
+
+    namespace Distort {
+        struct Face;
+        struct Vertex;
+        struct Surface;
+    } // namespace Distort
+
+
+    namespace Analysis {
+        struct Face;
+        struct Vertex;
+        struct Surface;
+    } // namespace Analysis
+
+
+    namespace ExistenceM {
+        struct Face;
+        struct Vertex;
+        struct Surface;
+    } // namespace ExistenceM
+
+
+    namespace TopologyM {
+        struct Face;
+        struct Vertex;
+        struct Surface;
+    } // namespace TopologyM
+
+
+    namespace XYZPositionM {
+        struct Face;
+        struct Vertex;
+        struct Surface;
+    } // namespace XYZPositionM
+
+
+    namespace XYZPositionConsequencesM {
+        struct Face;
+        struct Vertex;
+        struct Surface;
+    } // namespace XYZPositionConsequencesM
+
+
+    namespace DistortM {
+        struct Face;
+        struct Vertex;
+        struct Surface;
+    } // namespace DistortM
+
+
+    namespace AnalysisM {
+        struct Face;
+        struct Vertex;
+        struct Surface;
+    } // namespace AnalysisM
+
+
+    namespace AllM {
+        struct Face;
+        struct Vertex;
+        struct Surface;
+    } // namespace AllM
+    
+    struct Repr_Elt { 
+        bool operator==(Repr_Elt const & rhs) const { return repr == rhs.repr && idx == rhs.idx; }
+        bool operator!=(Repr_Elt const & rhs) const { return repr != rhs.repr || idx != rhs.idx; }
+    protected: 
+        Representation* repr; size_t idx; 
+        Repr_Elt() : repr(nullptr), idx(0) {}
+        Repr_Elt(Representation* repr, size_t idx) : repr(repr), idx(idx) {}
+        Repr_Elt(Repr_Elt const & src) : repr(src.repr), idx(src.idx) {}
+
+        friend struct SurfaceFromMRISPV::ExistenceM::Face;
+        friend struct SurfaceFromMRISPV::ExistenceM::Vertex;
+        friend struct SurfaceFromMRISPV::ExistenceM::Surface;
+        friend struct SurfaceFromMRISPV::Existence::Face;
+        friend struct SurfaceFromMRISPV::Existence::Vertex;
+        friend struct SurfaceFromMRISPV::Existence::Surface;
+        friend struct SurfaceFromMRISPV::TopologyM::Face;
+        friend struct SurfaceFromMRISPV::TopologyM::Vertex;
+        friend struct SurfaceFromMRISPV::TopologyM::Surface;
+        friend struct SurfaceFromMRISPV::Topology::Face;
+        friend struct SurfaceFromMRISPV::Topology::Vertex;
+        friend struct SurfaceFromMRISPV::Topology::Surface;
+        friend struct SurfaceFromMRISPV::XYZPositionM::Face;
+        friend struct SurfaceFromMRISPV::XYZPositionM::Vertex;
+        friend struct SurfaceFromMRISPV::XYZPositionM::Surface;
+        friend struct SurfaceFromMRISPV::XYZPosition::Face;
+        friend struct SurfaceFromMRISPV::XYZPosition::Vertex;
+        friend struct SurfaceFromMRISPV::XYZPosition::Surface;
+        friend struct SurfaceFromMRISPV::XYZPositionConsequencesM::Face;
+        friend struct SurfaceFromMRISPV::XYZPositionConsequencesM::Vertex;
+        friend struct SurfaceFromMRISPV::XYZPositionConsequencesM::Surface;
+        friend struct SurfaceFromMRISPV::XYZPositionConsequences::Face;
+        friend struct SurfaceFromMRISPV::XYZPositionConsequences::Vertex;
+        friend struct SurfaceFromMRISPV::XYZPositionConsequences::Surface;
+        friend struct SurfaceFromMRISPV::DistortM::Face;
+        friend struct SurfaceFromMRISPV::DistortM::Vertex;
+        friend struct SurfaceFromMRISPV::DistortM::Surface;
+        friend struct SurfaceFromMRISPV::Distort::Face;
+        friend struct SurfaceFromMRISPV::Distort::Vertex;
+        friend struct SurfaceFromMRISPV::Distort::Surface;
+        friend struct SurfaceFromMRISPV::AnalysisM::Face;
+        friend struct SurfaceFromMRISPV::AnalysisM::Vertex;
+        friend struct SurfaceFromMRISPV::AnalysisM::Surface;
+        friend struct SurfaceFromMRISPV::Analysis::Face;
+        friend struct SurfaceFromMRISPV::Analysis::Vertex;
+        friend struct SurfaceFromMRISPV::Analysis::Surface;
+        friend struct SurfaceFromMRISPV::AllM::Face;
+        friend struct SurfaceFromMRISPV::AllM::Vertex;
+        friend struct SurfaceFromMRISPV::AllM::Surface;
+    };
+} // SurfaceFromMRISPV

--- a/include/mrisurf_SurfaceFromMRISPV_generated_suffix.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_suffix.h
@@ -1,0 +1,2062 @@
+
+// GENERATED SOURCE - DO NOT DIRECTLY EDIT
+// 
+// =======================================
+namespace SurfaceFromMRISPV {
+    typedef MRISPV Representation;
+
+
+    namespace Existence {
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( TopologyM::Face const & src                ) : Repr_Elt(src) {}
+    Face::Face ( Topology::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( XYZPositionM::Face const & src             ) : Repr_Elt(src) {}
+    Face::Face ( XYZPosition::Face const & src              ) : Repr_Elt(src) {}
+    Face::Face ( XYZPositionConsequencesM::Face const & src ) : Repr_Elt(src) {}
+    Face::Face ( XYZPositionConsequences::Face const & src  ) : Repr_Elt(src) {}
+    Face::Face ( DistortM::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( Distort::Face const & src                  ) : Repr_Elt(src) {}
+    Face::Face ( AnalysisM::Face const & src                ) : Repr_Elt(src) {}
+    Face::Face ( Analysis::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
+
+    char Face::ripflag() const {
+        return repr->f_ripflag[idx];
+    }
+    
+    void Face::set_ripflag(char to) {
+        repr->f_ripflag[idx] = to;
+    }
+
+
+    Vertex::Vertex (                                              ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx   ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                           ) : Repr_Elt(src) {}
+    Vertex::Vertex ( TopologyM::Vertex const & src                ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Topology::Vertex const & src                 ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPositionM::Vertex const & src             ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPosition::Vertex const & src              ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPositionConsequencesM::Vertex const & src ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPositionConsequences::Vertex const & src  ) : Repr_Elt(src) {}
+    Vertex::Vertex ( DistortM::Vertex const & src                 ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Distort::Vertex const & src                  ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AnalysisM::Vertex const & src                ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Analysis::Vertex const & src                 ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                     ) : Repr_Elt(src) {}
+
+    char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
+        return repr->v_ripflag[idx];
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+    
+    #define CASE(WHICH, FIELD) \
+      case WHICH: \
+        *x = this->FIELD##x();  *y = this->FIELD##y();  *z = this->FIELD##z(); \
+        break;
+    
+      switch (which) {
+        default:
+          ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
+          break;
+      }
+    
+    #undef CASE
+    }
+    
+    void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
+        repr->v_ripflag[idx] = to;
+    }
+
+
+    Surface::Surface (                                               ) {}
+    Surface::Surface ( Representation* representation                ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src                           ) : Repr_Elt(src) {}
+    Surface::Surface ( TopologyM::Surface const & src                ) : Repr_Elt(src) {}
+    Surface::Surface ( Topology::Surface const & src                 ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPositionM::Surface const & src             ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPosition::Surface const & src              ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPositionConsequencesM::Surface const & src ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPositionConsequences::Surface const & src  ) : Repr_Elt(src) {}
+    Surface::Surface ( DistortM::Surface const & src                 ) : Repr_Elt(src) {}
+    Surface::Surface ( Distort::Surface const & src                  ) : Repr_Elt(src) {}
+    Surface::Surface ( AnalysisM::Surface const & src                ) : Repr_Elt(src) {}
+    Surface::Surface ( Analysis::Surface const & src                 ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src                     ) : Repr_Elt(src) {}
+
+    double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
+        return repr->radius;
+    }
+    MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
+        return repr->status;
+    }
+    MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        return repr->origxyz_status;
+    }
+
+
+    } // namespace Existence
+
+
+    namespace Topology {
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( XYZPositionM::Face const & src             ) : Repr_Elt(src) {}
+    Face::Face ( XYZPosition::Face const & src              ) : Repr_Elt(src) {}
+    Face::Face ( XYZPositionConsequencesM::Face const & src ) : Repr_Elt(src) {}
+    Face::Face ( XYZPositionConsequences::Face const & src  ) : Repr_Elt(src) {}
+    Face::Face ( DistortM::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( Distort::Face const & src                  ) : Repr_Elt(src) {}
+    Face::Face ( AnalysisM::Face const & src                ) : Repr_Elt(src) {}
+    Face::Face ( Analysis::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
+
+    char Face::ripflag() const {
+        return repr->f_ripflag[idx];
+    }
+    
+    void Face::set_ripflag(char to) {
+        repr->f_ripflag[idx] = to;
+    }
+
+
+    Vertex::Vertex (                                              ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx   ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                           ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPositionM::Vertex const & src             ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPosition::Vertex const & src              ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPositionConsequencesM::Vertex const & src ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPositionConsequences::Vertex const & src  ) : Repr_Elt(src) {}
+    Vertex::Vertex ( DistortM::Vertex const & src                 ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Distort::Vertex const & src                  ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AnalysisM::Vertex const & src                ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Analysis::Vertex const & src                 ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                     ) : Repr_Elt(src) {}
+
+    char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
+        return repr->v_ripflag[idx];
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+    
+    #define CASE(WHICH, FIELD) \
+      case WHICH: \
+        *x = this->FIELD##x();  *y = this->FIELD##y();  *z = this->FIELD##z(); \
+        break;
+    
+      switch (which) {
+        default:
+          ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
+          break;
+      }
+    
+    #undef CASE
+    }
+    
+    void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
+        repr->v_ripflag[idx] = to;
+    }
+
+
+    Surface::Surface (                                               ) {}
+    Surface::Surface ( Representation* representation                ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src                           ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPositionM::Surface const & src             ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPosition::Surface const & src              ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPositionConsequencesM::Surface const & src ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPositionConsequences::Surface const & src  ) : Repr_Elt(src) {}
+    Surface::Surface ( DistortM::Surface const & src                 ) : Repr_Elt(src) {}
+    Surface::Surface ( Distort::Surface const & src                  ) : Repr_Elt(src) {}
+    Surface::Surface ( AnalysisM::Surface const & src                ) : Repr_Elt(src) {}
+    Surface::Surface ( Analysis::Surface const & src                 ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src                     ) : Repr_Elt(src) {}
+
+    int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nvertices;
+    }
+    int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nfaces;
+    }
+    double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
+        return repr->radius;
+    }
+    MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
+        return repr->status;
+    }
+    MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        return repr->origxyz_status;
+    }
+
+
+    } // namespace Topology
+
+
+    namespace XYZPosition {
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( XYZPositionConsequencesM::Face const & src ) : Repr_Elt(src) {}
+    Face::Face ( XYZPositionConsequences::Face const & src  ) : Repr_Elt(src) {}
+    Face::Face ( DistortM::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( Distort::Face const & src                  ) : Repr_Elt(src) {}
+    Face::Face ( AnalysisM::Face const & src                ) : Repr_Elt(src) {}
+    Face::Face ( Analysis::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
+
+    char Face::ripflag() const {
+        return repr->f_ripflag[idx];
+    }
+    
+    void Face::set_ripflag(char to) {
+        repr->f_ripflag[idx] = to;
+    }
+
+
+    Vertex::Vertex (                                              ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx   ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                           ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPositionConsequencesM::Vertex const & src ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPositionConsequences::Vertex const & src  ) : Repr_Elt(src) {}
+    Vertex::Vertex ( DistortM::Vertex const & src                 ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Distort::Vertex const & src                  ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AnalysisM::Vertex const & src                ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Analysis::Vertex const & src                 ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                     ) : Repr_Elt(src) {}
+
+    float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        return repr->v_dist[idx][i];
+    }
+    int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
+        return repr->v_dist_capacity[idx];
+    }
+    float Vertex::x() const {  //  current coordinates	
+        return repr->v_x[idx];
+    }
+    float Vertex::y() const {  //  use MRISsetXYZ() to set
+        return repr->v_y[idx];
+    }
+    float Vertex::z() const {
+        return repr->v_z[idx];
+    }
+    char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
+        return repr->v_ripflag[idx];
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+    
+    #define CASE(WHICH, FIELD) \
+      case WHICH: \
+        *x = this->FIELD##x();  *y = this->FIELD##y();  *z = this->FIELD##z(); \
+        break;
+    
+      switch (which) {
+        CASE(CURRENT_VERTICES,)
+        default:
+          ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
+          break;
+      }
+    
+    #undef CASE
+    }
+    
+    void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
+        repr->v_ripflag[idx] = to;
+    }
+
+
+    Surface::Surface (                                               ) {}
+    Surface::Surface ( Representation* representation                ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src                           ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPositionConsequencesM::Surface const & src ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPositionConsequences::Surface const & src  ) : Repr_Elt(src) {}
+    Surface::Surface ( DistortM::Surface const & src                 ) : Repr_Elt(src) {}
+    Surface::Surface ( Distort::Surface const & src                  ) : Repr_Elt(src) {}
+    Surface::Surface ( AnalysisM::Surface const & src                ) : Repr_Elt(src) {}
+    Surface::Surface ( Analysis::Surface const & src                 ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src                     ) : Repr_Elt(src) {}
+
+    int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nvertices;
+    }
+    int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nfaces;
+    }
+    double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
+        return repr->radius;
+    }
+    MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
+        return repr->status;
+    }
+    MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        return repr->origxyz_status;
+    }
+
+
+    } // namespace XYZPosition
+
+
+    namespace XYZPositionConsequences {
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( DistortM::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( Distort::Face const & src                  ) : Repr_Elt(src) {}
+    Face::Face ( AnalysisM::Face const & src                ) : Repr_Elt(src) {}
+    Face::Face ( Analysis::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
+
+    float Face::area() const {
+        return repr->f_area[idx];
+    }
+    angles_per_triangle_t Face::angle() const {
+        return repr->f_angle[idx];
+    }
+    char Face::ripflag() const {
+        return repr->f_ripflag[idx];
+    }
+    PDMATRIX Face::norm() const {
+        return repr->f_norm[idx];
+    }
+    
+    void Face::set_ripflag(char to) {
+        repr->f_ripflag[idx] = to;
+    }
+
+
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( DistortM::Vertex const & src               ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Distort::Vertex const & src                ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AnalysisM::Vertex const & src              ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Analysis::Vertex const & src               ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
+
+    float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        return repr->v_dist[idx][i];
+    }
+    int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
+        return repr->v_dist_capacity[idx];
+    }
+    float Vertex::x() const {  //  current coordinates	
+        return repr->v_x[idx];
+    }
+    float Vertex::y() const {  //  use MRISsetXYZ() to set
+        return repr->v_y[idx];
+    }
+    float Vertex::z() const {
+        return repr->v_z[idx];
+    }
+    float Vertex::nx() const {
+        return repr->v_nx[idx];
+    }
+    float Vertex::ny() const {
+        return repr->v_ny[idx];
+    }
+    float Vertex::nz() const {  //  curr normal
+        return repr->v_nz[idx];
+    }
+    float Vertex::area() const {
+        return repr->v_area[idx];
+    }
+    char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
+        return repr->v_ripflag[idx];
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+    
+    #define CASE(WHICH, FIELD) \
+      case WHICH: \
+        *x = this->FIELD##x();  *y = this->FIELD##y();  *z = this->FIELD##z(); \
+        break;
+    
+      switch (which) {
+        CASE(CURRENT_VERTICES,)
+        CASE(VERTEX_NORMALS,n)
+        default:
+          ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
+          break;
+      }
+    
+    #undef CASE
+    }
+    
+    void Vertex::set_nx(float to) {
+        repr->v_nx[idx] = to;
+    }
+    void Vertex::set_ny(float to) {
+        repr->v_ny[idx] = to;
+    }
+    void Vertex::set_nz(float to) {  //  curr normal
+        repr->v_nz[idx] = to;
+    }
+    void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
+        repr->v_ripflag[idx] = to;
+    }
+
+
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( DistortM::Surface const & src  ) : Repr_Elt(src) {}
+    Surface::Surface ( Distort::Surface const & src   ) : Repr_Elt(src) {}
+    Surface::Surface ( AnalysisM::Surface const & src ) : Repr_Elt(src) {}
+    Surface::Surface ( Analysis::Surface const & src  ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
+
+    int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nvertices;
+    }
+    int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nfaces;
+    }
+    float Surface::xctr() const {
+        return repr->xctr;
+    }
+    float Surface::yctr() const {
+        return repr->yctr;
+    }
+    float Surface::zctr() const {
+        return repr->zctr;
+    }
+    float Surface::xlo() const {
+        return repr->xlo;
+    }
+    float Surface::ylo() const {
+        return repr->ylo;
+    }
+    float Surface::zlo() const {
+        return repr->zlo;
+    }
+    float Surface::xhi() const {
+        return repr->xhi;
+    }
+    float Surface::yhi() const {
+        return repr->yhi;
+    }
+    float Surface::zhi() const {
+        return repr->zhi;
+    }
+    float Surface::total_area() const {
+        return repr->total_area;
+    }
+    double Surface::avg_vertex_area() const {
+        return repr->avg_vertex_area;
+    }
+    double Surface::avg_vertex_dist() const {  //  set by MRIScomputeAvgInterVertexDist
+        return repr->avg_vertex_dist;
+    }
+    double Surface::std_vertex_dist() const {
+        return repr->std_vertex_dist;
+    }
+    float Surface::neg_area() const {
+        return repr->neg_area;
+    }
+    float Surface::neg_orig_area() const {  //  amount of original surface in folds
+        return repr->neg_orig_area;
+    }
+    double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
+        return repr->radius;
+    }
+    MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
+        return repr->status;
+    }
+    MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        return repr->origxyz_status;
+    }
+    
+    void Surface::set_xctr(float to) {
+        repr->xctr = to;
+    }
+    void Surface::set_yctr(float to) {
+        repr->yctr = to;
+    }
+    void Surface::set_zctr(float to) {
+        repr->zctr = to;
+    }
+    void Surface::set_xlo(float to) {
+        repr->xlo = to;
+    }
+    void Surface::set_ylo(float to) {
+        repr->ylo = to;
+    }
+    void Surface::set_zlo(float to) {
+        repr->zlo = to;
+    }
+    void Surface::set_xhi(float to) {
+        repr->xhi = to;
+    }
+    void Surface::set_yhi(float to) {
+        repr->yhi = to;
+    }
+    void Surface::set_zhi(float to) {
+        repr->zhi = to;
+    }
+    void Surface::set_total_area(float to) {
+        repr->total_area = to;
+    }
+    void Surface::set_avg_vertex_area(double to) {
+        repr->avg_vertex_area = to;
+    }
+
+
+    } // namespace XYZPositionConsequences
+
+
+    namespace Distort {
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( AnalysisM::Face const & src                ) : Repr_Elt(src) {}
+    Face::Face ( Analysis::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
+
+    float Face::area() const {
+        return repr->f_area[idx];
+    }
+    angles_per_triangle_t Face::angle() const {
+        return repr->f_angle[idx];
+    }
+    char Face::ripflag() const {
+        return repr->f_ripflag[idx];
+    }
+    PDMATRIX Face::norm() const {
+        return repr->f_norm[idx];
+    }
+    
+    void Face::set_ripflag(char to) {
+        repr->f_ripflag[idx] = to;
+    }
+
+
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AnalysisM::Vertex const & src              ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Analysis::Vertex const & src               ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
+
+    float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        return repr->v_dist[idx][i];
+    }
+    int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
+        return repr->v_dist_capacity[idx];
+    }
+    float Vertex::x() const {  //  current coordinates	
+        return repr->v_x[idx];
+    }
+    float Vertex::y() const {  //  use MRISsetXYZ() to set
+        return repr->v_y[idx];
+    }
+    float Vertex::z() const {
+        return repr->v_z[idx];
+    }
+    float Vertex::nx() const {
+        return repr->v_nx[idx];
+    }
+    float Vertex::ny() const {
+        return repr->v_ny[idx];
+    }
+    float Vertex::nz() const {  //  curr normal
+        return repr->v_nz[idx];
+    }
+    float Vertex::area() const {
+        return repr->v_area[idx];
+    }
+    float Vertex::origarea() const {
+        return repr->v_origarea[idx];
+    }
+    char Vertex::neg() const {  //  1 if the normal vector is inverted 
+        return repr->v_neg[idx];
+    }
+    char Vertex::border() const {  //  flag 
+        return repr->v_border[idx];
+    }
+    char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
+        return repr->v_ripflag[idx];
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+    
+    #define CASE(WHICH, FIELD) \
+      case WHICH: \
+        *x = this->FIELD##x();  *y = this->FIELD##y();  *z = this->FIELD##z(); \
+        break;
+    
+      switch (which) {
+        CASE(CURRENT_VERTICES,)
+        CASE(VERTEX_NORMALS,n)
+        default:
+          ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
+          break;
+      }
+    
+    #undef CASE
+    }
+    
+    void Vertex::set_nx(float to) {
+        repr->v_nx[idx] = to;
+    }
+    void Vertex::set_ny(float to) {
+        repr->v_ny[idx] = to;
+    }
+    void Vertex::set_nz(float to) {  //  curr normal
+        repr->v_nz[idx] = to;
+    }
+    void Vertex::set_origarea(float to) {
+        repr->v_origarea[idx] = to;
+    }
+    void Vertex::set_neg(char to) {  //  1 if the normal vector is inverted 
+        repr->v_neg[idx] = to;
+    }
+    void Vertex::set_border(char to) {  //  flag 
+        repr->v_border[idx] = to;
+    }
+    void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
+        repr->v_ripflag[idx] = to;
+    }
+
+
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( AnalysisM::Surface const & src ) : Repr_Elt(src) {}
+    Surface::Surface ( Analysis::Surface const & src  ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
+
+    int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nvertices;
+    }
+    int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nfaces;
+    }
+    float Surface::xctr() const {
+        return repr->xctr;
+    }
+    float Surface::yctr() const {
+        return repr->yctr;
+    }
+    float Surface::zctr() const {
+        return repr->zctr;
+    }
+    float Surface::xlo() const {
+        return repr->xlo;
+    }
+    float Surface::ylo() const {
+        return repr->ylo;
+    }
+    float Surface::zlo() const {
+        return repr->zlo;
+    }
+    float Surface::xhi() const {
+        return repr->xhi;
+    }
+    float Surface::yhi() const {
+        return repr->yhi;
+    }
+    float Surface::zhi() const {
+        return repr->zhi;
+    }
+    float Surface::total_area() const {
+        return repr->total_area;
+    }
+    double Surface::avg_vertex_area() const {
+        return repr->avg_vertex_area;
+    }
+    double Surface::avg_vertex_dist() const {  //  set by MRIScomputeAvgInterVertexDist
+        return repr->avg_vertex_dist;
+    }
+    double Surface::std_vertex_dist() const {
+        return repr->std_vertex_dist;
+    }
+    float Surface::neg_area() const {
+        return repr->neg_area;
+    }
+    float Surface::neg_orig_area() const {  //  amount of original surface in folds
+        return repr->neg_orig_area;
+    }
+    double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
+        return repr->radius;
+    }
+    MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
+        return repr->status;
+    }
+    MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        return repr->origxyz_status;
+    }
+    
+    void Surface::set_xctr(float to) {
+        repr->xctr = to;
+    }
+    void Surface::set_yctr(float to) {
+        repr->yctr = to;
+    }
+    void Surface::set_zctr(float to) {
+        repr->zctr = to;
+    }
+    void Surface::set_xlo(float to) {
+        repr->xlo = to;
+    }
+    void Surface::set_ylo(float to) {
+        repr->ylo = to;
+    }
+    void Surface::set_zlo(float to) {
+        repr->zlo = to;
+    }
+    void Surface::set_xhi(float to) {
+        repr->xhi = to;
+    }
+    void Surface::set_yhi(float to) {
+        repr->yhi = to;
+    }
+    void Surface::set_zhi(float to) {
+        repr->zhi = to;
+    }
+    void Surface::set_total_area(float to) {
+        repr->total_area = to;
+    }
+    void Surface::set_avg_vertex_area(double to) {
+        repr->avg_vertex_area = to;
+    }
+
+
+    } // namespace Distort
+
+
+    namespace Analysis {
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
+
+    float Face::area() const {
+        return repr->f_area[idx];
+    }
+    angles_per_triangle_t Face::angle() const {
+        return repr->f_angle[idx];
+    }
+    char Face::ripflag() const {
+        return repr->f_ripflag[idx];
+    }
+    PDMATRIX Face::norm() const {
+        return repr->f_norm[idx];
+    }
+    
+    void Face::set_ripflag(char to) {
+        repr->f_ripflag[idx] = to;
+    }
+
+
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
+
+    float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        return repr->v_dist[idx][i];
+    }
+    int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
+        return repr->v_dist_capacity[idx];
+    }
+    float Vertex::x() const {  //  current coordinates	
+        return repr->v_x[idx];
+    }
+    float Vertex::y() const {  //  use MRISsetXYZ() to set
+        return repr->v_y[idx];
+    }
+    float Vertex::z() const {
+        return repr->v_z[idx];
+    }
+    float Vertex::nx() const {
+        return repr->v_nx[idx];
+    }
+    float Vertex::ny() const {
+        return repr->v_ny[idx];
+    }
+    float Vertex::nz() const {  //  curr normal
+        return repr->v_nz[idx];
+    }
+    float Vertex::area() const {
+        return repr->v_area[idx];
+    }
+    float Vertex::origarea() const {
+        return repr->v_origarea[idx];
+    }
+    char Vertex::neg() const {  //  1 if the normal vector is inverted 
+        return repr->v_neg[idx];
+    }
+    char Vertex::border() const {  //  flag 
+        return repr->v_border[idx];
+    }
+    char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
+        return repr->v_ripflag[idx];
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+    
+    #define CASE(WHICH, FIELD) \
+      case WHICH: \
+        *x = this->FIELD##x();  *y = this->FIELD##y();  *z = this->FIELD##z(); \
+        break;
+    
+      switch (which) {
+        CASE(CURRENT_VERTICES,)
+        CASE(VERTEX_NORMALS,n)
+        default:
+          ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
+          break;
+      }
+    
+    #undef CASE
+    }
+    
+    void Vertex::set_nx(float to) {
+        repr->v_nx[idx] = to;
+    }
+    void Vertex::set_ny(float to) {
+        repr->v_ny[idx] = to;
+    }
+    void Vertex::set_nz(float to) {  //  curr normal
+        repr->v_nz[idx] = to;
+    }
+    void Vertex::set_origarea(float to) {
+        repr->v_origarea[idx] = to;
+    }
+    void Vertex::set_neg(char to) {  //  1 if the normal vector is inverted 
+        repr->v_neg[idx] = to;
+    }
+    void Vertex::set_border(char to) {  //  flag 
+        repr->v_border[idx] = to;
+    }
+    void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
+        repr->v_ripflag[idx] = to;
+    }
+
+
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
+
+    int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nvertices;
+    }
+    int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nfaces;
+    }
+    float Surface::xctr() const {
+        return repr->xctr;
+    }
+    float Surface::yctr() const {
+        return repr->yctr;
+    }
+    float Surface::zctr() const {
+        return repr->zctr;
+    }
+    float Surface::xlo() const {
+        return repr->xlo;
+    }
+    float Surface::ylo() const {
+        return repr->ylo;
+    }
+    float Surface::zlo() const {
+        return repr->zlo;
+    }
+    float Surface::xhi() const {
+        return repr->xhi;
+    }
+    float Surface::yhi() const {
+        return repr->yhi;
+    }
+    float Surface::zhi() const {
+        return repr->zhi;
+    }
+    float Surface::total_area() const {
+        return repr->total_area;
+    }
+    double Surface::avg_vertex_area() const {
+        return repr->avg_vertex_area;
+    }
+    double Surface::avg_vertex_dist() const {  //  set by MRIScomputeAvgInterVertexDist
+        return repr->avg_vertex_dist;
+    }
+    double Surface::std_vertex_dist() const {
+        return repr->std_vertex_dist;
+    }
+    float Surface::neg_area() const {
+        return repr->neg_area;
+    }
+    float Surface::neg_orig_area() const {  //  amount of original surface in folds
+        return repr->neg_orig_area;
+    }
+    double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
+        return repr->radius;
+    }
+    MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
+        return repr->status;
+    }
+    MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        return repr->origxyz_status;
+    }
+    
+    void Surface::set_xctr(float to) {
+        repr->xctr = to;
+    }
+    void Surface::set_yctr(float to) {
+        repr->yctr = to;
+    }
+    void Surface::set_zctr(float to) {
+        repr->zctr = to;
+    }
+    void Surface::set_xlo(float to) {
+        repr->xlo = to;
+    }
+    void Surface::set_ylo(float to) {
+        repr->ylo = to;
+    }
+    void Surface::set_zlo(float to) {
+        repr->zlo = to;
+    }
+    void Surface::set_xhi(float to) {
+        repr->xhi = to;
+    }
+    void Surface::set_yhi(float to) {
+        repr->yhi = to;
+    }
+    void Surface::set_zhi(float to) {
+        repr->zhi = to;
+    }
+    void Surface::set_total_area(float to) {
+        repr->total_area = to;
+    }
+    void Surface::set_avg_vertex_area(double to) {
+        repr->avg_vertex_area = to;
+    }
+
+
+    } // namespace Analysis
+
+
+    namespace ExistenceM {
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
+
+    char Face::ripflag() const {
+        return repr->f_ripflag[idx];
+    }
+    
+    void Face::set_ripflag(char to) {
+        repr->f_ripflag[idx] = to;
+    }
+
+
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
+
+    char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
+        return repr->v_ripflag[idx];
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+    
+    #define CASE(WHICH, FIELD) \
+      case WHICH: \
+        *x = this->FIELD##x();  *y = this->FIELD##y();  *z = this->FIELD##z(); \
+        break;
+    
+      switch (which) {
+        default:
+          ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
+          break;
+      }
+    
+    #undef CASE
+    }
+    
+    void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
+        repr->v_ripflag[idx] = to;
+    }
+
+
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
+
+    double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
+        return repr->radius;
+    }
+    MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
+        return repr->status;
+    }
+    MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        return repr->origxyz_status;
+    }
+    
+    void Surface::set_status(MRIS_Status to) {  //  type of surface (e.g. sphere, plane)
+        repr->status = to;
+    }
+    void Surface::set_origxyz_status(MRIS_Status to) {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        repr->origxyz_status = to;
+    }
+
+
+    } // namespace ExistenceM
+
+
+    namespace TopologyM {
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
+
+    char Face::ripflag() const {
+        return repr->f_ripflag[idx];
+    }
+    
+    void Face::set_ripflag(char to) {
+        repr->f_ripflag[idx] = to;
+    }
+
+
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
+
+    char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
+        return repr->v_ripflag[idx];
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+    
+    #define CASE(WHICH, FIELD) \
+      case WHICH: \
+        *x = this->FIELD##x();  *y = this->FIELD##y();  *z = this->FIELD##z(); \
+        break;
+    
+      switch (which) {
+        default:
+          ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
+          break;
+      }
+    
+    #undef CASE
+    }
+    
+    void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
+        repr->v_ripflag[idx] = to;
+    }
+
+
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
+
+    int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nvertices;
+    }
+    int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nfaces;
+    }
+    double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
+        return repr->radius;
+    }
+    MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
+        return repr->status;
+    }
+    MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        return repr->origxyz_status;
+    }
+
+
+    } // namespace TopologyM
+
+
+    namespace XYZPositionM {
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
+
+    char Face::ripflag() const {
+        return repr->f_ripflag[idx];
+    }
+    
+    void Face::set_ripflag(char to) {
+        repr->f_ripflag[idx] = to;
+    }
+
+
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
+
+    float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        return repr->v_dist[idx][i];
+    }
+    int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
+        return repr->v_dist_capacity[idx];
+    }
+    float Vertex::x() const {  //  current coordinates	
+        return repr->v_x[idx];
+    }
+    float Vertex::y() const {  //  use MRISsetXYZ() to set
+        return repr->v_y[idx];
+    }
+    float Vertex::z() const {
+        return repr->v_z[idx];
+    }
+    char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
+        return repr->v_ripflag[idx];
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+    
+    #define CASE(WHICH, FIELD) \
+      case WHICH: \
+        *x = this->FIELD##x();  *y = this->FIELD##y();  *z = this->FIELD##z(); \
+        break;
+    
+      switch (which) {
+        CASE(CURRENT_VERTICES,)
+        default:
+          ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
+          break;
+      }
+    
+    #undef CASE
+    }
+    
+    void Vertex::set_x(float to) {  //  current coordinates	
+        repr->v_x[idx] = to;
+    }
+    void Vertex::set_y(float to) {  //  use MRISsetXYZ() to set
+        repr->v_y[idx] = to;
+    }
+    void Vertex::set_z(float to) {
+        repr->v_z[idx] = to;
+    }
+    void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
+        repr->v_ripflag[idx] = to;
+    }
+
+
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
+
+    int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nvertices;
+    }
+    int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nfaces;
+    }
+    double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
+        return repr->radius;
+    }
+    MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
+        return repr->status;
+    }
+    MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        return repr->origxyz_status;
+    }
+
+
+    } // namespace XYZPositionM
+
+
+    namespace XYZPositionConsequencesM {
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
+
+    float Face::area() const {
+        return repr->f_area[idx];
+    }
+    angles_per_triangle_t Face::angle() const {
+        return repr->f_angle[idx];
+    }
+    char Face::ripflag() const {
+        return repr->f_ripflag[idx];
+    }
+    PDMATRIX Face::norm() const {
+        return repr->f_norm[idx];
+    }
+    
+    void Face::set_area(float to) {
+        repr->f_area[idx] = to;
+    }
+    void Face::set_angle(angles_per_triangle_t to) {
+        repr->f_angle[idx] = to;
+    }
+    void Face::set_ripflag(char to) {
+        repr->f_ripflag[idx] = to;
+    }
+    void Face::set_norm(PDMATRIX to) {
+        repr->f_norm[idx] = to;
+    }
+
+
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
+
+    float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        return repr->v_dist[idx][i];
+    }
+    int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
+        return repr->v_dist_capacity[idx];
+    }
+    float Vertex::x() const {  //  current coordinates	
+        return repr->v_x[idx];
+    }
+    float Vertex::y() const {  //  use MRISsetXYZ() to set
+        return repr->v_y[idx];
+    }
+    float Vertex::z() const {
+        return repr->v_z[idx];
+    }
+    float Vertex::nx() const {
+        return repr->v_nx[idx];
+    }
+    float Vertex::ny() const {
+        return repr->v_ny[idx];
+    }
+    float Vertex::nz() const {  //  curr normal
+        return repr->v_nz[idx];
+    }
+    float Vertex::area() const {
+        return repr->v_area[idx];
+    }
+    char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
+        return repr->v_ripflag[idx];
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+    
+    #define CASE(WHICH, FIELD) \
+      case WHICH: \
+        *x = this->FIELD##x();  *y = this->FIELD##y();  *z = this->FIELD##z(); \
+        break;
+    
+      switch (which) {
+        CASE(CURRENT_VERTICES,)
+        CASE(VERTEX_NORMALS,n)
+        default:
+          ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
+          break;
+      }
+    
+    #undef CASE
+    }
+    
+    void Vertex::set_nx(float to) {
+        repr->v_nx[idx] = to;
+    }
+    void Vertex::set_ny(float to) {
+        repr->v_ny[idx] = to;
+    }
+    void Vertex::set_nz(float to) {  //  curr normal
+        repr->v_nz[idx] = to;
+    }
+    void Vertex::set_area(float to) {
+        repr->v_area[idx] = to;
+    }
+    void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
+        repr->v_ripflag[idx] = to;
+    }
+
+
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
+
+    int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nvertices;
+    }
+    int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nfaces;
+    }
+    float Surface::xctr() const {
+        return repr->xctr;
+    }
+    float Surface::yctr() const {
+        return repr->yctr;
+    }
+    float Surface::zctr() const {
+        return repr->zctr;
+    }
+    float Surface::xlo() const {
+        return repr->xlo;
+    }
+    float Surface::ylo() const {
+        return repr->ylo;
+    }
+    float Surface::zlo() const {
+        return repr->zlo;
+    }
+    float Surface::xhi() const {
+        return repr->xhi;
+    }
+    float Surface::yhi() const {
+        return repr->yhi;
+    }
+    float Surface::zhi() const {
+        return repr->zhi;
+    }
+    float Surface::total_area() const {
+        return repr->total_area;
+    }
+    double Surface::avg_vertex_area() const {
+        return repr->avg_vertex_area;
+    }
+    double Surface::avg_vertex_dist() const {  //  set by MRIScomputeAvgInterVertexDist
+        return repr->avg_vertex_dist;
+    }
+    double Surface::std_vertex_dist() const {
+        return repr->std_vertex_dist;
+    }
+    float Surface::neg_area() const {
+        return repr->neg_area;
+    }
+    float Surface::neg_orig_area() const {  //  amount of original surface in folds
+        return repr->neg_orig_area;
+    }
+    double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
+        return repr->radius;
+    }
+    MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
+        return repr->status;
+    }
+    MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        return repr->origxyz_status;
+    }
+    
+    void Surface::set_xctr(float to) {
+        repr->xctr = to;
+    }
+    void Surface::set_yctr(float to) {
+        repr->yctr = to;
+    }
+    void Surface::set_zctr(float to) {
+        repr->zctr = to;
+    }
+    void Surface::set_xlo(float to) {
+        repr->xlo = to;
+    }
+    void Surface::set_ylo(float to) {
+        repr->ylo = to;
+    }
+    void Surface::set_zlo(float to) {
+        repr->zlo = to;
+    }
+    void Surface::set_xhi(float to) {
+        repr->xhi = to;
+    }
+    void Surface::set_yhi(float to) {
+        repr->yhi = to;
+    }
+    void Surface::set_zhi(float to) {
+        repr->zhi = to;
+    }
+    void Surface::set_total_area(float to) {
+        repr->total_area = to;
+    }
+    void Surface::set_avg_vertex_area(double to) {
+        repr->avg_vertex_area = to;
+    }
+    void Surface::set_avg_vertex_dist(double to) {  //  set by MRIScomputeAvgInterVertexDist
+        repr->avg_vertex_dist = to;
+    }
+    void Surface::set_std_vertex_dist(double to) {
+        repr->std_vertex_dist = to;
+    }
+    void Surface::set_neg_area(float to) {
+        repr->neg_area = to;
+    }
+    void Surface::set_neg_orig_area(float to) {  //  amount of original surface in folds
+        repr->neg_orig_area = to;
+    }
+
+
+    } // namespace XYZPositionConsequencesM
+
+
+    namespace DistortM {
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
+
+    float Face::area() const {
+        return repr->f_area[idx];
+    }
+    angles_per_triangle_t Face::angle() const {
+        return repr->f_angle[idx];
+    }
+    char Face::ripflag() const {
+        return repr->f_ripflag[idx];
+    }
+    PDMATRIX Face::norm() const {
+        return repr->f_norm[idx];
+    }
+    
+    void Face::set_ripflag(char to) {
+        repr->f_ripflag[idx] = to;
+    }
+
+
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
+
+    float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        return repr->v_dist[idx][i];
+    }
+    int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
+        return repr->v_dist_capacity[idx];
+    }
+    float Vertex::x() const {  //  current coordinates	
+        return repr->v_x[idx];
+    }
+    float Vertex::y() const {  //  use MRISsetXYZ() to set
+        return repr->v_y[idx];
+    }
+    float Vertex::z() const {
+        return repr->v_z[idx];
+    }
+    float Vertex::nx() const {
+        return repr->v_nx[idx];
+    }
+    float Vertex::ny() const {
+        return repr->v_ny[idx];
+    }
+    float Vertex::nz() const {  //  curr normal
+        return repr->v_nz[idx];
+    }
+    float Vertex::area() const {
+        return repr->v_area[idx];
+    }
+    float Vertex::origarea() const {
+        return repr->v_origarea[idx];
+    }
+    char Vertex::neg() const {  //  1 if the normal vector is inverted 
+        return repr->v_neg[idx];
+    }
+    char Vertex::border() const {  //  flag 
+        return repr->v_border[idx];
+    }
+    char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
+        return repr->v_ripflag[idx];
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+    
+    #define CASE(WHICH, FIELD) \
+      case WHICH: \
+        *x = this->FIELD##x();  *y = this->FIELD##y();  *z = this->FIELD##z(); \
+        break;
+    
+      switch (which) {
+        CASE(CURRENT_VERTICES,)
+        CASE(VERTEX_NORMALS,n)
+        default:
+          ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
+          break;
+      }
+    
+    #undef CASE
+    }
+    
+    void Vertex::set_nx(float to) {
+        repr->v_nx[idx] = to;
+    }
+    void Vertex::set_ny(float to) {
+        repr->v_ny[idx] = to;
+    }
+    void Vertex::set_nz(float to) {  //  curr normal
+        repr->v_nz[idx] = to;
+    }
+    void Vertex::set_origarea(float to) {
+        repr->v_origarea[idx] = to;
+    }
+    void Vertex::set_neg(char to) {  //  1 if the normal vector is inverted 
+        repr->v_neg[idx] = to;
+    }
+    void Vertex::set_border(char to) {  //  flag 
+        repr->v_border[idx] = to;
+    }
+    void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
+        repr->v_ripflag[idx] = to;
+    }
+
+
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
+
+    int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nvertices;
+    }
+    int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nfaces;
+    }
+    float Surface::xctr() const {
+        return repr->xctr;
+    }
+    float Surface::yctr() const {
+        return repr->yctr;
+    }
+    float Surface::zctr() const {
+        return repr->zctr;
+    }
+    float Surface::xlo() const {
+        return repr->xlo;
+    }
+    float Surface::ylo() const {
+        return repr->ylo;
+    }
+    float Surface::zlo() const {
+        return repr->zlo;
+    }
+    float Surface::xhi() const {
+        return repr->xhi;
+    }
+    float Surface::yhi() const {
+        return repr->yhi;
+    }
+    float Surface::zhi() const {
+        return repr->zhi;
+    }
+    float Surface::total_area() const {
+        return repr->total_area;
+    }
+    double Surface::avg_vertex_area() const {
+        return repr->avg_vertex_area;
+    }
+    double Surface::avg_vertex_dist() const {  //  set by MRIScomputeAvgInterVertexDist
+        return repr->avg_vertex_dist;
+    }
+    double Surface::std_vertex_dist() const {
+        return repr->std_vertex_dist;
+    }
+    float Surface::neg_area() const {
+        return repr->neg_area;
+    }
+    float Surface::neg_orig_area() const {  //  amount of original surface in folds
+        return repr->neg_orig_area;
+    }
+    double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
+        return repr->radius;
+    }
+    MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
+        return repr->status;
+    }
+    MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        return repr->origxyz_status;
+    }
+    
+    void Surface::set_xctr(float to) {
+        repr->xctr = to;
+    }
+    void Surface::set_yctr(float to) {
+        repr->yctr = to;
+    }
+    void Surface::set_zctr(float to) {
+        repr->zctr = to;
+    }
+    void Surface::set_xlo(float to) {
+        repr->xlo = to;
+    }
+    void Surface::set_ylo(float to) {
+        repr->ylo = to;
+    }
+    void Surface::set_zlo(float to) {
+        repr->zlo = to;
+    }
+    void Surface::set_xhi(float to) {
+        repr->xhi = to;
+    }
+    void Surface::set_yhi(float to) {
+        repr->yhi = to;
+    }
+    void Surface::set_zhi(float to) {
+        repr->zhi = to;
+    }
+    void Surface::set_total_area(float to) {
+        repr->total_area = to;
+    }
+    void Surface::set_avg_vertex_area(double to) {
+        repr->avg_vertex_area = to;
+    }
+
+
+    } // namespace DistortM
+
+
+    namespace AnalysisM {
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
+
+    float Face::area() const {
+        return repr->f_area[idx];
+    }
+    angles_per_triangle_t Face::angle() const {
+        return repr->f_angle[idx];
+    }
+    char Face::ripflag() const {
+        return repr->f_ripflag[idx];
+    }
+    PDMATRIX Face::norm() const {
+        return repr->f_norm[idx];
+    }
+    
+    void Face::set_ripflag(char to) {
+        repr->f_ripflag[idx] = to;
+    }
+
+
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
+
+    float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        return repr->v_dist[idx][i];
+    }
+    int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
+        return repr->v_dist_capacity[idx];
+    }
+    float Vertex::x() const {  //  current coordinates	
+        return repr->v_x[idx];
+    }
+    float Vertex::y() const {  //  use MRISsetXYZ() to set
+        return repr->v_y[idx];
+    }
+    float Vertex::z() const {
+        return repr->v_z[idx];
+    }
+    float Vertex::nx() const {
+        return repr->v_nx[idx];
+    }
+    float Vertex::ny() const {
+        return repr->v_ny[idx];
+    }
+    float Vertex::nz() const {  //  curr normal
+        return repr->v_nz[idx];
+    }
+    float Vertex::area() const {
+        return repr->v_area[idx];
+    }
+    float Vertex::origarea() const {
+        return repr->v_origarea[idx];
+    }
+    char Vertex::neg() const {  //  1 if the normal vector is inverted 
+        return repr->v_neg[idx];
+    }
+    char Vertex::border() const {  //  flag 
+        return repr->v_border[idx];
+    }
+    char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
+        return repr->v_ripflag[idx];
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+    
+    #define CASE(WHICH, FIELD) \
+      case WHICH: \
+        *x = this->FIELD##x();  *y = this->FIELD##y();  *z = this->FIELD##z(); \
+        break;
+    
+      switch (which) {
+        CASE(CURRENT_VERTICES,)
+        CASE(VERTEX_NORMALS,n)
+        default:
+          ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
+          break;
+      }
+    
+    #undef CASE
+    }
+    
+    void Vertex::set_nx(float to) {
+        repr->v_nx[idx] = to;
+    }
+    void Vertex::set_ny(float to) {
+        repr->v_ny[idx] = to;
+    }
+    void Vertex::set_nz(float to) {  //  curr normal
+        repr->v_nz[idx] = to;
+    }
+    void Vertex::set_origarea(float to) {
+        repr->v_origarea[idx] = to;
+    }
+    void Vertex::set_neg(char to) {  //  1 if the normal vector is inverted 
+        repr->v_neg[idx] = to;
+    }
+    void Vertex::set_border(char to) {  //  flag 
+        repr->v_border[idx] = to;
+    }
+    void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
+        repr->v_ripflag[idx] = to;
+    }
+
+
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
+
+    int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nvertices;
+    }
+    int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nfaces;
+    }
+    float Surface::xctr() const {
+        return repr->xctr;
+    }
+    float Surface::yctr() const {
+        return repr->yctr;
+    }
+    float Surface::zctr() const {
+        return repr->zctr;
+    }
+    float Surface::xlo() const {
+        return repr->xlo;
+    }
+    float Surface::ylo() const {
+        return repr->ylo;
+    }
+    float Surface::zlo() const {
+        return repr->zlo;
+    }
+    float Surface::xhi() const {
+        return repr->xhi;
+    }
+    float Surface::yhi() const {
+        return repr->yhi;
+    }
+    float Surface::zhi() const {
+        return repr->zhi;
+    }
+    float Surface::total_area() const {
+        return repr->total_area;
+    }
+    double Surface::avg_vertex_area() const {
+        return repr->avg_vertex_area;
+    }
+    double Surface::avg_vertex_dist() const {  //  set by MRIScomputeAvgInterVertexDist
+        return repr->avg_vertex_dist;
+    }
+    double Surface::std_vertex_dist() const {
+        return repr->std_vertex_dist;
+    }
+    float Surface::neg_area() const {
+        return repr->neg_area;
+    }
+    float Surface::neg_orig_area() const {  //  amount of original surface in folds
+        return repr->neg_orig_area;
+    }
+    double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
+        return repr->radius;
+    }
+    MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
+        return repr->status;
+    }
+    MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        return repr->origxyz_status;
+    }
+    
+    void Surface::set_xctr(float to) {
+        repr->xctr = to;
+    }
+    void Surface::set_yctr(float to) {
+        repr->yctr = to;
+    }
+    void Surface::set_zctr(float to) {
+        repr->zctr = to;
+    }
+    void Surface::set_xlo(float to) {
+        repr->xlo = to;
+    }
+    void Surface::set_ylo(float to) {
+        repr->ylo = to;
+    }
+    void Surface::set_zlo(float to) {
+        repr->zlo = to;
+    }
+    void Surface::set_xhi(float to) {
+        repr->xhi = to;
+    }
+    void Surface::set_yhi(float to) {
+        repr->yhi = to;
+    }
+    void Surface::set_zhi(float to) {
+        repr->zhi = to;
+    }
+    void Surface::set_total_area(float to) {
+        repr->total_area = to;
+    }
+    void Surface::set_avg_vertex_area(double to) {
+        repr->avg_vertex_area = to;
+    }
+
+
+    } // namespace AnalysisM
+
+
+    namespace AllM {
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+
+    float Face::area() const {
+        return repr->f_area[idx];
+    }
+    angles_per_triangle_t Face::angle() const {
+        return repr->f_angle[idx];
+    }
+    char Face::ripflag() const {
+        return repr->f_ripflag[idx];
+    }
+    PDMATRIX Face::norm() const {
+        return repr->f_norm[idx];
+    }
+    
+    void Face::set_area(float to) {
+        repr->f_area[idx] = to;
+    }
+    void Face::set_angle(angles_per_triangle_t to) {
+        repr->f_angle[idx] = to;
+    }
+    void Face::set_ripflag(char to) {
+        repr->f_ripflag[idx] = to;
+    }
+    void Face::set_norm(PDMATRIX to) {
+        repr->f_norm[idx] = to;
+    }
+
+
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+
+    float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        return repr->v_dist[idx][i];
+    }
+    int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
+        return repr->v_dist_capacity[idx];
+    }
+    float Vertex::x() const {  //  current coordinates	
+        return repr->v_x[idx];
+    }
+    float Vertex::y() const {  //  use MRISsetXYZ() to set
+        return repr->v_y[idx];
+    }
+    float Vertex::z() const {
+        return repr->v_z[idx];
+    }
+    float Vertex::nx() const {
+        return repr->v_nx[idx];
+    }
+    float Vertex::ny() const {
+        return repr->v_ny[idx];
+    }
+    float Vertex::nz() const {  //  curr normal
+        return repr->v_nz[idx];
+    }
+    float Vertex::area() const {
+        return repr->v_area[idx];
+    }
+    float Vertex::origarea() const {
+        return repr->v_origarea[idx];
+    }
+    char Vertex::neg() const {  //  1 if the normal vector is inverted 
+        return repr->v_neg[idx];
+    }
+    char Vertex::border() const {  //  flag 
+        return repr->v_border[idx];
+    }
+    char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
+        return repr->v_ripflag[idx];
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+    
+    #define CASE(WHICH, FIELD) \
+      case WHICH: \
+        *x = this->FIELD##x();  *y = this->FIELD##y();  *z = this->FIELD##z(); \
+        break;
+    
+      switch (which) {
+        CASE(CURRENT_VERTICES,)
+        CASE(VERTEX_NORMALS,n)
+        default:
+          ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
+          break;
+      }
+    
+    #undef CASE
+    }
+    
+    void Vertex::set_x(float to) {  //  current coordinates	
+        repr->v_x[idx] = to;
+    }
+    void Vertex::set_y(float to) {  //  use MRISsetXYZ() to set
+        repr->v_y[idx] = to;
+    }
+    void Vertex::set_z(float to) {
+        repr->v_z[idx] = to;
+    }
+    void Vertex::set_nx(float to) {
+        repr->v_nx[idx] = to;
+    }
+    void Vertex::set_ny(float to) {
+        repr->v_ny[idx] = to;
+    }
+    void Vertex::set_nz(float to) {  //  curr normal
+        repr->v_nz[idx] = to;
+    }
+    void Vertex::set_area(float to) {
+        repr->v_area[idx] = to;
+    }
+    void Vertex::set_origarea(float to) {
+        repr->v_origarea[idx] = to;
+    }
+    void Vertex::set_neg(char to) {  //  1 if the normal vector is inverted 
+        repr->v_neg[idx] = to;
+    }
+    void Vertex::set_border(char to) {  //  flag 
+        repr->v_border[idx] = to;
+    }
+    void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
+        repr->v_ripflag[idx] = to;
+    }
+
+
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+
+    int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nvertices;
+    }
+    int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        return repr->nfaces;
+    }
+    float Surface::xctr() const {
+        return repr->xctr;
+    }
+    float Surface::yctr() const {
+        return repr->yctr;
+    }
+    float Surface::zctr() const {
+        return repr->zctr;
+    }
+    float Surface::xlo() const {
+        return repr->xlo;
+    }
+    float Surface::ylo() const {
+        return repr->ylo;
+    }
+    float Surface::zlo() const {
+        return repr->zlo;
+    }
+    float Surface::xhi() const {
+        return repr->xhi;
+    }
+    float Surface::yhi() const {
+        return repr->yhi;
+    }
+    float Surface::zhi() const {
+        return repr->zhi;
+    }
+    float Surface::total_area() const {
+        return repr->total_area;
+    }
+    double Surface::avg_vertex_area() const {
+        return repr->avg_vertex_area;
+    }
+    double Surface::avg_vertex_dist() const {  //  set by MRIScomputeAvgInterVertexDist
+        return repr->avg_vertex_dist;
+    }
+    double Surface::std_vertex_dist() const {
+        return repr->std_vertex_dist;
+    }
+    float Surface::neg_area() const {
+        return repr->neg_area;
+    }
+    float Surface::neg_orig_area() const {  //  amount of original surface in folds
+        return repr->neg_orig_area;
+    }
+    double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
+        return repr->radius;
+    }
+    MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
+        return repr->status;
+    }
+    MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        return repr->origxyz_status;
+    }
+    
+    void Surface::set_xctr(float to) {
+        repr->xctr = to;
+    }
+    void Surface::set_yctr(float to) {
+        repr->yctr = to;
+    }
+    void Surface::set_zctr(float to) {
+        repr->zctr = to;
+    }
+    void Surface::set_xlo(float to) {
+        repr->xlo = to;
+    }
+    void Surface::set_ylo(float to) {
+        repr->ylo = to;
+    }
+    void Surface::set_zlo(float to) {
+        repr->zlo = to;
+    }
+    void Surface::set_xhi(float to) {
+        repr->xhi = to;
+    }
+    void Surface::set_yhi(float to) {
+        repr->yhi = to;
+    }
+    void Surface::set_zhi(float to) {
+        repr->zhi = to;
+    }
+    void Surface::set_total_area(float to) {
+        repr->total_area = to;
+    }
+    void Surface::set_avg_vertex_area(double to) {
+        repr->avg_vertex_area = to;
+    }
+    void Surface::set_avg_vertex_dist(double to) {  //  set by MRIScomputeAvgInterVertexDist
+        repr->avg_vertex_dist = to;
+    }
+    void Surface::set_std_vertex_dist(double to) {
+        repr->std_vertex_dist = to;
+    }
+    void Surface::set_neg_area(float to) {
+        repr->neg_area = to;
+    }
+    void Surface::set_neg_orig_area(float to) {  //  amount of original surface in folds
+        repr->neg_orig_area = to;
+    }
+    void Surface::set_status(MRIS_Status to) {  //  type of surface (e.g. sphere, plane)
+        repr->status = to;
+    }
+    void Surface::set_origxyz_status(MRIS_Status to) {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        repr->origxyz_status = to;
+    }
+
+
+    } // namespace AllM
+} // SurfaceFromMRISPV

--- a/include/mrisurf_SurfaceFromMRISPV_generated_suffix.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_suffix.h
@@ -113,6 +113,9 @@ namespace SurfaceFromMRISPV {
     Face::Face ( Analysis::Face const & src                 ) : Repr_Elt(src) {}
     Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
+    Vertex Face::v(size_t i) const {
+        return Vertex(repr,repr->f_v[idx][i]);
+    }
     char Face::ripflag() const {
         return repr->f_ripflag[idx];
     }
@@ -135,6 +138,12 @@ namespace SurfaceFromMRISPV {
     Vertex::Vertex ( Analysis::Vertex const & src                 ) : Repr_Elt(src) {}
     Vertex::Vertex ( AllM::Vertex const & src                     ) : Repr_Elt(src) {}
 
+    Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        return Face(repr,repr->v_f[idx][i]);
+    }
+    uchar Vertex::num() const {  //  number of neighboring faces                              
+        return repr->v_num[idx];
+    }
     char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
         return repr->v_ripflag[idx];
     }
@@ -154,6 +163,9 @@ namespace SurfaceFromMRISPV {
     #undef CASE
     }
     
+    void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        cheapAssert(repr == to.repr); repr->v_f[idx][i] = to.idx;
+    }
     void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
         repr->v_ripflag[idx] = to;
     }
@@ -177,6 +189,12 @@ namespace SurfaceFromMRISPV {
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
         return repr->nfaces;
+    }
+    Vertex Surface::vertices(size_t i) const {
+        return Vertex(repr,i);
+    }
+    Face Surface::faces(size_t i) const {
+        return Face(repr,i);
     }
     double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
         return repr->radius;
@@ -204,6 +222,9 @@ namespace SurfaceFromMRISPV {
     Face::Face ( Analysis::Face const & src                 ) : Repr_Elt(src) {}
     Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
+    Vertex Face::v(size_t i) const {
+        return Vertex(repr,repr->f_v[idx][i]);
+    }
     char Face::ripflag() const {
         return repr->f_ripflag[idx];
     }
@@ -224,6 +245,12 @@ namespace SurfaceFromMRISPV {
     Vertex::Vertex ( Analysis::Vertex const & src                 ) : Repr_Elt(src) {}
     Vertex::Vertex ( AllM::Vertex const & src                     ) : Repr_Elt(src) {}
 
+    Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        return Face(repr,repr->v_f[idx][i]);
+    }
+    uchar Vertex::num() const {  //  number of neighboring faces                              
+        return repr->v_num[idx];
+    }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         return repr->v_dist[idx][i];
     }
@@ -259,6 +286,9 @@ namespace SurfaceFromMRISPV {
     #undef CASE
     }
     
+    void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        cheapAssert(repr == to.repr); repr->v_f[idx][i] = to.idx;
+    }
     void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
         repr->v_ripflag[idx] = to;
     }
@@ -280,6 +310,12 @@ namespace SurfaceFromMRISPV {
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
         return repr->nfaces;
+    }
+    Vertex Surface::vertices(size_t i) const {
+        return Vertex(repr,i);
+    }
+    Face Surface::faces(size_t i) const {
+        return Face(repr,i);
     }
     double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
         return repr->radius;
@@ -305,6 +341,9 @@ namespace SurfaceFromMRISPV {
     Face::Face ( Analysis::Face const & src                 ) : Repr_Elt(src) {}
     Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
+    Vertex Face::v(size_t i) const {
+        return Vertex(repr,repr->f_v[idx][i]);
+    }
     float Face::area() const {
         return repr->f_area[idx];
     }
@@ -332,6 +371,12 @@ namespace SurfaceFromMRISPV {
     Vertex::Vertex ( Analysis::Vertex const & src               ) : Repr_Elt(src) {}
     Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
 
+    Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        return Face(repr,repr->v_f[idx][i]);
+    }
+    uchar Vertex::num() const {  //  number of neighboring faces                              
+        return repr->v_num[idx];
+    }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         return repr->v_dist[idx][i];
     }
@@ -380,6 +425,9 @@ namespace SurfaceFromMRISPV {
     #undef CASE
     }
     
+    void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        cheapAssert(repr == to.repr); repr->v_f[idx][i] = to.idx;
+    }
     void Vertex::set_nx(float to) {
         repr->v_nx[idx] = to;
     }
@@ -408,6 +456,12 @@ namespace SurfaceFromMRISPV {
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
         return repr->nfaces;
+    }
+    Vertex Surface::vertices(size_t i) const {
+        return Vertex(repr,i);
+    }
+    Face Surface::faces(size_t i) const {
+        return Face(repr,i);
     }
     float Surface::xctr() const {
         return repr->xctr;
@@ -510,6 +564,9 @@ namespace SurfaceFromMRISPV {
     Face::Face ( Analysis::Face const & src                 ) : Repr_Elt(src) {}
     Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
+    Vertex Face::v(size_t i) const {
+        return Vertex(repr,repr->f_v[idx][i]);
+    }
     float Face::area() const {
         return repr->f_area[idx];
     }
@@ -535,6 +592,12 @@ namespace SurfaceFromMRISPV {
     Vertex::Vertex ( Analysis::Vertex const & src               ) : Repr_Elt(src) {}
     Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
 
+    Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        return Face(repr,repr->v_f[idx][i]);
+    }
+    uchar Vertex::num() const {  //  number of neighboring faces                              
+        return repr->v_num[idx];
+    }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         return repr->v_dist[idx][i];
     }
@@ -592,6 +655,9 @@ namespace SurfaceFromMRISPV {
     #undef CASE
     }
     
+    void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        cheapAssert(repr == to.repr); repr->v_f[idx][i] = to.idx;
+    }
     void Vertex::set_nx(float to) {
         repr->v_nx[idx] = to;
     }
@@ -627,6 +693,12 @@ namespace SurfaceFromMRISPV {
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
         return repr->nfaces;
+    }
+    Vertex Surface::vertices(size_t i) const {
+        return Vertex(repr,i);
+    }
+    Face Surface::faces(size_t i) const {
+        return Face(repr,i);
     }
     float Surface::xctr() const {
         return repr->xctr;
@@ -727,6 +799,9 @@ namespace SurfaceFromMRISPV {
     Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
     Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
+    Vertex Face::v(size_t i) const {
+        return Vertex(repr,repr->f_v[idx][i]);
+    }
     float Face::area() const {
         return repr->f_area[idx];
     }
@@ -750,6 +825,12 @@ namespace SurfaceFromMRISPV {
     Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
     Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
 
+    Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        return Face(repr,repr->v_f[idx][i]);
+    }
+    uchar Vertex::num() const {  //  number of neighboring faces                              
+        return repr->v_num[idx];
+    }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         return repr->v_dist[idx][i];
     }
@@ -807,6 +888,9 @@ namespace SurfaceFromMRISPV {
     #undef CASE
     }
     
+    void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        cheapAssert(repr == to.repr); repr->v_f[idx][i] = to.idx;
+    }
     void Vertex::set_nx(float to) {
         repr->v_nx[idx] = to;
     }
@@ -840,6 +924,12 @@ namespace SurfaceFromMRISPV {
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
         return repr->nfaces;
+    }
+    Vertex Surface::vertices(size_t i) const {
+        return Vertex(repr,i);
+    }
+    Face Surface::faces(size_t i) const {
+        return Face(repr,i);
     }
     float Surface::xctr() const {
         return repr->xctr;
@@ -1010,10 +1100,16 @@ namespace SurfaceFromMRISPV {
     Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
     Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
+    Vertex Face::v(size_t i) const {
+        return Vertex(repr,repr->f_v[idx][i]);
+    }
     char Face::ripflag() const {
         return repr->f_ripflag[idx];
     }
     
+    void Face::set_v(size_t i, Vertex to) {
+        cheapAssert(repr == to.repr); repr->f_v[idx][i] = to.idx;
+    }
     void Face::set_ripflag(char to) {
         repr->f_ripflag[idx] = to;
     }
@@ -1024,6 +1120,12 @@ namespace SurfaceFromMRISPV {
     Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
     Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
 
+    Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        return Face(repr,repr->v_f[idx][i]);
+    }
+    uchar Vertex::num() const {  //  number of neighboring faces                              
+        return repr->v_num[idx];
+    }
     char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
         return repr->v_ripflag[idx];
     }
@@ -1043,6 +1145,12 @@ namespace SurfaceFromMRISPV {
     #undef CASE
     }
     
+    void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        cheapAssert(repr == to.repr); repr->v_f[idx][i] = to.idx;
+    }
+    void Vertex::set_num(uchar to) {  //  number of neighboring faces                              
+        repr->v_num[idx] = to;
+    }
     void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
         repr->v_ripflag[idx] = to;
     }
@@ -1058,6 +1166,12 @@ namespace SurfaceFromMRISPV {
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
         return repr->nfaces;
+    }
+    Vertex Surface::vertices(size_t i) const {
+        return Vertex(repr,i);
+    }
+    Face Surface::faces(size_t i) const {
+        return Face(repr,i);
     }
     double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
         return repr->radius;
@@ -1079,6 +1193,9 @@ namespace SurfaceFromMRISPV {
     Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
     Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
+    Vertex Face::v(size_t i) const {
+        return Vertex(repr,repr->f_v[idx][i]);
+    }
     char Face::ripflag() const {
         return repr->f_ripflag[idx];
     }
@@ -1093,6 +1210,12 @@ namespace SurfaceFromMRISPV {
     Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
     Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
 
+    Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        return Face(repr,repr->v_f[idx][i]);
+    }
+    uchar Vertex::num() const {  //  number of neighboring faces                              
+        return repr->v_num[idx];
+    }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         return repr->v_dist[idx][i];
     }
@@ -1128,6 +1251,9 @@ namespace SurfaceFromMRISPV {
     #undef CASE
     }
     
+    void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        cheapAssert(repr == to.repr); repr->v_f[idx][i] = to.idx;
+    }
     void Vertex::set_x(float to) {  //  current coordinates	
         repr->v_x[idx] = to;
     }
@@ -1153,6 +1279,12 @@ namespace SurfaceFromMRISPV {
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
         return repr->nfaces;
     }
+    Vertex Surface::vertices(size_t i) const {
+        return Vertex(repr,i);
+    }
+    Face Surface::faces(size_t i) const {
+        return Face(repr,i);
+    }
     double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
         return repr->radius;
     }
@@ -1173,6 +1305,9 @@ namespace SurfaceFromMRISPV {
     Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
     Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
+    Vertex Face::v(size_t i) const {
+        return Vertex(repr,repr->f_v[idx][i]);
+    }
     float Face::area() const {
         return repr->f_area[idx];
     }
@@ -1205,6 +1340,12 @@ namespace SurfaceFromMRISPV {
     Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
     Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
 
+    Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        return Face(repr,repr->v_f[idx][i]);
+    }
+    uchar Vertex::num() const {  //  number of neighboring faces                              
+        return repr->v_num[idx];
+    }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         return repr->v_dist[idx][i];
     }
@@ -1253,6 +1394,9 @@ namespace SurfaceFromMRISPV {
     #undef CASE
     }
     
+    void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        cheapAssert(repr == to.repr); repr->v_f[idx][i] = to.idx;
+    }
     void Vertex::set_nx(float to) {
         repr->v_nx[idx] = to;
     }
@@ -1280,6 +1424,12 @@ namespace SurfaceFromMRISPV {
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
         return repr->nfaces;
+    }
+    Vertex Surface::vertices(size_t i) const {
+        return Vertex(repr,i);
+    }
+    Face Surface::faces(size_t i) const {
+        return Face(repr,i);
     }
     float Surface::xctr() const {
         return repr->xctr;
@@ -1392,6 +1542,9 @@ namespace SurfaceFromMRISPV {
     Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
     Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
+    Vertex Face::v(size_t i) const {
+        return Vertex(repr,repr->f_v[idx][i]);
+    }
     float Face::area() const {
         return repr->f_area[idx];
     }
@@ -1415,6 +1568,12 @@ namespace SurfaceFromMRISPV {
     Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
     Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
 
+    Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        return Face(repr,repr->v_f[idx][i]);
+    }
+    uchar Vertex::num() const {  //  number of neighboring faces                              
+        return repr->v_num[idx];
+    }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         return repr->v_dist[idx][i];
     }
@@ -1472,6 +1631,9 @@ namespace SurfaceFromMRISPV {
     #undef CASE
     }
     
+    void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        cheapAssert(repr == to.repr); repr->v_f[idx][i] = to.idx;
+    }
     void Vertex::set_nx(float to) {
         repr->v_nx[idx] = to;
     }
@@ -1505,6 +1667,12 @@ namespace SurfaceFromMRISPV {
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
         return repr->nfaces;
+    }
+    Vertex Surface::vertices(size_t i) const {
+        return Vertex(repr,i);
+    }
+    Face Surface::faces(size_t i) const {
+        return Face(repr,i);
     }
     float Surface::xctr() const {
         return repr->xctr;
@@ -1605,6 +1773,9 @@ namespace SurfaceFromMRISPV {
     Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
     Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
+    Vertex Face::v(size_t i) const {
+        return Vertex(repr,repr->f_v[idx][i]);
+    }
     float Face::area() const {
         return repr->f_area[idx];
     }
@@ -1628,6 +1799,12 @@ namespace SurfaceFromMRISPV {
     Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
     Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
 
+    Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        return Face(repr,repr->v_f[idx][i]);
+    }
+    uchar Vertex::num() const {  //  number of neighboring faces                              
+        return repr->v_num[idx];
+    }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         return repr->v_dist[idx][i];
     }
@@ -1685,6 +1862,9 @@ namespace SurfaceFromMRISPV {
     #undef CASE
     }
     
+    void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        cheapAssert(repr == to.repr); repr->v_f[idx][i] = to.idx;
+    }
     void Vertex::set_nx(float to) {
         repr->v_nx[idx] = to;
     }
@@ -1718,6 +1898,12 @@ namespace SurfaceFromMRISPV {
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
         return repr->nfaces;
+    }
+    Vertex Surface::vertices(size_t i) const {
+        return Vertex(repr,i);
+    }
+    Face Surface::faces(size_t i) const {
+        return Face(repr,i);
     }
     float Surface::xctr() const {
         return repr->xctr;
@@ -1817,6 +2003,9 @@ namespace SurfaceFromMRISPV {
     Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
     Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
 
+    Vertex Face::v(size_t i) const {
+        return Vertex(repr,repr->f_v[idx][i]);
+    }
     float Face::area() const {
         return repr->f_area[idx];
     }
@@ -1830,6 +2019,9 @@ namespace SurfaceFromMRISPV {
         return repr->f_norm[idx];
     }
     
+    void Face::set_v(size_t i, Vertex to) {
+        cheapAssert(repr == to.repr); repr->f_v[idx][i] = to.idx;
+    }
     void Face::set_area(float to) {
         repr->f_area[idx] = to;
     }
@@ -1848,6 +2040,12 @@ namespace SurfaceFromMRISPV {
     Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
     Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
 
+    Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        return Face(repr,repr->v_f[idx][i]);
+    }
+    uchar Vertex::num() const {  //  number of neighboring faces                              
+        return repr->v_num[idx];
+    }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
         return repr->v_dist[idx][i];
     }
@@ -1905,6 +2103,12 @@ namespace SurfaceFromMRISPV {
     #undef CASE
     }
     
+    void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        cheapAssert(repr == to.repr); repr->v_f[idx][i] = to.idx;
+    }
+    void Vertex::set_num(uchar to) {  //  number of neighboring faces                              
+        repr->v_num[idx] = to;
+    }
     void Vertex::set_x(float to) {  //  current coordinates	
         repr->v_x[idx] = to;
     }
@@ -1949,6 +2153,12 @@ namespace SurfaceFromMRISPV {
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
         return repr->nfaces;
+    }
+    Vertex Surface::vertices(size_t i) const {
+        return Vertex(repr,i);
+    }
+    Face Surface::faces(size_t i) const {
+        return Face(repr,i);
     }
     float Surface::xctr() const {
         return repr->xctr;

--- a/include/mrisurf_SurfaceFromMRISPV_generated_suffix.h
+++ b/include/mrisurf_SurfaceFromMRISPV_generated_suffix.h
@@ -58,6 +58,7 @@ namespace SurfaceFromMRISPV {
     
       switch (which) {
         default:
+          *x = *y = *z = 0.0;
           ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
           break;
       }
@@ -156,6 +157,7 @@ namespace SurfaceFromMRISPV {
     
       switch (which) {
         default:
+          *x = *y = *z = 0.0;
           ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
           break;
       }
@@ -279,6 +281,7 @@ namespace SurfaceFromMRISPV {
       switch (which) {
         CASE(CURRENT_VERTICES,)
         default:
+          *x = *y = *z = 0.0;
           ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
           break;
       }
@@ -418,6 +421,7 @@ namespace SurfaceFromMRISPV {
         CASE(CURRENT_VERTICES,)
         CASE(VERTEX_NORMALS,n)
         default:
+          *x = *y = *z = 0.0;
           ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
           break;
       }
@@ -648,6 +652,7 @@ namespace SurfaceFromMRISPV {
         CASE(CURRENT_VERTICES,)
         CASE(VERTEX_NORMALS,n)
         default:
+          *x = *y = *z = 0.0;
           ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
           break;
       }
@@ -881,6 +886,7 @@ namespace SurfaceFromMRISPV {
         CASE(CURRENT_VERTICES,)
         CASE(VERTEX_NORMALS,n)
         default:
+          *x = *y = *z = 0.0;
           ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
           break;
       }
@@ -1056,6 +1062,7 @@ namespace SurfaceFromMRISPV {
     
       switch (which) {
         default:
+          *x = *y = *z = 0.0;
           ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
           break;
       }
@@ -1138,6 +1145,7 @@ namespace SurfaceFromMRISPV {
     
       switch (which) {
         default:
+          *x = *y = *z = 0.0;
           ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
           break;
       }
@@ -1244,6 +1252,7 @@ namespace SurfaceFromMRISPV {
       switch (which) {
         CASE(CURRENT_VERTICES,)
         default:
+          *x = *y = *z = 0.0;
           ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
           break;
       }
@@ -1387,6 +1396,7 @@ namespace SurfaceFromMRISPV {
         CASE(CURRENT_VERTICES,)
         CASE(VERTEX_NORMALS,n)
         default:
+          *x = *y = *z = 0.0;
           ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
           break;
       }
@@ -1624,6 +1634,7 @@ namespace SurfaceFromMRISPV {
         CASE(CURRENT_VERTICES,)
         CASE(VERTEX_NORMALS,n)
         default:
+          *x = *y = *z = 0.0;
           ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
           break;
       }
@@ -1855,6 +1866,7 @@ namespace SurfaceFromMRISPV {
         CASE(CURRENT_VERTICES,)
         CASE(VERTEX_NORMALS,n)
         default:
+          *x = *y = *z = 0.0;
           ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
           break;
       }
@@ -2096,6 +2108,7 @@ namespace SurfaceFromMRISPV {
         CASE(CURRENT_VERTICES,)
         CASE(VERTEX_NORMALS,n)
         default:
+          *x = *y = *z = 0.0;
           ErrorExit(ERROR_UNSUPPORTED, "which_coords: unsupported which %d", which);
           break;
       }

--- a/include/mrisurf_SurfaceFromMRIS_generated.h
+++ b/include/mrisurf_SurfaceFromMRIS_generated.h
@@ -3,8 +3,8 @@
 // GENERATED SOURCE - DO NOT DIRECTLY EDIT
 // 
 // =======================================
-#define SEPARATE_VERTEX_TOPOLOGY
 namespace SurfaceFromMRIS {
+    typedef MRIS Representation;
     #include "mrisurf_SurfaceFromMRIS_generated_Existence.h"
     #include "mrisurf_SurfaceFromMRIS_generated_Topology.h"
     #include "mrisurf_SurfaceFromMRIS_generated_XYZPosition.h"
@@ -18,5 +18,5 @@ namespace SurfaceFromMRIS {
     #include "mrisurf_SurfaceFromMRIS_generated_DistortM.h"
     #include "mrisurf_SurfaceFromMRIS_generated_AnalysisM.h"
     #include "mrisurf_SurfaceFromMRIS_generated_AllM.h"
-} // namespace SurfaceFromMRIS
+} // SurfaceFromMRIS
 #include "./mrisurf_SurfaceFromMRIS_generated_suffix.h"

--- a/include/mrisurf_SurfaceFromMRIS_generated.h
+++ b/include/mrisurf_SurfaceFromMRIS_generated.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "./mrisurf_SurfaceFromMRIS_generated_prefix.h"
 
 // GENERATED SOURCE - DO NOT DIRECTLY EDIT

--- a/include/mrisurf_SurfaceFromMRIS_generated_AllM.h
+++ b/include/mrisurf_SurfaceFromMRIS_generated_AllM.h
@@ -1,8 +1,8 @@
     namespace AllM {
-    struct Face : public MRIS_Elt {
-        inline Face                        (                        );
-        inline Face (                        Face const & src       );
-        inline Face (                        MRIS* mris, size_t idx );
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
         int fno     () const { return idx; }
 
         inline Vertex                v          ( size_t i  ) const ;
@@ -14,7 +14,7 @@
         inline int                   marked     (           ) const ;
         inline PDMATRIX              norm       (           ) const ;
         inline A3PDMATRIX            gradNorm   (           ) const ;
-                   
+        
         inline void set_v          ( size_t i,                Vertex to ) ;
         inline void set_area       (                           float to ) ;
         inline void set_angle      (           angles_per_triangle_t to ) ;
@@ -26,423 +26,424 @@
         inline void set_gradNorm   (                      A3PDMATRIX to ) ;
     };
 
-    struct Vertex : public MRIS_Elt {
-        inline Vertex (                                               );
-        inline Vertex (                        Vertex const & src     );
-        inline Vertex (                        MRIS* mris, size_t idx );
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
         int vno       () const { return idx; }
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces            
-        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex           
-        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                                          
+        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
+        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                      
         inline Vertex v                  ( size_t i  ) const ;  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i,                     
-        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                                              
-        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                                             
-        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur                                  
-        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                                       
-        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc                              
-        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                                         
-        inline uchar  num                (           ) const ;  //  number of neighboring faces                                                  
+        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
+        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                          
+        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                         
+        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur              
+        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                   
+        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc          
+        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                     
+        inline uchar  num                (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
-        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz           
-        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz        
-        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        //           
-        inline float  x                  (           ) const ;  //  current coordinates	                                                         
-        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set                                                      
-        inline float  z                  (           ) const ;                                                                                   
-        //           
-        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status                          
-        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(,                                                     
-        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set                                          
-        //           
-        inline float  nx                 (           ) const ;                                                                                   
-        inline float  ny                 (           ) const ;                                                                                   
-        inline float  nz                 (           ) const ;  //  curr normal                                                                  
-        inline float  pnx                (           ) const ;                                                                                   
-        inline float  pny                (           ) const ;                                                                                   
-        inline float  pnz                (           ) const ;  //  pial normal                                                                  
-        //           
-        inline float  wnx                (           ) const ;                                                                                   
-        inline float  wny                (           ) const ;                                                                                   
-        inline float  wnz                (           ) const ;  //  white normal                                                                 
-        inline float  onx                (           ) const ;                                                                                   
-        inline float  ony                (           ) const ;                                                                                   
-        inline float  onz                (           ) const ;  //  original normal                                                              
-        inline float  dx                 (           ) const ;                                                                                   
-        inline float  dy                 (           ) const ;                                                                                   
-        inline float  dz                 (           ) const ;  //  current change in position                                                   
-        inline float  odx                (           ) const ;                                                                                   
-        inline float  ody                (           ) const ;                                                                                   
-        inline float  odz                (           ) const ;  //  last change of position (for momentum,                                       
-        inline float  tdx                (           ) const ;                                                                                   
-        inline float  tdy                (           ) const ;                                                                                   
-        inline float  tdz                (           ) const ;  //  temporary storage for averaging gradient                                     
-        inline float  curv               (           ) const ;  //  curr curvature                                                               
-        inline float  curvbak            (           ) const ;                                                                                   
-        inline float  val                (           ) const ;  //  scalar data value (file: rh.val, sig2-rh.w)                                  
-        inline float  imag_val           (           ) const ;  //  imaginary part of complex data value                                         
-        inline float  cx                 (           ) const ;                                                                                   
-        inline float  cy                 (           ) const ;                                                                                   
-        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system                                   
-        inline float  tx                 (           ) const ;                                                                                   
-        inline float  ty                 (           ) const ;                                                                                   
-        inline float  tz                 (           ) const ;  //  tmp coordinate storage                                                       
-        inline float  tx2                (           ) const ;                                                                                   
-        inline float  ty2                (           ) const ;                                                                                   
-        inline float  tz2                (           ) const ;  //  tmp coordinate storage                                                       
-        inline float  targx              (           ) const ;                                                                                   
-        inline float  targy              (           ) const ;                                                                                   
-        inline float  targz              (           ) const ;  //  target coordinates                                                           
-        inline float  pialx              (           ) const ;                                                                                   
-        inline float  pialy              (           ) const ;                                                                                   
-        inline float  pialz              (           ) const ;  //  pial surface coordinates                                                     
-        inline float  whitex             (           ) const ;                                                                                   
-        inline float  whitey             (           ) const ;                                                                                   
-        inline float  whitez             (           ) const ;  //  white surface coordinates                                                    
-        inline float  l4x                (           ) const ;                                                                                   
-        inline float  l4y                (           ) const ;                                                                                   
-        inline float  l4z                (           ) const ;  //  layerIV surface coordinates                                                  
-        inline float  infx               (           ) const ;                                                                                   
-        inline float  infy               (           ) const ;                                                                                   
-        inline float  infz               (           ) const ;  //  inflated coordinates                                                         
-        inline float  fx                 (           ) const ;                                                                                   
-        inline float  fy                 (           ) const ;                                                                                   
-        inline float  fz                 (           ) const ;  //  flattened coordinates                                                        
-        inline int    px                 (           ) const ;                                                                                   
-        inline int    qx                 (           ) const ;                                                                                   
-        inline int    py                 (           ) const ;                                                                                   
-        inline int    qy                 (           ) const ;                                                                                   
-        inline int    pz                 (           ) const ;                                                                                   
-        inline int    qz                 (           ) const ;  //  rational coordinates for exact calculations                                  
-        inline float  e1x                (           ) const ;                                                                                   
-        inline float  e1y                (           ) const ;                                                                                   
-        inline float  e1z                (           ) const ;  //  1st basis vector for the local tangent plane                                 
-        inline float  e2x                (           ) const ;                                                                                   
-        inline float  e2y                (           ) const ;                                                                                   
-        inline float  e2z                (           ) const ;  //  2nd basis vector for the local tangent plane                                 
-        inline float  pe1x               (           ) const ;                                                                                   
-        inline float  pe1y               (           ) const ;                                                                                   
-        inline float  pe1z               (           ) const ;  //  1st basis vector for the local tangent plane                                 
-        inline float  pe2x               (           ) const ;                                                                                   
-        inline float  pe2y               (           ) const ;                                                                                   
-        inline float  pe2z               (           ) const ;  //  2nd basis vector for the local tangent plane                                 
-        inline float  nc                 (           ) const ;  //  curr length normal comp                                                      
-        inline float  val2               (           ) const ;  //  complex comp data value (file: sig3-rh.w)                                    
-        inline float  valbak             (           ) const ;  //  scalar data stack                                                            
-        inline float  val2bak            (           ) const ;  //  complex comp data stack                                                      
-        inline float  stat               (           ) const ;  //  statistic                                                                    
-        //           
-        inline int    undefval           (           ) const ;  //  [previously dist=0]                                                          
-        inline int    old_undefval       (           ) const ;  //  for smooth_val_sparse                                                        
-        inline int    fixedval           (           ) const ;  //  [previously val=0]                                                           
-        //           
-        inline float  fieldsign          (           ) const ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs)                                 
-        inline float  fsmask             (           ) const ;  //  significance mask (file: rh.fm)                                              
-        inline float  d                  (           ) const ;  //  for distance calculations                                                    
-        inline int    annotation         (           ) const ;  //  area label (defunct--now from label file name!)                              
-        inline char   oripflag           (           ) const ;                                                                                   
-        inline char   origripflag        (           ) const ;  //  cuts flags                                                                   
-        inline p_void vp                 (           ) const ;  //  to store user's information                                                  
-        inline float  theta              (           ) const ;                                                                                   
-        inline float  phi                (           ) const ;  //  parameterization                                                             
-        inline float  area               (           ) const ;                                                                                   
-        inline float  origarea           (           ) const ;                                                                                   
-        inline float  group_avg_area     (           ) const ;                                                                                   
-        inline float  K                  (           ) const ;  //  Gaussian curvature                                                           
-        inline float  H                  (           ) const ;  //  mean curvature                                                               
-        inline float  k1                 (           ) const ;                                                                                   
-        inline float  k2                 (           ) const ;  //  the principal curvatures                                                     
-        inline float  mean               (           ) const ;                                                                                   
-        inline float  mean_imag          (           ) const ;  //  imaginary part of complex statistic                                          
-        inline float  std_error          (           ) const ;                                                                                   
-        inline uint   flags              (           ) const ;                                                                                   
-        inline int    fno                (           ) const ;  //  face that this vertex is in                                                  
-        inline int    cropped            (           ) const ;                                                                                   
-        inline short  marked             (           ) const ;  //  for a variety of uses                                                        
-        inline short  marked2            (           ) const ;                                                                                   
-        inline short  marked3            (           ) const ;                                                                                   
-        inline char   neg                (           ) const ;  //  1 if the normal vector is inverted                                           
-        inline char   border             (           ) const ;  //  flag                                                                         
-        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache     
+        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz
+        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float  x                  (           ) const ;  //  current coordinates	
+        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set
+        inline float  z                  (           ) const ;
+        // 
+        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status
+        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(, 
+        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set
+        // 
+        inline float  nx                 (           ) const ;
+        inline float  ny                 (           ) const ;
+        inline float  nz                 (           ) const ;  //  curr normal
+        inline float  pnx                (           ) const ;
+        inline float  pny                (           ) const ;
+        inline float  pnz                (           ) const ;  //  pial normal
+        // 
+        inline float  wnx                (           ) const ;
+        inline float  wny                (           ) const ;
+        inline float  wnz                (           ) const ;  //  white normal
+        inline float  onx                (           ) const ;
+        inline float  ony                (           ) const ;
+        inline float  onz                (           ) const ;  //  original normal
+        inline float  dx                 (           ) const ;
+        inline float  dy                 (           ) const ;
+        inline float  dz                 (           ) const ;  //  current change in position
+        inline float  odx                (           ) const ;
+        inline float  ody                (           ) const ;
+        inline float  odz                (           ) const ;  //  last change of position (for momentum, 
+        inline float  tdx                (           ) const ;
+        inline float  tdy                (           ) const ;
+        inline float  tdz                (           ) const ;  //  temporary storage for averaging gradient
+        inline float  curv               (           ) const ;  //  curr curvature
+        inline float  curvbak            (           ) const ;
+        inline float  val                (           ) const ;  //  scalar data value (file: rh.val, sig2-rh.w)
+        inline float  imag_val           (           ) const ;  //  imaginary part of complex data value
+        inline float  cx                 (           ) const ;
+        inline float  cy                 (           ) const ;
+        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system
+        inline float  tx                 (           ) const ;
+        inline float  ty                 (           ) const ;
+        inline float  tz                 (           ) const ;  //  tmp coordinate storage
+        inline float  t2x                (           ) const ;
+        inline float  t2y                (           ) const ;
+        inline float  t2z                (           ) const ;  //  another tmp coordinate storage
+        inline float  targx              (           ) const ;
+        inline float  targy              (           ) const ;
+        inline float  targz              (           ) const ;  //  target coordinates
+        inline float  pialx              (           ) const ;
+        inline float  pialy              (           ) const ;
+        inline float  pialz              (           ) const ;  //  pial surface coordinates
+        inline float  whitex             (           ) const ;
+        inline float  whitey             (           ) const ;
+        inline float  whitez             (           ) const ;  //  white surface coordinates
+        inline float  l4x                (           ) const ;
+        inline float  l4y                (           ) const ;
+        inline float  l4z                (           ) const ;  //  layerIV surface coordinates
+        inline float  infx               (           ) const ;
+        inline float  infy               (           ) const ;
+        inline float  infz               (           ) const ;  //  inflated coordinates
+        inline float  fx                 (           ) const ;
+        inline float  fy                 (           ) const ;
+        inline float  fz                 (           ) const ;  //  flattened coordinates
+        inline int    px                 (           ) const ;
+        inline int    qx                 (           ) const ;
+        inline int    py                 (           ) const ;
+        inline int    qy                 (           ) const ;
+        inline int    pz                 (           ) const ;
+        inline int    qz                 (           ) const ;  //  rational coordinates for exact calculations
+        inline float  e1x                (           ) const ;
+        inline float  e1y                (           ) const ;
+        inline float  e1z                (           ) const ;  //  1st basis vector for the local tangent plane
+        inline float  e2x                (           ) const ;
+        inline float  e2y                (           ) const ;
+        inline float  e2z                (           ) const ;  //  2nd basis vector for the local tangent plane
+        inline float  pe1x               (           ) const ;
+        inline float  pe1y               (           ) const ;
+        inline float  pe1z               (           ) const ;  //  1st basis vector for the local tangent plane
+        inline float  pe2x               (           ) const ;
+        inline float  pe2y               (           ) const ;
+        inline float  pe2z               (           ) const ;  //  2nd basis vector for the local tangent plane
+        inline float  nc                 (           ) const ;  //  curr length normal comp 
+        inline float  val2               (           ) const ;  //  complex comp data value (file: sig3-rh.w) 
+        inline float  valbak             (           ) const ;  //  scalar data stack 
+        inline float  val2bak            (           ) const ;  //  complex comp data stack 
+        inline float  stat               (           ) const ;  //  statistic 
+        // 
+        inline int    undefval           (           ) const ;  //  [previously dist=0] 
+        inline int    old_undefval       (           ) const ;  //  for smooth_val_sparse 
+        inline int    fixedval           (           ) const ;  //  [previously val=0] 
+        // 
+        inline float  fieldsign          (           ) const ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
+        inline float  fsmask             (           ) const ;  //  significance mask (file: rh.fm) 
+        inline float  d                  (           ) const ;  //  for distance calculations 
+        inline int    annotation         (           ) const ;  //  area label (defunct--now from label file name!) 
+        inline char   oripflag           (           ) const ;
+        inline char   origripflag        (           ) const ;  //  cuts flags 
+        inline p_void vp                 (           ) const ;  //  to store user's information 
+        inline float  theta              (           ) const ;
+        inline float  phi                (           ) const ;  //  parameterization 
+        inline float  area               (           ) const ;
+        inline float  origarea           (           ) const ;
+        inline float  group_avg_area     (           ) const ;
+        inline float  K                  (           ) const ;  //  Gaussian curvature 
+        inline float  H                  (           ) const ;  //  mean curvature 
+        inline float  k1                 (           ) const ;
+        inline float  k2                 (           ) const ;  //  the principal curvatures 
+        inline float  mean               (           ) const ;
+        inline float  mean_imag          (           ) const ;  //  imaginary part of complex statistic 
+        inline float  std_error          (           ) const ;
+        inline uint   flags              (           ) const ;
+        inline int    fno                (           ) const ;  //  face that this vertex is in 
+        inline int    cropped            (           ) const ;
+        inline short  marked             (           ) const ;  //  for a variety of uses 
+        inline short  marked2            (           ) const ;
+        inline short  marked3            (           ) const ;
+        inline char   neg                (           ) const ;  //  1 if the normal vector is inverted 
+        inline char   border             (           ) const ;  //  flag 
+        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void   which_coords       (int which, float *x, float *y, float *z) const ;
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-                   
-        inline void set_f              ( size_t i,   Face to )    ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        inline void set_n              ( size_t i, size_t to )    ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        inline void set_e              ( size_t i,    int to )                     ;  //  edge state for neighboring vertices                      
+        
+        inline void set_f              ( size_t i,   Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline void set_n              ( size_t i, size_t to ) ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
+        inline void set_e              ( size_t i,    int to ) ;  //  edge state for neighboring vertices                      
         inline void set_v              ( size_t i, Vertex to ) ;  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        inline void set_vnum           (            short to )                     ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
-        inline void set_v2num          (            short to )                     ;  //  number of 1, or 2-hop neighbors                          
-        inline void set_v3num          (            short to )                     ;  //  number of 1,2,or 3-hop neighbors                         
-        inline void set_vtotal         (            short to )                     ;  //  total # of neighbors. copy of vnum.nsizeCur              
-        inline void set_nsizeMaxClock  (            short to )                     ;  //  copy of mris->nsizeMaxClock when v#num                   
-        inline void set_nsizeMax       (            uchar to )                     ;  //  the max nsize that was used to fill in vnum etc          
-        inline void set_nsizeCur       (            uchar to )                     ;  //  index of the current v#num in vtotal                     
-        inline void set_num            (            uchar to )                     ;  //  number of neighboring faces                              
-        //         
-        inline void set_x              (            float to )                                                          ;  //  current coordinates	
-        inline void set_y              (            float to )                                                       ;  //  use MRISsetXYZ() to set
-        inline void set_z              (            float to )                                                                                    ;
-        //         
-        inline void set_nx             (            float to )                                                                                    ;
-        inline void set_ny             (            float to )                                                                                    ;
-        inline void set_nz             (            float to )                                                                   ;  //  curr normal
-        inline void set_pnx            (            float to )                                                                                    ;
-        inline void set_pny            (            float to )                                                                                    ;
-        inline void set_pnz            (            float to )                                                                   ;  //  pial normal
-        //         
-        inline void set_wnx            (            float to )                                                                                    ;
-        inline void set_wny            (            float to )                                                                                    ;
-        inline void set_wnz            (            float to )                                                                  ;  //  white normal
-        inline void set_onx            (            float to )                                                                                    ;
-        inline void set_ony            (            float to )                                                                                    ;
-        inline void set_onz            (            float to )                                                               ;  //  original normal
-        inline void set_dx             (            float to )                                                                                    ;
-        inline void set_dy             (            float to )                                                                                    ;
-        inline void set_dz             (            float to )                                                    ;  //  current change in position
-        inline void set_odx            (            float to )                                                                                    ;
-        inline void set_ody            (            float to )                                                                                    ;
-        inline void set_odz            (            float to )                                       ;  //  last change of position (for momentum, 
-        inline void set_tdx            (            float to )                                                                                    ;
-        inline void set_tdy            (            float to )                                                                                    ;
-        inline void set_tdz            (            float to )                                      ;  //  temporary storage for averaging gradient
-        inline void set_curv           (            float to )                                                                ;  //  curr curvature
-        inline void set_curvbak        (            float to )                                                                                    ;
-        inline void set_val            (            float to )                                   ;  //  scalar data value (file: rh.val, sig2-rh.w)
-        inline void set_imag_val       (            float to )                                          ;  //  imaginary part of complex data value
-        inline void set_cx             (            float to )                                                                                    ;
-        inline void set_cy             (            float to )                                                                                    ;
-        inline void set_cz             (            float to )                                    ;  //  coordinates in canonical coordinate system
-        inline void set_tx             (            float to )                                                                                    ;
-        inline void set_ty             (            float to )                                                                                    ;
-        inline void set_tz             (            float to )                                                        ;  //  tmp coordinate storage
-        inline void set_tx2            (            float to )                                                                                    ;
-        inline void set_ty2            (            float to )                                                                                    ;
-        inline void set_tz2            (            float to )                                                        ;  //  tmp coordinate storage
-        inline void set_targx          (            float to )                                                                                    ;
-        inline void set_targy          (            float to )                                                                                    ;
-        inline void set_targz          (            float to )                                                            ;  //  target coordinates
-        inline void set_pialx          (            float to )                                                                                    ;
-        inline void set_pialy          (            float to )                                                                                    ;
-        inline void set_pialz          (            float to )                                                      ;  //  pial surface coordinates
-        inline void set_whitex         (            float to )                                                                                    ;
-        inline void set_whitey         (            float to )                                                                                    ;
-        inline void set_whitez         (            float to )                                                     ;  //  white surface coordinates
-        inline void set_l4x            (            float to )                                                                                    ;
-        inline void set_l4y            (            float to )                                                                                    ;
-        inline void set_l4z            (            float to )                                                   ;  //  layerIV surface coordinates
-        inline void set_infx           (            float to )                                                                                    ;
-        inline void set_infy           (            float to )                                                                                    ;
-        inline void set_infz           (            float to )                                                          ;  //  inflated coordinates
-        inline void set_fx             (            float to )                                                                                    ;
-        inline void set_fy             (            float to )                                                                                    ;
-        inline void set_fz             (            float to )                                                         ;  //  flattened coordinates
-        inline void set_px             (              int to )                                                                                    ;
-        inline void set_qx             (              int to )                                                                                    ;
-        inline void set_py             (              int to )                                                                                    ;
-        inline void set_qy             (              int to )                                                                                    ;
-        inline void set_pz             (              int to )                                                                                    ;
-        inline void set_qz             (              int to )                                   ;  //  rational coordinates for exact calculations
-        inline void set_e1x            (            float to )                                                                                    ;
-        inline void set_e1y            (            float to )                                                                                    ;
-        inline void set_e1z            (            float to )                                  ;  //  1st basis vector for the local tangent plane
-        inline void set_e2x            (            float to )                                                                                    ;
-        inline void set_e2y            (            float to )                                                                                    ;
-        inline void set_e2z            (            float to )                                  ;  //  2nd basis vector for the local tangent plane
-        inline void set_pe1x           (            float to )                                                                                    ;
-        inline void set_pe1y           (            float to )                                                                                    ;
-        inline void set_pe1z           (            float to )                                  ;  //  1st basis vector for the local tangent plane
-        inline void set_pe2x           (            float to )                                                                                    ;
-        inline void set_pe2y           (            float to )                                                                                    ;
-        inline void set_pe2z           (            float to )                                  ;  //  2nd basis vector for the local tangent plane
-        inline void set_nc             (            float to )                                                      ;  //  curr length normal comp 
-        inline void set_val2           (            float to )                                    ;  //  complex comp data value (file: sig3-rh.w) 
-        inline void set_valbak         (            float to )                                                            ;  //  scalar data stack 
-        inline void set_val2bak        (            float to )                                                      ;  //  complex comp data stack 
-        inline void set_stat           (            float to )                                                                    ;  //  statistic 
-        //         
-        inline void set_undefval       (              int to )                                                          ;  //  [previously dist=0] 
-        inline void set_old_undefval   (              int to )                                                        ;  //  for smooth_val_sparse 
-        inline void set_fixedval       (              int to )                                                           ;  //  [previously val=0] 
-        //         
-        inline void set_fieldsign      (            float to )                                 ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
-        inline void set_fsmask         (            float to )                                              ;  //  significance mask (file: rh.fm) 
-        inline void set_d              (            float to )                                                    ;  //  for distance calculations 
-        inline void set_annotation     (              int to )                              ;  //  area label (defunct--now from label file name!) 
-        inline void set_oripflag       (             char to )                                                                                    ;
-        inline void set_origripflag    (             char to )                                                                   ;  //  cuts flags 
-        inline void set_vp             (           p_void to )                                                  ;  //  to store user's information 
-        inline void set_theta          (            float to )                                                                                    ;
-        inline void set_phi            (            float to )                                                             ;  //  parameterization 
-        inline void set_area           (            float to )                                                                                    ;
-        inline void set_origarea       (            float to )                                                                                    ;
-        inline void set_group_avg_area (            float to )                                                                                    ;
-        inline void set_K              (            float to )                                                           ;  //  Gaussian curvature 
-        inline void set_H              (            float to )                                                               ;  //  mean curvature 
-        inline void set_k1             (            float to )                                                                                    ;
-        inline void set_k2             (            float to )                                                     ;  //  the principal curvatures 
-        inline void set_mean           (            float to )                                                                                    ;
-        inline void set_mean_imag      (            float to )                                          ;  //  imaginary part of complex statistic 
-        inline void set_std_error      (            float to )                                                                                    ;
-        inline void set_flags          (             uint to )                                                                                    ;
-        inline void set_fno            (              int to )                                                  ;  //  face that this vertex is in 
-        inline void set_cropped        (              int to )                                                                                    ;
-        inline void set_marked         (            short to )                                                        ;  //  for a variety of uses 
-        inline void set_marked2        (            short to )                                                                                    ;
-        inline void set_marked3        (            short to )                                                                                    ;
-        inline void set_neg            (             char to )                                           ;  //  1 if the normal vector is inverted 
-        inline void set_border         (             char to )                                                                         ;  //  flag 
-        inline void set_ripflag        (             char to )      ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_vnum           (            short to ) ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
+        inline void set_v2num          (            short to ) ;  //  number of 1, or 2-hop neighbors                          
+        inline void set_v3num          (            short to ) ;  //  number of 1,2,or 3-hop neighbors                         
+        inline void set_vtotal         (            short to ) ;  //  total # of neighbors. copy of vnum.nsizeCur              
+        inline void set_nsizeMaxClock  (            short to ) ;  //  copy of mris->nsizeMaxClock when v#num                   
+        inline void set_nsizeMax       (            uchar to ) ;  //  the max nsize that was used to fill in vnum etc          
+        inline void set_nsizeCur       (            uchar to ) ;  //  index of the current v#num in vtotal                     
+        inline void set_num            (            uchar to ) ;  //  number of neighboring faces                              
+        // 
+        inline void set_x              (            float to ) ;  //  current coordinates	
+        inline void set_y              (            float to ) ;  //  use MRISsetXYZ() to set
+        inline void set_z              (            float to ) ;
+        // 
+        inline void set_nx             (            float to ) ;
+        inline void set_ny             (            float to ) ;
+        inline void set_nz             (            float to ) ;  //  curr normal
+        inline void set_pnx            (            float to ) ;
+        inline void set_pny            (            float to ) ;
+        inline void set_pnz            (            float to ) ;  //  pial normal
+        // 
+        inline void set_wnx            (            float to ) ;
+        inline void set_wny            (            float to ) ;
+        inline void set_wnz            (            float to ) ;  //  white normal
+        inline void set_onx            (            float to ) ;
+        inline void set_ony            (            float to ) ;
+        inline void set_onz            (            float to ) ;  //  original normal
+        inline void set_dx             (            float to ) ;
+        inline void set_dy             (            float to ) ;
+        inline void set_dz             (            float to ) ;  //  current change in position
+        inline void set_odx            (            float to ) ;
+        inline void set_ody            (            float to ) ;
+        inline void set_odz            (            float to ) ;  //  last change of position (for momentum, 
+        inline void set_tdx            (            float to ) ;
+        inline void set_tdy            (            float to ) ;
+        inline void set_tdz            (            float to ) ;  //  temporary storage for averaging gradient
+        inline void set_curv           (            float to ) ;  //  curr curvature
+        inline void set_curvbak        (            float to ) ;
+        inline void set_val            (            float to ) ;  //  scalar data value (file: rh.val, sig2-rh.w)
+        inline void set_imag_val       (            float to ) ;  //  imaginary part of complex data value
+        inline void set_cx             (            float to ) ;
+        inline void set_cy             (            float to ) ;
+        inline void set_cz             (            float to ) ;  //  coordinates in canonical coordinate system
+        inline void set_tx             (            float to ) ;
+        inline void set_ty             (            float to ) ;
+        inline void set_tz             (            float to ) ;  //  tmp coordinate storage
+        inline void set_t2x            (            float to ) ;
+        inline void set_t2y            (            float to ) ;
+        inline void set_t2z            (            float to ) ;  //  another tmp coordinate storage
+        inline void set_targx          (            float to ) ;
+        inline void set_targy          (            float to ) ;
+        inline void set_targz          (            float to ) ;  //  target coordinates
+        inline void set_pialx          (            float to ) ;
+        inline void set_pialy          (            float to ) ;
+        inline void set_pialz          (            float to ) ;  //  pial surface coordinates
+        inline void set_whitex         (            float to ) ;
+        inline void set_whitey         (            float to ) ;
+        inline void set_whitez         (            float to ) ;  //  white surface coordinates
+        inline void set_l4x            (            float to ) ;
+        inline void set_l4y            (            float to ) ;
+        inline void set_l4z            (            float to ) ;  //  layerIV surface coordinates
+        inline void set_infx           (            float to ) ;
+        inline void set_infy           (            float to ) ;
+        inline void set_infz           (            float to ) ;  //  inflated coordinates
+        inline void set_fx             (            float to ) ;
+        inline void set_fy             (            float to ) ;
+        inline void set_fz             (            float to ) ;  //  flattened coordinates
+        inline void set_px             (              int to ) ;
+        inline void set_qx             (              int to ) ;
+        inline void set_py             (              int to ) ;
+        inline void set_qy             (              int to ) ;
+        inline void set_pz             (              int to ) ;
+        inline void set_qz             (              int to ) ;  //  rational coordinates for exact calculations
+        inline void set_e1x            (            float to ) ;
+        inline void set_e1y            (            float to ) ;
+        inline void set_e1z            (            float to ) ;  //  1st basis vector for the local tangent plane
+        inline void set_e2x            (            float to ) ;
+        inline void set_e2y            (            float to ) ;
+        inline void set_e2z            (            float to ) ;  //  2nd basis vector for the local tangent plane
+        inline void set_pe1x           (            float to ) ;
+        inline void set_pe1y           (            float to ) ;
+        inline void set_pe1z           (            float to ) ;  //  1st basis vector for the local tangent plane
+        inline void set_pe2x           (            float to ) ;
+        inline void set_pe2y           (            float to ) ;
+        inline void set_pe2z           (            float to ) ;  //  2nd basis vector for the local tangent plane
+        inline void set_nc             (            float to ) ;  //  curr length normal comp 
+        inline void set_val2           (            float to ) ;  //  complex comp data value (file: sig3-rh.w) 
+        inline void set_valbak         (            float to ) ;  //  scalar data stack 
+        inline void set_val2bak        (            float to ) ;  //  complex comp data stack 
+        inline void set_stat           (            float to ) ;  //  statistic 
+        // 
+        inline void set_undefval       (              int to ) ;  //  [previously dist=0] 
+        inline void set_old_undefval   (              int to ) ;  //  for smooth_val_sparse 
+        inline void set_fixedval       (              int to ) ;  //  [previously val=0] 
+        // 
+        inline void set_fieldsign      (            float to ) ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
+        inline void set_fsmask         (            float to ) ;  //  significance mask (file: rh.fm) 
+        inline void set_d              (            float to ) ;  //  for distance calculations 
+        inline void set_annotation     (              int to ) ;  //  area label (defunct--now from label file name!) 
+        inline void set_oripflag       (             char to ) ;
+        inline void set_origripflag    (             char to ) ;  //  cuts flags 
+        inline void set_vp             (           p_void to ) ;  //  to store user's information 
+        inline void set_theta          (            float to ) ;
+        inline void set_phi            (            float to ) ;  //  parameterization 
+        inline void set_area           (            float to ) ;
+        inline void set_origarea       (            float to ) ;
+        inline void set_group_avg_area (            float to ) ;
+        inline void set_K              (            float to ) ;  //  Gaussian curvature 
+        inline void set_H              (            float to ) ;  //  mean curvature 
+        inline void set_k1             (            float to ) ;
+        inline void set_k2             (            float to ) ;  //  the principal curvatures 
+        inline void set_mean           (            float to ) ;
+        inline void set_mean_imag      (            float to ) ;  //  imaginary part of complex statistic 
+        inline void set_std_error      (            float to ) ;
+        inline void set_flags          (             uint to ) ;
+        inline void set_fno            (              int to ) ;  //  face that this vertex is in 
+        inline void set_cropped        (              int to ) ;
+        inline void set_marked         (            short to ) ;  //  for a variety of uses 
+        inline void set_marked2        (            short to ) ;
+        inline void set_marked3        (            short to ) ;
+        inline void set_neg            (             char to ) ;  //  1 if the normal vector is inverted 
+        inline void set_border         (             char to ) ;  //  flag 
+        inline void set_ripflag        (             char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
-    struct Surface : public MRIS_Elt {
-        inline Surface (                     );
-        inline Surface ( Surface const & src );
-        inline Surface ( MRIS* mris          );
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
 
         // Fields being maintained by specialist functions
-        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen                                                                                     
-        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al                                          
-        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al                                             
-        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons                                                             
-        inline int                   nedges                   (           ) const ;  //  # of edges on surface                                                                                                  
-        inline int                   nstrips                  (           ) const ;                                                                                                                             
-        inline Vertex                vertices                 ( size_t i  ) const ;                                                                                                                             
-        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored                          
-        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored                     
-        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use                                                
-        inline Face                  faces                    ( size_t i  ) const ;                                                                                                                             
-        inline MRI_EDGE              edges                    ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;                                                                                                                             
-        inline STRIP                 strips                   ( size_t i  ) const ;                                                                                                                             
-        inline float                 xctr                     (           ) const ;                                                                                                                             
-        inline float                 yctr                     (           ) const ;                                                                                                                             
-        inline float                 zctr                     (           ) const ;                                                                                                                             
-        inline float                 xlo                      (           ) const ;                                                                                                                             
-        inline float                 ylo                      (           ) const ;                                                                                                                             
-        inline float                 zlo                      (           ) const ;                                                                                                                             
-        inline float                 xhi                      (           ) const ;                                                                                                                             
-        inline float                 yhi                      (           ) const ;                                                                                                                             
-        inline float                 zhi                      (           ) const ;                                                                                                                             
-        inline float                 x0                       (           ) const ;  //  center of spherical expansion                                                                                          
-        inline float                 y0                       (           ) const ;                                                                                                                             
-        inline float                 z0                       (           ) const ;                                                                                                                             
-        inline Vertex                v_temporal_pole          (           ) const ;                                                                                                                             
-        inline Vertex                v_frontal_pole           (           ) const ;                                                                                                                             
-        inline Vertex                v_occipital_pole         (           ) const ;                                                                                                                             
-        inline float                 max_curv                 (           ) const ;                                                                                                                             
-        inline float                 min_curv                 (           ) const ;                                                                                                                             
-        inline float                 total_area               (           ) const ;                                                                                                                             
-        inline double                avg_vertex_area          (           ) const ;                                                                                                                             
-        inline double                avg_vertex_dist          (           ) const ;  //  set by MRIScomputeAvgInterVertexDist                                                                                   
-        inline double                std_vertex_dist          (           ) const ;                                                                                                                             
-        inline float                 orig_area                (           ) const ;                                                                                                                             
-        inline float                 neg_area                 (           ) const ;                                                                                                                             
-        inline float                 neg_orig_area            (           ) const ;  //  amount of original surface in folds                                                                                    
-        inline int                   zeros                    (           ) const ;                                                                                                                             
-        inline int                   hemisphere               (           ) const ;  //  which hemisphere                                                                                                       
-        inline int                   initialized              (           ) const ;                                                                                                                             
-        inline PLTA                  lta                      (           ) const ;                                                                                                                             
-        inline PMATRIX               SRASToTalSRAS_           (           ) const ;                                                                                                                             
-        inline PMATRIX               TalSRASToSRAS_           (           ) const ;                                                                                                                             
-        inline int                   free_transform           (           ) const ;                                                                                                                             
-        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)                                                                                        
-        inline float                 a                        (           ) const ;                                                                                                                             
-        inline float                 b                        (           ) const ;                                                                                                                             
-        inline float                 c                        (           ) const ;  //  ellipsoid parameters                                                                                                   
-        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from                                                                                     
-        inline float                 Hmin                     (           ) const ;  //  min mean curvature                                                                                                     
-        inline float                 Hmax                     (           ) const ;  //  max mean curvature                                                                                                     
-        inline float                 Kmin                     (           ) const ;  //  min Gaussian curvature                                                                                                 
-        inline float                 Kmax                     (           ) const ;  //  max Gaussian curvature                                                                                                 
-        inline double                Ktotal                   (           ) const ;  //  total Gaussian curvature                                                                                               
-        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)                                                                                   
-        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from                                              
-        inline int                   patch                    (           ) const ;  //  if a patch of the surface                                                                                              
-        inline int                   nlabels                  (           ) const ;                                                                                                                             
-        inline PMRIS_AREA_LABEL      labels                   (           ) const ;  //  nlabels of these (may be null)                                                                                         
-        inline p_void                vp                       (           ) const ;  //  for misc. use                                                                                                          
-        inline float                 alpha                    (           ) const ;  //  rotation around z-axis                                                                                                 
-        inline float                 beta                     (           ) const ;  //  rotation around y-axis                                                                                                 
-        inline float                 gamma                    (           ) const ;  //  rotation around x-axis                                                                                                 
-        inline float                 da                       (           ) const ;                                                                                                                             
-        inline float                 db                       (           ) const ;                                                                                                                             
-        inline float                 dg                       (           ) const ;  //  old deltas                                                                                                             
-        inline int                   type                     (           ) const ;  //  what type of surface was this initially                                                                                
-        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces                                               
-        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces                                               
-        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject                                                                                                    
-        inline float                 canon_area               (           ) const ;                                                                                                                             
-        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true                                                                                    
-        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)                                                                          
-        inline float                 dy2                      ( size_t i  ) const ;                                                                                                                             
-        inline float                 dz2                      ( size_t i  ) const ;                                                                                                                             
-        inline PCOLOR_TABLE          ct                       (           ) const ;                                                                                                                             
+        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen
+        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons
+        inline int                   nedges                   (           ) const ;  //  # of edges on surface
+        inline int                   nstrips                  (           ) const ;
+        inline Vertex                vertices                 ( size_t i  ) const ;
+        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
+        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
+        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use
+        inline Face                  faces                    ( size_t i  ) const ;
+        inline MRI_EDGE              edges                    ( size_t i  ) const ;
+        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;
+        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;
+        inline STRIP                 strips                   ( size_t i  ) const ;
+        inline float                 xctr                     (           ) const ;
+        inline float                 yctr                     (           ) const ;
+        inline float                 zctr                     (           ) const ;
+        inline float                 xlo                      (           ) const ;
+        inline float                 ylo                      (           ) const ;
+        inline float                 zlo                      (           ) const ;
+        inline float                 xhi                      (           ) const ;
+        inline float                 yhi                      (           ) const ;
+        inline float                 zhi                      (           ) const ;
+        inline float                 x0                       (           ) const ;  //  center of spherical expansion
+        inline float                 y0                       (           ) const ;
+        inline float                 z0                       (           ) const ;
+        inline Vertex                v_temporal_pole          (           ) const ;
+        inline Vertex                v_frontal_pole           (           ) const ;
+        inline Vertex                v_occipital_pole         (           ) const ;
+        inline float                 max_curv                 (           ) const ;
+        inline float                 min_curv                 (           ) const ;
+        inline float                 total_area               (           ) const ;
+        inline double                avg_vertex_area          (           ) const ;
+        inline double                avg_vertex_dist          (           ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double                std_vertex_dist          (           ) const ;
+        inline float                 orig_area                (           ) const ;
+        inline float                 neg_area                 (           ) const ;
+        inline float                 neg_orig_area            (           ) const ;  //  amount of original surface in folds
+        inline int                   zeros                    (           ) const ;
+        inline int                   hemisphere               (           ) const ;  //  which hemisphere
+        inline int                   initialized              (           ) const ;
+        inline PLTA                  lta                      (           ) const ;
+        inline PMATRIX               SRASToTalSRAS_           (           ) const ;
+        inline PMATRIX               TalSRASToSRAS_           (           ) const ;
+        inline int                   free_transform           (           ) const ;
+        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline float                 a                        (           ) const ;
+        inline float                 b                        (           ) const ;
+        inline float                 c                        (           ) const ;  //  ellipsoid parameters
+        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from
+        inline float                 Hmin                     (           ) const ;  //  min mean curvature
+        inline float                 Hmax                     (           ) const ;  //  max mean curvature
+        inline float                 Kmin                     (           ) const ;  //  min Gaussian curvature
+        inline float                 Kmax                     (           ) const ;  //  max Gaussian curvature
+        inline double                Ktotal                   (           ) const ;  //  total Gaussian curvature
+        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int                   patch                    (           ) const ;  //  if a patch of the surface
+        inline int                   nlabels                  (           ) const ;
+        inline PMRIS_AREA_LABEL      labels                   (           ) const ;  //  nlabels of these (may be null)
+        inline p_void                vp                       (           ) const ;  //  for misc. use
+        inline float                 alpha                    (           ) const ;  //  rotation around z-axis
+        inline float                 beta                     (           ) const ;  //  rotation around y-axis
+        inline float                 gamma                    (           ) const ;  //  rotation around x-axis
+        inline float                 da                       (           ) const ;
+        inline float                 db                       (           ) const ;
+        inline float                 dg                       (           ) const ;  //  old deltas
+        inline int                   type                     (           ) const ;  //  what type of surface was this initially
+        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
+        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
+        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject
+        inline float                 canon_area               (           ) const ;
+        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true
+        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)
+        inline float                 dy2                      ( size_t i  ) const ;
+        inline float                 dz2                      ( size_t i  ) const ;
+        inline PCOLOR_TABLE          ct                       (           ) const ;
         inline int                   useRealRAS               (           ) const ;  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1                                                 
-        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;                                                                                                                             
-        inline int                   ncmds                    (           ) const ;                                                                                                                             
-        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group                                                                                
-        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex                                                                           
-        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces                                                                                                      
-        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here                                                                               
-        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel                                                                                    
-        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for                                                                                    
-        inline p_void                mht                      (           ) const ;                                                                                                                             
-        inline p_void                temps                    (           ) const ;                                                                                                                             
-                   
-        inline void set_strips           ( size_t i,            STRIP to )                                                                                ;
-        inline void set_xctr             (                      float to )                                                                                ;
-        inline void set_yctr             (                      float to )                                                                                ;
-        inline void set_zctr             (                      float to )                                                                                ;
-        inline void set_xlo              (                      float to )                                                                                ;
-        inline void set_ylo              (                      float to )                                                                                ;
-        inline void set_zlo              (                      float to )                                                                                ;
-        inline void set_xhi              (                      float to )                                                                                ;
-        inline void set_yhi              (                      float to )                                                                                ;
-        inline void set_zhi              (                      float to )                                                                                ;
-        inline void set_x0               (                      float to )                                             ;  //  center of spherical expansion
-        inline void set_y0               (                      float to )                                                                                ;
-        inline void set_z0               (                      float to )                                                                                ;
-        inline void set_v_temporal_pole  (                     Vertex to )                                                                                ;
-        inline void set_v_frontal_pole   (                     Vertex to )                                                                                ;
-        inline void set_v_occipital_pole (                     Vertex to )                                                                                ;
-        inline void set_max_curv         (                      float to )                                                                                ;
-        inline void set_min_curv         (                      float to )                                                                                ;
-        inline void set_total_area       (                      float to )                                                                                ;
-        inline void set_avg_vertex_area  (                     double to )                                                                                ;
-        inline void set_avg_vertex_dist  (                     double to )                                      ;  //  set by MRIScomputeAvgInterVertexDist
-        inline void set_std_vertex_dist  (                     double to )                                                                                ;
-        inline void set_orig_area        (                      float to )                                                                                ;
-        inline void set_neg_area         (                      float to )                                                                                ;
-        inline void set_neg_orig_area    (                      float to )                                       ;  //  amount of original surface in folds
-        inline void set_zeros            (                        int to )                                                                                ;
-        inline void set_hemisphere       (                        int to )                                                          ;  //  which hemisphere
-        inline void set_fname            (               MRIS_fname_t to )                                        ;  //  file it was originally loaded from
-        inline void set_Hmin             (                      float to )                                                        ;  //  min mean curvature
-        inline void set_Hmax             (                      float to )                                                        ;  //  max mean curvature
-        inline void set_Kmin             (                      float to )                                                    ;  //  min Gaussian curvature
-        inline void set_Kmax             (                      float to )                                                    ;  //  max Gaussian curvature
-        inline void set_Ktotal           (                     double to )                                                  ;  //  total Gaussian curvature
-        inline void set_status           (                MRIS_Status to )                                      ;  //  type of surface (e.g. sphere, plane)
+        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1
+        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;
+        inline int                   ncmds                    (           ) const ;
+        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group
+        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex
+        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces
+        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here
+        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel
+        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for
+        inline p_void                mht                      (           ) const ;
+        inline p_void                temps                    (           ) const ;
+        
+        inline void set_strips           ( size_t i,            STRIP to ) ;
+        inline void set_xctr             (                      float to ) ;
+        inline void set_yctr             (                      float to ) ;
+        inline void set_zctr             (                      float to ) ;
+        inline void set_xlo              (                      float to ) ;
+        inline void set_ylo              (                      float to ) ;
+        inline void set_zlo              (                      float to ) ;
+        inline void set_xhi              (                      float to ) ;
+        inline void set_yhi              (                      float to ) ;
+        inline void set_zhi              (                      float to ) ;
+        inline void set_x0               (                      float to ) ;  //  center of spherical expansion
+        inline void set_y0               (                      float to ) ;
+        inline void set_z0               (                      float to ) ;
+        inline void set_v_temporal_pole  (                     Vertex to ) ;
+        inline void set_v_frontal_pole   (                     Vertex to ) ;
+        inline void set_v_occipital_pole (                     Vertex to ) ;
+        inline void set_max_curv         (                      float to ) ;
+        inline void set_min_curv         (                      float to ) ;
+        inline void set_total_area       (                      float to ) ;
+        inline void set_avg_vertex_area  (                     double to ) ;
+        inline void set_avg_vertex_dist  (                     double to ) ;  //  set by MRIScomputeAvgInterVertexDist
+        inline void set_std_vertex_dist  (                     double to ) ;
+        inline void set_orig_area        (                      float to ) ;
+        inline void set_neg_area         (                      float to ) ;
+        inline void set_neg_orig_area    (                      float to ) ;  //  amount of original surface in folds
+        inline void set_zeros            (                        int to ) ;
+        inline void set_hemisphere       (                        int to ) ;  //  which hemisphere
+        inline void set_fname            (               MRIS_fname_t to ) ;  //  file it was originally loaded from
+        inline void set_Hmin             (                      float to ) ;  //  min mean curvature
+        inline void set_Hmax             (                      float to ) ;  //  max mean curvature
+        inline void set_Kmin             (                      float to ) ;  //  min Gaussian curvature
+        inline void set_Kmax             (                      float to ) ;  //  max Gaussian curvature
+        inline void set_Ktotal           (                     double to ) ;  //  total Gaussian curvature
+        inline void set_status           (                MRIS_Status to ) ;  //  type of surface (e.g. sphere, plane)
         inline void set_origxyz_status   (                MRIS_Status to ) ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-        inline void set_patch            (                        int to )                                                 ;  //  if a patch of the surface
-        inline void set_nlabels          (                        int to )                                                                                ;
-        inline void set_labels           (           PMRIS_AREA_LABEL to )                                            ;  //  nlabels of these (may be null)
-        inline void set_vp               (                     p_void to )                                                             ;  //  for misc. use
-        inline void set_alpha            (                      float to )                                                    ;  //  rotation around z-axis
-        inline void set_beta             (                      float to )                                                    ;  //  rotation around y-axis
-        inline void set_gamma            (                      float to )                                                    ;  //  rotation around x-axis
-        inline void set_da               (                      float to )                                                                                ;
-        inline void set_db               (                      float to )                                                                                ;
-        inline void set_dg               (                      float to )                                                                ;  //  old deltas
-        inline void set_type             (                        int to )                                   ;  //  what type of surface was this initially
+        inline void set_patch            (                        int to ) ;  //  if a patch of the surface
+        inline void set_nlabels          (                        int to ) ;
+        inline void set_labels           (           PMRIS_AREA_LABEL to ) ;  //  nlabels of these (may be null)
+        inline void set_vp               (                     p_void to ) ;  //  for misc. use
+        inline void set_alpha            (                      float to ) ;  //  rotation around z-axis
+        inline void set_beta             (                      float to ) ;  //  rotation around y-axis
+        inline void set_gamma            (                      float to ) ;  //  rotation around x-axis
+        inline void set_da               (                      float to ) ;
+        inline void set_db               (                      float to ) ;
+        inline void set_dg               (                      float to ) ;  //  old deltas
+        inline void set_type             (                        int to ) ;  //  what type of surface was this initially
     };
 
     } // namespace AllM

--- a/include/mrisurf_SurfaceFromMRIS_generated_Analysis.h
+++ b/include/mrisurf_SurfaceFromMRIS_generated_Analysis.h
@@ -1,9 +1,9 @@
     namespace Analysis {
-    struct Face : public MRIS_Elt {
-        inline Face                        (                        );
-        inline Face (                        Face const & src       );
-        inline Face (                        MRIS* mris, size_t idx );
-        inline Face (                        AllM::Face const & src );
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
         inline Vertex                v          ( size_t i  ) const ;
@@ -15,408 +15,409 @@
         inline int                   marked     (           ) const ;
         inline PDMATRIX              norm       (           ) const ;
         inline A3PDMATRIX            gradNorm   (           ) const ;
-                   
+        
         inline void set_orig_angle (  angles_per_triangle_t to ) ;
         inline void set_ripflag    (                   char to ) ;
         inline void set_oripflag   (                   char to ) ;
         inline void set_marked     (                    int to ) ;
     };
 
-    struct Vertex : public MRIS_Elt {
-        inline Vertex (                                                 );
-        inline Vertex (                        Vertex const & src       );
-        inline Vertex (                        MRIS* mris, size_t idx   );
-        inline Vertex (                        AllM::Vertex const & src );
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        AllM::Vertex const & src                   );
         int vno       () const { return idx; }
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces            
-        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex           
-        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                                          
+        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
+        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                      
         inline Vertex v                  ( size_t i  ) const ;  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i,                     
-        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                                              
-        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                                             
-        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur                                  
-        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                                       
-        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc                              
-        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                                         
-        inline uchar  num                (           ) const ;  //  number of neighboring faces                                                  
+        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
+        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                          
+        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                         
+        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur              
+        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                   
+        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc          
+        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                     
+        inline uchar  num                (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
-        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz           
-        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz        
-        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        //           
-        inline float  x                  (           ) const ;  //  current coordinates	                                                         
-        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set                                                      
-        inline float  z                  (           ) const ;                                                                                   
-        //           
-        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status                          
-        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(,                                                     
-        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set                                          
-        //           
-        inline float  nx                 (           ) const ;                                                                                   
-        inline float  ny                 (           ) const ;                                                                                   
-        inline float  nz                 (           ) const ;  //  curr normal                                                                  
-        inline float  pnx                (           ) const ;                                                                                   
-        inline float  pny                (           ) const ;                                                                                   
-        inline float  pnz                (           ) const ;  //  pial normal                                                                  
-        //           
-        inline float  wnx                (           ) const ;                                                                                   
-        inline float  wny                (           ) const ;                                                                                   
-        inline float  wnz                (           ) const ;  //  white normal                                                                 
-        inline float  onx                (           ) const ;                                                                                   
-        inline float  ony                (           ) const ;                                                                                   
-        inline float  onz                (           ) const ;  //  original normal                                                              
-        inline float  dx                 (           ) const ;                                                                                   
-        inline float  dy                 (           ) const ;                                                                                   
-        inline float  dz                 (           ) const ;  //  current change in position                                                   
-        inline float  odx                (           ) const ;                                                                                   
-        inline float  ody                (           ) const ;                                                                                   
-        inline float  odz                (           ) const ;  //  last change of position (for momentum,                                       
-        inline float  tdx                (           ) const ;                                                                                   
-        inline float  tdy                (           ) const ;                                                                                   
-        inline float  tdz                (           ) const ;  //  temporary storage for averaging gradient                                     
-        inline float  curv               (           ) const ;  //  curr curvature                                                               
-        inline float  curvbak            (           ) const ;                                                                                   
-        inline float  val                (           ) const ;  //  scalar data value (file: rh.val, sig2-rh.w)                                  
-        inline float  imag_val           (           ) const ;  //  imaginary part of complex data value                                         
-        inline float  cx                 (           ) const ;                                                                                   
-        inline float  cy                 (           ) const ;                                                                                   
-        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system                                   
-        inline float  tx                 (           ) const ;                                                                                   
-        inline float  ty                 (           ) const ;                                                                                   
-        inline float  tz                 (           ) const ;  //  tmp coordinate storage                                                       
-        inline float  tx2                (           ) const ;                                                                                   
-        inline float  ty2                (           ) const ;                                                                                   
-        inline float  tz2                (           ) const ;  //  tmp coordinate storage                                                       
-        inline float  targx              (           ) const ;                                                                                   
-        inline float  targy              (           ) const ;                                                                                   
-        inline float  targz              (           ) const ;  //  target coordinates                                                           
-        inline float  pialx              (           ) const ;                                                                                   
-        inline float  pialy              (           ) const ;                                                                                   
-        inline float  pialz              (           ) const ;  //  pial surface coordinates                                                     
-        inline float  whitex             (           ) const ;                                                                                   
-        inline float  whitey             (           ) const ;                                                                                   
-        inline float  whitez             (           ) const ;  //  white surface coordinates                                                    
-        inline float  l4x                (           ) const ;                                                                                   
-        inline float  l4y                (           ) const ;                                                                                   
-        inline float  l4z                (           ) const ;  //  layerIV surface coordinates                                                  
-        inline float  infx               (           ) const ;                                                                                   
-        inline float  infy               (           ) const ;                                                                                   
-        inline float  infz               (           ) const ;  //  inflated coordinates                                                         
-        inline float  fx                 (           ) const ;                                                                                   
-        inline float  fy                 (           ) const ;                                                                                   
-        inline float  fz                 (           ) const ;  //  flattened coordinates                                                        
-        inline int    px                 (           ) const ;                                                                                   
-        inline int    qx                 (           ) const ;                                                                                   
-        inline int    py                 (           ) const ;                                                                                   
-        inline int    qy                 (           ) const ;                                                                                   
-        inline int    pz                 (           ) const ;                                                                                   
-        inline int    qz                 (           ) const ;  //  rational coordinates for exact calculations                                  
-        inline float  e1x                (           ) const ;                                                                                   
-        inline float  e1y                (           ) const ;                                                                                   
-        inline float  e1z                (           ) const ;  //  1st basis vector for the local tangent plane                                 
-        inline float  e2x                (           ) const ;                                                                                   
-        inline float  e2y                (           ) const ;                                                                                   
-        inline float  e2z                (           ) const ;  //  2nd basis vector for the local tangent plane                                 
-        inline float  pe1x               (           ) const ;                                                                                   
-        inline float  pe1y               (           ) const ;                                                                                   
-        inline float  pe1z               (           ) const ;  //  1st basis vector for the local tangent plane                                 
-        inline float  pe2x               (           ) const ;                                                                                   
-        inline float  pe2y               (           ) const ;                                                                                   
-        inline float  pe2z               (           ) const ;  //  2nd basis vector for the local tangent plane                                 
-        inline float  nc                 (           ) const ;  //  curr length normal comp                                                      
-        inline float  val2               (           ) const ;  //  complex comp data value (file: sig3-rh.w)                                    
-        inline float  valbak             (           ) const ;  //  scalar data stack                                                            
-        inline float  val2bak            (           ) const ;  //  complex comp data stack                                                      
-        inline float  stat               (           ) const ;  //  statistic                                                                    
-        //           
-        inline int    undefval           (           ) const ;  //  [previously dist=0]                                                          
-        inline int    old_undefval       (           ) const ;  //  for smooth_val_sparse                                                        
-        inline int    fixedval           (           ) const ;  //  [previously val=0]                                                           
-        //           
-        inline float  fieldsign          (           ) const ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs)                                 
-        inline float  fsmask             (           ) const ;  //  significance mask (file: rh.fm)                                              
-        inline float  d                  (           ) const ;  //  for distance calculations                                                    
-        inline int    annotation         (           ) const ;  //  area label (defunct--now from label file name!)                              
-        inline char   oripflag           (           ) const ;                                                                                   
-        inline char   origripflag        (           ) const ;  //  cuts flags                                                                   
-        inline p_void vp                 (           ) const ;  //  to store user's information                                                  
-        inline float  theta              (           ) const ;                                                                                   
-        inline float  phi                (           ) const ;  //  parameterization                                                             
-        inline float  area               (           ) const ;                                                                                   
-        inline float  origarea           (           ) const ;                                                                                   
-        inline float  group_avg_area     (           ) const ;                                                                                   
-        inline float  K                  (           ) const ;  //  Gaussian curvature                                                           
-        inline float  H                  (           ) const ;  //  mean curvature                                                               
-        inline float  k1                 (           ) const ;                                                                                   
-        inline float  k2                 (           ) const ;  //  the principal curvatures                                                     
-        inline float  mean               (           ) const ;                                                                                   
-        inline float  mean_imag          (           ) const ;  //  imaginary part of complex statistic                                          
-        inline float  std_error          (           ) const ;                                                                                   
-        inline uint   flags              (           ) const ;                                                                                   
-        inline int    fno                (           ) const ;  //  face that this vertex is in                                                  
-        inline int    cropped            (           ) const ;                                                                                   
-        inline short  marked             (           ) const ;  //  for a variety of uses                                                        
-        inline short  marked2            (           ) const ;                                                                                   
-        inline short  marked3            (           ) const ;                                                                                   
-        inline char   neg                (           ) const ;  //  1 if the normal vector is inverted                                           
-        inline char   border             (           ) const ;  //  flag                                                                         
-        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache     
+        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz
+        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float  x                  (           ) const ;  //  current coordinates	
+        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set
+        inline float  z                  (           ) const ;
+        // 
+        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status
+        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(, 
+        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set
+        // 
+        inline float  nx                 (           ) const ;
+        inline float  ny                 (           ) const ;
+        inline float  nz                 (           ) const ;  //  curr normal
+        inline float  pnx                (           ) const ;
+        inline float  pny                (           ) const ;
+        inline float  pnz                (           ) const ;  //  pial normal
+        // 
+        inline float  wnx                (           ) const ;
+        inline float  wny                (           ) const ;
+        inline float  wnz                (           ) const ;  //  white normal
+        inline float  onx                (           ) const ;
+        inline float  ony                (           ) const ;
+        inline float  onz                (           ) const ;  //  original normal
+        inline float  dx                 (           ) const ;
+        inline float  dy                 (           ) const ;
+        inline float  dz                 (           ) const ;  //  current change in position
+        inline float  odx                (           ) const ;
+        inline float  ody                (           ) const ;
+        inline float  odz                (           ) const ;  //  last change of position (for momentum, 
+        inline float  tdx                (           ) const ;
+        inline float  tdy                (           ) const ;
+        inline float  tdz                (           ) const ;  //  temporary storage for averaging gradient
+        inline float  curv               (           ) const ;  //  curr curvature
+        inline float  curvbak            (           ) const ;
+        inline float  val                (           ) const ;  //  scalar data value (file: rh.val, sig2-rh.w)
+        inline float  imag_val           (           ) const ;  //  imaginary part of complex data value
+        inline float  cx                 (           ) const ;
+        inline float  cy                 (           ) const ;
+        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system
+        inline float  tx                 (           ) const ;
+        inline float  ty                 (           ) const ;
+        inline float  tz                 (           ) const ;  //  tmp coordinate storage
+        inline float  t2x                (           ) const ;
+        inline float  t2y                (           ) const ;
+        inline float  t2z                (           ) const ;  //  another tmp coordinate storage
+        inline float  targx              (           ) const ;
+        inline float  targy              (           ) const ;
+        inline float  targz              (           ) const ;  //  target coordinates
+        inline float  pialx              (           ) const ;
+        inline float  pialy              (           ) const ;
+        inline float  pialz              (           ) const ;  //  pial surface coordinates
+        inline float  whitex             (           ) const ;
+        inline float  whitey             (           ) const ;
+        inline float  whitez             (           ) const ;  //  white surface coordinates
+        inline float  l4x                (           ) const ;
+        inline float  l4y                (           ) const ;
+        inline float  l4z                (           ) const ;  //  layerIV surface coordinates
+        inline float  infx               (           ) const ;
+        inline float  infy               (           ) const ;
+        inline float  infz               (           ) const ;  //  inflated coordinates
+        inline float  fx                 (           ) const ;
+        inline float  fy                 (           ) const ;
+        inline float  fz                 (           ) const ;  //  flattened coordinates
+        inline int    px                 (           ) const ;
+        inline int    qx                 (           ) const ;
+        inline int    py                 (           ) const ;
+        inline int    qy                 (           ) const ;
+        inline int    pz                 (           ) const ;
+        inline int    qz                 (           ) const ;  //  rational coordinates for exact calculations
+        inline float  e1x                (           ) const ;
+        inline float  e1y                (           ) const ;
+        inline float  e1z                (           ) const ;  //  1st basis vector for the local tangent plane
+        inline float  e2x                (           ) const ;
+        inline float  e2y                (           ) const ;
+        inline float  e2z                (           ) const ;  //  2nd basis vector for the local tangent plane
+        inline float  pe1x               (           ) const ;
+        inline float  pe1y               (           ) const ;
+        inline float  pe1z               (           ) const ;  //  1st basis vector for the local tangent plane
+        inline float  pe2x               (           ) const ;
+        inline float  pe2y               (           ) const ;
+        inline float  pe2z               (           ) const ;  //  2nd basis vector for the local tangent plane
+        inline float  nc                 (           ) const ;  //  curr length normal comp 
+        inline float  val2               (           ) const ;  //  complex comp data value (file: sig3-rh.w) 
+        inline float  valbak             (           ) const ;  //  scalar data stack 
+        inline float  val2bak            (           ) const ;  //  complex comp data stack 
+        inline float  stat               (           ) const ;  //  statistic 
+        // 
+        inline int    undefval           (           ) const ;  //  [previously dist=0] 
+        inline int    old_undefval       (           ) const ;  //  for smooth_val_sparse 
+        inline int    fixedval           (           ) const ;  //  [previously val=0] 
+        // 
+        inline float  fieldsign          (           ) const ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
+        inline float  fsmask             (           ) const ;  //  significance mask (file: rh.fm) 
+        inline float  d                  (           ) const ;  //  for distance calculations 
+        inline int    annotation         (           ) const ;  //  area label (defunct--now from label file name!) 
+        inline char   oripflag           (           ) const ;
+        inline char   origripflag        (           ) const ;  //  cuts flags 
+        inline p_void vp                 (           ) const ;  //  to store user's information 
+        inline float  theta              (           ) const ;
+        inline float  phi                (           ) const ;  //  parameterization 
+        inline float  area               (           ) const ;
+        inline float  origarea           (           ) const ;
+        inline float  group_avg_area     (           ) const ;
+        inline float  K                  (           ) const ;  //  Gaussian curvature 
+        inline float  H                  (           ) const ;  //  mean curvature 
+        inline float  k1                 (           ) const ;
+        inline float  k2                 (           ) const ;  //  the principal curvatures 
+        inline float  mean               (           ) const ;
+        inline float  mean_imag          (           ) const ;  //  imaginary part of complex statistic 
+        inline float  std_error          (           ) const ;
+        inline uint   flags              (           ) const ;
+        inline int    fno                (           ) const ;  //  face that this vertex is in 
+        inline int    cropped            (           ) const ;
+        inline short  marked             (           ) const ;  //  for a variety of uses 
+        inline short  marked2            (           ) const ;
+        inline short  marked3            (           ) const ;
+        inline char   neg                (           ) const ;  //  1 if the normal vector is inverted 
+        inline char   border             (           ) const ;  //  flag 
+        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void   which_coords       (int which, float *x, float *y, float *z) const ;
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-                   
+        
         inline void set_f              ( size_t i,   Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
         inline void set_n              ( size_t i, size_t to ) ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        inline void set_e              ( size_t i,    int to )                  ;  //  edge state for neighboring vertices                      
-        //         
-        inline void set_nx             (            float to )                                                                                 ;
-        inline void set_ny             (            float to )                                                                                 ;
-        inline void set_nz             (            float to )                                                                ;  //  curr normal
-        inline void set_pnx            (            float to )                                                                                 ;
-        inline void set_pny            (            float to )                                                                                 ;
-        inline void set_pnz            (            float to )                                                                ;  //  pial normal
-        //         
-        inline void set_wnx            (            float to )                                                                                 ;
-        inline void set_wny            (            float to )                                                                                 ;
-        inline void set_wnz            (            float to )                                                               ;  //  white normal
-        inline void set_onx            (            float to )                                                                                 ;
-        inline void set_ony            (            float to )                                                                                 ;
-        inline void set_onz            (            float to )                                                            ;  //  original normal
-        inline void set_dx             (            float to )                                                                                 ;
-        inline void set_dy             (            float to )                                                                                 ;
-        inline void set_dz             (            float to )                                                 ;  //  current change in position
-        inline void set_odx            (            float to )                                                                                 ;
-        inline void set_ody            (            float to )                                                                                 ;
-        inline void set_odz            (            float to )                                    ;  //  last change of position (for momentum, 
-        inline void set_tdx            (            float to )                                                                                 ;
-        inline void set_tdy            (            float to )                                                                                 ;
-        inline void set_tdz            (            float to )                                   ;  //  temporary storage for averaging gradient
-        inline void set_curv           (            float to )                                                             ;  //  curr curvature
-        inline void set_curvbak        (            float to )                                                                                 ;
-        inline void set_val            (            float to )                                ;  //  scalar data value (file: rh.val, sig2-rh.w)
-        inline void set_imag_val       (            float to )                                       ;  //  imaginary part of complex data value
-        inline void set_cx             (            float to )                                                                                 ;
-        inline void set_cy             (            float to )                                                                                 ;
-        inline void set_cz             (            float to )                                 ;  //  coordinates in canonical coordinate system
-        inline void set_tx             (            float to )                                                                                 ;
-        inline void set_ty             (            float to )                                                                                 ;
-        inline void set_tz             (            float to )                                                     ;  //  tmp coordinate storage
-        inline void set_tx2            (            float to )                                                                                 ;
-        inline void set_ty2            (            float to )                                                                                 ;
-        inline void set_tz2            (            float to )                                                     ;  //  tmp coordinate storage
-        inline void set_targx          (            float to )                                                                                 ;
-        inline void set_targy          (            float to )                                                                                 ;
-        inline void set_targz          (            float to )                                                         ;  //  target coordinates
-        inline void set_pialx          (            float to )                                                                                 ;
-        inline void set_pialy          (            float to )                                                                                 ;
-        inline void set_pialz          (            float to )                                                   ;  //  pial surface coordinates
-        inline void set_whitex         (            float to )                                                                                 ;
-        inline void set_whitey         (            float to )                                                                                 ;
-        inline void set_whitez         (            float to )                                                  ;  //  white surface coordinates
-        inline void set_l4x            (            float to )                                                                                 ;
-        inline void set_l4y            (            float to )                                                                                 ;
-        inline void set_l4z            (            float to )                                                ;  //  layerIV surface coordinates
-        inline void set_infx           (            float to )                                                                                 ;
-        inline void set_infy           (            float to )                                                                                 ;
-        inline void set_infz           (            float to )                                                       ;  //  inflated coordinates
-        inline void set_fx             (            float to )                                                                                 ;
-        inline void set_fy             (            float to )                                                                                 ;
-        inline void set_fz             (            float to )                                                      ;  //  flattened coordinates
-        inline void set_px             (              int to )                                                                                 ;
-        inline void set_qx             (              int to )                                                                                 ;
-        inline void set_py             (              int to )                                                                                 ;
-        inline void set_qy             (              int to )                                                                                 ;
-        inline void set_pz             (              int to )                                                                                 ;
-        inline void set_qz             (              int to )                                ;  //  rational coordinates for exact calculations
-        inline void set_e1x            (            float to )                                                                                 ;
-        inline void set_e1y            (            float to )                                                                                 ;
-        inline void set_e1z            (            float to )                               ;  //  1st basis vector for the local tangent plane
-        inline void set_e2x            (            float to )                                                                                 ;
-        inline void set_e2y            (            float to )                                                                                 ;
-        inline void set_e2z            (            float to )                               ;  //  2nd basis vector for the local tangent plane
-        inline void set_pe1x           (            float to )                                                                                 ;
-        inline void set_pe1y           (            float to )                                                                                 ;
-        inline void set_pe1z           (            float to )                               ;  //  1st basis vector for the local tangent plane
-        inline void set_pe2x           (            float to )                                                                                 ;
-        inline void set_pe2y           (            float to )                                                                                 ;
-        inline void set_pe2z           (            float to )                               ;  //  2nd basis vector for the local tangent plane
-        inline void set_nc             (            float to )                                                   ;  //  curr length normal comp 
-        inline void set_val2           (            float to )                                 ;  //  complex comp data value (file: sig3-rh.w) 
-        inline void set_valbak         (            float to )                                                         ;  //  scalar data stack 
-        inline void set_val2bak        (            float to )                                                   ;  //  complex comp data stack 
-        inline void set_stat           (            float to )                                                                 ;  //  statistic 
-        //         
-        inline void set_undefval       (              int to )                                                       ;  //  [previously dist=0] 
-        inline void set_old_undefval   (              int to )                                                     ;  //  for smooth_val_sparse 
-        inline void set_fixedval       (              int to )                                                        ;  //  [previously val=0] 
-        //         
-        inline void set_fieldsign      (            float to )                              ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
-        inline void set_fsmask         (            float to )                                           ;  //  significance mask (file: rh.fm) 
-        inline void set_d              (            float to )                                                 ;  //  for distance calculations 
-        inline void set_annotation     (              int to )                           ;  //  area label (defunct--now from label file name!) 
-        inline void set_oripflag       (             char to )                                                                                 ;
-        inline void set_origripflag    (             char to )                                                                ;  //  cuts flags 
-        inline void set_vp             (           p_void to )                                               ;  //  to store user's information 
-        inline void set_theta          (            float to )                                                                                 ;
-        inline void set_phi            (            float to )                                                          ;  //  parameterization 
-        inline void set_origarea       (            float to )                                                                                 ;
-        inline void set_group_avg_area (            float to )                                                                                 ;
-        inline void set_K              (            float to )                                                        ;  //  Gaussian curvature 
-        inline void set_H              (            float to )                                                            ;  //  mean curvature 
-        inline void set_k1             (            float to )                                                                                 ;
-        inline void set_k2             (            float to )                                                  ;  //  the principal curvatures 
-        inline void set_mean           (            float to )                                                                                 ;
-        inline void set_mean_imag      (            float to )                                       ;  //  imaginary part of complex statistic 
-        inline void set_std_error      (            float to )                                                                                 ;
-        inline void set_flags          (             uint to )                                                                                 ;
-        inline void set_fno            (              int to )                                               ;  //  face that this vertex is in 
-        inline void set_cropped        (              int to )                                                                                 ;
-        inline void set_marked         (            short to )                                                     ;  //  for a variety of uses 
-        inline void set_marked2        (            short to )                                                                                 ;
-        inline void set_marked3        (            short to )                                                                                 ;
-        inline void set_neg            (             char to )                                        ;  //  1 if the normal vector is inverted 
-        inline void set_border         (             char to )                                                                      ;  //  flag 
-        inline void set_ripflag        (             char to )   ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_e              ( size_t i,    int to ) ;  //  edge state for neighboring vertices                      
+        // 
+        inline void set_nx             (            float to ) ;
+        inline void set_ny             (            float to ) ;
+        inline void set_nz             (            float to ) ;  //  curr normal
+        inline void set_pnx            (            float to ) ;
+        inline void set_pny            (            float to ) ;
+        inline void set_pnz            (            float to ) ;  //  pial normal
+        // 
+        inline void set_wnx            (            float to ) ;
+        inline void set_wny            (            float to ) ;
+        inline void set_wnz            (            float to ) ;  //  white normal
+        inline void set_onx            (            float to ) ;
+        inline void set_ony            (            float to ) ;
+        inline void set_onz            (            float to ) ;  //  original normal
+        inline void set_dx             (            float to ) ;
+        inline void set_dy             (            float to ) ;
+        inline void set_dz             (            float to ) ;  //  current change in position
+        inline void set_odx            (            float to ) ;
+        inline void set_ody            (            float to ) ;
+        inline void set_odz            (            float to ) ;  //  last change of position (for momentum, 
+        inline void set_tdx            (            float to ) ;
+        inline void set_tdy            (            float to ) ;
+        inline void set_tdz            (            float to ) ;  //  temporary storage for averaging gradient
+        inline void set_curv           (            float to ) ;  //  curr curvature
+        inline void set_curvbak        (            float to ) ;
+        inline void set_val            (            float to ) ;  //  scalar data value (file: rh.val, sig2-rh.w)
+        inline void set_imag_val       (            float to ) ;  //  imaginary part of complex data value
+        inline void set_cx             (            float to ) ;
+        inline void set_cy             (            float to ) ;
+        inline void set_cz             (            float to ) ;  //  coordinates in canonical coordinate system
+        inline void set_tx             (            float to ) ;
+        inline void set_ty             (            float to ) ;
+        inline void set_tz             (            float to ) ;  //  tmp coordinate storage
+        inline void set_t2x            (            float to ) ;
+        inline void set_t2y            (            float to ) ;
+        inline void set_t2z            (            float to ) ;  //  another tmp coordinate storage
+        inline void set_targx          (            float to ) ;
+        inline void set_targy          (            float to ) ;
+        inline void set_targz          (            float to ) ;  //  target coordinates
+        inline void set_pialx          (            float to ) ;
+        inline void set_pialy          (            float to ) ;
+        inline void set_pialz          (            float to ) ;  //  pial surface coordinates
+        inline void set_whitex         (            float to ) ;
+        inline void set_whitey         (            float to ) ;
+        inline void set_whitez         (            float to ) ;  //  white surface coordinates
+        inline void set_l4x            (            float to ) ;
+        inline void set_l4y            (            float to ) ;
+        inline void set_l4z            (            float to ) ;  //  layerIV surface coordinates
+        inline void set_infx           (            float to ) ;
+        inline void set_infy           (            float to ) ;
+        inline void set_infz           (            float to ) ;  //  inflated coordinates
+        inline void set_fx             (            float to ) ;
+        inline void set_fy             (            float to ) ;
+        inline void set_fz             (            float to ) ;  //  flattened coordinates
+        inline void set_px             (              int to ) ;
+        inline void set_qx             (              int to ) ;
+        inline void set_py             (              int to ) ;
+        inline void set_qy             (              int to ) ;
+        inline void set_pz             (              int to ) ;
+        inline void set_qz             (              int to ) ;  //  rational coordinates for exact calculations
+        inline void set_e1x            (            float to ) ;
+        inline void set_e1y            (            float to ) ;
+        inline void set_e1z            (            float to ) ;  //  1st basis vector for the local tangent plane
+        inline void set_e2x            (            float to ) ;
+        inline void set_e2y            (            float to ) ;
+        inline void set_e2z            (            float to ) ;  //  2nd basis vector for the local tangent plane
+        inline void set_pe1x           (            float to ) ;
+        inline void set_pe1y           (            float to ) ;
+        inline void set_pe1z           (            float to ) ;  //  1st basis vector for the local tangent plane
+        inline void set_pe2x           (            float to ) ;
+        inline void set_pe2y           (            float to ) ;
+        inline void set_pe2z           (            float to ) ;  //  2nd basis vector for the local tangent plane
+        inline void set_nc             (            float to ) ;  //  curr length normal comp 
+        inline void set_val2           (            float to ) ;  //  complex comp data value (file: sig3-rh.w) 
+        inline void set_valbak         (            float to ) ;  //  scalar data stack 
+        inline void set_val2bak        (            float to ) ;  //  complex comp data stack 
+        inline void set_stat           (            float to ) ;  //  statistic 
+        // 
+        inline void set_undefval       (              int to ) ;  //  [previously dist=0] 
+        inline void set_old_undefval   (              int to ) ;  //  for smooth_val_sparse 
+        inline void set_fixedval       (              int to ) ;  //  [previously val=0] 
+        // 
+        inline void set_fieldsign      (            float to ) ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
+        inline void set_fsmask         (            float to ) ;  //  significance mask (file: rh.fm) 
+        inline void set_d              (            float to ) ;  //  for distance calculations 
+        inline void set_annotation     (              int to ) ;  //  area label (defunct--now from label file name!) 
+        inline void set_oripflag       (             char to ) ;
+        inline void set_origripflag    (             char to ) ;  //  cuts flags 
+        inline void set_vp             (           p_void to ) ;  //  to store user's information 
+        inline void set_theta          (            float to ) ;
+        inline void set_phi            (            float to ) ;  //  parameterization 
+        inline void set_origarea       (            float to ) ;
+        inline void set_group_avg_area (            float to ) ;
+        inline void set_K              (            float to ) ;  //  Gaussian curvature 
+        inline void set_H              (            float to ) ;  //  mean curvature 
+        inline void set_k1             (            float to ) ;
+        inline void set_k2             (            float to ) ;  //  the principal curvatures 
+        inline void set_mean           (            float to ) ;
+        inline void set_mean_imag      (            float to ) ;  //  imaginary part of complex statistic 
+        inline void set_std_error      (            float to ) ;
+        inline void set_flags          (             uint to ) ;
+        inline void set_fno            (              int to ) ;  //  face that this vertex is in 
+        inline void set_cropped        (              int to ) ;
+        inline void set_marked         (            short to ) ;  //  for a variety of uses 
+        inline void set_marked2        (            short to ) ;
+        inline void set_marked3        (            short to ) ;
+        inline void set_neg            (             char to ) ;  //  1 if the normal vector is inverted 
+        inline void set_border         (             char to ) ;  //  flag 
+        inline void set_ripflag        (             char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
-    struct Surface : public MRIS_Elt {
-        inline Surface (                           );
-        inline Surface ( Surface const & src       );
-        inline Surface ( MRIS* mris                );
-        inline Surface ( AllM::Surface const & src );
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
+        inline Surface ( AllM::Surface const & src      );
 
         // Fields being maintained by specialist functions
-        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen                                                                                     
-        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al                                          
-        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al                                             
-        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons                                                             
-        inline int                   nedges                   (           ) const ;  //  # of edges on surface                                                                                                  
-        inline int                   nstrips                  (           ) const ;                                                                                                                             
-        inline Vertex                vertices                 ( size_t i  ) const ;                                                                                                                             
-        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored                          
-        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored                     
-        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use                                                
-        inline Face                  faces                    ( size_t i  ) const ;                                                                                                                             
-        inline MRI_EDGE              edges                    ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;                                                                                                                             
-        inline STRIP                 strips                   ( size_t i  ) const ;                                                                                                                             
-        inline float                 xctr                     (           ) const ;                                                                                                                             
-        inline float                 yctr                     (           ) const ;                                                                                                                             
-        inline float                 zctr                     (           ) const ;                                                                                                                             
-        inline float                 xlo                      (           ) const ;                                                                                                                             
-        inline float                 ylo                      (           ) const ;                                                                                                                             
-        inline float                 zlo                      (           ) const ;                                                                                                                             
-        inline float                 xhi                      (           ) const ;                                                                                                                             
-        inline float                 yhi                      (           ) const ;                                                                                                                             
-        inline float                 zhi                      (           ) const ;                                                                                                                             
-        inline float                 x0                       (           ) const ;  //  center of spherical expansion                                                                                          
-        inline float                 y0                       (           ) const ;                                                                                                                             
-        inline float                 z0                       (           ) const ;                                                                                                                             
-        inline Vertex                v_temporal_pole          (           ) const ;                                                                                                                             
-        inline Vertex                v_frontal_pole           (           ) const ;                                                                                                                             
-        inline Vertex                v_occipital_pole         (           ) const ;                                                                                                                             
-        inline float                 max_curv                 (           ) const ;                                                                                                                             
-        inline float                 min_curv                 (           ) const ;                                                                                                                             
-        inline float                 total_area               (           ) const ;                                                                                                                             
-        inline double                avg_vertex_area          (           ) const ;                                                                                                                             
-        inline double                avg_vertex_dist          (           ) const ;  //  set by MRIScomputeAvgInterVertexDist                                                                                   
-        inline double                std_vertex_dist          (           ) const ;                                                                                                                             
-        inline float                 orig_area                (           ) const ;                                                                                                                             
-        inline float                 neg_area                 (           ) const ;                                                                                                                             
-        inline float                 neg_orig_area            (           ) const ;  //  amount of original surface in folds                                                                                    
-        inline int                   zeros                    (           ) const ;                                                                                                                             
-        inline int                   hemisphere               (           ) const ;  //  which hemisphere                                                                                                       
-        inline int                   initialized              (           ) const ;                                                                                                                             
-        inline PLTA                  lta                      (           ) const ;                                                                                                                             
-        inline PMATRIX               SRASToTalSRAS_           (           ) const ;                                                                                                                             
-        inline PMATRIX               TalSRASToSRAS_           (           ) const ;                                                                                                                             
-        inline int                   free_transform           (           ) const ;                                                                                                                             
-        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)                                                                                        
-        inline float                 a                        (           ) const ;                                                                                                                             
-        inline float                 b                        (           ) const ;                                                                                                                             
-        inline float                 c                        (           ) const ;  //  ellipsoid parameters                                                                                                   
-        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from                                                                                     
-        inline float                 Hmin                     (           ) const ;  //  min mean curvature                                                                                                     
-        inline float                 Hmax                     (           ) const ;  //  max mean curvature                                                                                                     
-        inline float                 Kmin                     (           ) const ;  //  min Gaussian curvature                                                                                                 
-        inline float                 Kmax                     (           ) const ;  //  max Gaussian curvature                                                                                                 
-        inline double                Ktotal                   (           ) const ;  //  total Gaussian curvature                                                                                               
-        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)                                                                                   
-        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from                                              
-        inline int                   patch                    (           ) const ;  //  if a patch of the surface                                                                                              
-        inline int                   nlabels                  (           ) const ;                                                                                                                             
-        inline PMRIS_AREA_LABEL      labels                   (           ) const ;  //  nlabels of these (may be null)                                                                                         
-        inline p_void                vp                       (           ) const ;  //  for misc. use                                                                                                          
-        inline float                 alpha                    (           ) const ;  //  rotation around z-axis                                                                                                 
-        inline float                 beta                     (           ) const ;  //  rotation around y-axis                                                                                                 
-        inline float                 gamma                    (           ) const ;  //  rotation around x-axis                                                                                                 
-        inline float                 da                       (           ) const ;                                                                                                                             
-        inline float                 db                       (           ) const ;                                                                                                                             
-        inline float                 dg                       (           ) const ;  //  old deltas                                                                                                             
-        inline int                   type                     (           ) const ;  //  what type of surface was this initially                                                                                
-        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces                                               
-        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces                                               
-        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject                                                                                                    
-        inline float                 canon_area               (           ) const ;                                                                                                                             
-        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true                                                                                    
-        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)                                                                          
-        inline float                 dy2                      ( size_t i  ) const ;                                                                                                                             
-        inline float                 dz2                      ( size_t i  ) const ;                                                                                                                             
-        inline PCOLOR_TABLE          ct                       (           ) const ;                                                                                                                             
+        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen
+        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons
+        inline int                   nedges                   (           ) const ;  //  # of edges on surface
+        inline int                   nstrips                  (           ) const ;
+        inline Vertex                vertices                 ( size_t i  ) const ;
+        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
+        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
+        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use
+        inline Face                  faces                    ( size_t i  ) const ;
+        inline MRI_EDGE              edges                    ( size_t i  ) const ;
+        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;
+        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;
+        inline STRIP                 strips                   ( size_t i  ) const ;
+        inline float                 xctr                     (           ) const ;
+        inline float                 yctr                     (           ) const ;
+        inline float                 zctr                     (           ) const ;
+        inline float                 xlo                      (           ) const ;
+        inline float                 ylo                      (           ) const ;
+        inline float                 zlo                      (           ) const ;
+        inline float                 xhi                      (           ) const ;
+        inline float                 yhi                      (           ) const ;
+        inline float                 zhi                      (           ) const ;
+        inline float                 x0                       (           ) const ;  //  center of spherical expansion
+        inline float                 y0                       (           ) const ;
+        inline float                 z0                       (           ) const ;
+        inline Vertex                v_temporal_pole          (           ) const ;
+        inline Vertex                v_frontal_pole           (           ) const ;
+        inline Vertex                v_occipital_pole         (           ) const ;
+        inline float                 max_curv                 (           ) const ;
+        inline float                 min_curv                 (           ) const ;
+        inline float                 total_area               (           ) const ;
+        inline double                avg_vertex_area          (           ) const ;
+        inline double                avg_vertex_dist          (           ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double                std_vertex_dist          (           ) const ;
+        inline float                 orig_area                (           ) const ;
+        inline float                 neg_area                 (           ) const ;
+        inline float                 neg_orig_area            (           ) const ;  //  amount of original surface in folds
+        inline int                   zeros                    (           ) const ;
+        inline int                   hemisphere               (           ) const ;  //  which hemisphere
+        inline int                   initialized              (           ) const ;
+        inline PLTA                  lta                      (           ) const ;
+        inline PMATRIX               SRASToTalSRAS_           (           ) const ;
+        inline PMATRIX               TalSRASToSRAS_           (           ) const ;
+        inline int                   free_transform           (           ) const ;
+        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline float                 a                        (           ) const ;
+        inline float                 b                        (           ) const ;
+        inline float                 c                        (           ) const ;  //  ellipsoid parameters
+        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from
+        inline float                 Hmin                     (           ) const ;  //  min mean curvature
+        inline float                 Hmax                     (           ) const ;  //  max mean curvature
+        inline float                 Kmin                     (           ) const ;  //  min Gaussian curvature
+        inline float                 Kmax                     (           ) const ;  //  max Gaussian curvature
+        inline double                Ktotal                   (           ) const ;  //  total Gaussian curvature
+        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int                   patch                    (           ) const ;  //  if a patch of the surface
+        inline int                   nlabels                  (           ) const ;
+        inline PMRIS_AREA_LABEL      labels                   (           ) const ;  //  nlabels of these (may be null)
+        inline p_void                vp                       (           ) const ;  //  for misc. use
+        inline float                 alpha                    (           ) const ;  //  rotation around z-axis
+        inline float                 beta                     (           ) const ;  //  rotation around y-axis
+        inline float                 gamma                    (           ) const ;  //  rotation around x-axis
+        inline float                 da                       (           ) const ;
+        inline float                 db                       (           ) const ;
+        inline float                 dg                       (           ) const ;  //  old deltas
+        inline int                   type                     (           ) const ;  //  what type of surface was this initially
+        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
+        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
+        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject
+        inline float                 canon_area               (           ) const ;
+        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true
+        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)
+        inline float                 dy2                      ( size_t i  ) const ;
+        inline float                 dz2                      ( size_t i  ) const ;
+        inline PCOLOR_TABLE          ct                       (           ) const ;
         inline int                   useRealRAS               (           ) const ;  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1                                                 
-        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;                                                                                                                             
-        inline int                   ncmds                    (           ) const ;                                                                                                                             
-        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group                                                                                
-        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex                                                                           
-        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces                                                                                                      
-        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here                                                                               
-        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel                                                                                    
-        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for                                                                                    
-        inline p_void                mht                      (           ) const ;                                                                                                                             
-        inline p_void                temps                    (           ) const ;                                                                                                                             
-                   
-        inline void set_strips           ( size_t i,            STRIP to )                                              ;
-        inline void set_xctr             (                      float to )                                              ;
-        inline void set_yctr             (                      float to )                                              ;
-        inline void set_zctr             (                      float to )                                              ;
-        inline void set_xlo              (                      float to )                                              ;
-        inline void set_ylo              (                      float to )                                              ;
-        inline void set_zlo              (                      float to )                                              ;
-        inline void set_xhi              (                      float to )                                              ;
-        inline void set_yhi              (                      float to )                                              ;
-        inline void set_zhi              (                      float to )                                              ;
-        inline void set_x0               (                      float to )           ;  //  center of spherical expansion
-        inline void set_y0               (                      float to )                                              ;
-        inline void set_z0               (                      float to )                                              ;
-        inline void set_v_temporal_pole  (                     Vertex to )                                              ;
-        inline void set_v_frontal_pole   (                     Vertex to )                                              ;
-        inline void set_v_occipital_pole (                     Vertex to )                                              ;
-        inline void set_max_curv         (                      float to )                                              ;
-        inline void set_min_curv         (                      float to )                                              ;
-        inline void set_total_area       (                      float to )                                              ;
-        inline void set_avg_vertex_area  (                     double to )                                              ;
-        inline void set_zeros            (                        int to )                                              ;
-        inline void set_hemisphere       (                        int to )                        ;  //  which hemisphere
-        inline void set_Hmin             (                      float to )                      ;  //  min mean curvature
-        inline void set_Hmax             (                      float to )                      ;  //  max mean curvature
-        inline void set_Kmin             (                      float to )                  ;  //  min Gaussian curvature
-        inline void set_Kmax             (                      float to )                  ;  //  max Gaussian curvature
-        inline void set_Ktotal           (                     double to )                ;  //  total Gaussian curvature
-        inline void set_nlabels          (                        int to )                                              ;
-        inline void set_labels           (           PMRIS_AREA_LABEL to )          ;  //  nlabels of these (may be null)
-        inline void set_vp               (                     p_void to )                           ;  //  for misc. use
-        inline void set_alpha            (                      float to )                  ;  //  rotation around z-axis
-        inline void set_beta             (                      float to )                  ;  //  rotation around y-axis
-        inline void set_gamma            (                      float to )                  ;  //  rotation around x-axis
-        inline void set_da               (                      float to )                                              ;
-        inline void set_db               (                      float to )                                              ;
-        inline void set_dg               (                      float to )                              ;  //  old deltas
+        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1
+        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;
+        inline int                   ncmds                    (           ) const ;
+        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group
+        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex
+        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces
+        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here
+        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel
+        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for
+        inline p_void                mht                      (           ) const ;
+        inline p_void                temps                    (           ) const ;
+        
+        inline void set_strips           ( size_t i,            STRIP to ) ;
+        inline void set_xctr             (                      float to ) ;
+        inline void set_yctr             (                      float to ) ;
+        inline void set_zctr             (                      float to ) ;
+        inline void set_xlo              (                      float to ) ;
+        inline void set_ylo              (                      float to ) ;
+        inline void set_zlo              (                      float to ) ;
+        inline void set_xhi              (                      float to ) ;
+        inline void set_yhi              (                      float to ) ;
+        inline void set_zhi              (                      float to ) ;
+        inline void set_x0               (                      float to ) ;  //  center of spherical expansion
+        inline void set_y0               (                      float to ) ;
+        inline void set_z0               (                      float to ) ;
+        inline void set_v_temporal_pole  (                     Vertex to ) ;
+        inline void set_v_frontal_pole   (                     Vertex to ) ;
+        inline void set_v_occipital_pole (                     Vertex to ) ;
+        inline void set_max_curv         (                      float to ) ;
+        inline void set_min_curv         (                      float to ) ;
+        inline void set_total_area       (                      float to ) ;
+        inline void set_avg_vertex_area  (                     double to ) ;
+        inline void set_zeros            (                        int to ) ;
+        inline void set_hemisphere       (                        int to ) ;  //  which hemisphere
+        inline void set_Hmin             (                      float to ) ;  //  min mean curvature
+        inline void set_Hmax             (                      float to ) ;  //  max mean curvature
+        inline void set_Kmin             (                      float to ) ;  //  min Gaussian curvature
+        inline void set_Kmax             (                      float to ) ;  //  max Gaussian curvature
+        inline void set_Ktotal           (                     double to ) ;  //  total Gaussian curvature
+        inline void set_nlabels          (                        int to ) ;
+        inline void set_labels           (           PMRIS_AREA_LABEL to ) ;  //  nlabels of these (may be null)
+        inline void set_vp               (                     p_void to ) ;  //  for misc. use
+        inline void set_alpha            (                      float to ) ;  //  rotation around z-axis
+        inline void set_beta             (                      float to ) ;  //  rotation around y-axis
+        inline void set_gamma            (                      float to ) ;  //  rotation around x-axis
+        inline void set_da               (                      float to ) ;
+        inline void set_db               (                      float to ) ;
+        inline void set_dg               (                      float to ) ;  //  old deltas
         inline void set_type             (                        int to ) ;  //  what type of surface was this initially
     };
 

--- a/include/mrisurf_SurfaceFromMRIS_generated_AnalysisM.h
+++ b/include/mrisurf_SurfaceFromMRIS_generated_AnalysisM.h
@@ -1,9 +1,9 @@
     namespace AnalysisM {
-    struct Face : public MRIS_Elt {
-        inline Face                        (                        );
-        inline Face (                        Face const & src       );
-        inline Face (                        MRIS* mris, size_t idx );
-        inline Face (                        AllM::Face const & src );
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
         inline Vertex                v          ( size_t i  ) const ;
@@ -15,408 +15,409 @@
         inline int                   marked     (           ) const ;
         inline PDMATRIX              norm       (           ) const ;
         inline A3PDMATRIX            gradNorm   (           ) const ;
-                   
+        
         inline void set_orig_angle (  angles_per_triangle_t to ) ;
         inline void set_ripflag    (                   char to ) ;
         inline void set_oripflag   (                   char to ) ;
         inline void set_marked     (                    int to ) ;
     };
 
-    struct Vertex : public MRIS_Elt {
-        inline Vertex (                                                 );
-        inline Vertex (                        Vertex const & src       );
-        inline Vertex (                        MRIS* mris, size_t idx   );
-        inline Vertex (                        AllM::Vertex const & src );
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        AllM::Vertex const & src                   );
         int vno       () const { return idx; }
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces            
-        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex           
-        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                                          
+        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
+        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                      
         inline Vertex v                  ( size_t i  ) const ;  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i,                     
-        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                                              
-        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                                             
-        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur                                  
-        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                                       
-        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc                              
-        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                                         
-        inline uchar  num                (           ) const ;  //  number of neighboring faces                                                  
+        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
+        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                          
+        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                         
+        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur              
+        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                   
+        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc          
+        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                     
+        inline uchar  num                (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
-        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz           
-        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz        
-        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        //           
-        inline float  x                  (           ) const ;  //  current coordinates	                                                         
-        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set                                                      
-        inline float  z                  (           ) const ;                                                                                   
-        //           
-        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status                          
-        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(,                                                     
-        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set                                          
-        //           
-        inline float  nx                 (           ) const ;                                                                                   
-        inline float  ny                 (           ) const ;                                                                                   
-        inline float  nz                 (           ) const ;  //  curr normal                                                                  
-        inline float  pnx                (           ) const ;                                                                                   
-        inline float  pny                (           ) const ;                                                                                   
-        inline float  pnz                (           ) const ;  //  pial normal                                                                  
-        //           
-        inline float  wnx                (           ) const ;                                                                                   
-        inline float  wny                (           ) const ;                                                                                   
-        inline float  wnz                (           ) const ;  //  white normal                                                                 
-        inline float  onx                (           ) const ;                                                                                   
-        inline float  ony                (           ) const ;                                                                                   
-        inline float  onz                (           ) const ;  //  original normal                                                              
-        inline float  dx                 (           ) const ;                                                                                   
-        inline float  dy                 (           ) const ;                                                                                   
-        inline float  dz                 (           ) const ;  //  current change in position                                                   
-        inline float  odx                (           ) const ;                                                                                   
-        inline float  ody                (           ) const ;                                                                                   
-        inline float  odz                (           ) const ;  //  last change of position (for momentum,                                       
-        inline float  tdx                (           ) const ;                                                                                   
-        inline float  tdy                (           ) const ;                                                                                   
-        inline float  tdz                (           ) const ;  //  temporary storage for averaging gradient                                     
-        inline float  curv               (           ) const ;  //  curr curvature                                                               
-        inline float  curvbak            (           ) const ;                                                                                   
-        inline float  val                (           ) const ;  //  scalar data value (file: rh.val, sig2-rh.w)                                  
-        inline float  imag_val           (           ) const ;  //  imaginary part of complex data value                                         
-        inline float  cx                 (           ) const ;                                                                                   
-        inline float  cy                 (           ) const ;                                                                                   
-        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system                                   
-        inline float  tx                 (           ) const ;                                                                                   
-        inline float  ty                 (           ) const ;                                                                                   
-        inline float  tz                 (           ) const ;  //  tmp coordinate storage                                                       
-        inline float  tx2                (           ) const ;                                                                                   
-        inline float  ty2                (           ) const ;                                                                                   
-        inline float  tz2                (           ) const ;  //  tmp coordinate storage                                                       
-        inline float  targx              (           ) const ;                                                                                   
-        inline float  targy              (           ) const ;                                                                                   
-        inline float  targz              (           ) const ;  //  target coordinates                                                           
-        inline float  pialx              (           ) const ;                                                                                   
-        inline float  pialy              (           ) const ;                                                                                   
-        inline float  pialz              (           ) const ;  //  pial surface coordinates                                                     
-        inline float  whitex             (           ) const ;                                                                                   
-        inline float  whitey             (           ) const ;                                                                                   
-        inline float  whitez             (           ) const ;  //  white surface coordinates                                                    
-        inline float  l4x                (           ) const ;                                                                                   
-        inline float  l4y                (           ) const ;                                                                                   
-        inline float  l4z                (           ) const ;  //  layerIV surface coordinates                                                  
-        inline float  infx               (           ) const ;                                                                                   
-        inline float  infy               (           ) const ;                                                                                   
-        inline float  infz               (           ) const ;  //  inflated coordinates                                                         
-        inline float  fx                 (           ) const ;                                                                                   
-        inline float  fy                 (           ) const ;                                                                                   
-        inline float  fz                 (           ) const ;  //  flattened coordinates                                                        
-        inline int    px                 (           ) const ;                                                                                   
-        inline int    qx                 (           ) const ;                                                                                   
-        inline int    py                 (           ) const ;                                                                                   
-        inline int    qy                 (           ) const ;                                                                                   
-        inline int    pz                 (           ) const ;                                                                                   
-        inline int    qz                 (           ) const ;  //  rational coordinates for exact calculations                                  
-        inline float  e1x                (           ) const ;                                                                                   
-        inline float  e1y                (           ) const ;                                                                                   
-        inline float  e1z                (           ) const ;  //  1st basis vector for the local tangent plane                                 
-        inline float  e2x                (           ) const ;                                                                                   
-        inline float  e2y                (           ) const ;                                                                                   
-        inline float  e2z                (           ) const ;  //  2nd basis vector for the local tangent plane                                 
-        inline float  pe1x               (           ) const ;                                                                                   
-        inline float  pe1y               (           ) const ;                                                                                   
-        inline float  pe1z               (           ) const ;  //  1st basis vector for the local tangent plane                                 
-        inline float  pe2x               (           ) const ;                                                                                   
-        inline float  pe2y               (           ) const ;                                                                                   
-        inline float  pe2z               (           ) const ;  //  2nd basis vector for the local tangent plane                                 
-        inline float  nc                 (           ) const ;  //  curr length normal comp                                                      
-        inline float  val2               (           ) const ;  //  complex comp data value (file: sig3-rh.w)                                    
-        inline float  valbak             (           ) const ;  //  scalar data stack                                                            
-        inline float  val2bak            (           ) const ;  //  complex comp data stack                                                      
-        inline float  stat               (           ) const ;  //  statistic                                                                    
-        //           
-        inline int    undefval           (           ) const ;  //  [previously dist=0]                                                          
-        inline int    old_undefval       (           ) const ;  //  for smooth_val_sparse                                                        
-        inline int    fixedval           (           ) const ;  //  [previously val=0]                                                           
-        //           
-        inline float  fieldsign          (           ) const ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs)                                 
-        inline float  fsmask             (           ) const ;  //  significance mask (file: rh.fm)                                              
-        inline float  d                  (           ) const ;  //  for distance calculations                                                    
-        inline int    annotation         (           ) const ;  //  area label (defunct--now from label file name!)                              
-        inline char   oripflag           (           ) const ;                                                                                   
-        inline char   origripflag        (           ) const ;  //  cuts flags                                                                   
-        inline p_void vp                 (           ) const ;  //  to store user's information                                                  
-        inline float  theta              (           ) const ;                                                                                   
-        inline float  phi                (           ) const ;  //  parameterization                                                             
-        inline float  area               (           ) const ;                                                                                   
-        inline float  origarea           (           ) const ;                                                                                   
-        inline float  group_avg_area     (           ) const ;                                                                                   
-        inline float  K                  (           ) const ;  //  Gaussian curvature                                                           
-        inline float  H                  (           ) const ;  //  mean curvature                                                               
-        inline float  k1                 (           ) const ;                                                                                   
-        inline float  k2                 (           ) const ;  //  the principal curvatures                                                     
-        inline float  mean               (           ) const ;                                                                                   
-        inline float  mean_imag          (           ) const ;  //  imaginary part of complex statistic                                          
-        inline float  std_error          (           ) const ;                                                                                   
-        inline uint   flags              (           ) const ;                                                                                   
-        inline int    fno                (           ) const ;  //  face that this vertex is in                                                  
-        inline int    cropped            (           ) const ;                                                                                   
-        inline short  marked             (           ) const ;  //  for a variety of uses                                                        
-        inline short  marked2            (           ) const ;                                                                                   
-        inline short  marked3            (           ) const ;                                                                                   
-        inline char   neg                (           ) const ;  //  1 if the normal vector is inverted                                           
-        inline char   border             (           ) const ;  //  flag                                                                         
-        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache     
+        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz
+        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float  x                  (           ) const ;  //  current coordinates	
+        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set
+        inline float  z                  (           ) const ;
+        // 
+        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status
+        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(, 
+        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set
+        // 
+        inline float  nx                 (           ) const ;
+        inline float  ny                 (           ) const ;
+        inline float  nz                 (           ) const ;  //  curr normal
+        inline float  pnx                (           ) const ;
+        inline float  pny                (           ) const ;
+        inline float  pnz                (           ) const ;  //  pial normal
+        // 
+        inline float  wnx                (           ) const ;
+        inline float  wny                (           ) const ;
+        inline float  wnz                (           ) const ;  //  white normal
+        inline float  onx                (           ) const ;
+        inline float  ony                (           ) const ;
+        inline float  onz                (           ) const ;  //  original normal
+        inline float  dx                 (           ) const ;
+        inline float  dy                 (           ) const ;
+        inline float  dz                 (           ) const ;  //  current change in position
+        inline float  odx                (           ) const ;
+        inline float  ody                (           ) const ;
+        inline float  odz                (           ) const ;  //  last change of position (for momentum, 
+        inline float  tdx                (           ) const ;
+        inline float  tdy                (           ) const ;
+        inline float  tdz                (           ) const ;  //  temporary storage for averaging gradient
+        inline float  curv               (           ) const ;  //  curr curvature
+        inline float  curvbak            (           ) const ;
+        inline float  val                (           ) const ;  //  scalar data value (file: rh.val, sig2-rh.w)
+        inline float  imag_val           (           ) const ;  //  imaginary part of complex data value
+        inline float  cx                 (           ) const ;
+        inline float  cy                 (           ) const ;
+        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system
+        inline float  tx                 (           ) const ;
+        inline float  ty                 (           ) const ;
+        inline float  tz                 (           ) const ;  //  tmp coordinate storage
+        inline float  t2x                (           ) const ;
+        inline float  t2y                (           ) const ;
+        inline float  t2z                (           ) const ;  //  another tmp coordinate storage
+        inline float  targx              (           ) const ;
+        inline float  targy              (           ) const ;
+        inline float  targz              (           ) const ;  //  target coordinates
+        inline float  pialx              (           ) const ;
+        inline float  pialy              (           ) const ;
+        inline float  pialz              (           ) const ;  //  pial surface coordinates
+        inline float  whitex             (           ) const ;
+        inline float  whitey             (           ) const ;
+        inline float  whitez             (           ) const ;  //  white surface coordinates
+        inline float  l4x                (           ) const ;
+        inline float  l4y                (           ) const ;
+        inline float  l4z                (           ) const ;  //  layerIV surface coordinates
+        inline float  infx               (           ) const ;
+        inline float  infy               (           ) const ;
+        inline float  infz               (           ) const ;  //  inflated coordinates
+        inline float  fx                 (           ) const ;
+        inline float  fy                 (           ) const ;
+        inline float  fz                 (           ) const ;  //  flattened coordinates
+        inline int    px                 (           ) const ;
+        inline int    qx                 (           ) const ;
+        inline int    py                 (           ) const ;
+        inline int    qy                 (           ) const ;
+        inline int    pz                 (           ) const ;
+        inline int    qz                 (           ) const ;  //  rational coordinates for exact calculations
+        inline float  e1x                (           ) const ;
+        inline float  e1y                (           ) const ;
+        inline float  e1z                (           ) const ;  //  1st basis vector for the local tangent plane
+        inline float  e2x                (           ) const ;
+        inline float  e2y                (           ) const ;
+        inline float  e2z                (           ) const ;  //  2nd basis vector for the local tangent plane
+        inline float  pe1x               (           ) const ;
+        inline float  pe1y               (           ) const ;
+        inline float  pe1z               (           ) const ;  //  1st basis vector for the local tangent plane
+        inline float  pe2x               (           ) const ;
+        inline float  pe2y               (           ) const ;
+        inline float  pe2z               (           ) const ;  //  2nd basis vector for the local tangent plane
+        inline float  nc                 (           ) const ;  //  curr length normal comp 
+        inline float  val2               (           ) const ;  //  complex comp data value (file: sig3-rh.w) 
+        inline float  valbak             (           ) const ;  //  scalar data stack 
+        inline float  val2bak            (           ) const ;  //  complex comp data stack 
+        inline float  stat               (           ) const ;  //  statistic 
+        // 
+        inline int    undefval           (           ) const ;  //  [previously dist=0] 
+        inline int    old_undefval       (           ) const ;  //  for smooth_val_sparse 
+        inline int    fixedval           (           ) const ;  //  [previously val=0] 
+        // 
+        inline float  fieldsign          (           ) const ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
+        inline float  fsmask             (           ) const ;  //  significance mask (file: rh.fm) 
+        inline float  d                  (           ) const ;  //  for distance calculations 
+        inline int    annotation         (           ) const ;  //  area label (defunct--now from label file name!) 
+        inline char   oripflag           (           ) const ;
+        inline char   origripflag        (           ) const ;  //  cuts flags 
+        inline p_void vp                 (           ) const ;  //  to store user's information 
+        inline float  theta              (           ) const ;
+        inline float  phi                (           ) const ;  //  parameterization 
+        inline float  area               (           ) const ;
+        inline float  origarea           (           ) const ;
+        inline float  group_avg_area     (           ) const ;
+        inline float  K                  (           ) const ;  //  Gaussian curvature 
+        inline float  H                  (           ) const ;  //  mean curvature 
+        inline float  k1                 (           ) const ;
+        inline float  k2                 (           ) const ;  //  the principal curvatures 
+        inline float  mean               (           ) const ;
+        inline float  mean_imag          (           ) const ;  //  imaginary part of complex statistic 
+        inline float  std_error          (           ) const ;
+        inline uint   flags              (           ) const ;
+        inline int    fno                (           ) const ;  //  face that this vertex is in 
+        inline int    cropped            (           ) const ;
+        inline short  marked             (           ) const ;  //  for a variety of uses 
+        inline short  marked2            (           ) const ;
+        inline short  marked3            (           ) const ;
+        inline char   neg                (           ) const ;  //  1 if the normal vector is inverted 
+        inline char   border             (           ) const ;  //  flag 
+        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void   which_coords       (int which, float *x, float *y, float *z) const ;
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-                   
+        
         inline void set_f              ( size_t i,   Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
         inline void set_n              ( size_t i, size_t to ) ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        inline void set_e              ( size_t i,    int to )                  ;  //  edge state for neighboring vertices                      
-        //         
-        inline void set_nx             (            float to )                                                                                 ;
-        inline void set_ny             (            float to )                                                                                 ;
-        inline void set_nz             (            float to )                                                                ;  //  curr normal
-        inline void set_pnx            (            float to )                                                                                 ;
-        inline void set_pny            (            float to )                                                                                 ;
-        inline void set_pnz            (            float to )                                                                ;  //  pial normal
-        //         
-        inline void set_wnx            (            float to )                                                                                 ;
-        inline void set_wny            (            float to )                                                                                 ;
-        inline void set_wnz            (            float to )                                                               ;  //  white normal
-        inline void set_onx            (            float to )                                                                                 ;
-        inline void set_ony            (            float to )                                                                                 ;
-        inline void set_onz            (            float to )                                                            ;  //  original normal
-        inline void set_dx             (            float to )                                                                                 ;
-        inline void set_dy             (            float to )                                                                                 ;
-        inline void set_dz             (            float to )                                                 ;  //  current change in position
-        inline void set_odx            (            float to )                                                                                 ;
-        inline void set_ody            (            float to )                                                                                 ;
-        inline void set_odz            (            float to )                                    ;  //  last change of position (for momentum, 
-        inline void set_tdx            (            float to )                                                                                 ;
-        inline void set_tdy            (            float to )                                                                                 ;
-        inline void set_tdz            (            float to )                                   ;  //  temporary storage for averaging gradient
-        inline void set_curv           (            float to )                                                             ;  //  curr curvature
-        inline void set_curvbak        (            float to )                                                                                 ;
-        inline void set_val            (            float to )                                ;  //  scalar data value (file: rh.val, sig2-rh.w)
-        inline void set_imag_val       (            float to )                                       ;  //  imaginary part of complex data value
-        inline void set_cx             (            float to )                                                                                 ;
-        inline void set_cy             (            float to )                                                                                 ;
-        inline void set_cz             (            float to )                                 ;  //  coordinates in canonical coordinate system
-        inline void set_tx             (            float to )                                                                                 ;
-        inline void set_ty             (            float to )                                                                                 ;
-        inline void set_tz             (            float to )                                                     ;  //  tmp coordinate storage
-        inline void set_tx2            (            float to )                                                                                 ;
-        inline void set_ty2            (            float to )                                                                                 ;
-        inline void set_tz2            (            float to )                                                     ;  //  tmp coordinate storage
-        inline void set_targx          (            float to )                                                                                 ;
-        inline void set_targy          (            float to )                                                                                 ;
-        inline void set_targz          (            float to )                                                         ;  //  target coordinates
-        inline void set_pialx          (            float to )                                                                                 ;
-        inline void set_pialy          (            float to )                                                                                 ;
-        inline void set_pialz          (            float to )                                                   ;  //  pial surface coordinates
-        inline void set_whitex         (            float to )                                                                                 ;
-        inline void set_whitey         (            float to )                                                                                 ;
-        inline void set_whitez         (            float to )                                                  ;  //  white surface coordinates
-        inline void set_l4x            (            float to )                                                                                 ;
-        inline void set_l4y            (            float to )                                                                                 ;
-        inline void set_l4z            (            float to )                                                ;  //  layerIV surface coordinates
-        inline void set_infx           (            float to )                                                                                 ;
-        inline void set_infy           (            float to )                                                                                 ;
-        inline void set_infz           (            float to )                                                       ;  //  inflated coordinates
-        inline void set_fx             (            float to )                                                                                 ;
-        inline void set_fy             (            float to )                                                                                 ;
-        inline void set_fz             (            float to )                                                      ;  //  flattened coordinates
-        inline void set_px             (              int to )                                                                                 ;
-        inline void set_qx             (              int to )                                                                                 ;
-        inline void set_py             (              int to )                                                                                 ;
-        inline void set_qy             (              int to )                                                                                 ;
-        inline void set_pz             (              int to )                                                                                 ;
-        inline void set_qz             (              int to )                                ;  //  rational coordinates for exact calculations
-        inline void set_e1x            (            float to )                                                                                 ;
-        inline void set_e1y            (            float to )                                                                                 ;
-        inline void set_e1z            (            float to )                               ;  //  1st basis vector for the local tangent plane
-        inline void set_e2x            (            float to )                                                                                 ;
-        inline void set_e2y            (            float to )                                                                                 ;
-        inline void set_e2z            (            float to )                               ;  //  2nd basis vector for the local tangent plane
-        inline void set_pe1x           (            float to )                                                                                 ;
-        inline void set_pe1y           (            float to )                                                                                 ;
-        inline void set_pe1z           (            float to )                               ;  //  1st basis vector for the local tangent plane
-        inline void set_pe2x           (            float to )                                                                                 ;
-        inline void set_pe2y           (            float to )                                                                                 ;
-        inline void set_pe2z           (            float to )                               ;  //  2nd basis vector for the local tangent plane
-        inline void set_nc             (            float to )                                                   ;  //  curr length normal comp 
-        inline void set_val2           (            float to )                                 ;  //  complex comp data value (file: sig3-rh.w) 
-        inline void set_valbak         (            float to )                                                         ;  //  scalar data stack 
-        inline void set_val2bak        (            float to )                                                   ;  //  complex comp data stack 
-        inline void set_stat           (            float to )                                                                 ;  //  statistic 
-        //         
-        inline void set_undefval       (              int to )                                                       ;  //  [previously dist=0] 
-        inline void set_old_undefval   (              int to )                                                     ;  //  for smooth_val_sparse 
-        inline void set_fixedval       (              int to )                                                        ;  //  [previously val=0] 
-        //         
-        inline void set_fieldsign      (            float to )                              ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
-        inline void set_fsmask         (            float to )                                           ;  //  significance mask (file: rh.fm) 
-        inline void set_d              (            float to )                                                 ;  //  for distance calculations 
-        inline void set_annotation     (              int to )                           ;  //  area label (defunct--now from label file name!) 
-        inline void set_oripflag       (             char to )                                                                                 ;
-        inline void set_origripflag    (             char to )                                                                ;  //  cuts flags 
-        inline void set_vp             (           p_void to )                                               ;  //  to store user's information 
-        inline void set_theta          (            float to )                                                                                 ;
-        inline void set_phi            (            float to )                                                          ;  //  parameterization 
-        inline void set_origarea       (            float to )                                                                                 ;
-        inline void set_group_avg_area (            float to )                                                                                 ;
-        inline void set_K              (            float to )                                                        ;  //  Gaussian curvature 
-        inline void set_H              (            float to )                                                            ;  //  mean curvature 
-        inline void set_k1             (            float to )                                                                                 ;
-        inline void set_k2             (            float to )                                                  ;  //  the principal curvatures 
-        inline void set_mean           (            float to )                                                                                 ;
-        inline void set_mean_imag      (            float to )                                       ;  //  imaginary part of complex statistic 
-        inline void set_std_error      (            float to )                                                                                 ;
-        inline void set_flags          (             uint to )                                                                                 ;
-        inline void set_fno            (              int to )                                               ;  //  face that this vertex is in 
-        inline void set_cropped        (              int to )                                                                                 ;
-        inline void set_marked         (            short to )                                                     ;  //  for a variety of uses 
-        inline void set_marked2        (            short to )                                                                                 ;
-        inline void set_marked3        (            short to )                                                                                 ;
-        inline void set_neg            (             char to )                                        ;  //  1 if the normal vector is inverted 
-        inline void set_border         (             char to )                                                                      ;  //  flag 
-        inline void set_ripflag        (             char to )   ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_e              ( size_t i,    int to ) ;  //  edge state for neighboring vertices                      
+        // 
+        inline void set_nx             (            float to ) ;
+        inline void set_ny             (            float to ) ;
+        inline void set_nz             (            float to ) ;  //  curr normal
+        inline void set_pnx            (            float to ) ;
+        inline void set_pny            (            float to ) ;
+        inline void set_pnz            (            float to ) ;  //  pial normal
+        // 
+        inline void set_wnx            (            float to ) ;
+        inline void set_wny            (            float to ) ;
+        inline void set_wnz            (            float to ) ;  //  white normal
+        inline void set_onx            (            float to ) ;
+        inline void set_ony            (            float to ) ;
+        inline void set_onz            (            float to ) ;  //  original normal
+        inline void set_dx             (            float to ) ;
+        inline void set_dy             (            float to ) ;
+        inline void set_dz             (            float to ) ;  //  current change in position
+        inline void set_odx            (            float to ) ;
+        inline void set_ody            (            float to ) ;
+        inline void set_odz            (            float to ) ;  //  last change of position (for momentum, 
+        inline void set_tdx            (            float to ) ;
+        inline void set_tdy            (            float to ) ;
+        inline void set_tdz            (            float to ) ;  //  temporary storage for averaging gradient
+        inline void set_curv           (            float to ) ;  //  curr curvature
+        inline void set_curvbak        (            float to ) ;
+        inline void set_val            (            float to ) ;  //  scalar data value (file: rh.val, sig2-rh.w)
+        inline void set_imag_val       (            float to ) ;  //  imaginary part of complex data value
+        inline void set_cx             (            float to ) ;
+        inline void set_cy             (            float to ) ;
+        inline void set_cz             (            float to ) ;  //  coordinates in canonical coordinate system
+        inline void set_tx             (            float to ) ;
+        inline void set_ty             (            float to ) ;
+        inline void set_tz             (            float to ) ;  //  tmp coordinate storage
+        inline void set_t2x            (            float to ) ;
+        inline void set_t2y            (            float to ) ;
+        inline void set_t2z            (            float to ) ;  //  another tmp coordinate storage
+        inline void set_targx          (            float to ) ;
+        inline void set_targy          (            float to ) ;
+        inline void set_targz          (            float to ) ;  //  target coordinates
+        inline void set_pialx          (            float to ) ;
+        inline void set_pialy          (            float to ) ;
+        inline void set_pialz          (            float to ) ;  //  pial surface coordinates
+        inline void set_whitex         (            float to ) ;
+        inline void set_whitey         (            float to ) ;
+        inline void set_whitez         (            float to ) ;  //  white surface coordinates
+        inline void set_l4x            (            float to ) ;
+        inline void set_l4y            (            float to ) ;
+        inline void set_l4z            (            float to ) ;  //  layerIV surface coordinates
+        inline void set_infx           (            float to ) ;
+        inline void set_infy           (            float to ) ;
+        inline void set_infz           (            float to ) ;  //  inflated coordinates
+        inline void set_fx             (            float to ) ;
+        inline void set_fy             (            float to ) ;
+        inline void set_fz             (            float to ) ;  //  flattened coordinates
+        inline void set_px             (              int to ) ;
+        inline void set_qx             (              int to ) ;
+        inline void set_py             (              int to ) ;
+        inline void set_qy             (              int to ) ;
+        inline void set_pz             (              int to ) ;
+        inline void set_qz             (              int to ) ;  //  rational coordinates for exact calculations
+        inline void set_e1x            (            float to ) ;
+        inline void set_e1y            (            float to ) ;
+        inline void set_e1z            (            float to ) ;  //  1st basis vector for the local tangent plane
+        inline void set_e2x            (            float to ) ;
+        inline void set_e2y            (            float to ) ;
+        inline void set_e2z            (            float to ) ;  //  2nd basis vector for the local tangent plane
+        inline void set_pe1x           (            float to ) ;
+        inline void set_pe1y           (            float to ) ;
+        inline void set_pe1z           (            float to ) ;  //  1st basis vector for the local tangent plane
+        inline void set_pe2x           (            float to ) ;
+        inline void set_pe2y           (            float to ) ;
+        inline void set_pe2z           (            float to ) ;  //  2nd basis vector for the local tangent plane
+        inline void set_nc             (            float to ) ;  //  curr length normal comp 
+        inline void set_val2           (            float to ) ;  //  complex comp data value (file: sig3-rh.w) 
+        inline void set_valbak         (            float to ) ;  //  scalar data stack 
+        inline void set_val2bak        (            float to ) ;  //  complex comp data stack 
+        inline void set_stat           (            float to ) ;  //  statistic 
+        // 
+        inline void set_undefval       (              int to ) ;  //  [previously dist=0] 
+        inline void set_old_undefval   (              int to ) ;  //  for smooth_val_sparse 
+        inline void set_fixedval       (              int to ) ;  //  [previously val=0] 
+        // 
+        inline void set_fieldsign      (            float to ) ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
+        inline void set_fsmask         (            float to ) ;  //  significance mask (file: rh.fm) 
+        inline void set_d              (            float to ) ;  //  for distance calculations 
+        inline void set_annotation     (              int to ) ;  //  area label (defunct--now from label file name!) 
+        inline void set_oripflag       (             char to ) ;
+        inline void set_origripflag    (             char to ) ;  //  cuts flags 
+        inline void set_vp             (           p_void to ) ;  //  to store user's information 
+        inline void set_theta          (            float to ) ;
+        inline void set_phi            (            float to ) ;  //  parameterization 
+        inline void set_origarea       (            float to ) ;
+        inline void set_group_avg_area (            float to ) ;
+        inline void set_K              (            float to ) ;  //  Gaussian curvature 
+        inline void set_H              (            float to ) ;  //  mean curvature 
+        inline void set_k1             (            float to ) ;
+        inline void set_k2             (            float to ) ;  //  the principal curvatures 
+        inline void set_mean           (            float to ) ;
+        inline void set_mean_imag      (            float to ) ;  //  imaginary part of complex statistic 
+        inline void set_std_error      (            float to ) ;
+        inline void set_flags          (             uint to ) ;
+        inline void set_fno            (              int to ) ;  //  face that this vertex is in 
+        inline void set_cropped        (              int to ) ;
+        inline void set_marked         (            short to ) ;  //  for a variety of uses 
+        inline void set_marked2        (            short to ) ;
+        inline void set_marked3        (            short to ) ;
+        inline void set_neg            (             char to ) ;  //  1 if the normal vector is inverted 
+        inline void set_border         (             char to ) ;  //  flag 
+        inline void set_ripflag        (             char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
-    struct Surface : public MRIS_Elt {
-        inline Surface (                           );
-        inline Surface ( Surface const & src       );
-        inline Surface ( MRIS* mris                );
-        inline Surface ( AllM::Surface const & src );
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
+        inline Surface ( AllM::Surface const & src      );
 
         // Fields being maintained by specialist functions
-        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen                                                                                     
-        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al                                          
-        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al                                             
-        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons                                                             
-        inline int                   nedges                   (           ) const ;  //  # of edges on surface                                                                                                  
-        inline int                   nstrips                  (           ) const ;                                                                                                                             
-        inline Vertex                vertices                 ( size_t i  ) const ;                                                                                                                             
-        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored                          
-        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored                     
-        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use                                                
-        inline Face                  faces                    ( size_t i  ) const ;                                                                                                                             
-        inline MRI_EDGE              edges                    ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;                                                                                                                             
-        inline STRIP                 strips                   ( size_t i  ) const ;                                                                                                                             
-        inline float                 xctr                     (           ) const ;                                                                                                                             
-        inline float                 yctr                     (           ) const ;                                                                                                                             
-        inline float                 zctr                     (           ) const ;                                                                                                                             
-        inline float                 xlo                      (           ) const ;                                                                                                                             
-        inline float                 ylo                      (           ) const ;                                                                                                                             
-        inline float                 zlo                      (           ) const ;                                                                                                                             
-        inline float                 xhi                      (           ) const ;                                                                                                                             
-        inline float                 yhi                      (           ) const ;                                                                                                                             
-        inline float                 zhi                      (           ) const ;                                                                                                                             
-        inline float                 x0                       (           ) const ;  //  center of spherical expansion                                                                                          
-        inline float                 y0                       (           ) const ;                                                                                                                             
-        inline float                 z0                       (           ) const ;                                                                                                                             
-        inline Vertex                v_temporal_pole          (           ) const ;                                                                                                                             
-        inline Vertex                v_frontal_pole           (           ) const ;                                                                                                                             
-        inline Vertex                v_occipital_pole         (           ) const ;                                                                                                                             
-        inline float                 max_curv                 (           ) const ;                                                                                                                             
-        inline float                 min_curv                 (           ) const ;                                                                                                                             
-        inline float                 total_area               (           ) const ;                                                                                                                             
-        inline double                avg_vertex_area          (           ) const ;                                                                                                                             
-        inline double                avg_vertex_dist          (           ) const ;  //  set by MRIScomputeAvgInterVertexDist                                                                                   
-        inline double                std_vertex_dist          (           ) const ;                                                                                                                             
-        inline float                 orig_area                (           ) const ;                                                                                                                             
-        inline float                 neg_area                 (           ) const ;                                                                                                                             
-        inline float                 neg_orig_area            (           ) const ;  //  amount of original surface in folds                                                                                    
-        inline int                   zeros                    (           ) const ;                                                                                                                             
-        inline int                   hemisphere               (           ) const ;  //  which hemisphere                                                                                                       
-        inline int                   initialized              (           ) const ;                                                                                                                             
-        inline PLTA                  lta                      (           ) const ;                                                                                                                             
-        inline PMATRIX               SRASToTalSRAS_           (           ) const ;                                                                                                                             
-        inline PMATRIX               TalSRASToSRAS_           (           ) const ;                                                                                                                             
-        inline int                   free_transform           (           ) const ;                                                                                                                             
-        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)                                                                                        
-        inline float                 a                        (           ) const ;                                                                                                                             
-        inline float                 b                        (           ) const ;                                                                                                                             
-        inline float                 c                        (           ) const ;  //  ellipsoid parameters                                                                                                   
-        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from                                                                                     
-        inline float                 Hmin                     (           ) const ;  //  min mean curvature                                                                                                     
-        inline float                 Hmax                     (           ) const ;  //  max mean curvature                                                                                                     
-        inline float                 Kmin                     (           ) const ;  //  min Gaussian curvature                                                                                                 
-        inline float                 Kmax                     (           ) const ;  //  max Gaussian curvature                                                                                                 
-        inline double                Ktotal                   (           ) const ;  //  total Gaussian curvature                                                                                               
-        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)                                                                                   
-        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from                                              
-        inline int                   patch                    (           ) const ;  //  if a patch of the surface                                                                                              
-        inline int                   nlabels                  (           ) const ;                                                                                                                             
-        inline PMRIS_AREA_LABEL      labels                   (           ) const ;  //  nlabels of these (may be null)                                                                                         
-        inline p_void                vp                       (           ) const ;  //  for misc. use                                                                                                          
-        inline float                 alpha                    (           ) const ;  //  rotation around z-axis                                                                                                 
-        inline float                 beta                     (           ) const ;  //  rotation around y-axis                                                                                                 
-        inline float                 gamma                    (           ) const ;  //  rotation around x-axis                                                                                                 
-        inline float                 da                       (           ) const ;                                                                                                                             
-        inline float                 db                       (           ) const ;                                                                                                                             
-        inline float                 dg                       (           ) const ;  //  old deltas                                                                                                             
-        inline int                   type                     (           ) const ;  //  what type of surface was this initially                                                                                
-        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces                                               
-        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces                                               
-        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject                                                                                                    
-        inline float                 canon_area               (           ) const ;                                                                                                                             
-        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true                                                                                    
-        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)                                                                          
-        inline float                 dy2                      ( size_t i  ) const ;                                                                                                                             
-        inline float                 dz2                      ( size_t i  ) const ;                                                                                                                             
-        inline PCOLOR_TABLE          ct                       (           ) const ;                                                                                                                             
+        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen
+        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons
+        inline int                   nedges                   (           ) const ;  //  # of edges on surface
+        inline int                   nstrips                  (           ) const ;
+        inline Vertex                vertices                 ( size_t i  ) const ;
+        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
+        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
+        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use
+        inline Face                  faces                    ( size_t i  ) const ;
+        inline MRI_EDGE              edges                    ( size_t i  ) const ;
+        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;
+        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;
+        inline STRIP                 strips                   ( size_t i  ) const ;
+        inline float                 xctr                     (           ) const ;
+        inline float                 yctr                     (           ) const ;
+        inline float                 zctr                     (           ) const ;
+        inline float                 xlo                      (           ) const ;
+        inline float                 ylo                      (           ) const ;
+        inline float                 zlo                      (           ) const ;
+        inline float                 xhi                      (           ) const ;
+        inline float                 yhi                      (           ) const ;
+        inline float                 zhi                      (           ) const ;
+        inline float                 x0                       (           ) const ;  //  center of spherical expansion
+        inline float                 y0                       (           ) const ;
+        inline float                 z0                       (           ) const ;
+        inline Vertex                v_temporal_pole          (           ) const ;
+        inline Vertex                v_frontal_pole           (           ) const ;
+        inline Vertex                v_occipital_pole         (           ) const ;
+        inline float                 max_curv                 (           ) const ;
+        inline float                 min_curv                 (           ) const ;
+        inline float                 total_area               (           ) const ;
+        inline double                avg_vertex_area          (           ) const ;
+        inline double                avg_vertex_dist          (           ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double                std_vertex_dist          (           ) const ;
+        inline float                 orig_area                (           ) const ;
+        inline float                 neg_area                 (           ) const ;
+        inline float                 neg_orig_area            (           ) const ;  //  amount of original surface in folds
+        inline int                   zeros                    (           ) const ;
+        inline int                   hemisphere               (           ) const ;  //  which hemisphere
+        inline int                   initialized              (           ) const ;
+        inline PLTA                  lta                      (           ) const ;
+        inline PMATRIX               SRASToTalSRAS_           (           ) const ;
+        inline PMATRIX               TalSRASToSRAS_           (           ) const ;
+        inline int                   free_transform           (           ) const ;
+        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline float                 a                        (           ) const ;
+        inline float                 b                        (           ) const ;
+        inline float                 c                        (           ) const ;  //  ellipsoid parameters
+        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from
+        inline float                 Hmin                     (           ) const ;  //  min mean curvature
+        inline float                 Hmax                     (           ) const ;  //  max mean curvature
+        inline float                 Kmin                     (           ) const ;  //  min Gaussian curvature
+        inline float                 Kmax                     (           ) const ;  //  max Gaussian curvature
+        inline double                Ktotal                   (           ) const ;  //  total Gaussian curvature
+        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int                   patch                    (           ) const ;  //  if a patch of the surface
+        inline int                   nlabels                  (           ) const ;
+        inline PMRIS_AREA_LABEL      labels                   (           ) const ;  //  nlabels of these (may be null)
+        inline p_void                vp                       (           ) const ;  //  for misc. use
+        inline float                 alpha                    (           ) const ;  //  rotation around z-axis
+        inline float                 beta                     (           ) const ;  //  rotation around y-axis
+        inline float                 gamma                    (           ) const ;  //  rotation around x-axis
+        inline float                 da                       (           ) const ;
+        inline float                 db                       (           ) const ;
+        inline float                 dg                       (           ) const ;  //  old deltas
+        inline int                   type                     (           ) const ;  //  what type of surface was this initially
+        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
+        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
+        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject
+        inline float                 canon_area               (           ) const ;
+        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true
+        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)
+        inline float                 dy2                      ( size_t i  ) const ;
+        inline float                 dz2                      ( size_t i  ) const ;
+        inline PCOLOR_TABLE          ct                       (           ) const ;
         inline int                   useRealRAS               (           ) const ;  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1                                                 
-        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;                                                                                                                             
-        inline int                   ncmds                    (           ) const ;                                                                                                                             
-        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group                                                                                
-        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex                                                                           
-        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces                                                                                                      
-        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here                                                                               
-        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel                                                                                    
-        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for                                                                                    
-        inline p_void                mht                      (           ) const ;                                                                                                                             
-        inline p_void                temps                    (           ) const ;                                                                                                                             
-                   
-        inline void set_strips           ( size_t i,            STRIP to )                                              ;
-        inline void set_xctr             (                      float to )                                              ;
-        inline void set_yctr             (                      float to )                                              ;
-        inline void set_zctr             (                      float to )                                              ;
-        inline void set_xlo              (                      float to )                                              ;
-        inline void set_ylo              (                      float to )                                              ;
-        inline void set_zlo              (                      float to )                                              ;
-        inline void set_xhi              (                      float to )                                              ;
-        inline void set_yhi              (                      float to )                                              ;
-        inline void set_zhi              (                      float to )                                              ;
-        inline void set_x0               (                      float to )           ;  //  center of spherical expansion
-        inline void set_y0               (                      float to )                                              ;
-        inline void set_z0               (                      float to )                                              ;
-        inline void set_v_temporal_pole  (                     Vertex to )                                              ;
-        inline void set_v_frontal_pole   (                     Vertex to )                                              ;
-        inline void set_v_occipital_pole (                     Vertex to )                                              ;
-        inline void set_max_curv         (                      float to )                                              ;
-        inline void set_min_curv         (                      float to )                                              ;
-        inline void set_total_area       (                      float to )                                              ;
-        inline void set_avg_vertex_area  (                     double to )                                              ;
-        inline void set_zeros            (                        int to )                                              ;
-        inline void set_hemisphere       (                        int to )                        ;  //  which hemisphere
-        inline void set_Hmin             (                      float to )                      ;  //  min mean curvature
-        inline void set_Hmax             (                      float to )                      ;  //  max mean curvature
-        inline void set_Kmin             (                      float to )                  ;  //  min Gaussian curvature
-        inline void set_Kmax             (                      float to )                  ;  //  max Gaussian curvature
-        inline void set_Ktotal           (                     double to )                ;  //  total Gaussian curvature
-        inline void set_nlabels          (                        int to )                                              ;
-        inline void set_labels           (           PMRIS_AREA_LABEL to )          ;  //  nlabels of these (may be null)
-        inline void set_vp               (                     p_void to )                           ;  //  for misc. use
-        inline void set_alpha            (                      float to )                  ;  //  rotation around z-axis
-        inline void set_beta             (                      float to )                  ;  //  rotation around y-axis
-        inline void set_gamma            (                      float to )                  ;  //  rotation around x-axis
-        inline void set_da               (                      float to )                                              ;
-        inline void set_db               (                      float to )                                              ;
-        inline void set_dg               (                      float to )                              ;  //  old deltas
+        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1
+        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;
+        inline int                   ncmds                    (           ) const ;
+        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group
+        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex
+        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces
+        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here
+        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel
+        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for
+        inline p_void                mht                      (           ) const ;
+        inline p_void                temps                    (           ) const ;
+        
+        inline void set_strips           ( size_t i,            STRIP to ) ;
+        inline void set_xctr             (                      float to ) ;
+        inline void set_yctr             (                      float to ) ;
+        inline void set_zctr             (                      float to ) ;
+        inline void set_xlo              (                      float to ) ;
+        inline void set_ylo              (                      float to ) ;
+        inline void set_zlo              (                      float to ) ;
+        inline void set_xhi              (                      float to ) ;
+        inline void set_yhi              (                      float to ) ;
+        inline void set_zhi              (                      float to ) ;
+        inline void set_x0               (                      float to ) ;  //  center of spherical expansion
+        inline void set_y0               (                      float to ) ;
+        inline void set_z0               (                      float to ) ;
+        inline void set_v_temporal_pole  (                     Vertex to ) ;
+        inline void set_v_frontal_pole   (                     Vertex to ) ;
+        inline void set_v_occipital_pole (                     Vertex to ) ;
+        inline void set_max_curv         (                      float to ) ;
+        inline void set_min_curv         (                      float to ) ;
+        inline void set_total_area       (                      float to ) ;
+        inline void set_avg_vertex_area  (                     double to ) ;
+        inline void set_zeros            (                        int to ) ;
+        inline void set_hemisphere       (                        int to ) ;  //  which hemisphere
+        inline void set_Hmin             (                      float to ) ;  //  min mean curvature
+        inline void set_Hmax             (                      float to ) ;  //  max mean curvature
+        inline void set_Kmin             (                      float to ) ;  //  min Gaussian curvature
+        inline void set_Kmax             (                      float to ) ;  //  max Gaussian curvature
+        inline void set_Ktotal           (                     double to ) ;  //  total Gaussian curvature
+        inline void set_nlabels          (                        int to ) ;
+        inline void set_labels           (           PMRIS_AREA_LABEL to ) ;  //  nlabels of these (may be null)
+        inline void set_vp               (                     p_void to ) ;  //  for misc. use
+        inline void set_alpha            (                      float to ) ;  //  rotation around z-axis
+        inline void set_beta             (                      float to ) ;  //  rotation around y-axis
+        inline void set_gamma            (                      float to ) ;  //  rotation around x-axis
+        inline void set_da               (                      float to ) ;
+        inline void set_db               (                      float to ) ;
+        inline void set_dg               (                      float to ) ;  //  old deltas
         inline void set_type             (                        int to ) ;  //  what type of surface was this initially
     };
 

--- a/include/mrisurf_SurfaceFromMRIS_generated_Distort.h
+++ b/include/mrisurf_SurfaceFromMRIS_generated_Distort.h
@@ -1,11 +1,11 @@
     namespace Distort {
-    struct Face : public MRIS_Elt {
-        inline Face                        (                             );
-        inline Face (                        Face const & src            );
-        inline Face (                        MRIS* mris, size_t idx      );
-        inline Face (                        AnalysisM::Face const & src );
-        inline Face (                        Analysis::Face const & src  );
-        inline Face (                        AllM::Face const & src      );
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        AnalysisM::Face const & src                );
+        inline Face (                        Analysis::Face const & src                 );
+        inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
         inline Vertex                v          ( size_t i  ) const ;
@@ -17,412 +17,413 @@
         inline int                   marked     (           ) const ;
         inline PDMATRIX              norm       (           ) const ;
         inline A3PDMATRIX            gradNorm   (           ) const ;
-                   
+        
         inline void set_orig_angle (  angles_per_triangle_t to ) ;
         inline void set_ripflag    (                   char to ) ;
         inline void set_oripflag   (                   char to ) ;
         inline void set_marked     (                    int to ) ;
     };
 
-    struct Vertex : public MRIS_Elt {
-        inline Vertex (                                                      );
-        inline Vertex (                        Vertex const & src            );
-        inline Vertex (                        MRIS* mris, size_t idx        );
-        inline Vertex (                        AnalysisM::Vertex const & src );
-        inline Vertex (                        Analysis::Vertex const & src  );
-        inline Vertex (                        AllM::Vertex const & src      );
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        AnalysisM::Vertex const & src              );
+        inline Vertex (                        Analysis::Vertex const & src               );
+        inline Vertex (                        AllM::Vertex const & src                   );
         int vno       () const { return idx; }
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces            
-        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex           
-        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                                          
+        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
+        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                      
         inline Vertex v                  ( size_t i  ) const ;  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i,                     
-        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                                              
-        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                                             
-        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur                                  
-        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                                       
-        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc                              
-        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                                         
-        inline uchar  num                (           ) const ;  //  number of neighboring faces                                                  
+        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
+        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                          
+        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                         
+        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur              
+        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                   
+        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc          
+        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                     
+        inline uchar  num                (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
-        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz           
-        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz        
-        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        //           
-        inline float  x                  (           ) const ;  //  current coordinates	                                                         
-        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set                                                      
-        inline float  z                  (           ) const ;                                                                                   
-        //           
-        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status                          
-        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(,                                                     
-        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set                                          
-        //           
-        inline float  nx                 (           ) const ;                                                                                   
-        inline float  ny                 (           ) const ;                                                                                   
-        inline float  nz                 (           ) const ;  //  curr normal                                                                  
-        inline float  pnx                (           ) const ;                                                                                   
-        inline float  pny                (           ) const ;                                                                                   
-        inline float  pnz                (           ) const ;  //  pial normal                                                                  
-        //           
-        inline float  wnx                (           ) const ;                                                                                   
-        inline float  wny                (           ) const ;                                                                                   
-        inline float  wnz                (           ) const ;  //  white normal                                                                 
-        inline float  onx                (           ) const ;                                                                                   
-        inline float  ony                (           ) const ;                                                                                   
-        inline float  onz                (           ) const ;  //  original normal                                                              
-        inline float  dx                 (           ) const ;                                                                                   
-        inline float  dy                 (           ) const ;                                                                                   
-        inline float  dz                 (           ) const ;  //  current change in position                                                   
-        inline float  odx                (           ) const ;                                                                                   
-        inline float  ody                (           ) const ;                                                                                   
-        inline float  odz                (           ) const ;  //  last change of position (for momentum,                                       
-        inline float  tdx                (           ) const ;                                                                                   
-        inline float  tdy                (           ) const ;                                                                                   
-        inline float  tdz                (           ) const ;  //  temporary storage for averaging gradient                                     
-        inline float  curv               (           ) const ;  //  curr curvature                                                               
-        inline float  curvbak            (           ) const ;                                                                                   
-        inline float  val                (           ) const ;  //  scalar data value (file: rh.val, sig2-rh.w)                                  
-        inline float  imag_val           (           ) const ;  //  imaginary part of complex data value                                         
-        inline float  cx                 (           ) const ;                                                                                   
-        inline float  cy                 (           ) const ;                                                                                   
-        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system                                   
-        inline float  tx                 (           ) const ;                                                                                   
-        inline float  ty                 (           ) const ;                                                                                   
-        inline float  tz                 (           ) const ;  //  tmp coordinate storage                                                       
-        inline float  tx2                (           ) const ;                                                                                   
-        inline float  ty2                (           ) const ;                                                                                   
-        inline float  tz2                (           ) const ;  //  tmp coordinate storage                                                       
-        inline float  targx              (           ) const ;                                                                                   
-        inline float  targy              (           ) const ;                                                                                   
-        inline float  targz              (           ) const ;  //  target coordinates                                                           
-        inline float  pialx              (           ) const ;                                                                                   
-        inline float  pialy              (           ) const ;                                                                                   
-        inline float  pialz              (           ) const ;  //  pial surface coordinates                                                     
-        inline float  whitex             (           ) const ;                                                                                   
-        inline float  whitey             (           ) const ;                                                                                   
-        inline float  whitez             (           ) const ;  //  white surface coordinates                                                    
-        inline float  l4x                (           ) const ;                                                                                   
-        inline float  l4y                (           ) const ;                                                                                   
-        inline float  l4z                (           ) const ;  //  layerIV surface coordinates                                                  
-        inline float  infx               (           ) const ;                                                                                   
-        inline float  infy               (           ) const ;                                                                                   
-        inline float  infz               (           ) const ;  //  inflated coordinates                                                         
-        inline float  fx                 (           ) const ;                                                                                   
-        inline float  fy                 (           ) const ;                                                                                   
-        inline float  fz                 (           ) const ;  //  flattened coordinates                                                        
-        inline int    px                 (           ) const ;                                                                                   
-        inline int    qx                 (           ) const ;                                                                                   
-        inline int    py                 (           ) const ;                                                                                   
-        inline int    qy                 (           ) const ;                                                                                   
-        inline int    pz                 (           ) const ;                                                                                   
-        inline int    qz                 (           ) const ;  //  rational coordinates for exact calculations                                  
-        inline float  e1x                (           ) const ;                                                                                   
-        inline float  e1y                (           ) const ;                                                                                   
-        inline float  e1z                (           ) const ;  //  1st basis vector for the local tangent plane                                 
-        inline float  e2x                (           ) const ;                                                                                   
-        inline float  e2y                (           ) const ;                                                                                   
-        inline float  e2z                (           ) const ;  //  2nd basis vector for the local tangent plane                                 
-        inline float  pe1x               (           ) const ;                                                                                   
-        inline float  pe1y               (           ) const ;                                                                                   
-        inline float  pe1z               (           ) const ;  //  1st basis vector for the local tangent plane                                 
-        inline float  pe2x               (           ) const ;                                                                                   
-        inline float  pe2y               (           ) const ;                                                                                   
-        inline float  pe2z               (           ) const ;  //  2nd basis vector for the local tangent plane                                 
-        inline float  nc                 (           ) const ;  //  curr length normal comp                                                      
-        inline float  val2               (           ) const ;  //  complex comp data value (file: sig3-rh.w)                                    
-        inline float  valbak             (           ) const ;  //  scalar data stack                                                            
-        inline float  val2bak            (           ) const ;  //  complex comp data stack                                                      
-        inline float  stat               (           ) const ;  //  statistic                                                                    
-        //           
-        inline int    undefval           (           ) const ;  //  [previously dist=0]                                                          
-        inline int    old_undefval       (           ) const ;  //  for smooth_val_sparse                                                        
-        inline int    fixedval           (           ) const ;  //  [previously val=0]                                                           
-        //           
-        inline float  fieldsign          (           ) const ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs)                                 
-        inline float  fsmask             (           ) const ;  //  significance mask (file: rh.fm)                                              
-        inline float  d                  (           ) const ;  //  for distance calculations                                                    
-        inline int    annotation         (           ) const ;  //  area label (defunct--now from label file name!)                              
-        inline char   oripflag           (           ) const ;                                                                                   
-        inline char   origripflag        (           ) const ;  //  cuts flags                                                                   
-        inline p_void vp                 (           ) const ;  //  to store user's information                                                  
-        inline float  theta              (           ) const ;                                                                                   
-        inline float  phi                (           ) const ;  //  parameterization                                                             
-        inline float  area               (           ) const ;                                                                                   
-        inline float  origarea           (           ) const ;                                                                                   
-        inline float  group_avg_area     (           ) const ;                                                                                   
-        inline float  K                  (           ) const ;  //  Gaussian curvature                                                           
-        inline float  H                  (           ) const ;  //  mean curvature                                                               
-        inline float  k1                 (           ) const ;                                                                                   
-        inline float  k2                 (           ) const ;  //  the principal curvatures                                                     
-        inline float  mean               (           ) const ;                                                                                   
-        inline float  mean_imag          (           ) const ;  //  imaginary part of complex statistic                                          
-        inline float  std_error          (           ) const ;                                                                                   
-        inline uint   flags              (           ) const ;                                                                                   
-        inline int    fno                (           ) const ;  //  face that this vertex is in                                                  
-        inline int    cropped            (           ) const ;                                                                                   
-        inline short  marked             (           ) const ;  //  for a variety of uses                                                        
-        inline short  marked2            (           ) const ;                                                                                   
-        inline short  marked3            (           ) const ;                                                                                   
-        inline char   neg                (           ) const ;  //  1 if the normal vector is inverted                                           
-        inline char   border             (           ) const ;  //  flag                                                                         
-        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache     
+        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz
+        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float  x                  (           ) const ;  //  current coordinates	
+        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set
+        inline float  z                  (           ) const ;
+        // 
+        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status
+        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(, 
+        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set
+        // 
+        inline float  nx                 (           ) const ;
+        inline float  ny                 (           ) const ;
+        inline float  nz                 (           ) const ;  //  curr normal
+        inline float  pnx                (           ) const ;
+        inline float  pny                (           ) const ;
+        inline float  pnz                (           ) const ;  //  pial normal
+        // 
+        inline float  wnx                (           ) const ;
+        inline float  wny                (           ) const ;
+        inline float  wnz                (           ) const ;  //  white normal
+        inline float  onx                (           ) const ;
+        inline float  ony                (           ) const ;
+        inline float  onz                (           ) const ;  //  original normal
+        inline float  dx                 (           ) const ;
+        inline float  dy                 (           ) const ;
+        inline float  dz                 (           ) const ;  //  current change in position
+        inline float  odx                (           ) const ;
+        inline float  ody                (           ) const ;
+        inline float  odz                (           ) const ;  //  last change of position (for momentum, 
+        inline float  tdx                (           ) const ;
+        inline float  tdy                (           ) const ;
+        inline float  tdz                (           ) const ;  //  temporary storage for averaging gradient
+        inline float  curv               (           ) const ;  //  curr curvature
+        inline float  curvbak            (           ) const ;
+        inline float  val                (           ) const ;  //  scalar data value (file: rh.val, sig2-rh.w)
+        inline float  imag_val           (           ) const ;  //  imaginary part of complex data value
+        inline float  cx                 (           ) const ;
+        inline float  cy                 (           ) const ;
+        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system
+        inline float  tx                 (           ) const ;
+        inline float  ty                 (           ) const ;
+        inline float  tz                 (           ) const ;  //  tmp coordinate storage
+        inline float  t2x                (           ) const ;
+        inline float  t2y                (           ) const ;
+        inline float  t2z                (           ) const ;  //  another tmp coordinate storage
+        inline float  targx              (           ) const ;
+        inline float  targy              (           ) const ;
+        inline float  targz              (           ) const ;  //  target coordinates
+        inline float  pialx              (           ) const ;
+        inline float  pialy              (           ) const ;
+        inline float  pialz              (           ) const ;  //  pial surface coordinates
+        inline float  whitex             (           ) const ;
+        inline float  whitey             (           ) const ;
+        inline float  whitez             (           ) const ;  //  white surface coordinates
+        inline float  l4x                (           ) const ;
+        inline float  l4y                (           ) const ;
+        inline float  l4z                (           ) const ;  //  layerIV surface coordinates
+        inline float  infx               (           ) const ;
+        inline float  infy               (           ) const ;
+        inline float  infz               (           ) const ;  //  inflated coordinates
+        inline float  fx                 (           ) const ;
+        inline float  fy                 (           ) const ;
+        inline float  fz                 (           ) const ;  //  flattened coordinates
+        inline int    px                 (           ) const ;
+        inline int    qx                 (           ) const ;
+        inline int    py                 (           ) const ;
+        inline int    qy                 (           ) const ;
+        inline int    pz                 (           ) const ;
+        inline int    qz                 (           ) const ;  //  rational coordinates for exact calculations
+        inline float  e1x                (           ) const ;
+        inline float  e1y                (           ) const ;
+        inline float  e1z                (           ) const ;  //  1st basis vector for the local tangent plane
+        inline float  e2x                (           ) const ;
+        inline float  e2y                (           ) const ;
+        inline float  e2z                (           ) const ;  //  2nd basis vector for the local tangent plane
+        inline float  pe1x               (           ) const ;
+        inline float  pe1y               (           ) const ;
+        inline float  pe1z               (           ) const ;  //  1st basis vector for the local tangent plane
+        inline float  pe2x               (           ) const ;
+        inline float  pe2y               (           ) const ;
+        inline float  pe2z               (           ) const ;  //  2nd basis vector for the local tangent plane
+        inline float  nc                 (           ) const ;  //  curr length normal comp 
+        inline float  val2               (           ) const ;  //  complex comp data value (file: sig3-rh.w) 
+        inline float  valbak             (           ) const ;  //  scalar data stack 
+        inline float  val2bak            (           ) const ;  //  complex comp data stack 
+        inline float  stat               (           ) const ;  //  statistic 
+        // 
+        inline int    undefval           (           ) const ;  //  [previously dist=0] 
+        inline int    old_undefval       (           ) const ;  //  for smooth_val_sparse 
+        inline int    fixedval           (           ) const ;  //  [previously val=0] 
+        // 
+        inline float  fieldsign          (           ) const ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
+        inline float  fsmask             (           ) const ;  //  significance mask (file: rh.fm) 
+        inline float  d                  (           ) const ;  //  for distance calculations 
+        inline int    annotation         (           ) const ;  //  area label (defunct--now from label file name!) 
+        inline char   oripflag           (           ) const ;
+        inline char   origripflag        (           ) const ;  //  cuts flags 
+        inline p_void vp                 (           ) const ;  //  to store user's information 
+        inline float  theta              (           ) const ;
+        inline float  phi                (           ) const ;  //  parameterization 
+        inline float  area               (           ) const ;
+        inline float  origarea           (           ) const ;
+        inline float  group_avg_area     (           ) const ;
+        inline float  K                  (           ) const ;  //  Gaussian curvature 
+        inline float  H                  (           ) const ;  //  mean curvature 
+        inline float  k1                 (           ) const ;
+        inline float  k2                 (           ) const ;  //  the principal curvatures 
+        inline float  mean               (           ) const ;
+        inline float  mean_imag          (           ) const ;  //  imaginary part of complex statistic 
+        inline float  std_error          (           ) const ;
+        inline uint   flags              (           ) const ;
+        inline int    fno                (           ) const ;  //  face that this vertex is in 
+        inline int    cropped            (           ) const ;
+        inline short  marked             (           ) const ;  //  for a variety of uses 
+        inline short  marked2            (           ) const ;
+        inline short  marked3            (           ) const ;
+        inline char   neg                (           ) const ;  //  1 if the normal vector is inverted 
+        inline char   border             (           ) const ;  //  flag 
+        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void   which_coords       (int which, float *x, float *y, float *z) const ;
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-                   
+        
         inline void set_f              ( size_t i,   Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
         inline void set_n              ( size_t i, size_t to ) ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        inline void set_e              ( size_t i,    int to )                  ;  //  edge state for neighboring vertices                      
-        //         
-        inline void set_nx             (            float to )                                                                                 ;
-        inline void set_ny             (            float to )                                                                                 ;
-        inline void set_nz             (            float to )                                                                ;  //  curr normal
-        inline void set_pnx            (            float to )                                                                                 ;
-        inline void set_pny            (            float to )                                                                                 ;
-        inline void set_pnz            (            float to )                                                                ;  //  pial normal
-        //         
-        inline void set_wnx            (            float to )                                                                                 ;
-        inline void set_wny            (            float to )                                                                                 ;
-        inline void set_wnz            (            float to )                                                               ;  //  white normal
-        inline void set_onx            (            float to )                                                                                 ;
-        inline void set_ony            (            float to )                                                                                 ;
-        inline void set_onz            (            float to )                                                            ;  //  original normal
-        inline void set_dx             (            float to )                                                                                 ;
-        inline void set_dy             (            float to )                                                                                 ;
-        inline void set_dz             (            float to )                                                 ;  //  current change in position
-        inline void set_odx            (            float to )                                                                                 ;
-        inline void set_ody            (            float to )                                                                                 ;
-        inline void set_odz            (            float to )                                    ;  //  last change of position (for momentum, 
-        inline void set_tdx            (            float to )                                                                                 ;
-        inline void set_tdy            (            float to )                                                                                 ;
-        inline void set_tdz            (            float to )                                   ;  //  temporary storage for averaging gradient
-        inline void set_curv           (            float to )                                                             ;  //  curr curvature
-        inline void set_curvbak        (            float to )                                                                                 ;
-        inline void set_val            (            float to )                                ;  //  scalar data value (file: rh.val, sig2-rh.w)
-        inline void set_imag_val       (            float to )                                       ;  //  imaginary part of complex data value
-        inline void set_cx             (            float to )                                                                                 ;
-        inline void set_cy             (            float to )                                                                                 ;
-        inline void set_cz             (            float to )                                 ;  //  coordinates in canonical coordinate system
-        inline void set_tx             (            float to )                                                                                 ;
-        inline void set_ty             (            float to )                                                                                 ;
-        inline void set_tz             (            float to )                                                     ;  //  tmp coordinate storage
-        inline void set_tx2            (            float to )                                                                                 ;
-        inline void set_ty2            (            float to )                                                                                 ;
-        inline void set_tz2            (            float to )                                                     ;  //  tmp coordinate storage
-        inline void set_targx          (            float to )                                                                                 ;
-        inline void set_targy          (            float to )                                                                                 ;
-        inline void set_targz          (            float to )                                                         ;  //  target coordinates
-        inline void set_pialx          (            float to )                                                                                 ;
-        inline void set_pialy          (            float to )                                                                                 ;
-        inline void set_pialz          (            float to )                                                   ;  //  pial surface coordinates
-        inline void set_whitex         (            float to )                                                                                 ;
-        inline void set_whitey         (            float to )                                                                                 ;
-        inline void set_whitez         (            float to )                                                  ;  //  white surface coordinates
-        inline void set_l4x            (            float to )                                                                                 ;
-        inline void set_l4y            (            float to )                                                                                 ;
-        inline void set_l4z            (            float to )                                                ;  //  layerIV surface coordinates
-        inline void set_infx           (            float to )                                                                                 ;
-        inline void set_infy           (            float to )                                                                                 ;
-        inline void set_infz           (            float to )                                                       ;  //  inflated coordinates
-        inline void set_fx             (            float to )                                                                                 ;
-        inline void set_fy             (            float to )                                                                                 ;
-        inline void set_fz             (            float to )                                                      ;  //  flattened coordinates
-        inline void set_px             (              int to )                                                                                 ;
-        inline void set_qx             (              int to )                                                                                 ;
-        inline void set_py             (              int to )                                                                                 ;
-        inline void set_qy             (              int to )                                                                                 ;
-        inline void set_pz             (              int to )                                                                                 ;
-        inline void set_qz             (              int to )                                ;  //  rational coordinates for exact calculations
-        inline void set_e1x            (            float to )                                                                                 ;
-        inline void set_e1y            (            float to )                                                                                 ;
-        inline void set_e1z            (            float to )                               ;  //  1st basis vector for the local tangent plane
-        inline void set_e2x            (            float to )                                                                                 ;
-        inline void set_e2y            (            float to )                                                                                 ;
-        inline void set_e2z            (            float to )                               ;  //  2nd basis vector for the local tangent plane
-        inline void set_pe1x           (            float to )                                                                                 ;
-        inline void set_pe1y           (            float to )                                                                                 ;
-        inline void set_pe1z           (            float to )                               ;  //  1st basis vector for the local tangent plane
-        inline void set_pe2x           (            float to )                                                                                 ;
-        inline void set_pe2y           (            float to )                                                                                 ;
-        inline void set_pe2z           (            float to )                               ;  //  2nd basis vector for the local tangent plane
-        inline void set_nc             (            float to )                                                   ;  //  curr length normal comp 
-        inline void set_val2           (            float to )                                 ;  //  complex comp data value (file: sig3-rh.w) 
-        inline void set_valbak         (            float to )                                                         ;  //  scalar data stack 
-        inline void set_val2bak        (            float to )                                                   ;  //  complex comp data stack 
-        inline void set_stat           (            float to )                                                                 ;  //  statistic 
-        //         
-        inline void set_undefval       (              int to )                                                       ;  //  [previously dist=0] 
-        inline void set_old_undefval   (              int to )                                                     ;  //  for smooth_val_sparse 
-        inline void set_fixedval       (              int to )                                                        ;  //  [previously val=0] 
-        //         
-        inline void set_fieldsign      (            float to )                              ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
-        inline void set_fsmask         (            float to )                                           ;  //  significance mask (file: rh.fm) 
-        inline void set_d              (            float to )                                                 ;  //  for distance calculations 
-        inline void set_annotation     (              int to )                           ;  //  area label (defunct--now from label file name!) 
-        inline void set_oripflag       (             char to )                                                                                 ;
-        inline void set_origripflag    (             char to )                                                                ;  //  cuts flags 
-        inline void set_vp             (           p_void to )                                               ;  //  to store user's information 
-        inline void set_theta          (            float to )                                                                                 ;
-        inline void set_phi            (            float to )                                                          ;  //  parameterization 
-        inline void set_origarea       (            float to )                                                                                 ;
-        inline void set_group_avg_area (            float to )                                                                                 ;
-        inline void set_K              (            float to )                                                        ;  //  Gaussian curvature 
-        inline void set_H              (            float to )                                                            ;  //  mean curvature 
-        inline void set_k1             (            float to )                                                                                 ;
-        inline void set_k2             (            float to )                                                  ;  //  the principal curvatures 
-        inline void set_mean           (            float to )                                                                                 ;
-        inline void set_mean_imag      (            float to )                                       ;  //  imaginary part of complex statistic 
-        inline void set_std_error      (            float to )                                                                                 ;
-        inline void set_flags          (             uint to )                                                                                 ;
-        inline void set_fno            (              int to )                                               ;  //  face that this vertex is in 
-        inline void set_cropped        (              int to )                                                                                 ;
-        inline void set_marked         (            short to )                                                     ;  //  for a variety of uses 
-        inline void set_marked2        (            short to )                                                                                 ;
-        inline void set_marked3        (            short to )                                                                                 ;
-        inline void set_neg            (             char to )                                        ;  //  1 if the normal vector is inverted 
-        inline void set_border         (             char to )                                                                      ;  //  flag 
-        inline void set_ripflag        (             char to )   ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_e              ( size_t i,    int to ) ;  //  edge state for neighboring vertices                      
+        // 
+        inline void set_nx             (            float to ) ;
+        inline void set_ny             (            float to ) ;
+        inline void set_nz             (            float to ) ;  //  curr normal
+        inline void set_pnx            (            float to ) ;
+        inline void set_pny            (            float to ) ;
+        inline void set_pnz            (            float to ) ;  //  pial normal
+        // 
+        inline void set_wnx            (            float to ) ;
+        inline void set_wny            (            float to ) ;
+        inline void set_wnz            (            float to ) ;  //  white normal
+        inline void set_onx            (            float to ) ;
+        inline void set_ony            (            float to ) ;
+        inline void set_onz            (            float to ) ;  //  original normal
+        inline void set_dx             (            float to ) ;
+        inline void set_dy             (            float to ) ;
+        inline void set_dz             (            float to ) ;  //  current change in position
+        inline void set_odx            (            float to ) ;
+        inline void set_ody            (            float to ) ;
+        inline void set_odz            (            float to ) ;  //  last change of position (for momentum, 
+        inline void set_tdx            (            float to ) ;
+        inline void set_tdy            (            float to ) ;
+        inline void set_tdz            (            float to ) ;  //  temporary storage for averaging gradient
+        inline void set_curv           (            float to ) ;  //  curr curvature
+        inline void set_curvbak        (            float to ) ;
+        inline void set_val            (            float to ) ;  //  scalar data value (file: rh.val, sig2-rh.w)
+        inline void set_imag_val       (            float to ) ;  //  imaginary part of complex data value
+        inline void set_cx             (            float to ) ;
+        inline void set_cy             (            float to ) ;
+        inline void set_cz             (            float to ) ;  //  coordinates in canonical coordinate system
+        inline void set_tx             (            float to ) ;
+        inline void set_ty             (            float to ) ;
+        inline void set_tz             (            float to ) ;  //  tmp coordinate storage
+        inline void set_t2x            (            float to ) ;
+        inline void set_t2y            (            float to ) ;
+        inline void set_t2z            (            float to ) ;  //  another tmp coordinate storage
+        inline void set_targx          (            float to ) ;
+        inline void set_targy          (            float to ) ;
+        inline void set_targz          (            float to ) ;  //  target coordinates
+        inline void set_pialx          (            float to ) ;
+        inline void set_pialy          (            float to ) ;
+        inline void set_pialz          (            float to ) ;  //  pial surface coordinates
+        inline void set_whitex         (            float to ) ;
+        inline void set_whitey         (            float to ) ;
+        inline void set_whitez         (            float to ) ;  //  white surface coordinates
+        inline void set_l4x            (            float to ) ;
+        inline void set_l4y            (            float to ) ;
+        inline void set_l4z            (            float to ) ;  //  layerIV surface coordinates
+        inline void set_infx           (            float to ) ;
+        inline void set_infy           (            float to ) ;
+        inline void set_infz           (            float to ) ;  //  inflated coordinates
+        inline void set_fx             (            float to ) ;
+        inline void set_fy             (            float to ) ;
+        inline void set_fz             (            float to ) ;  //  flattened coordinates
+        inline void set_px             (              int to ) ;
+        inline void set_qx             (              int to ) ;
+        inline void set_py             (              int to ) ;
+        inline void set_qy             (              int to ) ;
+        inline void set_pz             (              int to ) ;
+        inline void set_qz             (              int to ) ;  //  rational coordinates for exact calculations
+        inline void set_e1x            (            float to ) ;
+        inline void set_e1y            (            float to ) ;
+        inline void set_e1z            (            float to ) ;  //  1st basis vector for the local tangent plane
+        inline void set_e2x            (            float to ) ;
+        inline void set_e2y            (            float to ) ;
+        inline void set_e2z            (            float to ) ;  //  2nd basis vector for the local tangent plane
+        inline void set_pe1x           (            float to ) ;
+        inline void set_pe1y           (            float to ) ;
+        inline void set_pe1z           (            float to ) ;  //  1st basis vector for the local tangent plane
+        inline void set_pe2x           (            float to ) ;
+        inline void set_pe2y           (            float to ) ;
+        inline void set_pe2z           (            float to ) ;  //  2nd basis vector for the local tangent plane
+        inline void set_nc             (            float to ) ;  //  curr length normal comp 
+        inline void set_val2           (            float to ) ;  //  complex comp data value (file: sig3-rh.w) 
+        inline void set_valbak         (            float to ) ;  //  scalar data stack 
+        inline void set_val2bak        (            float to ) ;  //  complex comp data stack 
+        inline void set_stat           (            float to ) ;  //  statistic 
+        // 
+        inline void set_undefval       (              int to ) ;  //  [previously dist=0] 
+        inline void set_old_undefval   (              int to ) ;  //  for smooth_val_sparse 
+        inline void set_fixedval       (              int to ) ;  //  [previously val=0] 
+        // 
+        inline void set_fieldsign      (            float to ) ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
+        inline void set_fsmask         (            float to ) ;  //  significance mask (file: rh.fm) 
+        inline void set_d              (            float to ) ;  //  for distance calculations 
+        inline void set_annotation     (              int to ) ;  //  area label (defunct--now from label file name!) 
+        inline void set_oripflag       (             char to ) ;
+        inline void set_origripflag    (             char to ) ;  //  cuts flags 
+        inline void set_vp             (           p_void to ) ;  //  to store user's information 
+        inline void set_theta          (            float to ) ;
+        inline void set_phi            (            float to ) ;  //  parameterization 
+        inline void set_origarea       (            float to ) ;
+        inline void set_group_avg_area (            float to ) ;
+        inline void set_K              (            float to ) ;  //  Gaussian curvature 
+        inline void set_H              (            float to ) ;  //  mean curvature 
+        inline void set_k1             (            float to ) ;
+        inline void set_k2             (            float to ) ;  //  the principal curvatures 
+        inline void set_mean           (            float to ) ;
+        inline void set_mean_imag      (            float to ) ;  //  imaginary part of complex statistic 
+        inline void set_std_error      (            float to ) ;
+        inline void set_flags          (             uint to ) ;
+        inline void set_fno            (              int to ) ;  //  face that this vertex is in 
+        inline void set_cropped        (              int to ) ;
+        inline void set_marked         (            short to ) ;  //  for a variety of uses 
+        inline void set_marked2        (            short to ) ;
+        inline void set_marked3        (            short to ) ;
+        inline void set_neg            (             char to ) ;  //  1 if the normal vector is inverted 
+        inline void set_border         (             char to ) ;  //  flag 
+        inline void set_ripflag        (             char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
-    struct Surface : public MRIS_Elt {
+    struct Surface : public Repr_Elt {
         inline Surface (                                );
         inline Surface ( Surface const & src            );
-        inline Surface ( MRIS* mris                     );
+        inline Surface ( Representation* representation );
         inline Surface ( AnalysisM::Surface const & src );
         inline Surface ( Analysis::Surface const & src  );
         inline Surface ( AllM::Surface const & src      );
 
         // Fields being maintained by specialist functions
-        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen                                                                                     
-        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al                                          
-        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al                                             
-        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons                                                             
-        inline int                   nedges                   (           ) const ;  //  # of edges on surface                                                                                                  
-        inline int                   nstrips                  (           ) const ;                                                                                                                             
-        inline Vertex                vertices                 ( size_t i  ) const ;                                                                                                                             
-        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored                          
-        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored                     
-        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use                                                
-        inline Face                  faces                    ( size_t i  ) const ;                                                                                                                             
-        inline MRI_EDGE              edges                    ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;                                                                                                                             
-        inline STRIP                 strips                   ( size_t i  ) const ;                                                                                                                             
-        inline float                 xctr                     (           ) const ;                                                                                                                             
-        inline float                 yctr                     (           ) const ;                                                                                                                             
-        inline float                 zctr                     (           ) const ;                                                                                                                             
-        inline float                 xlo                      (           ) const ;                                                                                                                             
-        inline float                 ylo                      (           ) const ;                                                                                                                             
-        inline float                 zlo                      (           ) const ;                                                                                                                             
-        inline float                 xhi                      (           ) const ;                                                                                                                             
-        inline float                 yhi                      (           ) const ;                                                                                                                             
-        inline float                 zhi                      (           ) const ;                                                                                                                             
-        inline float                 x0                       (           ) const ;  //  center of spherical expansion                                                                                          
-        inline float                 y0                       (           ) const ;                                                                                                                             
-        inline float                 z0                       (           ) const ;                                                                                                                             
-        inline Vertex                v_temporal_pole          (           ) const ;                                                                                                                             
-        inline Vertex                v_frontal_pole           (           ) const ;                                                                                                                             
-        inline Vertex                v_occipital_pole         (           ) const ;                                                                                                                             
-        inline float                 max_curv                 (           ) const ;                                                                                                                             
-        inline float                 min_curv                 (           ) const ;                                                                                                                             
-        inline float                 total_area               (           ) const ;                                                                                                                             
-        inline double                avg_vertex_area          (           ) const ;                                                                                                                             
-        inline double                avg_vertex_dist          (           ) const ;  //  set by MRIScomputeAvgInterVertexDist                                                                                   
-        inline double                std_vertex_dist          (           ) const ;                                                                                                                             
-        inline float                 orig_area                (           ) const ;                                                                                                                             
-        inline float                 neg_area                 (           ) const ;                                                                                                                             
-        inline float                 neg_orig_area            (           ) const ;  //  amount of original surface in folds                                                                                    
-        inline int                   zeros                    (           ) const ;                                                                                                                             
-        inline int                   hemisphere               (           ) const ;  //  which hemisphere                                                                                                       
-        inline int                   initialized              (           ) const ;                                                                                                                             
-        inline PLTA                  lta                      (           ) const ;                                                                                                                             
-        inline PMATRIX               SRASToTalSRAS_           (           ) const ;                                                                                                                             
-        inline PMATRIX               TalSRASToSRAS_           (           ) const ;                                                                                                                             
-        inline int                   free_transform           (           ) const ;                                                                                                                             
-        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)                                                                                        
-        inline float                 a                        (           ) const ;                                                                                                                             
-        inline float                 b                        (           ) const ;                                                                                                                             
-        inline float                 c                        (           ) const ;  //  ellipsoid parameters                                                                                                   
-        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from                                                                                     
-        inline float                 Hmin                     (           ) const ;  //  min mean curvature                                                                                                     
-        inline float                 Hmax                     (           ) const ;  //  max mean curvature                                                                                                     
-        inline float                 Kmin                     (           ) const ;  //  min Gaussian curvature                                                                                                 
-        inline float                 Kmax                     (           ) const ;  //  max Gaussian curvature                                                                                                 
-        inline double                Ktotal                   (           ) const ;  //  total Gaussian curvature                                                                                               
-        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)                                                                                   
-        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from                                              
-        inline int                   patch                    (           ) const ;  //  if a patch of the surface                                                                                              
-        inline int                   nlabels                  (           ) const ;                                                                                                                             
-        inline PMRIS_AREA_LABEL      labels                   (           ) const ;  //  nlabels of these (may be null)                                                                                         
-        inline p_void                vp                       (           ) const ;  //  for misc. use                                                                                                          
-        inline float                 alpha                    (           ) const ;  //  rotation around z-axis                                                                                                 
-        inline float                 beta                     (           ) const ;  //  rotation around y-axis                                                                                                 
-        inline float                 gamma                    (           ) const ;  //  rotation around x-axis                                                                                                 
-        inline float                 da                       (           ) const ;                                                                                                                             
-        inline float                 db                       (           ) const ;                                                                                                                             
-        inline float                 dg                       (           ) const ;  //  old deltas                                                                                                             
-        inline int                   type                     (           ) const ;  //  what type of surface was this initially                                                                                
-        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces                                               
-        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces                                               
-        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject                                                                                                    
-        inline float                 canon_area               (           ) const ;                                                                                                                             
-        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true                                                                                    
-        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)                                                                          
-        inline float                 dy2                      ( size_t i  ) const ;                                                                                                                             
-        inline float                 dz2                      ( size_t i  ) const ;                                                                                                                             
-        inline PCOLOR_TABLE          ct                       (           ) const ;                                                                                                                             
+        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen
+        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons
+        inline int                   nedges                   (           ) const ;  //  # of edges on surface
+        inline int                   nstrips                  (           ) const ;
+        inline Vertex                vertices                 ( size_t i  ) const ;
+        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
+        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
+        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use
+        inline Face                  faces                    ( size_t i  ) const ;
+        inline MRI_EDGE              edges                    ( size_t i  ) const ;
+        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;
+        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;
+        inline STRIP                 strips                   ( size_t i  ) const ;
+        inline float                 xctr                     (           ) const ;
+        inline float                 yctr                     (           ) const ;
+        inline float                 zctr                     (           ) const ;
+        inline float                 xlo                      (           ) const ;
+        inline float                 ylo                      (           ) const ;
+        inline float                 zlo                      (           ) const ;
+        inline float                 xhi                      (           ) const ;
+        inline float                 yhi                      (           ) const ;
+        inline float                 zhi                      (           ) const ;
+        inline float                 x0                       (           ) const ;  //  center of spherical expansion
+        inline float                 y0                       (           ) const ;
+        inline float                 z0                       (           ) const ;
+        inline Vertex                v_temporal_pole          (           ) const ;
+        inline Vertex                v_frontal_pole           (           ) const ;
+        inline Vertex                v_occipital_pole         (           ) const ;
+        inline float                 max_curv                 (           ) const ;
+        inline float                 min_curv                 (           ) const ;
+        inline float                 total_area               (           ) const ;
+        inline double                avg_vertex_area          (           ) const ;
+        inline double                avg_vertex_dist          (           ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double                std_vertex_dist          (           ) const ;
+        inline float                 orig_area                (           ) const ;
+        inline float                 neg_area                 (           ) const ;
+        inline float                 neg_orig_area            (           ) const ;  //  amount of original surface in folds
+        inline int                   zeros                    (           ) const ;
+        inline int                   hemisphere               (           ) const ;  //  which hemisphere
+        inline int                   initialized              (           ) const ;
+        inline PLTA                  lta                      (           ) const ;
+        inline PMATRIX               SRASToTalSRAS_           (           ) const ;
+        inline PMATRIX               TalSRASToSRAS_           (           ) const ;
+        inline int                   free_transform           (           ) const ;
+        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline float                 a                        (           ) const ;
+        inline float                 b                        (           ) const ;
+        inline float                 c                        (           ) const ;  //  ellipsoid parameters
+        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from
+        inline float                 Hmin                     (           ) const ;  //  min mean curvature
+        inline float                 Hmax                     (           ) const ;  //  max mean curvature
+        inline float                 Kmin                     (           ) const ;  //  min Gaussian curvature
+        inline float                 Kmax                     (           ) const ;  //  max Gaussian curvature
+        inline double                Ktotal                   (           ) const ;  //  total Gaussian curvature
+        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int                   patch                    (           ) const ;  //  if a patch of the surface
+        inline int                   nlabels                  (           ) const ;
+        inline PMRIS_AREA_LABEL      labels                   (           ) const ;  //  nlabels of these (may be null)
+        inline p_void                vp                       (           ) const ;  //  for misc. use
+        inline float                 alpha                    (           ) const ;  //  rotation around z-axis
+        inline float                 beta                     (           ) const ;  //  rotation around y-axis
+        inline float                 gamma                    (           ) const ;  //  rotation around x-axis
+        inline float                 da                       (           ) const ;
+        inline float                 db                       (           ) const ;
+        inline float                 dg                       (           ) const ;  //  old deltas
+        inline int                   type                     (           ) const ;  //  what type of surface was this initially
+        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
+        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
+        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject
+        inline float                 canon_area               (           ) const ;
+        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true
+        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)
+        inline float                 dy2                      ( size_t i  ) const ;
+        inline float                 dz2                      ( size_t i  ) const ;
+        inline PCOLOR_TABLE          ct                       (           ) const ;
         inline int                   useRealRAS               (           ) const ;  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1                                                 
-        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;                                                                                                                             
-        inline int                   ncmds                    (           ) const ;                                                                                                                             
-        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group                                                                                
-        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex                                                                           
-        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces                                                                                                      
-        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here                                                                               
-        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel                                                                                    
-        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for                                                                                    
-        inline p_void                mht                      (           ) const ;                                                                                                                             
-        inline p_void                temps                    (           ) const ;                                                                                                                             
-                   
-        inline void set_strips           ( size_t i,            STRIP to )                                              ;
-        inline void set_xctr             (                      float to )                                              ;
-        inline void set_yctr             (                      float to )                                              ;
-        inline void set_zctr             (                      float to )                                              ;
-        inline void set_xlo              (                      float to )                                              ;
-        inline void set_ylo              (                      float to )                                              ;
-        inline void set_zlo              (                      float to )                                              ;
-        inline void set_xhi              (                      float to )                                              ;
-        inline void set_yhi              (                      float to )                                              ;
-        inline void set_zhi              (                      float to )                                              ;
-        inline void set_x0               (                      float to )           ;  //  center of spherical expansion
-        inline void set_y0               (                      float to )                                              ;
-        inline void set_z0               (                      float to )                                              ;
-        inline void set_v_temporal_pole  (                     Vertex to )                                              ;
-        inline void set_v_frontal_pole   (                     Vertex to )                                              ;
-        inline void set_v_occipital_pole (                     Vertex to )                                              ;
-        inline void set_max_curv         (                      float to )                                              ;
-        inline void set_min_curv         (                      float to )                                              ;
-        inline void set_total_area       (                      float to )                                              ;
-        inline void set_avg_vertex_area  (                     double to )                                              ;
-        inline void set_zeros            (                        int to )                                              ;
-        inline void set_hemisphere       (                        int to )                        ;  //  which hemisphere
-        inline void set_Hmin             (                      float to )                      ;  //  min mean curvature
-        inline void set_Hmax             (                      float to )                      ;  //  max mean curvature
-        inline void set_Kmin             (                      float to )                  ;  //  min Gaussian curvature
-        inline void set_Kmax             (                      float to )                  ;  //  max Gaussian curvature
-        inline void set_Ktotal           (                     double to )                ;  //  total Gaussian curvature
-        inline void set_nlabels          (                        int to )                                              ;
-        inline void set_labels           (           PMRIS_AREA_LABEL to )          ;  //  nlabels of these (may be null)
-        inline void set_vp               (                     p_void to )                           ;  //  for misc. use
-        inline void set_alpha            (                      float to )                  ;  //  rotation around z-axis
-        inline void set_beta             (                      float to )                  ;  //  rotation around y-axis
-        inline void set_gamma            (                      float to )                  ;  //  rotation around x-axis
-        inline void set_da               (                      float to )                                              ;
-        inline void set_db               (                      float to )                                              ;
-        inline void set_dg               (                      float to )                              ;  //  old deltas
+        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1
+        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;
+        inline int                   ncmds                    (           ) const ;
+        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group
+        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex
+        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces
+        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here
+        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel
+        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for
+        inline p_void                mht                      (           ) const ;
+        inline p_void                temps                    (           ) const ;
+        
+        inline void set_strips           ( size_t i,            STRIP to ) ;
+        inline void set_xctr             (                      float to ) ;
+        inline void set_yctr             (                      float to ) ;
+        inline void set_zctr             (                      float to ) ;
+        inline void set_xlo              (                      float to ) ;
+        inline void set_ylo              (                      float to ) ;
+        inline void set_zlo              (                      float to ) ;
+        inline void set_xhi              (                      float to ) ;
+        inline void set_yhi              (                      float to ) ;
+        inline void set_zhi              (                      float to ) ;
+        inline void set_x0               (                      float to ) ;  //  center of spherical expansion
+        inline void set_y0               (                      float to ) ;
+        inline void set_z0               (                      float to ) ;
+        inline void set_v_temporal_pole  (                     Vertex to ) ;
+        inline void set_v_frontal_pole   (                     Vertex to ) ;
+        inline void set_v_occipital_pole (                     Vertex to ) ;
+        inline void set_max_curv         (                      float to ) ;
+        inline void set_min_curv         (                      float to ) ;
+        inline void set_total_area       (                      float to ) ;
+        inline void set_avg_vertex_area  (                     double to ) ;
+        inline void set_zeros            (                        int to ) ;
+        inline void set_hemisphere       (                        int to ) ;  //  which hemisphere
+        inline void set_Hmin             (                      float to ) ;  //  min mean curvature
+        inline void set_Hmax             (                      float to ) ;  //  max mean curvature
+        inline void set_Kmin             (                      float to ) ;  //  min Gaussian curvature
+        inline void set_Kmax             (                      float to ) ;  //  max Gaussian curvature
+        inline void set_Ktotal           (                     double to ) ;  //  total Gaussian curvature
+        inline void set_nlabels          (                        int to ) ;
+        inline void set_labels           (           PMRIS_AREA_LABEL to ) ;  //  nlabels of these (may be null)
+        inline void set_vp               (                     p_void to ) ;  //  for misc. use
+        inline void set_alpha            (                      float to ) ;  //  rotation around z-axis
+        inline void set_beta             (                      float to ) ;  //  rotation around y-axis
+        inline void set_gamma            (                      float to ) ;  //  rotation around x-axis
+        inline void set_da               (                      float to ) ;
+        inline void set_db               (                      float to ) ;
+        inline void set_dg               (                      float to ) ;  //  old deltas
         inline void set_type             (                        int to ) ;  //  what type of surface was this initially
     };
 

--- a/include/mrisurf_SurfaceFromMRIS_generated_DistortM.h
+++ b/include/mrisurf_SurfaceFromMRIS_generated_DistortM.h
@@ -1,9 +1,9 @@
     namespace DistortM {
-    struct Face : public MRIS_Elt {
-        inline Face                        (                        );
-        inline Face (                        Face const & src       );
-        inline Face (                        MRIS* mris, size_t idx );
-        inline Face (                        AllM::Face const & src );
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
         inline Vertex                v          ( size_t i  ) const ;
@@ -15,408 +15,409 @@
         inline int                   marked     (           ) const ;
         inline PDMATRIX              norm       (           ) const ;
         inline A3PDMATRIX            gradNorm   (           ) const ;
-                   
+        
         inline void set_orig_angle (  angles_per_triangle_t to ) ;
         inline void set_ripflag    (                   char to ) ;
         inline void set_oripflag   (                   char to ) ;
         inline void set_marked     (                    int to ) ;
     };
 
-    struct Vertex : public MRIS_Elt {
-        inline Vertex (                                                 );
-        inline Vertex (                        Vertex const & src       );
-        inline Vertex (                        MRIS* mris, size_t idx   );
-        inline Vertex (                        AllM::Vertex const & src );
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        AllM::Vertex const & src                   );
         int vno       () const { return idx; }
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces            
-        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex           
-        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                                          
+        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
+        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                      
         inline Vertex v                  ( size_t i  ) const ;  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i,                     
-        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                                              
-        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                                             
-        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur                                  
-        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                                       
-        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc                              
-        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                                         
-        inline uchar  num                (           ) const ;  //  number of neighboring faces                                                  
+        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
+        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                          
+        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                         
+        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur              
+        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                   
+        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc          
+        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                     
+        inline uchar  num                (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
-        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz           
-        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz        
-        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        //           
-        inline float  x                  (           ) const ;  //  current coordinates	                                                         
-        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set                                                      
-        inline float  z                  (           ) const ;                                                                                   
-        //           
-        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status                          
-        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(,                                                     
-        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set                                          
-        //           
-        inline float  nx                 (           ) const ;                                                                                   
-        inline float  ny                 (           ) const ;                                                                                   
-        inline float  nz                 (           ) const ;  //  curr normal                                                                  
-        inline float  pnx                (           ) const ;                                                                                   
-        inline float  pny                (           ) const ;                                                                                   
-        inline float  pnz                (           ) const ;  //  pial normal                                                                  
-        //           
-        inline float  wnx                (           ) const ;                                                                                   
-        inline float  wny                (           ) const ;                                                                                   
-        inline float  wnz                (           ) const ;  //  white normal                                                                 
-        inline float  onx                (           ) const ;                                                                                   
-        inline float  ony                (           ) const ;                                                                                   
-        inline float  onz                (           ) const ;  //  original normal                                                              
-        inline float  dx                 (           ) const ;                                                                                   
-        inline float  dy                 (           ) const ;                                                                                   
-        inline float  dz                 (           ) const ;  //  current change in position                                                   
-        inline float  odx                (           ) const ;                                                                                   
-        inline float  ody                (           ) const ;                                                                                   
-        inline float  odz                (           ) const ;  //  last change of position (for momentum,                                       
-        inline float  tdx                (           ) const ;                                                                                   
-        inline float  tdy                (           ) const ;                                                                                   
-        inline float  tdz                (           ) const ;  //  temporary storage for averaging gradient                                     
-        inline float  curv               (           ) const ;  //  curr curvature                                                               
-        inline float  curvbak            (           ) const ;                                                                                   
-        inline float  val                (           ) const ;  //  scalar data value (file: rh.val, sig2-rh.w)                                  
-        inline float  imag_val           (           ) const ;  //  imaginary part of complex data value                                         
-        inline float  cx                 (           ) const ;                                                                                   
-        inline float  cy                 (           ) const ;                                                                                   
-        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system                                   
-        inline float  tx                 (           ) const ;                                                                                   
-        inline float  ty                 (           ) const ;                                                                                   
-        inline float  tz                 (           ) const ;  //  tmp coordinate storage                                                       
-        inline float  tx2                (           ) const ;                                                                                   
-        inline float  ty2                (           ) const ;                                                                                   
-        inline float  tz2                (           ) const ;  //  tmp coordinate storage                                                       
-        inline float  targx              (           ) const ;                                                                                   
-        inline float  targy              (           ) const ;                                                                                   
-        inline float  targz              (           ) const ;  //  target coordinates                                                           
-        inline float  pialx              (           ) const ;                                                                                   
-        inline float  pialy              (           ) const ;                                                                                   
-        inline float  pialz              (           ) const ;  //  pial surface coordinates                                                     
-        inline float  whitex             (           ) const ;                                                                                   
-        inline float  whitey             (           ) const ;                                                                                   
-        inline float  whitez             (           ) const ;  //  white surface coordinates                                                    
-        inline float  l4x                (           ) const ;                                                                                   
-        inline float  l4y                (           ) const ;                                                                                   
-        inline float  l4z                (           ) const ;  //  layerIV surface coordinates                                                  
-        inline float  infx               (           ) const ;                                                                                   
-        inline float  infy               (           ) const ;                                                                                   
-        inline float  infz               (           ) const ;  //  inflated coordinates                                                         
-        inline float  fx                 (           ) const ;                                                                                   
-        inline float  fy                 (           ) const ;                                                                                   
-        inline float  fz                 (           ) const ;  //  flattened coordinates                                                        
-        inline int    px                 (           ) const ;                                                                                   
-        inline int    qx                 (           ) const ;                                                                                   
-        inline int    py                 (           ) const ;                                                                                   
-        inline int    qy                 (           ) const ;                                                                                   
-        inline int    pz                 (           ) const ;                                                                                   
-        inline int    qz                 (           ) const ;  //  rational coordinates for exact calculations                                  
-        inline float  e1x                (           ) const ;                                                                                   
-        inline float  e1y                (           ) const ;                                                                                   
-        inline float  e1z                (           ) const ;  //  1st basis vector for the local tangent plane                                 
-        inline float  e2x                (           ) const ;                                                                                   
-        inline float  e2y                (           ) const ;                                                                                   
-        inline float  e2z                (           ) const ;  //  2nd basis vector for the local tangent plane                                 
-        inline float  pe1x               (           ) const ;                                                                                   
-        inline float  pe1y               (           ) const ;                                                                                   
-        inline float  pe1z               (           ) const ;  //  1st basis vector for the local tangent plane                                 
-        inline float  pe2x               (           ) const ;                                                                                   
-        inline float  pe2y               (           ) const ;                                                                                   
-        inline float  pe2z               (           ) const ;  //  2nd basis vector for the local tangent plane                                 
-        inline float  nc                 (           ) const ;  //  curr length normal comp                                                      
-        inline float  val2               (           ) const ;  //  complex comp data value (file: sig3-rh.w)                                    
-        inline float  valbak             (           ) const ;  //  scalar data stack                                                            
-        inline float  val2bak            (           ) const ;  //  complex comp data stack                                                      
-        inline float  stat               (           ) const ;  //  statistic                                                                    
-        //           
-        inline int    undefval           (           ) const ;  //  [previously dist=0]                                                          
-        inline int    old_undefval       (           ) const ;  //  for smooth_val_sparse                                                        
-        inline int    fixedval           (           ) const ;  //  [previously val=0]                                                           
-        //           
-        inline float  fieldsign          (           ) const ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs)                                 
-        inline float  fsmask             (           ) const ;  //  significance mask (file: rh.fm)                                              
-        inline float  d                  (           ) const ;  //  for distance calculations                                                    
-        inline int    annotation         (           ) const ;  //  area label (defunct--now from label file name!)                              
-        inline char   oripflag           (           ) const ;                                                                                   
-        inline char   origripflag        (           ) const ;  //  cuts flags                                                                   
-        inline p_void vp                 (           ) const ;  //  to store user's information                                                  
-        inline float  theta              (           ) const ;                                                                                   
-        inline float  phi                (           ) const ;  //  parameterization                                                             
-        inline float  area               (           ) const ;                                                                                   
-        inline float  origarea           (           ) const ;                                                                                   
-        inline float  group_avg_area     (           ) const ;                                                                                   
-        inline float  K                  (           ) const ;  //  Gaussian curvature                                                           
-        inline float  H                  (           ) const ;  //  mean curvature                                                               
-        inline float  k1                 (           ) const ;                                                                                   
-        inline float  k2                 (           ) const ;  //  the principal curvatures                                                     
-        inline float  mean               (           ) const ;                                                                                   
-        inline float  mean_imag          (           ) const ;  //  imaginary part of complex statistic                                          
-        inline float  std_error          (           ) const ;                                                                                   
-        inline uint   flags              (           ) const ;                                                                                   
-        inline int    fno                (           ) const ;  //  face that this vertex is in                                                  
-        inline int    cropped            (           ) const ;                                                                                   
-        inline short  marked             (           ) const ;  //  for a variety of uses                                                        
-        inline short  marked2            (           ) const ;                                                                                   
-        inline short  marked3            (           ) const ;                                                                                   
-        inline char   neg                (           ) const ;  //  1 if the normal vector is inverted                                           
-        inline char   border             (           ) const ;  //  flag                                                                         
-        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache     
+        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz
+        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float  x                  (           ) const ;  //  current coordinates	
+        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set
+        inline float  z                  (           ) const ;
+        // 
+        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status
+        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(, 
+        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set
+        // 
+        inline float  nx                 (           ) const ;
+        inline float  ny                 (           ) const ;
+        inline float  nz                 (           ) const ;  //  curr normal
+        inline float  pnx                (           ) const ;
+        inline float  pny                (           ) const ;
+        inline float  pnz                (           ) const ;  //  pial normal
+        // 
+        inline float  wnx                (           ) const ;
+        inline float  wny                (           ) const ;
+        inline float  wnz                (           ) const ;  //  white normal
+        inline float  onx                (           ) const ;
+        inline float  ony                (           ) const ;
+        inline float  onz                (           ) const ;  //  original normal
+        inline float  dx                 (           ) const ;
+        inline float  dy                 (           ) const ;
+        inline float  dz                 (           ) const ;  //  current change in position
+        inline float  odx                (           ) const ;
+        inline float  ody                (           ) const ;
+        inline float  odz                (           ) const ;  //  last change of position (for momentum, 
+        inline float  tdx                (           ) const ;
+        inline float  tdy                (           ) const ;
+        inline float  tdz                (           ) const ;  //  temporary storage for averaging gradient
+        inline float  curv               (           ) const ;  //  curr curvature
+        inline float  curvbak            (           ) const ;
+        inline float  val                (           ) const ;  //  scalar data value (file: rh.val, sig2-rh.w)
+        inline float  imag_val           (           ) const ;  //  imaginary part of complex data value
+        inline float  cx                 (           ) const ;
+        inline float  cy                 (           ) const ;
+        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system
+        inline float  tx                 (           ) const ;
+        inline float  ty                 (           ) const ;
+        inline float  tz                 (           ) const ;  //  tmp coordinate storage
+        inline float  t2x                (           ) const ;
+        inline float  t2y                (           ) const ;
+        inline float  t2z                (           ) const ;  //  another tmp coordinate storage
+        inline float  targx              (           ) const ;
+        inline float  targy              (           ) const ;
+        inline float  targz              (           ) const ;  //  target coordinates
+        inline float  pialx              (           ) const ;
+        inline float  pialy              (           ) const ;
+        inline float  pialz              (           ) const ;  //  pial surface coordinates
+        inline float  whitex             (           ) const ;
+        inline float  whitey             (           ) const ;
+        inline float  whitez             (           ) const ;  //  white surface coordinates
+        inline float  l4x                (           ) const ;
+        inline float  l4y                (           ) const ;
+        inline float  l4z                (           ) const ;  //  layerIV surface coordinates
+        inline float  infx               (           ) const ;
+        inline float  infy               (           ) const ;
+        inline float  infz               (           ) const ;  //  inflated coordinates
+        inline float  fx                 (           ) const ;
+        inline float  fy                 (           ) const ;
+        inline float  fz                 (           ) const ;  //  flattened coordinates
+        inline int    px                 (           ) const ;
+        inline int    qx                 (           ) const ;
+        inline int    py                 (           ) const ;
+        inline int    qy                 (           ) const ;
+        inline int    pz                 (           ) const ;
+        inline int    qz                 (           ) const ;  //  rational coordinates for exact calculations
+        inline float  e1x                (           ) const ;
+        inline float  e1y                (           ) const ;
+        inline float  e1z                (           ) const ;  //  1st basis vector for the local tangent plane
+        inline float  e2x                (           ) const ;
+        inline float  e2y                (           ) const ;
+        inline float  e2z                (           ) const ;  //  2nd basis vector for the local tangent plane
+        inline float  pe1x               (           ) const ;
+        inline float  pe1y               (           ) const ;
+        inline float  pe1z               (           ) const ;  //  1st basis vector for the local tangent plane
+        inline float  pe2x               (           ) const ;
+        inline float  pe2y               (           ) const ;
+        inline float  pe2z               (           ) const ;  //  2nd basis vector for the local tangent plane
+        inline float  nc                 (           ) const ;  //  curr length normal comp 
+        inline float  val2               (           ) const ;  //  complex comp data value (file: sig3-rh.w) 
+        inline float  valbak             (           ) const ;  //  scalar data stack 
+        inline float  val2bak            (           ) const ;  //  complex comp data stack 
+        inline float  stat               (           ) const ;  //  statistic 
+        // 
+        inline int    undefval           (           ) const ;  //  [previously dist=0] 
+        inline int    old_undefval       (           ) const ;  //  for smooth_val_sparse 
+        inline int    fixedval           (           ) const ;  //  [previously val=0] 
+        // 
+        inline float  fieldsign          (           ) const ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
+        inline float  fsmask             (           ) const ;  //  significance mask (file: rh.fm) 
+        inline float  d                  (           ) const ;  //  for distance calculations 
+        inline int    annotation         (           ) const ;  //  area label (defunct--now from label file name!) 
+        inline char   oripflag           (           ) const ;
+        inline char   origripflag        (           ) const ;  //  cuts flags 
+        inline p_void vp                 (           ) const ;  //  to store user's information 
+        inline float  theta              (           ) const ;
+        inline float  phi                (           ) const ;  //  parameterization 
+        inline float  area               (           ) const ;
+        inline float  origarea           (           ) const ;
+        inline float  group_avg_area     (           ) const ;
+        inline float  K                  (           ) const ;  //  Gaussian curvature 
+        inline float  H                  (           ) const ;  //  mean curvature 
+        inline float  k1                 (           ) const ;
+        inline float  k2                 (           ) const ;  //  the principal curvatures 
+        inline float  mean               (           ) const ;
+        inline float  mean_imag          (           ) const ;  //  imaginary part of complex statistic 
+        inline float  std_error          (           ) const ;
+        inline uint   flags              (           ) const ;
+        inline int    fno                (           ) const ;  //  face that this vertex is in 
+        inline int    cropped            (           ) const ;
+        inline short  marked             (           ) const ;  //  for a variety of uses 
+        inline short  marked2            (           ) const ;
+        inline short  marked3            (           ) const ;
+        inline char   neg                (           ) const ;  //  1 if the normal vector is inverted 
+        inline char   border             (           ) const ;  //  flag 
+        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void   which_coords       (int which, float *x, float *y, float *z) const ;
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-                   
+        
         inline void set_f              ( size_t i,   Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
         inline void set_n              ( size_t i, size_t to ) ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        inline void set_e              ( size_t i,    int to )                  ;  //  edge state for neighboring vertices                      
-        //         
-        inline void set_nx             (            float to )                                                                                 ;
-        inline void set_ny             (            float to )                                                                                 ;
-        inline void set_nz             (            float to )                                                                ;  //  curr normal
-        inline void set_pnx            (            float to )                                                                                 ;
-        inline void set_pny            (            float to )                                                                                 ;
-        inline void set_pnz            (            float to )                                                                ;  //  pial normal
-        //         
-        inline void set_wnx            (            float to )                                                                                 ;
-        inline void set_wny            (            float to )                                                                                 ;
-        inline void set_wnz            (            float to )                                                               ;  //  white normal
-        inline void set_onx            (            float to )                                                                                 ;
-        inline void set_ony            (            float to )                                                                                 ;
-        inline void set_onz            (            float to )                                                            ;  //  original normal
-        inline void set_dx             (            float to )                                                                                 ;
-        inline void set_dy             (            float to )                                                                                 ;
-        inline void set_dz             (            float to )                                                 ;  //  current change in position
-        inline void set_odx            (            float to )                                                                                 ;
-        inline void set_ody            (            float to )                                                                                 ;
-        inline void set_odz            (            float to )                                    ;  //  last change of position (for momentum, 
-        inline void set_tdx            (            float to )                                                                                 ;
-        inline void set_tdy            (            float to )                                                                                 ;
-        inline void set_tdz            (            float to )                                   ;  //  temporary storage for averaging gradient
-        inline void set_curv           (            float to )                                                             ;  //  curr curvature
-        inline void set_curvbak        (            float to )                                                                                 ;
-        inline void set_val            (            float to )                                ;  //  scalar data value (file: rh.val, sig2-rh.w)
-        inline void set_imag_val       (            float to )                                       ;  //  imaginary part of complex data value
-        inline void set_cx             (            float to )                                                                                 ;
-        inline void set_cy             (            float to )                                                                                 ;
-        inline void set_cz             (            float to )                                 ;  //  coordinates in canonical coordinate system
-        inline void set_tx             (            float to )                                                                                 ;
-        inline void set_ty             (            float to )                                                                                 ;
-        inline void set_tz             (            float to )                                                     ;  //  tmp coordinate storage
-        inline void set_tx2            (            float to )                                                                                 ;
-        inline void set_ty2            (            float to )                                                                                 ;
-        inline void set_tz2            (            float to )                                                     ;  //  tmp coordinate storage
-        inline void set_targx          (            float to )                                                                                 ;
-        inline void set_targy          (            float to )                                                                                 ;
-        inline void set_targz          (            float to )                                                         ;  //  target coordinates
-        inline void set_pialx          (            float to )                                                                                 ;
-        inline void set_pialy          (            float to )                                                                                 ;
-        inline void set_pialz          (            float to )                                                   ;  //  pial surface coordinates
-        inline void set_whitex         (            float to )                                                                                 ;
-        inline void set_whitey         (            float to )                                                                                 ;
-        inline void set_whitez         (            float to )                                                  ;  //  white surface coordinates
-        inline void set_l4x            (            float to )                                                                                 ;
-        inline void set_l4y            (            float to )                                                                                 ;
-        inline void set_l4z            (            float to )                                                ;  //  layerIV surface coordinates
-        inline void set_infx           (            float to )                                                                                 ;
-        inline void set_infy           (            float to )                                                                                 ;
-        inline void set_infz           (            float to )                                                       ;  //  inflated coordinates
-        inline void set_fx             (            float to )                                                                                 ;
-        inline void set_fy             (            float to )                                                                                 ;
-        inline void set_fz             (            float to )                                                      ;  //  flattened coordinates
-        inline void set_px             (              int to )                                                                                 ;
-        inline void set_qx             (              int to )                                                                                 ;
-        inline void set_py             (              int to )                                                                                 ;
-        inline void set_qy             (              int to )                                                                                 ;
-        inline void set_pz             (              int to )                                                                                 ;
-        inline void set_qz             (              int to )                                ;  //  rational coordinates for exact calculations
-        inline void set_e1x            (            float to )                                                                                 ;
-        inline void set_e1y            (            float to )                                                                                 ;
-        inline void set_e1z            (            float to )                               ;  //  1st basis vector for the local tangent plane
-        inline void set_e2x            (            float to )                                                                                 ;
-        inline void set_e2y            (            float to )                                                                                 ;
-        inline void set_e2z            (            float to )                               ;  //  2nd basis vector for the local tangent plane
-        inline void set_pe1x           (            float to )                                                                                 ;
-        inline void set_pe1y           (            float to )                                                                                 ;
-        inline void set_pe1z           (            float to )                               ;  //  1st basis vector for the local tangent plane
-        inline void set_pe2x           (            float to )                                                                                 ;
-        inline void set_pe2y           (            float to )                                                                                 ;
-        inline void set_pe2z           (            float to )                               ;  //  2nd basis vector for the local tangent plane
-        inline void set_nc             (            float to )                                                   ;  //  curr length normal comp 
-        inline void set_val2           (            float to )                                 ;  //  complex comp data value (file: sig3-rh.w) 
-        inline void set_valbak         (            float to )                                                         ;  //  scalar data stack 
-        inline void set_val2bak        (            float to )                                                   ;  //  complex comp data stack 
-        inline void set_stat           (            float to )                                                                 ;  //  statistic 
-        //         
-        inline void set_undefval       (              int to )                                                       ;  //  [previously dist=0] 
-        inline void set_old_undefval   (              int to )                                                     ;  //  for smooth_val_sparse 
-        inline void set_fixedval       (              int to )                                                        ;  //  [previously val=0] 
-        //         
-        inline void set_fieldsign      (            float to )                              ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
-        inline void set_fsmask         (            float to )                                           ;  //  significance mask (file: rh.fm) 
-        inline void set_d              (            float to )                                                 ;  //  for distance calculations 
-        inline void set_annotation     (              int to )                           ;  //  area label (defunct--now from label file name!) 
-        inline void set_oripflag       (             char to )                                                                                 ;
-        inline void set_origripflag    (             char to )                                                                ;  //  cuts flags 
-        inline void set_vp             (           p_void to )                                               ;  //  to store user's information 
-        inline void set_theta          (            float to )                                                                                 ;
-        inline void set_phi            (            float to )                                                          ;  //  parameterization 
-        inline void set_origarea       (            float to )                                                                                 ;
-        inline void set_group_avg_area (            float to )                                                                                 ;
-        inline void set_K              (            float to )                                                        ;  //  Gaussian curvature 
-        inline void set_H              (            float to )                                                            ;  //  mean curvature 
-        inline void set_k1             (            float to )                                                                                 ;
-        inline void set_k2             (            float to )                                                  ;  //  the principal curvatures 
-        inline void set_mean           (            float to )                                                                                 ;
-        inline void set_mean_imag      (            float to )                                       ;  //  imaginary part of complex statistic 
-        inline void set_std_error      (            float to )                                                                                 ;
-        inline void set_flags          (             uint to )                                                                                 ;
-        inline void set_fno            (              int to )                                               ;  //  face that this vertex is in 
-        inline void set_cropped        (              int to )                                                                                 ;
-        inline void set_marked         (            short to )                                                     ;  //  for a variety of uses 
-        inline void set_marked2        (            short to )                                                                                 ;
-        inline void set_marked3        (            short to )                                                                                 ;
-        inline void set_neg            (             char to )                                        ;  //  1 if the normal vector is inverted 
-        inline void set_border         (             char to )                                                                      ;  //  flag 
-        inline void set_ripflag        (             char to )   ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_e              ( size_t i,    int to ) ;  //  edge state for neighboring vertices                      
+        // 
+        inline void set_nx             (            float to ) ;
+        inline void set_ny             (            float to ) ;
+        inline void set_nz             (            float to ) ;  //  curr normal
+        inline void set_pnx            (            float to ) ;
+        inline void set_pny            (            float to ) ;
+        inline void set_pnz            (            float to ) ;  //  pial normal
+        // 
+        inline void set_wnx            (            float to ) ;
+        inline void set_wny            (            float to ) ;
+        inline void set_wnz            (            float to ) ;  //  white normal
+        inline void set_onx            (            float to ) ;
+        inline void set_ony            (            float to ) ;
+        inline void set_onz            (            float to ) ;  //  original normal
+        inline void set_dx             (            float to ) ;
+        inline void set_dy             (            float to ) ;
+        inline void set_dz             (            float to ) ;  //  current change in position
+        inline void set_odx            (            float to ) ;
+        inline void set_ody            (            float to ) ;
+        inline void set_odz            (            float to ) ;  //  last change of position (for momentum, 
+        inline void set_tdx            (            float to ) ;
+        inline void set_tdy            (            float to ) ;
+        inline void set_tdz            (            float to ) ;  //  temporary storage for averaging gradient
+        inline void set_curv           (            float to ) ;  //  curr curvature
+        inline void set_curvbak        (            float to ) ;
+        inline void set_val            (            float to ) ;  //  scalar data value (file: rh.val, sig2-rh.w)
+        inline void set_imag_val       (            float to ) ;  //  imaginary part of complex data value
+        inline void set_cx             (            float to ) ;
+        inline void set_cy             (            float to ) ;
+        inline void set_cz             (            float to ) ;  //  coordinates in canonical coordinate system
+        inline void set_tx             (            float to ) ;
+        inline void set_ty             (            float to ) ;
+        inline void set_tz             (            float to ) ;  //  tmp coordinate storage
+        inline void set_t2x            (            float to ) ;
+        inline void set_t2y            (            float to ) ;
+        inline void set_t2z            (            float to ) ;  //  another tmp coordinate storage
+        inline void set_targx          (            float to ) ;
+        inline void set_targy          (            float to ) ;
+        inline void set_targz          (            float to ) ;  //  target coordinates
+        inline void set_pialx          (            float to ) ;
+        inline void set_pialy          (            float to ) ;
+        inline void set_pialz          (            float to ) ;  //  pial surface coordinates
+        inline void set_whitex         (            float to ) ;
+        inline void set_whitey         (            float to ) ;
+        inline void set_whitez         (            float to ) ;  //  white surface coordinates
+        inline void set_l4x            (            float to ) ;
+        inline void set_l4y            (            float to ) ;
+        inline void set_l4z            (            float to ) ;  //  layerIV surface coordinates
+        inline void set_infx           (            float to ) ;
+        inline void set_infy           (            float to ) ;
+        inline void set_infz           (            float to ) ;  //  inflated coordinates
+        inline void set_fx             (            float to ) ;
+        inline void set_fy             (            float to ) ;
+        inline void set_fz             (            float to ) ;  //  flattened coordinates
+        inline void set_px             (              int to ) ;
+        inline void set_qx             (              int to ) ;
+        inline void set_py             (              int to ) ;
+        inline void set_qy             (              int to ) ;
+        inline void set_pz             (              int to ) ;
+        inline void set_qz             (              int to ) ;  //  rational coordinates for exact calculations
+        inline void set_e1x            (            float to ) ;
+        inline void set_e1y            (            float to ) ;
+        inline void set_e1z            (            float to ) ;  //  1st basis vector for the local tangent plane
+        inline void set_e2x            (            float to ) ;
+        inline void set_e2y            (            float to ) ;
+        inline void set_e2z            (            float to ) ;  //  2nd basis vector for the local tangent plane
+        inline void set_pe1x           (            float to ) ;
+        inline void set_pe1y           (            float to ) ;
+        inline void set_pe1z           (            float to ) ;  //  1st basis vector for the local tangent plane
+        inline void set_pe2x           (            float to ) ;
+        inline void set_pe2y           (            float to ) ;
+        inline void set_pe2z           (            float to ) ;  //  2nd basis vector for the local tangent plane
+        inline void set_nc             (            float to ) ;  //  curr length normal comp 
+        inline void set_val2           (            float to ) ;  //  complex comp data value (file: sig3-rh.w) 
+        inline void set_valbak         (            float to ) ;  //  scalar data stack 
+        inline void set_val2bak        (            float to ) ;  //  complex comp data stack 
+        inline void set_stat           (            float to ) ;  //  statistic 
+        // 
+        inline void set_undefval       (              int to ) ;  //  [previously dist=0] 
+        inline void set_old_undefval   (              int to ) ;  //  for smooth_val_sparse 
+        inline void set_fixedval       (              int to ) ;  //  [previously val=0] 
+        // 
+        inline void set_fieldsign      (            float to ) ;  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
+        inline void set_fsmask         (            float to ) ;  //  significance mask (file: rh.fm) 
+        inline void set_d              (            float to ) ;  //  for distance calculations 
+        inline void set_annotation     (              int to ) ;  //  area label (defunct--now from label file name!) 
+        inline void set_oripflag       (             char to ) ;
+        inline void set_origripflag    (             char to ) ;  //  cuts flags 
+        inline void set_vp             (           p_void to ) ;  //  to store user's information 
+        inline void set_theta          (            float to ) ;
+        inline void set_phi            (            float to ) ;  //  parameterization 
+        inline void set_origarea       (            float to ) ;
+        inline void set_group_avg_area (            float to ) ;
+        inline void set_K              (            float to ) ;  //  Gaussian curvature 
+        inline void set_H              (            float to ) ;  //  mean curvature 
+        inline void set_k1             (            float to ) ;
+        inline void set_k2             (            float to ) ;  //  the principal curvatures 
+        inline void set_mean           (            float to ) ;
+        inline void set_mean_imag      (            float to ) ;  //  imaginary part of complex statistic 
+        inline void set_std_error      (            float to ) ;
+        inline void set_flags          (             uint to ) ;
+        inline void set_fno            (              int to ) ;  //  face that this vertex is in 
+        inline void set_cropped        (              int to ) ;
+        inline void set_marked         (            short to ) ;  //  for a variety of uses 
+        inline void set_marked2        (            short to ) ;
+        inline void set_marked3        (            short to ) ;
+        inline void set_neg            (             char to ) ;  //  1 if the normal vector is inverted 
+        inline void set_border         (             char to ) ;  //  flag 
+        inline void set_ripflag        (             char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
-    struct Surface : public MRIS_Elt {
-        inline Surface (                           );
-        inline Surface ( Surface const & src       );
-        inline Surface ( MRIS* mris                );
-        inline Surface ( AllM::Surface const & src );
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
+        inline Surface ( AllM::Surface const & src      );
 
         // Fields being maintained by specialist functions
-        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen                                                                                     
-        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al                                          
-        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al                                             
-        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons                                                             
-        inline int                   nedges                   (           ) const ;  //  # of edges on surface                                                                                                  
-        inline int                   nstrips                  (           ) const ;                                                                                                                             
-        inline Vertex                vertices                 ( size_t i  ) const ;                                                                                                                             
-        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored                          
-        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored                     
-        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use                                                
-        inline Face                  faces                    ( size_t i  ) const ;                                                                                                                             
-        inline MRI_EDGE              edges                    ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;                                                                                                                             
-        inline STRIP                 strips                   ( size_t i  ) const ;                                                                                                                             
-        inline float                 xctr                     (           ) const ;                                                                                                                             
-        inline float                 yctr                     (           ) const ;                                                                                                                             
-        inline float                 zctr                     (           ) const ;                                                                                                                             
-        inline float                 xlo                      (           ) const ;                                                                                                                             
-        inline float                 ylo                      (           ) const ;                                                                                                                             
-        inline float                 zlo                      (           ) const ;                                                                                                                             
-        inline float                 xhi                      (           ) const ;                                                                                                                             
-        inline float                 yhi                      (           ) const ;                                                                                                                             
-        inline float                 zhi                      (           ) const ;                                                                                                                             
-        inline float                 x0                       (           ) const ;  //  center of spherical expansion                                                                                          
-        inline float                 y0                       (           ) const ;                                                                                                                             
-        inline float                 z0                       (           ) const ;                                                                                                                             
-        inline Vertex                v_temporal_pole          (           ) const ;                                                                                                                             
-        inline Vertex                v_frontal_pole           (           ) const ;                                                                                                                             
-        inline Vertex                v_occipital_pole         (           ) const ;                                                                                                                             
-        inline float                 max_curv                 (           ) const ;                                                                                                                             
-        inline float                 min_curv                 (           ) const ;                                                                                                                             
-        inline float                 total_area               (           ) const ;                                                                                                                             
-        inline double                avg_vertex_area          (           ) const ;                                                                                                                             
-        inline double                avg_vertex_dist          (           ) const ;  //  set by MRIScomputeAvgInterVertexDist                                                                                   
-        inline double                std_vertex_dist          (           ) const ;                                                                                                                             
-        inline float                 orig_area                (           ) const ;                                                                                                                             
-        inline float                 neg_area                 (           ) const ;                                                                                                                             
-        inline float                 neg_orig_area            (           ) const ;  //  amount of original surface in folds                                                                                    
-        inline int                   zeros                    (           ) const ;                                                                                                                             
-        inline int                   hemisphere               (           ) const ;  //  which hemisphere                                                                                                       
-        inline int                   initialized              (           ) const ;                                                                                                                             
-        inline PLTA                  lta                      (           ) const ;                                                                                                                             
-        inline PMATRIX               SRASToTalSRAS_           (           ) const ;                                                                                                                             
-        inline PMATRIX               TalSRASToSRAS_           (           ) const ;                                                                                                                             
-        inline int                   free_transform           (           ) const ;                                                                                                                             
-        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)                                                                                        
-        inline float                 a                        (           ) const ;                                                                                                                             
-        inline float                 b                        (           ) const ;                                                                                                                             
-        inline float                 c                        (           ) const ;  //  ellipsoid parameters                                                                                                   
-        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from                                                                                     
-        inline float                 Hmin                     (           ) const ;  //  min mean curvature                                                                                                     
-        inline float                 Hmax                     (           ) const ;  //  max mean curvature                                                                                                     
-        inline float                 Kmin                     (           ) const ;  //  min Gaussian curvature                                                                                                 
-        inline float                 Kmax                     (           ) const ;  //  max Gaussian curvature                                                                                                 
-        inline double                Ktotal                   (           ) const ;  //  total Gaussian curvature                                                                                               
-        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)                                                                                   
-        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from                                              
-        inline int                   patch                    (           ) const ;  //  if a patch of the surface                                                                                              
-        inline int                   nlabels                  (           ) const ;                                                                                                                             
-        inline PMRIS_AREA_LABEL      labels                   (           ) const ;  //  nlabels of these (may be null)                                                                                         
-        inline p_void                vp                       (           ) const ;  //  for misc. use                                                                                                          
-        inline float                 alpha                    (           ) const ;  //  rotation around z-axis                                                                                                 
-        inline float                 beta                     (           ) const ;  //  rotation around y-axis                                                                                                 
-        inline float                 gamma                    (           ) const ;  //  rotation around x-axis                                                                                                 
-        inline float                 da                       (           ) const ;                                                                                                                             
-        inline float                 db                       (           ) const ;                                                                                                                             
-        inline float                 dg                       (           ) const ;  //  old deltas                                                                                                             
-        inline int                   type                     (           ) const ;  //  what type of surface was this initially                                                                                
-        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces                                               
-        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces                                               
-        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject                                                                                                    
-        inline float                 canon_area               (           ) const ;                                                                                                                             
-        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true                                                                                    
-        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)                                                                          
-        inline float                 dy2                      ( size_t i  ) const ;                                                                                                                             
-        inline float                 dz2                      ( size_t i  ) const ;                                                                                                                             
-        inline PCOLOR_TABLE          ct                       (           ) const ;                                                                                                                             
+        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen
+        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons
+        inline int                   nedges                   (           ) const ;  //  # of edges on surface
+        inline int                   nstrips                  (           ) const ;
+        inline Vertex                vertices                 ( size_t i  ) const ;
+        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
+        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
+        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use
+        inline Face                  faces                    ( size_t i  ) const ;
+        inline MRI_EDGE              edges                    ( size_t i  ) const ;
+        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;
+        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;
+        inline STRIP                 strips                   ( size_t i  ) const ;
+        inline float                 xctr                     (           ) const ;
+        inline float                 yctr                     (           ) const ;
+        inline float                 zctr                     (           ) const ;
+        inline float                 xlo                      (           ) const ;
+        inline float                 ylo                      (           ) const ;
+        inline float                 zlo                      (           ) const ;
+        inline float                 xhi                      (           ) const ;
+        inline float                 yhi                      (           ) const ;
+        inline float                 zhi                      (           ) const ;
+        inline float                 x0                       (           ) const ;  //  center of spherical expansion
+        inline float                 y0                       (           ) const ;
+        inline float                 z0                       (           ) const ;
+        inline Vertex                v_temporal_pole          (           ) const ;
+        inline Vertex                v_frontal_pole           (           ) const ;
+        inline Vertex                v_occipital_pole         (           ) const ;
+        inline float                 max_curv                 (           ) const ;
+        inline float                 min_curv                 (           ) const ;
+        inline float                 total_area               (           ) const ;
+        inline double                avg_vertex_area          (           ) const ;
+        inline double                avg_vertex_dist          (           ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double                std_vertex_dist          (           ) const ;
+        inline float                 orig_area                (           ) const ;
+        inline float                 neg_area                 (           ) const ;
+        inline float                 neg_orig_area            (           ) const ;  //  amount of original surface in folds
+        inline int                   zeros                    (           ) const ;
+        inline int                   hemisphere               (           ) const ;  //  which hemisphere
+        inline int                   initialized              (           ) const ;
+        inline PLTA                  lta                      (           ) const ;
+        inline PMATRIX               SRASToTalSRAS_           (           ) const ;
+        inline PMATRIX               TalSRASToSRAS_           (           ) const ;
+        inline int                   free_transform           (           ) const ;
+        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline float                 a                        (           ) const ;
+        inline float                 b                        (           ) const ;
+        inline float                 c                        (           ) const ;  //  ellipsoid parameters
+        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from
+        inline float                 Hmin                     (           ) const ;  //  min mean curvature
+        inline float                 Hmax                     (           ) const ;  //  max mean curvature
+        inline float                 Kmin                     (           ) const ;  //  min Gaussian curvature
+        inline float                 Kmax                     (           ) const ;  //  max Gaussian curvature
+        inline double                Ktotal                   (           ) const ;  //  total Gaussian curvature
+        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int                   patch                    (           ) const ;  //  if a patch of the surface
+        inline int                   nlabels                  (           ) const ;
+        inline PMRIS_AREA_LABEL      labels                   (           ) const ;  //  nlabels of these (may be null)
+        inline p_void                vp                       (           ) const ;  //  for misc. use
+        inline float                 alpha                    (           ) const ;  //  rotation around z-axis
+        inline float                 beta                     (           ) const ;  //  rotation around y-axis
+        inline float                 gamma                    (           ) const ;  //  rotation around x-axis
+        inline float                 da                       (           ) const ;
+        inline float                 db                       (           ) const ;
+        inline float                 dg                       (           ) const ;  //  old deltas
+        inline int                   type                     (           ) const ;  //  what type of surface was this initially
+        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
+        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
+        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject
+        inline float                 canon_area               (           ) const ;
+        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true
+        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)
+        inline float                 dy2                      ( size_t i  ) const ;
+        inline float                 dz2                      ( size_t i  ) const ;
+        inline PCOLOR_TABLE          ct                       (           ) const ;
         inline int                   useRealRAS               (           ) const ;  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1                                                 
-        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;                                                                                                                             
-        inline int                   ncmds                    (           ) const ;                                                                                                                             
-        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group                                                                                
-        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex                                                                           
-        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces                                                                                                      
-        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here                                                                               
-        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel                                                                                    
-        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for                                                                                    
-        inline p_void                mht                      (           ) const ;                                                                                                                             
-        inline p_void                temps                    (           ) const ;                                                                                                                             
-                   
-        inline void set_strips           ( size_t i,            STRIP to )                                              ;
-        inline void set_xctr             (                      float to )                                              ;
-        inline void set_yctr             (                      float to )                                              ;
-        inline void set_zctr             (                      float to )                                              ;
-        inline void set_xlo              (                      float to )                                              ;
-        inline void set_ylo              (                      float to )                                              ;
-        inline void set_zlo              (                      float to )                                              ;
-        inline void set_xhi              (                      float to )                                              ;
-        inline void set_yhi              (                      float to )                                              ;
-        inline void set_zhi              (                      float to )                                              ;
-        inline void set_x0               (                      float to )           ;  //  center of spherical expansion
-        inline void set_y0               (                      float to )                                              ;
-        inline void set_z0               (                      float to )                                              ;
-        inline void set_v_temporal_pole  (                     Vertex to )                                              ;
-        inline void set_v_frontal_pole   (                     Vertex to )                                              ;
-        inline void set_v_occipital_pole (                     Vertex to )                                              ;
-        inline void set_max_curv         (                      float to )                                              ;
-        inline void set_min_curv         (                      float to )                                              ;
-        inline void set_total_area       (                      float to )                                              ;
-        inline void set_avg_vertex_area  (                     double to )                                              ;
-        inline void set_zeros            (                        int to )                                              ;
-        inline void set_hemisphere       (                        int to )                        ;  //  which hemisphere
-        inline void set_Hmin             (                      float to )                      ;  //  min mean curvature
-        inline void set_Hmax             (                      float to )                      ;  //  max mean curvature
-        inline void set_Kmin             (                      float to )                  ;  //  min Gaussian curvature
-        inline void set_Kmax             (                      float to )                  ;  //  max Gaussian curvature
-        inline void set_Ktotal           (                     double to )                ;  //  total Gaussian curvature
-        inline void set_nlabels          (                        int to )                                              ;
-        inline void set_labels           (           PMRIS_AREA_LABEL to )          ;  //  nlabels of these (may be null)
-        inline void set_vp               (                     p_void to )                           ;  //  for misc. use
-        inline void set_alpha            (                      float to )                  ;  //  rotation around z-axis
-        inline void set_beta             (                      float to )                  ;  //  rotation around y-axis
-        inline void set_gamma            (                      float to )                  ;  //  rotation around x-axis
-        inline void set_da               (                      float to )                                              ;
-        inline void set_db               (                      float to )                                              ;
-        inline void set_dg               (                      float to )                              ;  //  old deltas
+        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1
+        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;
+        inline int                   ncmds                    (           ) const ;
+        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group
+        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex
+        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces
+        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here
+        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel
+        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for
+        inline p_void                mht                      (           ) const ;
+        inline p_void                temps                    (           ) const ;
+        
+        inline void set_strips           ( size_t i,            STRIP to ) ;
+        inline void set_xctr             (                      float to ) ;
+        inline void set_yctr             (                      float to ) ;
+        inline void set_zctr             (                      float to ) ;
+        inline void set_xlo              (                      float to ) ;
+        inline void set_ylo              (                      float to ) ;
+        inline void set_zlo              (                      float to ) ;
+        inline void set_xhi              (                      float to ) ;
+        inline void set_yhi              (                      float to ) ;
+        inline void set_zhi              (                      float to ) ;
+        inline void set_x0               (                      float to ) ;  //  center of spherical expansion
+        inline void set_y0               (                      float to ) ;
+        inline void set_z0               (                      float to ) ;
+        inline void set_v_temporal_pole  (                     Vertex to ) ;
+        inline void set_v_frontal_pole   (                     Vertex to ) ;
+        inline void set_v_occipital_pole (                     Vertex to ) ;
+        inline void set_max_curv         (                      float to ) ;
+        inline void set_min_curv         (                      float to ) ;
+        inline void set_total_area       (                      float to ) ;
+        inline void set_avg_vertex_area  (                     double to ) ;
+        inline void set_zeros            (                        int to ) ;
+        inline void set_hemisphere       (                        int to ) ;  //  which hemisphere
+        inline void set_Hmin             (                      float to ) ;  //  min mean curvature
+        inline void set_Hmax             (                      float to ) ;  //  max mean curvature
+        inline void set_Kmin             (                      float to ) ;  //  min Gaussian curvature
+        inline void set_Kmax             (                      float to ) ;  //  max Gaussian curvature
+        inline void set_Ktotal           (                     double to ) ;  //  total Gaussian curvature
+        inline void set_nlabels          (                        int to ) ;
+        inline void set_labels           (           PMRIS_AREA_LABEL to ) ;  //  nlabels of these (may be null)
+        inline void set_vp               (                     p_void to ) ;  //  for misc. use
+        inline void set_alpha            (                      float to ) ;  //  rotation around z-axis
+        inline void set_beta             (                      float to ) ;  //  rotation around y-axis
+        inline void set_gamma            (                      float to ) ;  //  rotation around x-axis
+        inline void set_da               (                      float to ) ;
+        inline void set_db               (                      float to ) ;
+        inline void set_dg               (                      float to ) ;  //  old deltas
         inline void set_type             (                        int to ) ;  //  what type of surface was this initially
     };
 

--- a/include/mrisurf_SurfaceFromMRIS_generated_Existence.h
+++ b/include/mrisurf_SurfaceFromMRIS_generated_Existence.h
@@ -1,8 +1,8 @@
     namespace Existence {
-    struct Face : public MRIS_Elt {
+    struct Face : public Repr_Elt {
         inline Face                        (                                            );
         inline Face (                        Face const & src                           );
-        inline Face (                        MRIS* mris, size_t idx                     );
+        inline Face (                        Representation* representation, size_t idx );
         inline Face (                        TopologyM::Face const & src                );
         inline Face (                        Topology::Face const & src                 );
         inline Face (                        XYZPositionM::Face const & src             );
@@ -19,16 +19,16 @@
         inline char ripflag  (   ) const ;
         inline char oripflag (   ) const ;
         inline int  marked   (   ) const ;
-                   
+        
         inline void set_ripflag  (  char to ) ;
         inline void set_oripflag (  char to ) ;
         inline void set_marked   (   int to ) ;
     };
 
-    struct Vertex : public MRIS_Elt {
+    struct Vertex : public Repr_Elt {
         inline Vertex (                                                                     );
         inline Vertex (                        Vertex const & src                           );
-        inline Vertex (                        MRIS* mris, size_t idx                       );
+        inline Vertex (                        Representation* representation, size_t idx   );
         inline Vertex (                        TopologyM::Vertex const & src                );
         inline Vertex (                        Topology::Vertex const & src                 );
         inline Vertex (                        XYZPositionM::Vertex const & src             );
@@ -42,15 +42,16 @@
         inline Vertex (                        AllM::Vertex const & src                     );
         int vno       () const { return idx; }
 
-        inline char ripflag (   ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
-                   
+        inline char ripflag      (    ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void which_coords (int which, float *x, float *y, float *z) const ;
+        
         inline void set_ripflag (  char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
-    struct Surface : public MRIS_Elt {
+    struct Surface : public Repr_Elt {
         inline Surface (                                               );
         inline Surface ( Surface const & src                           );
-        inline Surface ( MRIS* mris                                    );
+        inline Surface ( Representation* representation                );
         inline Surface ( TopologyM::Surface const & src                );
         inline Surface ( Topology::Surface const & src                 );
         inline Surface ( XYZPositionM::Surface const & src             );
@@ -63,40 +64,40 @@
         inline Surface ( Analysis::Surface const & src                 );
         inline Surface ( AllM::Surface const & src                     );
 
-        inline int                 initialized              (           ) const ;                                                                                                                             
-        inline PLTA                lta                      (           ) const ;                                                                                                                             
-        inline PMATRIX             SRASToTalSRAS_           (           ) const ;                                                                                                                             
-        inline PMATRIX             TalSRASToSRAS_           (           ) const ;                                                                                                                             
-        inline int                 free_transform           (           ) const ;                                                                                                                             
-        inline double              radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)                                                                                        
-        inline float               a                        (           ) const ;                                                                                                                             
-        inline float               b                        (           ) const ;                                                                                                                             
-        inline float               c                        (           ) const ;  //  ellipsoid parameters                                                                                                   
-        inline MRIS_fname_t        fname                    (           ) const ;  //  file it was originally loaded from                                                                                     
-        inline MRIS_Status         status                   (           ) const ;  //  type of surface (e.g. sphere, plane)                                                                                   
-        inline MRIS_Status         origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from                                              
-        inline int                 patch                    (           ) const ;  //  if a patch of the surface                                                                                              
-        inline int                 max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces                                               
-        inline int                 max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces                                               
-        inline MRIS_subject_name_t subject_name             (           ) const ;  //  name of the subject                                                                                                    
-        inline float               canon_area               (           ) const ;                                                                                                                             
-        inline int                 noscale                  (           ) const ;  //  don't scale by surface area if true                                                                                    
-        inline float               dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)                                                                          
-        inline float               dy2                      ( size_t i  ) const ;                                                                                                                             
-        inline float               dz2                      ( size_t i  ) const ;                                                                                                                             
-        inline PCOLOR_TABLE        ct                       (           ) const ;                                                                                                                             
+        inline int                 initialized              (           ) const ;
+        inline PLTA                lta                      (           ) const ;
+        inline PMATRIX             SRASToTalSRAS_           (           ) const ;
+        inline PMATRIX             TalSRASToSRAS_           (           ) const ;
+        inline int                 free_transform           (           ) const ;
+        inline double              radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline float               a                        (           ) const ;
+        inline float               b                        (           ) const ;
+        inline float               c                        (           ) const ;  //  ellipsoid parameters
+        inline MRIS_fname_t        fname                    (           ) const ;  //  file it was originally loaded from
+        inline MRIS_Status         status                   (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status         origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int                 patch                    (           ) const ;  //  if a patch of the surface
+        inline int                 max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
+        inline int                 max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
+        inline MRIS_subject_name_t subject_name             (           ) const ;  //  name of the subject
+        inline float               canon_area               (           ) const ;
+        inline int                 noscale                  (           ) const ;  //  don't scale by surface area if true
+        inline float               dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)
+        inline float               dy2                      ( size_t i  ) const ;
+        inline float               dz2                      ( size_t i  ) const ;
+        inline PCOLOR_TABLE        ct                       (           ) const ;
         inline int                 useRealRAS               (           ) const ;  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        inline VOL_GEOM            vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1                                                 
-        inline MRIS_cmdlines_t     cmdlines                 (           ) const ;                                                                                                                             
-        inline int                 ncmds                    (           ) const ;                                                                                                                             
-        inline float               group_avg_surface_area   (           ) const ;  //  average of total surface area for group                                                                                
-        inline int                 group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex                                                                           
-        inline int                 triangle_links_removed   (           ) const ;  //  for quad surfaces                                                                                                      
-        inline p_void              user_parms               (           ) const ;  //  for whatever the user wants to hang here                                                                               
-        inline PMATRIX             m_sras2vox               (           ) const ;  //  for converting surface ras to voxel                                                                                    
-        inline PMRI                mri_sras2vox             (           ) const ;  //  volume that the above matrix is for                                                                                    
-        inline p_void              mht                      (           ) const ;                                                                                                                             
-        inline p_void              temps                    (           ) const ;                                                                                                                             
+        inline VOL_GEOM            vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1
+        inline MRIS_cmdlines_t     cmdlines                 (           ) const ;
+        inline int                 ncmds                    (           ) const ;
+        inline float               group_avg_surface_area   (           ) const ;  //  average of total surface area for group
+        inline int                 group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex
+        inline int                 triangle_links_removed   (           ) const ;  //  for quad surfaces
+        inline p_void              user_parms               (           ) const ;  //  for whatever the user wants to hang here
+        inline PMATRIX             m_sras2vox               (           ) const ;  //  for converting surface ras to voxel
+        inline PMRI                mri_sras2vox             (           ) const ;  //  volume that the above matrix is for
+        inline p_void              mht                      (           ) const ;
+        inline p_void              temps                    (           ) const ;
     };
 
     } // namespace Existence

--- a/include/mrisurf_SurfaceFromMRIS_generated_ExistenceM.h
+++ b/include/mrisurf_SurfaceFromMRIS_generated_ExistenceM.h
@@ -1,77 +1,78 @@
     namespace ExistenceM {
-    struct Face : public MRIS_Elt {
-        inline Face                        (                        );
-        inline Face (                        Face const & src       );
-        inline Face (                        MRIS* mris, size_t idx );
-        inline Face (                        AllM::Face const & src );
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
         inline char ripflag  (   ) const ;
         inline char oripflag (   ) const ;
         inline int  marked   (   ) const ;
-                   
+        
         inline void set_ripflag  (  char to ) ;
         inline void set_oripflag (  char to ) ;
         inline void set_marked   (   int to ) ;
     };
 
-    struct Vertex : public MRIS_Elt {
-        inline Vertex (                                                 );
-        inline Vertex (                        Vertex const & src       );
-        inline Vertex (                        MRIS* mris, size_t idx   );
-        inline Vertex (                        AllM::Vertex const & src );
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        AllM::Vertex const & src                   );
         int vno       () const { return idx; }
 
-        inline char ripflag (   ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
-                   
+        inline char ripflag      (    ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void which_coords (int which, float *x, float *y, float *z) const ;
+        
         inline void set_ripflag (  char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
-    struct Surface : public MRIS_Elt {
-        inline Surface (                           );
-        inline Surface ( Surface const & src       );
-        inline Surface ( MRIS* mris                );
-        inline Surface ( AllM::Surface const & src );
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
+        inline Surface ( AllM::Surface const & src      );
 
-        inline int                 initialized              (           ) const ;                                                                                                                             
-        inline PLTA                lta                      (           ) const ;                                                                                                                             
-        inline PMATRIX             SRASToTalSRAS_           (           ) const ;                                                                                                                             
-        inline PMATRIX             TalSRASToSRAS_           (           ) const ;                                                                                                                             
-        inline int                 free_transform           (           ) const ;                                                                                                                             
-        inline double              radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)                                                                                        
-        inline float               a                        (           ) const ;                                                                                                                             
-        inline float               b                        (           ) const ;                                                                                                                             
-        inline float               c                        (           ) const ;  //  ellipsoid parameters                                                                                                   
-        inline MRIS_fname_t        fname                    (           ) const ;  //  file it was originally loaded from                                                                                     
-        inline MRIS_Status         status                   (           ) const ;  //  type of surface (e.g. sphere, plane)                                                                                   
-        inline MRIS_Status         origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from                                              
-        inline int                 patch                    (           ) const ;  //  if a patch of the surface                                                                                              
-        inline int                 max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces                                               
-        inline int                 max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces                                               
-        inline MRIS_subject_name_t subject_name             (           ) const ;  //  name of the subject                                                                                                    
-        inline float               canon_area               (           ) const ;                                                                                                                             
-        inline int                 noscale                  (           ) const ;  //  don't scale by surface area if true                                                                                    
-        inline float               dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)                                                                          
-        inline float               dy2                      ( size_t i  ) const ;                                                                                                                             
-        inline float               dz2                      ( size_t i  ) const ;                                                                                                                             
-        inline PCOLOR_TABLE        ct                       (           ) const ;                                                                                                                             
+        inline int                 initialized              (           ) const ;
+        inline PLTA                lta                      (           ) const ;
+        inline PMATRIX             SRASToTalSRAS_           (           ) const ;
+        inline PMATRIX             TalSRASToSRAS_           (           ) const ;
+        inline int                 free_transform           (           ) const ;
+        inline double              radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline float               a                        (           ) const ;
+        inline float               b                        (           ) const ;
+        inline float               c                        (           ) const ;  //  ellipsoid parameters
+        inline MRIS_fname_t        fname                    (           ) const ;  //  file it was originally loaded from
+        inline MRIS_Status         status                   (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status         origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int                 patch                    (           ) const ;  //  if a patch of the surface
+        inline int                 max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
+        inline int                 max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
+        inline MRIS_subject_name_t subject_name             (           ) const ;  //  name of the subject
+        inline float               canon_area               (           ) const ;
+        inline int                 noscale                  (           ) const ;  //  don't scale by surface area if true
+        inline float               dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)
+        inline float               dy2                      ( size_t i  ) const ;
+        inline float               dz2                      ( size_t i  ) const ;
+        inline PCOLOR_TABLE        ct                       (           ) const ;
         inline int                 useRealRAS               (           ) const ;  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        inline VOL_GEOM            vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1                                                 
-        inline MRIS_cmdlines_t     cmdlines                 (           ) const ;                                                                                                                             
-        inline int                 ncmds                    (           ) const ;                                                                                                                             
-        inline float               group_avg_surface_area   (           ) const ;  //  average of total surface area for group                                                                                
-        inline int                 group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex                                                                           
-        inline int                 triangle_links_removed   (           ) const ;  //  for quad surfaces                                                                                                      
-        inline p_void              user_parms               (           ) const ;  //  for whatever the user wants to hang here                                                                               
-        inline PMATRIX             m_sras2vox               (           ) const ;  //  for converting surface ras to voxel                                                                                    
-        inline PMRI                mri_sras2vox             (           ) const ;  //  volume that the above matrix is for                                                                                    
-        inline p_void              mht                      (           ) const ;                                                                                                                             
-        inline p_void              temps                    (           ) const ;                                                                                                                             
-                   
-        inline void set_fname          (  MRIS_fname_t to )                                        ;  //  file it was originally loaded from
-        inline void set_status         (   MRIS_Status to )                                      ;  //  type of surface (e.g. sphere, plane)
+        inline VOL_GEOM            vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1
+        inline MRIS_cmdlines_t     cmdlines                 (           ) const ;
+        inline int                 ncmds                    (           ) const ;
+        inline float               group_avg_surface_area   (           ) const ;  //  average of total surface area for group
+        inline int                 group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex
+        inline int                 triangle_links_removed   (           ) const ;  //  for quad surfaces
+        inline p_void              user_parms               (           ) const ;  //  for whatever the user wants to hang here
+        inline PMATRIX             m_sras2vox               (           ) const ;  //  for converting surface ras to voxel
+        inline PMRI                mri_sras2vox             (           ) const ;  //  volume that the above matrix is for
+        inline p_void              mht                      (           ) const ;
+        inline p_void              temps                    (           ) const ;
+        
+        inline void set_fname          (  MRIS_fname_t to ) ;  //  file it was originally loaded from
+        inline void set_status         (   MRIS_Status to ) ;  //  type of surface (e.g. sphere, plane)
         inline void set_origxyz_status (   MRIS_Status to ) ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-        inline void set_patch          (           int to )                                                 ;  //  if a patch of the surface
+        inline void set_patch          (           int to ) ;  //  if a patch of the surface
     };
 
     } // namespace ExistenceM

--- a/include/mrisurf_SurfaceFromMRIS_generated_Topology.h
+++ b/include/mrisurf_SurfaceFromMRIS_generated_Topology.h
@@ -1,8 +1,8 @@
     namespace Topology {
-    struct Face : public MRIS_Elt {
+    struct Face : public Repr_Elt {
         inline Face                        (                                            );
         inline Face (                        Face const & src                           );
-        inline Face (                        MRIS* mris, size_t idx                     );
+        inline Face (                        Representation* representation, size_t idx );
         inline Face (                        XYZPositionM::Face const & src             );
         inline Face (                        XYZPosition::Face const & src              );
         inline Face (                        XYZPositionConsequencesM::Face const & src );
@@ -18,16 +18,16 @@
         inline char   ripflag  (           ) const ;
         inline char   oripflag (           ) const ;
         inline int    marked   (           ) const ;
-                   
+        
         inline void set_ripflag  (  char to ) ;
         inline void set_oripflag (  char to ) ;
         inline void set_marked   (   int to ) ;
     };
 
-    struct Vertex : public MRIS_Elt {
+    struct Vertex : public Repr_Elt {
         inline Vertex (                                                                     );
         inline Vertex (                        Vertex const & src                           );
-        inline Vertex (                        MRIS* mris, size_t idx                       );
+        inline Vertex (                        Representation* representation, size_t idx   );
         inline Vertex (                        XYZPositionM::Vertex const & src             );
         inline Vertex (                        XYZPosition::Vertex const & src              );
         inline Vertex (                        XYZPositionConsequencesM::Vertex const & src );
@@ -41,32 +41,33 @@
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-        inline Face   f             ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces            
-        inline size_t n             ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex           
-        inline int    e             ( size_t i  ) const ;  //  edge state for neighboring vertices                                          
+        inline Face   f             ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline size_t n             ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
+        inline int    e             ( size_t i  ) const ;  //  edge state for neighboring vertices                      
         inline Vertex v             ( size_t i  ) const ;  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        inline short  vnum          (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i,                     
-        inline short  v2num         (           ) const ;  //  number of 1, or 2-hop neighbors                                              
-        inline short  v3num         (           ) const ;  //  number of 1,2,or 3-hop neighbors                                             
-        inline short  vtotal        (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur                                  
-        inline short  nsizeMaxClock (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                                       
-        inline uchar  nsizeMax      (           ) const ;  //  the max nsize that was used to fill in vnum etc                              
-        inline uchar  nsizeCur      (           ) const ;  //  index of the current v#num in vtotal                                         
-        inline uchar  num           (           ) const ;  //  number of neighboring faces                                                  
-        inline char   ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache     
+        inline short  vnum          (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
+        inline short  v2num         (           ) const ;  //  number of 1, or 2-hop neighbors                          
+        inline short  v3num         (           ) const ;  //  number of 1,2,or 3-hop neighbors                         
+        inline short  vtotal        (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur              
+        inline short  nsizeMaxClock (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                   
+        inline uchar  nsizeMax      (           ) const ;  //  the max nsize that was used to fill in vnum etc          
+        inline uchar  nsizeCur      (           ) const ;  //  index of the current v#num in vtotal                     
+        inline uchar  num           (           ) const ;  //  number of neighboring faces                              
+        inline char   ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void   which_coords  (int which, float *x, float *y, float *z) const ;
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-                   
+        
         inline void set_f       ( size_t i,   Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
         inline void set_n       ( size_t i, size_t to ) ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        inline void set_e       ( size_t i,    int to )                  ;  //  edge state for neighboring vertices                      
-        inline void set_ripflag (             char to )   ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_e       ( size_t i,    int to ) ;  //  edge state for neighboring vertices                      
+        inline void set_ripflag (             char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
-    struct Surface : public MRIS_Elt {
+    struct Surface : public Repr_Elt {
         inline Surface (                                               );
         inline Surface ( Surface const & src                           );
-        inline Surface ( MRIS* mris                                    );
+        inline Surface ( Representation* representation                );
         inline Surface ( XYZPositionM::Surface const & src             );
         inline Surface ( XYZPosition::Surface const & src              );
         inline Surface ( XYZPositionConsequencesM::Surface const & src );
@@ -78,54 +79,54 @@
         inline Surface ( AllM::Surface const & src                     );
 
         // Fields being maintained by specialist functions
-        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen                                                                                     
-        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al                                          
-        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al                                             
-        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons                                                             
-        inline int                   nedges                   (           ) const ;  //  # of edges on surface                                                                                                  
-        inline int                   nstrips                  (           ) const ;                                                                                                                             
-        inline Vertex                vertices                 ( size_t i  ) const ;                                                                                                                             
-        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored                          
-        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored                     
-        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use                                                
-        inline Face                  faces                    ( size_t i  ) const ;                                                                                                                             
-        inline MRI_EDGE              edges                    ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;                                                                                                                             
-        inline int                   initialized              (           ) const ;                                                                                                                             
-        inline PLTA                  lta                      (           ) const ;                                                                                                                             
-        inline PMATRIX               SRASToTalSRAS_           (           ) const ;                                                                                                                             
-        inline PMATRIX               TalSRASToSRAS_           (           ) const ;                                                                                                                             
-        inline int                   free_transform           (           ) const ;                                                                                                                             
-        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)                                                                                        
-        inline float                 a                        (           ) const ;                                                                                                                             
-        inline float                 b                        (           ) const ;                                                                                                                             
-        inline float                 c                        (           ) const ;  //  ellipsoid parameters                                                                                                   
-        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from                                                                                     
-        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)                                                                                   
-        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from                                              
-        inline int                   patch                    (           ) const ;  //  if a patch of the surface                                                                                              
-        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces                                               
-        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces                                               
-        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject                                                                                                    
-        inline float                 canon_area               (           ) const ;                                                                                                                             
-        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true                                                                                    
-        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)                                                                          
-        inline float                 dy2                      ( size_t i  ) const ;                                                                                                                             
-        inline float                 dz2                      ( size_t i  ) const ;                                                                                                                             
-        inline PCOLOR_TABLE          ct                       (           ) const ;                                                                                                                             
+        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen
+        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons
+        inline int                   nedges                   (           ) const ;  //  # of edges on surface
+        inline int                   nstrips                  (           ) const ;
+        inline Vertex                vertices                 ( size_t i  ) const ;
+        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
+        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
+        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use
+        inline Face                  faces                    ( size_t i  ) const ;
+        inline MRI_EDGE              edges                    ( size_t i  ) const ;
+        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;
+        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;
+        inline int                   initialized              (           ) const ;
+        inline PLTA                  lta                      (           ) const ;
+        inline PMATRIX               SRASToTalSRAS_           (           ) const ;
+        inline PMATRIX               TalSRASToSRAS_           (           ) const ;
+        inline int                   free_transform           (           ) const ;
+        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline float                 a                        (           ) const ;
+        inline float                 b                        (           ) const ;
+        inline float                 c                        (           ) const ;  //  ellipsoid parameters
+        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from
+        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int                   patch                    (           ) const ;  //  if a patch of the surface
+        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
+        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
+        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject
+        inline float                 canon_area               (           ) const ;
+        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true
+        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)
+        inline float                 dy2                      ( size_t i  ) const ;
+        inline float                 dz2                      ( size_t i  ) const ;
+        inline PCOLOR_TABLE          ct                       (           ) const ;
         inline int                   useRealRAS               (           ) const ;  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1                                                 
-        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;                                                                                                                             
-        inline int                   ncmds                    (           ) const ;                                                                                                                             
-        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group                                                                                
-        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex                                                                           
-        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces                                                                                                      
-        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here                                                                               
-        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel                                                                                    
-        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for                                                                                    
-        inline p_void                mht                      (           ) const ;                                                                                                                             
-        inline p_void                temps                    (           ) const ;                                                                                                                             
+        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1
+        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;
+        inline int                   ncmds                    (           ) const ;
+        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group
+        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex
+        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces
+        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here
+        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel
+        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for
+        inline p_void                mht                      (           ) const ;
+        inline p_void                temps                    (           ) const ;
     };
 
     } // namespace Topology

--- a/include/mrisurf_SurfaceFromMRIS_generated_TopologyM.h
+++ b/include/mrisurf_SurfaceFromMRIS_generated_TopologyM.h
@@ -1,117 +1,118 @@
     namespace TopologyM {
-    struct Face : public MRIS_Elt {
-        inline Face                        (                        );
-        inline Face (                        Face const & src       );
-        inline Face (                        MRIS* mris, size_t idx );
-        inline Face (                        AllM::Face const & src );
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
         inline Vertex v        ( size_t i  ) const ;
         inline char   ripflag  (           ) const ;
         inline char   oripflag (           ) const ;
         inline int    marked   (           ) const ;
-                   
+        
         inline void set_v        ( size_t i, Vertex to ) ;
         inline void set_ripflag  (             char to ) ;
         inline void set_oripflag (             char to ) ;
         inline void set_marked   (              int to ) ;
     };
 
-    struct Vertex : public MRIS_Elt {
-        inline Vertex (                                                 );
-        inline Vertex (                        Vertex const & src       );
-        inline Vertex (                        MRIS* mris, size_t idx   );
-        inline Vertex (                        AllM::Vertex const & src );
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        AllM::Vertex const & src                   );
         int vno       () const { return idx; }
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-        inline Face   f             ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces            
-        inline size_t n             ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex           
-        inline int    e             ( size_t i  ) const ;  //  edge state for neighboring vertices                                          
+        inline Face   f             ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline size_t n             ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
+        inline int    e             ( size_t i  ) const ;  //  edge state for neighboring vertices                      
         inline Vertex v             ( size_t i  ) const ;  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        inline short  vnum          (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i,                     
-        inline short  v2num         (           ) const ;  //  number of 1, or 2-hop neighbors                                              
-        inline short  v3num         (           ) const ;  //  number of 1,2,or 3-hop neighbors                                             
-        inline short  vtotal        (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur                                  
-        inline short  nsizeMaxClock (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                                       
-        inline uchar  nsizeMax      (           ) const ;  //  the max nsize that was used to fill in vnum etc                              
-        inline uchar  nsizeCur      (           ) const ;  //  index of the current v#num in vtotal                                         
-        inline uchar  num           (           ) const ;  //  number of neighboring faces                                                  
-        inline char   ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache     
+        inline short  vnum          (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
+        inline short  v2num         (           ) const ;  //  number of 1, or 2-hop neighbors                          
+        inline short  v3num         (           ) const ;  //  number of 1,2,or 3-hop neighbors                         
+        inline short  vtotal        (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur              
+        inline short  nsizeMaxClock (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                   
+        inline uchar  nsizeMax      (           ) const ;  //  the max nsize that was used to fill in vnum etc          
+        inline uchar  nsizeCur      (           ) const ;  //  index of the current v#num in vtotal                     
+        inline uchar  num           (           ) const ;  //  number of neighboring faces                              
+        inline char   ripflag       (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void   which_coords  (int which, float *x, float *y, float *z) const ;
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-                   
-        inline void set_f             ( size_t i,   Face to )    ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        inline void set_n             ( size_t i, size_t to )    ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        inline void set_e             ( size_t i,    int to )                     ;  //  edge state for neighboring vertices                      
+        
+        inline void set_f             ( size_t i,   Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline void set_n             ( size_t i, size_t to ) ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
+        inline void set_e             ( size_t i,    int to ) ;  //  edge state for neighboring vertices                      
         inline void set_v             ( size_t i, Vertex to ) ;  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        inline void set_vnum          (            short to )                     ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
-        inline void set_v2num         (            short to )                     ;  //  number of 1, or 2-hop neighbors                          
-        inline void set_v3num         (            short to )                     ;  //  number of 1,2,or 3-hop neighbors                         
-        inline void set_vtotal        (            short to )                     ;  //  total # of neighbors. copy of vnum.nsizeCur              
-        inline void set_nsizeMaxClock (            short to )                     ;  //  copy of mris->nsizeMaxClock when v#num                   
-        inline void set_nsizeMax      (            uchar to )                     ;  //  the max nsize that was used to fill in vnum etc          
-        inline void set_nsizeCur      (            uchar to )                     ;  //  index of the current v#num in vtotal                     
-        inline void set_num           (            uchar to )                     ;  //  number of neighboring faces                              
-        inline void set_ripflag       (             char to )      ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_vnum          (            short to ) ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
+        inline void set_v2num         (            short to ) ;  //  number of 1, or 2-hop neighbors                          
+        inline void set_v3num         (            short to ) ;  //  number of 1,2,or 3-hop neighbors                         
+        inline void set_vtotal        (            short to ) ;  //  total # of neighbors. copy of vnum.nsizeCur              
+        inline void set_nsizeMaxClock (            short to ) ;  //  copy of mris->nsizeMaxClock when v#num                   
+        inline void set_nsizeMax      (            uchar to ) ;  //  the max nsize that was used to fill in vnum etc          
+        inline void set_nsizeCur      (            uchar to ) ;  //  index of the current v#num in vtotal                     
+        inline void set_num           (            uchar to ) ;  //  number of neighboring faces                              
+        inline void set_ripflag       (             char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
-    struct Surface : public MRIS_Elt {
-        inline Surface (                           );
-        inline Surface ( Surface const & src       );
-        inline Surface ( MRIS* mris                );
-        inline Surface ( AllM::Surface const & src );
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
+        inline Surface ( AllM::Surface const & src      );
 
         // Fields being maintained by specialist functions
-        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen                                                                                     
-        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al                                          
-        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al                                             
-        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons                                                             
-        inline int                   nedges                   (           ) const ;  //  # of edges on surface                                                                                                  
-        inline int                   nstrips                  (           ) const ;                                                                                                                             
-        inline Vertex                vertices                 ( size_t i  ) const ;                                                                                                                             
-        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored                          
-        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored                     
-        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use                                                
-        inline Face                  faces                    ( size_t i  ) const ;                                                                                                                             
-        inline MRI_EDGE              edges                    ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;                                                                                                                             
-        inline int                   initialized              (           ) const ;                                                                                                                             
-        inline PLTA                  lta                      (           ) const ;                                                                                                                             
-        inline PMATRIX               SRASToTalSRAS_           (           ) const ;                                                                                                                             
-        inline PMATRIX               TalSRASToSRAS_           (           ) const ;                                                                                                                             
-        inline int                   free_transform           (           ) const ;                                                                                                                             
-        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)                                                                                        
-        inline float                 a                        (           ) const ;                                                                                                                             
-        inline float                 b                        (           ) const ;                                                                                                                             
-        inline float                 c                        (           ) const ;  //  ellipsoid parameters                                                                                                   
-        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from                                                                                     
-        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)                                                                                   
-        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from                                              
-        inline int                   patch                    (           ) const ;  //  if a patch of the surface                                                                                              
-        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces                                               
-        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces                                               
-        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject                                                                                                    
-        inline float                 canon_area               (           ) const ;                                                                                                                             
-        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true                                                                                    
-        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)                                                                          
-        inline float                 dy2                      ( size_t i  ) const ;                                                                                                                             
-        inline float                 dz2                      ( size_t i  ) const ;                                                                                                                             
-        inline PCOLOR_TABLE          ct                       (           ) const ;                                                                                                                             
+        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen
+        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons
+        inline int                   nedges                   (           ) const ;  //  # of edges on surface
+        inline int                   nstrips                  (           ) const ;
+        inline Vertex                vertices                 ( size_t i  ) const ;
+        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
+        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
+        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use
+        inline Face                  faces                    ( size_t i  ) const ;
+        inline MRI_EDGE              edges                    ( size_t i  ) const ;
+        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;
+        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;
+        inline int                   initialized              (           ) const ;
+        inline PLTA                  lta                      (           ) const ;
+        inline PMATRIX               SRASToTalSRAS_           (           ) const ;
+        inline PMATRIX               TalSRASToSRAS_           (           ) const ;
+        inline int                   free_transform           (           ) const ;
+        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline float                 a                        (           ) const ;
+        inline float                 b                        (           ) const ;
+        inline float                 c                        (           ) const ;  //  ellipsoid parameters
+        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from
+        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int                   patch                    (           ) const ;  //  if a patch of the surface
+        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
+        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
+        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject
+        inline float                 canon_area               (           ) const ;
+        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true
+        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)
+        inline float                 dy2                      ( size_t i  ) const ;
+        inline float                 dz2                      ( size_t i  ) const ;
+        inline PCOLOR_TABLE          ct                       (           ) const ;
         inline int                   useRealRAS               (           ) const ;  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1                                                 
-        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;                                                                                                                             
-        inline int                   ncmds                    (           ) const ;                                                                                                                             
-        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group                                                                                
-        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex                                                                           
-        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces                                                                                                      
-        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here                                                                               
-        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel                                                                                    
-        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for                                                                                    
-        inline p_void                mht                      (           ) const ;                                                                                                                             
-        inline p_void                temps                    (           ) const ;                                                                                                                             
+        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1
+        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;
+        inline int                   ncmds                    (           ) const ;
+        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group
+        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex
+        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces
+        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here
+        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel
+        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for
+        inline p_void                mht                      (           ) const ;
+        inline p_void                temps                    (           ) const ;
     };
 
     } // namespace TopologyM

--- a/include/mrisurf_SurfaceFromMRIS_generated_XYZPosition.h
+++ b/include/mrisurf_SurfaceFromMRIS_generated_XYZPosition.h
@@ -1,8 +1,8 @@
     namespace XYZPosition {
-    struct Face : public MRIS_Elt {
+    struct Face : public Repr_Elt {
         inline Face                        (                                            );
         inline Face (                        Face const & src                           );
-        inline Face (                        MRIS* mris, size_t idx                     );
+        inline Face (                        Representation* representation, size_t idx );
         inline Face (                        XYZPositionConsequencesM::Face const & src );
         inline Face (                        XYZPositionConsequences::Face const & src  );
         inline Face (                        DistortM::Face const & src                 );
@@ -16,16 +16,16 @@
         inline char   ripflag  (           ) const ;
         inline char   oripflag (           ) const ;
         inline int    marked   (           ) const ;
-                   
+        
         inline void set_ripflag  (  char to ) ;
         inline void set_oripflag (  char to ) ;
         inline void set_marked   (   int to ) ;
     };
 
-    struct Vertex : public MRIS_Elt {
+    struct Vertex : public Repr_Elt {
         inline Vertex (                                                                     );
         inline Vertex (                        Vertex const & src                           );
-        inline Vertex (                        MRIS* mris, size_t idx                       );
+        inline Vertex (                        Representation* representation, size_t idx   );
         inline Vertex (                        XYZPositionConsequencesM::Vertex const & src );
         inline Vertex (                        XYZPositionConsequences::Vertex const & src  );
         inline Vertex (                        DistortM::Vertex const & src                 );
@@ -37,51 +37,52 @@
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces            
-        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex           
-        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                                          
+        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
+        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                      
         inline Vertex v                  ( size_t i  ) const ;  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i,                     
-        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                                              
-        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                                             
-        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur                                  
-        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                                       
-        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc                              
-        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                                         
-        inline uchar  num                (           ) const ;  //  number of neighboring faces                                                  
+        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
+        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                          
+        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                         
+        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur              
+        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                   
+        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc          
+        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                     
+        inline uchar  num                (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
-        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz           
-        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz        
-        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        //           
-        inline float  x                  (           ) const ;  //  current coordinates	                                                         
-        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set                                                      
-        inline float  z                  (           ) const ;                                                                                   
-        //           
-        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status                          
-        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(,                                                     
-        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set                                          
-        inline float  cx                 (           ) const ;                                                                                   
-        inline float  cy                 (           ) const ;                                                                                   
-        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system                                   
-        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache     
+        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz
+        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float  x                  (           ) const ;  //  current coordinates	
+        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set
+        inline float  z                  (           ) const ;
+        // 
+        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status
+        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(, 
+        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set
+        inline float  cx                 (           ) const ;
+        inline float  cy                 (           ) const ;
+        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system
+        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void   which_coords       (int which, float *x, float *y, float *z) const ;
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-                   
+        
         inline void set_f       ( size_t i,   Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
         inline void set_n       ( size_t i, size_t to ) ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        inline void set_e       ( size_t i,    int to )                  ;  //  edge state for neighboring vertices                      
-        inline void set_cx      (            float to )                                                                                 ;
-        inline void set_cy      (            float to )                                                                                 ;
-        inline void set_cz      (            float to )                                 ;  //  coordinates in canonical coordinate system
-        inline void set_ripflag (             char to )   ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_e       ( size_t i,    int to ) ;  //  edge state for neighboring vertices                      
+        inline void set_cx      (            float to ) ;
+        inline void set_cy      (            float to ) ;
+        inline void set_cz      (            float to ) ;  //  coordinates in canonical coordinate system
+        inline void set_ripflag (             char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
-    struct Surface : public MRIS_Elt {
+    struct Surface : public Repr_Elt {
         inline Surface (                                               );
         inline Surface ( Surface const & src                           );
-        inline Surface ( MRIS* mris                                    );
+        inline Surface ( Representation* representation                );
         inline Surface ( XYZPositionConsequencesM::Surface const & src );
         inline Surface ( XYZPositionConsequences::Surface const & src  );
         inline Surface ( DistortM::Surface const & src                 );
@@ -91,70 +92,70 @@
         inline Surface ( AllM::Surface const & src                     );
 
         // Fields being maintained by specialist functions
-        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen                                                                                     
-        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al                                          
-        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al                                             
-        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons                                                             
-        inline int                   nedges                   (           ) const ;  //  # of edges on surface                                                                                                  
-        inline int                   nstrips                  (           ) const ;                                                                                                                             
-        inline Vertex                vertices                 ( size_t i  ) const ;                                                                                                                             
-        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored                          
-        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored                     
-        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use                                                
-        inline Face                  faces                    ( size_t i  ) const ;                                                                                                                             
-        inline MRI_EDGE              edges                    ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;                                                                                                                             
-        inline int                   initialized              (           ) const ;                                                                                                                             
-        inline PLTA                  lta                      (           ) const ;                                                                                                                             
-        inline PMATRIX               SRASToTalSRAS_           (           ) const ;                                                                                                                             
-        inline PMATRIX               TalSRASToSRAS_           (           ) const ;                                                                                                                             
-        inline int                   free_transform           (           ) const ;                                                                                                                             
-        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)                                                                                        
-        inline float                 a                        (           ) const ;                                                                                                                             
-        inline float                 b                        (           ) const ;                                                                                                                             
-        inline float                 c                        (           ) const ;  //  ellipsoid parameters                                                                                                   
-        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from                                                                                     
-        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)                                                                                   
-        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from                                              
-        inline int                   patch                    (           ) const ;  //  if a patch of the surface                                                                                              
-        inline p_void                vp                       (           ) const ;  //  for misc. use                                                                                                          
-        inline float                 alpha                    (           ) const ;  //  rotation around z-axis                                                                                                 
-        inline float                 beta                     (           ) const ;  //  rotation around y-axis                                                                                                 
-        inline float                 gamma                    (           ) const ;  //  rotation around x-axis                                                                                                 
-        inline float                 da                       (           ) const ;                                                                                                                             
-        inline float                 db                       (           ) const ;                                                                                                                             
-        inline float                 dg                       (           ) const ;  //  old deltas                                                                                                             
-        inline int                   type                     (           ) const ;  //  what type of surface was this initially                                                                                
-        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces                                               
-        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces                                               
-        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject                                                                                                    
-        inline float                 canon_area               (           ) const ;                                                                                                                             
-        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true                                                                                    
-        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)                                                                          
-        inline float                 dy2                      ( size_t i  ) const ;                                                                                                                             
-        inline float                 dz2                      ( size_t i  ) const ;                                                                                                                             
-        inline PCOLOR_TABLE          ct                       (           ) const ;                                                                                                                             
+        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen
+        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons
+        inline int                   nedges                   (           ) const ;  //  # of edges on surface
+        inline int                   nstrips                  (           ) const ;
+        inline Vertex                vertices                 ( size_t i  ) const ;
+        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
+        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
+        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use
+        inline Face                  faces                    ( size_t i  ) const ;
+        inline MRI_EDGE              edges                    ( size_t i  ) const ;
+        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;
+        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;
+        inline int                   initialized              (           ) const ;
+        inline PLTA                  lta                      (           ) const ;
+        inline PMATRIX               SRASToTalSRAS_           (           ) const ;
+        inline PMATRIX               TalSRASToSRAS_           (           ) const ;
+        inline int                   free_transform           (           ) const ;
+        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline float                 a                        (           ) const ;
+        inline float                 b                        (           ) const ;
+        inline float                 c                        (           ) const ;  //  ellipsoid parameters
+        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from
+        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int                   patch                    (           ) const ;  //  if a patch of the surface
+        inline p_void                vp                       (           ) const ;  //  for misc. use
+        inline float                 alpha                    (           ) const ;  //  rotation around z-axis
+        inline float                 beta                     (           ) const ;  //  rotation around y-axis
+        inline float                 gamma                    (           ) const ;  //  rotation around x-axis
+        inline float                 da                       (           ) const ;
+        inline float                 db                       (           ) const ;
+        inline float                 dg                       (           ) const ;  //  old deltas
+        inline int                   type                     (           ) const ;  //  what type of surface was this initially
+        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
+        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
+        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject
+        inline float                 canon_area               (           ) const ;
+        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true
+        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)
+        inline float                 dy2                      ( size_t i  ) const ;
+        inline float                 dz2                      ( size_t i  ) const ;
+        inline PCOLOR_TABLE          ct                       (           ) const ;
         inline int                   useRealRAS               (           ) const ;  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1                                                 
-        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;                                                                                                                             
-        inline int                   ncmds                    (           ) const ;                                                                                                                             
-        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group                                                                                
-        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex                                                                           
-        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces                                                                                                      
-        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here                                                                               
-        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel                                                                                    
-        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for                                                                                    
-        inline p_void                mht                      (           ) const ;                                                                                                                             
-        inline p_void                temps                    (           ) const ;                                                                                                                             
-                   
-        inline void set_vp    (  p_void to )                           ;  //  for misc. use
-        inline void set_alpha (   float to )                  ;  //  rotation around z-axis
-        inline void set_beta  (   float to )                  ;  //  rotation around y-axis
-        inline void set_gamma (   float to )                  ;  //  rotation around x-axis
-        inline void set_da    (   float to )                                              ;
-        inline void set_db    (   float to )                                              ;
-        inline void set_dg    (   float to )                              ;  //  old deltas
+        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1
+        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;
+        inline int                   ncmds                    (           ) const ;
+        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group
+        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex
+        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces
+        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here
+        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel
+        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for
+        inline p_void                mht                      (           ) const ;
+        inline p_void                temps                    (           ) const ;
+        
+        inline void set_vp    (  p_void to ) ;  //  for misc. use
+        inline void set_alpha (   float to ) ;  //  rotation around z-axis
+        inline void set_beta  (   float to ) ;  //  rotation around y-axis
+        inline void set_gamma (   float to ) ;  //  rotation around x-axis
+        inline void set_da    (   float to ) ;
+        inline void set_db    (   float to ) ;
+        inline void set_dg    (   float to ) ;  //  old deltas
         inline void set_type  (     int to ) ;  //  what type of surface was this initially
     };
 

--- a/include/mrisurf_SurfaceFromMRIS_generated_XYZPositionConsequences.h
+++ b/include/mrisurf_SurfaceFromMRIS_generated_XYZPositionConsequences.h
@@ -1,13 +1,13 @@
     namespace XYZPositionConsequences {
-    struct Face : public MRIS_Elt {
-        inline Face                        (                             );
-        inline Face (                        Face const & src            );
-        inline Face (                        MRIS* mris, size_t idx      );
-        inline Face (                        DistortM::Face const & src  );
-        inline Face (                        Distort::Face const & src   );
-        inline Face (                        AnalysisM::Face const & src );
-        inline Face (                        Analysis::Face const & src  );
-        inline Face (                        AllM::Face const & src      );
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        DistortM::Face const & src                 );
+        inline Face (                        Distort::Face const & src                  );
+        inline Face (                        AnalysisM::Face const & src                );
+        inline Face (                        Analysis::Face const & src                 );
+        inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
         inline Vertex                v          ( size_t i  ) const ;
@@ -19,80 +19,81 @@
         inline int                   marked     (           ) const ;
         inline PDMATRIX              norm       (           ) const ;
         inline A3PDMATRIX            gradNorm   (           ) const ;
-                   
+        
         inline void set_orig_angle (  angles_per_triangle_t to ) ;
         inline void set_ripflag    (                   char to ) ;
         inline void set_oripflag   (                   char to ) ;
         inline void set_marked     (                    int to ) ;
     };
 
-    struct Vertex : public MRIS_Elt {
-        inline Vertex (                                                      );
-        inline Vertex (                        Vertex const & src            );
-        inline Vertex (                        MRIS* mris, size_t idx        );
-        inline Vertex (                        DistortM::Vertex const & src  );
-        inline Vertex (                        Distort::Vertex const & src   );
-        inline Vertex (                        AnalysisM::Vertex const & src );
-        inline Vertex (                        Analysis::Vertex const & src  );
-        inline Vertex (                        AllM::Vertex const & src      );
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        DistortM::Vertex const & src               );
+        inline Vertex (                        Distort::Vertex const & src                );
+        inline Vertex (                        AnalysisM::Vertex const & src              );
+        inline Vertex (                        Analysis::Vertex const & src               );
+        inline Vertex (                        AllM::Vertex const & src                   );
         int vno       () const { return idx; }
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces            
-        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex           
-        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                                          
+        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
+        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                      
         inline Vertex v                  ( size_t i  ) const ;  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i,                     
-        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                                              
-        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                                             
-        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur                                  
-        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                                       
-        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc                              
-        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                                         
-        inline uchar  num                (           ) const ;  //  number of neighboring faces                                                  
+        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
+        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                          
+        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                         
+        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur              
+        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                   
+        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc          
+        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                     
+        inline uchar  num                (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
-        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz           
-        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz        
-        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        //           
-        inline float  x                  (           ) const ;  //  current coordinates	                                                         
-        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set                                                      
-        inline float  z                  (           ) const ;                                                                                   
-        //           
-        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status                          
-        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(,                                                     
-        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set                                          
-        //           
-        inline float  nx                 (           ) const ;                                                                                   
-        inline float  ny                 (           ) const ;                                                                                   
-        inline float  nz                 (           ) const ;  //  curr normal                                                                  
-        inline float  cx                 (           ) const ;                                                                                   
-        inline float  cy                 (           ) const ;                                                                                   
-        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system                                   
-        inline float  area               (           ) const ;                                                                                   
-        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache     
+        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz
+        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float  x                  (           ) const ;  //  current coordinates	
+        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set
+        inline float  z                  (           ) const ;
+        // 
+        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status
+        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(, 
+        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set
+        // 
+        inline float  nx                 (           ) const ;
+        inline float  ny                 (           ) const ;
+        inline float  nz                 (           ) const ;  //  curr normal
+        inline float  cx                 (           ) const ;
+        inline float  cy                 (           ) const ;
+        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system
+        inline float  area               (           ) const ;
+        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void   which_coords       (int which, float *x, float *y, float *z) const ;
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-                   
+        
         inline void set_f       ( size_t i,   Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
         inline void set_n       ( size_t i, size_t to ) ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        inline void set_e       ( size_t i,    int to )                  ;  //  edge state for neighboring vertices                      
-        //         
-        inline void set_nx      (            float to )                                                                                 ;
-        inline void set_ny      (            float to )                                                                                 ;
-        inline void set_nz      (            float to )                                                                ;  //  curr normal
-        inline void set_cx      (            float to )                                                                                 ;
-        inline void set_cy      (            float to )                                                                                 ;
-        inline void set_cz      (            float to )                                 ;  //  coordinates in canonical coordinate system
-        inline void set_ripflag (             char to )   ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_e       ( size_t i,    int to ) ;  //  edge state for neighboring vertices                      
+        // 
+        inline void set_nx      (            float to ) ;
+        inline void set_ny      (            float to ) ;
+        inline void set_nz      (            float to ) ;  //  curr normal
+        inline void set_cx      (            float to ) ;
+        inline void set_cy      (            float to ) ;
+        inline void set_cz      (            float to ) ;  //  coordinates in canonical coordinate system
+        inline void set_ripflag (             char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
-    struct Surface : public MRIS_Elt {
+    struct Surface : public Repr_Elt {
         inline Surface (                                );
         inline Surface ( Surface const & src            );
-        inline Surface ( MRIS* mris                     );
+        inline Surface ( Representation* representation );
         inline Surface ( DistortM::Surface const & src  );
         inline Surface ( Distort::Surface const & src   );
         inline Surface ( AnalysisM::Surface const & src );
@@ -100,133 +101,133 @@
         inline Surface ( AllM::Surface const & src      );
 
         // Fields being maintained by specialist functions
-        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen                                                                                     
-        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al                                          
-        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al                                             
-        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons                                                             
-        inline int                   nedges                   (           ) const ;  //  # of edges on surface                                                                                                  
-        inline int                   nstrips                  (           ) const ;                                                                                                                             
-        inline Vertex                vertices                 ( size_t i  ) const ;                                                                                                                             
-        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored                          
-        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored                     
-        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use                                                
-        inline Face                  faces                    ( size_t i  ) const ;                                                                                                                             
-        inline MRI_EDGE              edges                    ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;                                                                                                                             
-        inline STRIP                 strips                   ( size_t i  ) const ;                                                                                                                             
-        inline float                 xctr                     (           ) const ;                                                                                                                             
-        inline float                 yctr                     (           ) const ;                                                                                                                             
-        inline float                 zctr                     (           ) const ;                                                                                                                             
-        inline float                 xlo                      (           ) const ;                                                                                                                             
-        inline float                 ylo                      (           ) const ;                                                                                                                             
-        inline float                 zlo                      (           ) const ;                                                                                                                             
-        inline float                 xhi                      (           ) const ;                                                                                                                             
-        inline float                 yhi                      (           ) const ;                                                                                                                             
-        inline float                 zhi                      (           ) const ;                                                                                                                             
-        inline float                 x0                       (           ) const ;  //  center of spherical expansion                                                                                          
-        inline float                 y0                       (           ) const ;                                                                                                                             
-        inline float                 z0                       (           ) const ;                                                                                                                             
-        inline Vertex                v_temporal_pole          (           ) const ;                                                                                                                             
-        inline Vertex                v_frontal_pole           (           ) const ;                                                                                                                             
-        inline Vertex                v_occipital_pole         (           ) const ;                                                                                                                             
-        inline float                 max_curv                 (           ) const ;                                                                                                                             
-        inline float                 min_curv                 (           ) const ;                                                                                                                             
-        inline float                 total_area               (           ) const ;                                                                                                                             
-        inline double                avg_vertex_area          (           ) const ;                                                                                                                             
-        inline double                avg_vertex_dist          (           ) const ;  //  set by MRIScomputeAvgInterVertexDist                                                                                   
-        inline double                std_vertex_dist          (           ) const ;                                                                                                                             
-        inline float                 orig_area                (           ) const ;                                                                                                                             
-        inline float                 neg_area                 (           ) const ;                                                                                                                             
-        inline float                 neg_orig_area            (           ) const ;  //  amount of original surface in folds                                                                                    
-        inline int                   zeros                    (           ) const ;                                                                                                                             
-        inline int                   hemisphere               (           ) const ;  //  which hemisphere                                                                                                       
-        inline int                   initialized              (           ) const ;                                                                                                                             
-        inline PLTA                  lta                      (           ) const ;                                                                                                                             
-        inline PMATRIX               SRASToTalSRAS_           (           ) const ;                                                                                                                             
-        inline PMATRIX               TalSRASToSRAS_           (           ) const ;                                                                                                                             
-        inline int                   free_transform           (           ) const ;                                                                                                                             
-        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)                                                                                        
-        inline float                 a                        (           ) const ;                                                                                                                             
-        inline float                 b                        (           ) const ;                                                                                                                             
-        inline float                 c                        (           ) const ;  //  ellipsoid parameters                                                                                                   
-        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from                                                                                     
-        inline float                 Hmin                     (           ) const ;  //  min mean curvature                                                                                                     
-        inline float                 Hmax                     (           ) const ;  //  max mean curvature                                                                                                     
-        inline float                 Kmin                     (           ) const ;  //  min Gaussian curvature                                                                                                 
-        inline float                 Kmax                     (           ) const ;  //  max Gaussian curvature                                                                                                 
-        inline double                Ktotal                   (           ) const ;  //  total Gaussian curvature                                                                                               
-        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)                                                                                   
-        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from                                              
-        inline int                   patch                    (           ) const ;  //  if a patch of the surface                                                                                              
-        inline int                   nlabels                  (           ) const ;                                                                                                                             
-        inline PMRIS_AREA_LABEL      labels                   (           ) const ;  //  nlabels of these (may be null)                                                                                         
-        inline p_void                vp                       (           ) const ;  //  for misc. use                                                                                                          
-        inline float                 alpha                    (           ) const ;  //  rotation around z-axis                                                                                                 
-        inline float                 beta                     (           ) const ;  //  rotation around y-axis                                                                                                 
-        inline float                 gamma                    (           ) const ;  //  rotation around x-axis                                                                                                 
-        inline float                 da                       (           ) const ;                                                                                                                             
-        inline float                 db                       (           ) const ;                                                                                                                             
-        inline float                 dg                       (           ) const ;  //  old deltas                                                                                                             
-        inline int                   type                     (           ) const ;  //  what type of surface was this initially                                                                                
-        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces                                               
-        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces                                               
-        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject                                                                                                    
-        inline float                 canon_area               (           ) const ;                                                                                                                             
-        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true                                                                                    
-        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)                                                                          
-        inline float                 dy2                      ( size_t i  ) const ;                                                                                                                             
-        inline float                 dz2                      ( size_t i  ) const ;                                                                                                                             
-        inline PCOLOR_TABLE          ct                       (           ) const ;                                                                                                                             
+        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen
+        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons
+        inline int                   nedges                   (           ) const ;  //  # of edges on surface
+        inline int                   nstrips                  (           ) const ;
+        inline Vertex                vertices                 ( size_t i  ) const ;
+        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
+        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
+        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use
+        inline Face                  faces                    ( size_t i  ) const ;
+        inline MRI_EDGE              edges                    ( size_t i  ) const ;
+        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;
+        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;
+        inline STRIP                 strips                   ( size_t i  ) const ;
+        inline float                 xctr                     (           ) const ;
+        inline float                 yctr                     (           ) const ;
+        inline float                 zctr                     (           ) const ;
+        inline float                 xlo                      (           ) const ;
+        inline float                 ylo                      (           ) const ;
+        inline float                 zlo                      (           ) const ;
+        inline float                 xhi                      (           ) const ;
+        inline float                 yhi                      (           ) const ;
+        inline float                 zhi                      (           ) const ;
+        inline float                 x0                       (           ) const ;  //  center of spherical expansion
+        inline float                 y0                       (           ) const ;
+        inline float                 z0                       (           ) const ;
+        inline Vertex                v_temporal_pole          (           ) const ;
+        inline Vertex                v_frontal_pole           (           ) const ;
+        inline Vertex                v_occipital_pole         (           ) const ;
+        inline float                 max_curv                 (           ) const ;
+        inline float                 min_curv                 (           ) const ;
+        inline float                 total_area               (           ) const ;
+        inline double                avg_vertex_area          (           ) const ;
+        inline double                avg_vertex_dist          (           ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double                std_vertex_dist          (           ) const ;
+        inline float                 orig_area                (           ) const ;
+        inline float                 neg_area                 (           ) const ;
+        inline float                 neg_orig_area            (           ) const ;  //  amount of original surface in folds
+        inline int                   zeros                    (           ) const ;
+        inline int                   hemisphere               (           ) const ;  //  which hemisphere
+        inline int                   initialized              (           ) const ;
+        inline PLTA                  lta                      (           ) const ;
+        inline PMATRIX               SRASToTalSRAS_           (           ) const ;
+        inline PMATRIX               TalSRASToSRAS_           (           ) const ;
+        inline int                   free_transform           (           ) const ;
+        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline float                 a                        (           ) const ;
+        inline float                 b                        (           ) const ;
+        inline float                 c                        (           ) const ;  //  ellipsoid parameters
+        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from
+        inline float                 Hmin                     (           ) const ;  //  min mean curvature
+        inline float                 Hmax                     (           ) const ;  //  max mean curvature
+        inline float                 Kmin                     (           ) const ;  //  min Gaussian curvature
+        inline float                 Kmax                     (           ) const ;  //  max Gaussian curvature
+        inline double                Ktotal                   (           ) const ;  //  total Gaussian curvature
+        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int                   patch                    (           ) const ;  //  if a patch of the surface
+        inline int                   nlabels                  (           ) const ;
+        inline PMRIS_AREA_LABEL      labels                   (           ) const ;  //  nlabels of these (may be null)
+        inline p_void                vp                       (           ) const ;  //  for misc. use
+        inline float                 alpha                    (           ) const ;  //  rotation around z-axis
+        inline float                 beta                     (           ) const ;  //  rotation around y-axis
+        inline float                 gamma                    (           ) const ;  //  rotation around x-axis
+        inline float                 da                       (           ) const ;
+        inline float                 db                       (           ) const ;
+        inline float                 dg                       (           ) const ;  //  old deltas
+        inline int                   type                     (           ) const ;  //  what type of surface was this initially
+        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
+        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
+        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject
+        inline float                 canon_area               (           ) const ;
+        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true
+        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)
+        inline float                 dy2                      ( size_t i  ) const ;
+        inline float                 dz2                      ( size_t i  ) const ;
+        inline PCOLOR_TABLE          ct                       (           ) const ;
         inline int                   useRealRAS               (           ) const ;  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1                                                 
-        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;                                                                                                                             
-        inline int                   ncmds                    (           ) const ;                                                                                                                             
-        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group                                                                                
-        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex                                                                           
-        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces                                                                                                      
-        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here                                                                               
-        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel                                                                                    
-        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for                                                                                    
-        inline p_void                mht                      (           ) const ;                                                                                                                             
-        inline p_void                temps                    (           ) const ;                                                                                                                             
-                   
-        inline void set_strips           ( size_t i,            STRIP to )                                              ;
-        inline void set_xctr             (                      float to )                                              ;
-        inline void set_yctr             (                      float to )                                              ;
-        inline void set_zctr             (                      float to )                                              ;
-        inline void set_xlo              (                      float to )                                              ;
-        inline void set_ylo              (                      float to )                                              ;
-        inline void set_zlo              (                      float to )                                              ;
-        inline void set_xhi              (                      float to )                                              ;
-        inline void set_yhi              (                      float to )                                              ;
-        inline void set_zhi              (                      float to )                                              ;
-        inline void set_x0               (                      float to )           ;  //  center of spherical expansion
-        inline void set_y0               (                      float to )                                              ;
-        inline void set_z0               (                      float to )                                              ;
-        inline void set_v_temporal_pole  (                     Vertex to )                                              ;
-        inline void set_v_frontal_pole   (                     Vertex to )                                              ;
-        inline void set_v_occipital_pole (                     Vertex to )                                              ;
-        inline void set_max_curv         (                      float to )                                              ;
-        inline void set_min_curv         (                      float to )                                              ;
-        inline void set_total_area       (                      float to )                                              ;
-        inline void set_avg_vertex_area  (                     double to )                                              ;
-        inline void set_zeros            (                        int to )                                              ;
-        inline void set_hemisphere       (                        int to )                        ;  //  which hemisphere
-        inline void set_Hmin             (                      float to )                      ;  //  min mean curvature
-        inline void set_Hmax             (                      float to )                      ;  //  max mean curvature
-        inline void set_Kmin             (                      float to )                  ;  //  min Gaussian curvature
-        inline void set_Kmax             (                      float to )                  ;  //  max Gaussian curvature
-        inline void set_Ktotal           (                     double to )                ;  //  total Gaussian curvature
-        inline void set_nlabels          (                        int to )                                              ;
-        inline void set_labels           (           PMRIS_AREA_LABEL to )          ;  //  nlabels of these (may be null)
-        inline void set_vp               (                     p_void to )                           ;  //  for misc. use
-        inline void set_alpha            (                      float to )                  ;  //  rotation around z-axis
-        inline void set_beta             (                      float to )                  ;  //  rotation around y-axis
-        inline void set_gamma            (                      float to )                  ;  //  rotation around x-axis
-        inline void set_da               (                      float to )                                              ;
-        inline void set_db               (                      float to )                                              ;
-        inline void set_dg               (                      float to )                              ;  //  old deltas
+        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1
+        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;
+        inline int                   ncmds                    (           ) const ;
+        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group
+        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex
+        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces
+        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here
+        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel
+        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for
+        inline p_void                mht                      (           ) const ;
+        inline p_void                temps                    (           ) const ;
+        
+        inline void set_strips           ( size_t i,            STRIP to ) ;
+        inline void set_xctr             (                      float to ) ;
+        inline void set_yctr             (                      float to ) ;
+        inline void set_zctr             (                      float to ) ;
+        inline void set_xlo              (                      float to ) ;
+        inline void set_ylo              (                      float to ) ;
+        inline void set_zlo              (                      float to ) ;
+        inline void set_xhi              (                      float to ) ;
+        inline void set_yhi              (                      float to ) ;
+        inline void set_zhi              (                      float to ) ;
+        inline void set_x0               (                      float to ) ;  //  center of spherical expansion
+        inline void set_y0               (                      float to ) ;
+        inline void set_z0               (                      float to ) ;
+        inline void set_v_temporal_pole  (                     Vertex to ) ;
+        inline void set_v_frontal_pole   (                     Vertex to ) ;
+        inline void set_v_occipital_pole (                     Vertex to ) ;
+        inline void set_max_curv         (                      float to ) ;
+        inline void set_min_curv         (                      float to ) ;
+        inline void set_total_area       (                      float to ) ;
+        inline void set_avg_vertex_area  (                     double to ) ;
+        inline void set_zeros            (                        int to ) ;
+        inline void set_hemisphere       (                        int to ) ;  //  which hemisphere
+        inline void set_Hmin             (                      float to ) ;  //  min mean curvature
+        inline void set_Hmax             (                      float to ) ;  //  max mean curvature
+        inline void set_Kmin             (                      float to ) ;  //  min Gaussian curvature
+        inline void set_Kmax             (                      float to ) ;  //  max Gaussian curvature
+        inline void set_Ktotal           (                     double to ) ;  //  total Gaussian curvature
+        inline void set_nlabels          (                        int to ) ;
+        inline void set_labels           (           PMRIS_AREA_LABEL to ) ;  //  nlabels of these (may be null)
+        inline void set_vp               (                     p_void to ) ;  //  for misc. use
+        inline void set_alpha            (                      float to ) ;  //  rotation around z-axis
+        inline void set_beta             (                      float to ) ;  //  rotation around y-axis
+        inline void set_gamma            (                      float to ) ;  //  rotation around x-axis
+        inline void set_da               (                      float to ) ;
+        inline void set_db               (                      float to ) ;
+        inline void set_dg               (                      float to ) ;  //  old deltas
         inline void set_type             (                        int to ) ;  //  what type of surface was this initially
     };
 

--- a/include/mrisurf_SurfaceFromMRIS_generated_XYZPositionConsequencesM.h
+++ b/include/mrisurf_SurfaceFromMRIS_generated_XYZPositionConsequencesM.h
@@ -1,9 +1,9 @@
     namespace XYZPositionConsequencesM {
-    struct Face : public MRIS_Elt {
-        inline Face                        (                        );
-        inline Face (                        Face const & src       );
-        inline Face (                        MRIS* mris, size_t idx );
-        inline Face (                        AllM::Face const & src );
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
         inline Vertex                v          ( size_t i  ) const ;
@@ -15,7 +15,7 @@
         inline int                   marked     (           ) const ;
         inline PDMATRIX              norm       (           ) const ;
         inline A3PDMATRIX            gradNorm   (           ) const ;
-                   
+        
         inline void set_area       (                  float to ) ;
         inline void set_angle      (  angles_per_triangle_t to ) ;
         inline void set_orig_angle (  angles_per_triangle_t to ) ;
@@ -26,205 +26,206 @@
         inline void set_gradNorm   (             A3PDMATRIX to ) ;
     };
 
-    struct Vertex : public MRIS_Elt {
-        inline Vertex (                                                 );
-        inline Vertex (                        Vertex const & src       );
-        inline Vertex (                        MRIS* mris, size_t idx   );
-        inline Vertex (                        AllM::Vertex const & src );
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        AllM::Vertex const & src                   );
         int vno       () const { return idx; }
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces            
-        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex           
-        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                                          
+        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
+        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                      
         inline Vertex v                  ( size_t i  ) const ;  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i,                     
-        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                                              
-        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                                             
-        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur                                  
-        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                                       
-        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc                              
-        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                                         
-        inline uchar  num                (           ) const ;  //  number of neighboring faces                                                  
+        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
+        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                          
+        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                         
+        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur              
+        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                   
+        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc          
+        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                     
+        inline uchar  num                (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
-        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz           
-        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz        
-        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        //           
-        inline float  x                  (           ) const ;  //  current coordinates	                                                         
-        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set                                                      
-        inline float  z                  (           ) const ;                                                                                   
-        //           
-        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status                          
-        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(,                                                     
-        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set                                          
-        //           
-        inline float  nx                 (           ) const ;                                                                                   
-        inline float  ny                 (           ) const ;                                                                                   
-        inline float  nz                 (           ) const ;  //  curr normal                                                                  
-        inline float  cx                 (           ) const ;                                                                                   
-        inline float  cy                 (           ) const ;                                                                                   
-        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system                                   
-        inline float  area               (           ) const ;                                                                                   
-        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache     
+        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz
+        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float  x                  (           ) const ;  //  current coordinates	
+        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set
+        inline float  z                  (           ) const ;
+        // 
+        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status
+        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(, 
+        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set
+        // 
+        inline float  nx                 (           ) const ;
+        inline float  ny                 (           ) const ;
+        inline float  nz                 (           ) const ;  //  curr normal
+        inline float  cx                 (           ) const ;
+        inline float  cy                 (           ) const ;
+        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system
+        inline float  area               (           ) const ;
+        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void   which_coords       (int which, float *x, float *y, float *z) const ;
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-                   
+        
         inline void set_f       ( size_t i,   Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
         inline void set_n       ( size_t i, size_t to ) ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        inline void set_e       ( size_t i,    int to )                  ;  //  edge state for neighboring vertices                      
-        //         
-        inline void set_nx      (            float to )                                                                                 ;
-        inline void set_ny      (            float to )                                                                                 ;
-        inline void set_nz      (            float to )                                                                ;  //  curr normal
-        inline void set_cx      (            float to )                                                                                 ;
-        inline void set_cy      (            float to )                                                                                 ;
-        inline void set_cz      (            float to )                                 ;  //  coordinates in canonical coordinate system
-        inline void set_area    (            float to )                                                                                 ;
-        inline void set_ripflag (             char to )   ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_e       ( size_t i,    int to ) ;  //  edge state for neighboring vertices                      
+        // 
+        inline void set_nx      (            float to ) ;
+        inline void set_ny      (            float to ) ;
+        inline void set_nz      (            float to ) ;  //  curr normal
+        inline void set_cx      (            float to ) ;
+        inline void set_cy      (            float to ) ;
+        inline void set_cz      (            float to ) ;  //  coordinates in canonical coordinate system
+        inline void set_area    (            float to ) ;
+        inline void set_ripflag (             char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
-    struct Surface : public MRIS_Elt {
-        inline Surface (                           );
-        inline Surface ( Surface const & src       );
-        inline Surface ( MRIS* mris                );
-        inline Surface ( AllM::Surface const & src );
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
+        inline Surface ( AllM::Surface const & src      );
 
         // Fields being maintained by specialist functions
-        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen                                                                                     
-        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al                                          
-        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al                                             
-        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons                                                             
-        inline int                   nedges                   (           ) const ;  //  # of edges on surface                                                                                                  
-        inline int                   nstrips                  (           ) const ;                                                                                                                             
-        inline Vertex                vertices                 ( size_t i  ) const ;                                                                                                                             
-        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored                          
-        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored                     
-        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use                                                
-        inline Face                  faces                    ( size_t i  ) const ;                                                                                                                             
-        inline MRI_EDGE              edges                    ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;                                                                                                                             
-        inline STRIP                 strips                   ( size_t i  ) const ;                                                                                                                             
-        inline float                 xctr                     (           ) const ;                                                                                                                             
-        inline float                 yctr                     (           ) const ;                                                                                                                             
-        inline float                 zctr                     (           ) const ;                                                                                                                             
-        inline float                 xlo                      (           ) const ;                                                                                                                             
-        inline float                 ylo                      (           ) const ;                                                                                                                             
-        inline float                 zlo                      (           ) const ;                                                                                                                             
-        inline float                 xhi                      (           ) const ;                                                                                                                             
-        inline float                 yhi                      (           ) const ;                                                                                                                             
-        inline float                 zhi                      (           ) const ;                                                                                                                             
-        inline float                 x0                       (           ) const ;  //  center of spherical expansion                                                                                          
-        inline float                 y0                       (           ) const ;                                                                                                                             
-        inline float                 z0                       (           ) const ;                                                                                                                             
-        inline Vertex                v_temporal_pole          (           ) const ;                                                                                                                             
-        inline Vertex                v_frontal_pole           (           ) const ;                                                                                                                             
-        inline Vertex                v_occipital_pole         (           ) const ;                                                                                                                             
-        inline float                 max_curv                 (           ) const ;                                                                                                                             
-        inline float                 min_curv                 (           ) const ;                                                                                                                             
-        inline float                 total_area               (           ) const ;                                                                                                                             
-        inline double                avg_vertex_area          (           ) const ;                                                                                                                             
-        inline double                avg_vertex_dist          (           ) const ;  //  set by MRIScomputeAvgInterVertexDist                                                                                   
-        inline double                std_vertex_dist          (           ) const ;                                                                                                                             
-        inline float                 orig_area                (           ) const ;                                                                                                                             
-        inline float                 neg_area                 (           ) const ;                                                                                                                             
-        inline float                 neg_orig_area            (           ) const ;  //  amount of original surface in folds                                                                                    
-        inline int                   zeros                    (           ) const ;                                                                                                                             
-        inline int                   hemisphere               (           ) const ;  //  which hemisphere                                                                                                       
-        inline int                   initialized              (           ) const ;                                                                                                                             
-        inline PLTA                  lta                      (           ) const ;                                                                                                                             
-        inline PMATRIX               SRASToTalSRAS_           (           ) const ;                                                                                                                             
-        inline PMATRIX               TalSRASToSRAS_           (           ) const ;                                                                                                                             
-        inline int                   free_transform           (           ) const ;                                                                                                                             
-        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)                                                                                        
-        inline float                 a                        (           ) const ;                                                                                                                             
-        inline float                 b                        (           ) const ;                                                                                                                             
-        inline float                 c                        (           ) const ;  //  ellipsoid parameters                                                                                                   
-        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from                                                                                     
-        inline float                 Hmin                     (           ) const ;  //  min mean curvature                                                                                                     
-        inline float                 Hmax                     (           ) const ;  //  max mean curvature                                                                                                     
-        inline float                 Kmin                     (           ) const ;  //  min Gaussian curvature                                                                                                 
-        inline float                 Kmax                     (           ) const ;  //  max Gaussian curvature                                                                                                 
-        inline double                Ktotal                   (           ) const ;  //  total Gaussian curvature                                                                                               
-        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)                                                                                   
-        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from                                              
-        inline int                   patch                    (           ) const ;  //  if a patch of the surface                                                                                              
-        inline int                   nlabels                  (           ) const ;                                                                                                                             
-        inline PMRIS_AREA_LABEL      labels                   (           ) const ;  //  nlabels of these (may be null)                                                                                         
-        inline p_void                vp                       (           ) const ;  //  for misc. use                                                                                                          
-        inline float                 alpha                    (           ) const ;  //  rotation around z-axis                                                                                                 
-        inline float                 beta                     (           ) const ;  //  rotation around y-axis                                                                                                 
-        inline float                 gamma                    (           ) const ;  //  rotation around x-axis                                                                                                 
-        inline float                 da                       (           ) const ;                                                                                                                             
-        inline float                 db                       (           ) const ;                                                                                                                             
-        inline float                 dg                       (           ) const ;  //  old deltas                                                                                                             
-        inline int                   type                     (           ) const ;  //  what type of surface was this initially                                                                                
-        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces                                               
-        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces                                               
-        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject                                                                                                    
-        inline float                 canon_area               (           ) const ;                                                                                                                             
-        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true                                                                                    
-        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)                                                                          
-        inline float                 dy2                      ( size_t i  ) const ;                                                                                                                             
-        inline float                 dz2                      ( size_t i  ) const ;                                                                                                                             
-        inline PCOLOR_TABLE          ct                       (           ) const ;                                                                                                                             
+        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen
+        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons
+        inline int                   nedges                   (           ) const ;  //  # of edges on surface
+        inline int                   nstrips                  (           ) const ;
+        inline Vertex                vertices                 ( size_t i  ) const ;
+        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
+        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
+        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use
+        inline Face                  faces                    ( size_t i  ) const ;
+        inline MRI_EDGE              edges                    ( size_t i  ) const ;
+        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;
+        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;
+        inline STRIP                 strips                   ( size_t i  ) const ;
+        inline float                 xctr                     (           ) const ;
+        inline float                 yctr                     (           ) const ;
+        inline float                 zctr                     (           ) const ;
+        inline float                 xlo                      (           ) const ;
+        inline float                 ylo                      (           ) const ;
+        inline float                 zlo                      (           ) const ;
+        inline float                 xhi                      (           ) const ;
+        inline float                 yhi                      (           ) const ;
+        inline float                 zhi                      (           ) const ;
+        inline float                 x0                       (           ) const ;  //  center of spherical expansion
+        inline float                 y0                       (           ) const ;
+        inline float                 z0                       (           ) const ;
+        inline Vertex                v_temporal_pole          (           ) const ;
+        inline Vertex                v_frontal_pole           (           ) const ;
+        inline Vertex                v_occipital_pole         (           ) const ;
+        inline float                 max_curv                 (           ) const ;
+        inline float                 min_curv                 (           ) const ;
+        inline float                 total_area               (           ) const ;
+        inline double                avg_vertex_area          (           ) const ;
+        inline double                avg_vertex_dist          (           ) const ;  //  set by MRIScomputeAvgInterVertexDist
+        inline double                std_vertex_dist          (           ) const ;
+        inline float                 orig_area                (           ) const ;
+        inline float                 neg_area                 (           ) const ;
+        inline float                 neg_orig_area            (           ) const ;  //  amount of original surface in folds
+        inline int                   zeros                    (           ) const ;
+        inline int                   hemisphere               (           ) const ;  //  which hemisphere
+        inline int                   initialized              (           ) const ;
+        inline PLTA                  lta                      (           ) const ;
+        inline PMATRIX               SRASToTalSRAS_           (           ) const ;
+        inline PMATRIX               TalSRASToSRAS_           (           ) const ;
+        inline int                   free_transform           (           ) const ;
+        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline float                 a                        (           ) const ;
+        inline float                 b                        (           ) const ;
+        inline float                 c                        (           ) const ;  //  ellipsoid parameters
+        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from
+        inline float                 Hmin                     (           ) const ;  //  min mean curvature
+        inline float                 Hmax                     (           ) const ;  //  max mean curvature
+        inline float                 Kmin                     (           ) const ;  //  min Gaussian curvature
+        inline float                 Kmax                     (           ) const ;  //  max Gaussian curvature
+        inline double                Ktotal                   (           ) const ;  //  total Gaussian curvature
+        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int                   patch                    (           ) const ;  //  if a patch of the surface
+        inline int                   nlabels                  (           ) const ;
+        inline PMRIS_AREA_LABEL      labels                   (           ) const ;  //  nlabels of these (may be null)
+        inline p_void                vp                       (           ) const ;  //  for misc. use
+        inline float                 alpha                    (           ) const ;  //  rotation around z-axis
+        inline float                 beta                     (           ) const ;  //  rotation around y-axis
+        inline float                 gamma                    (           ) const ;  //  rotation around x-axis
+        inline float                 da                       (           ) const ;
+        inline float                 db                       (           ) const ;
+        inline float                 dg                       (           ) const ;  //  old deltas
+        inline int                   type                     (           ) const ;  //  what type of surface was this initially
+        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
+        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
+        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject
+        inline float                 canon_area               (           ) const ;
+        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true
+        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)
+        inline float                 dy2                      ( size_t i  ) const ;
+        inline float                 dz2                      ( size_t i  ) const ;
+        inline PCOLOR_TABLE          ct                       (           ) const ;
         inline int                   useRealRAS               (           ) const ;  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1                                                 
-        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;                                                                                                                             
-        inline int                   ncmds                    (           ) const ;                                                                                                                             
-        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group                                                                                
-        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex                                                                           
-        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces                                                                                                      
-        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here                                                                               
-        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel                                                                                    
-        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for                                                                                    
-        inline p_void                mht                      (           ) const ;                                                                                                                             
-        inline p_void                temps                    (           ) const ;                                                                                                                             
-                   
-        inline void set_strips           ( size_t i,            STRIP to )                                              ;
-        inline void set_xctr             (                      float to )                                              ;
-        inline void set_yctr             (                      float to )                                              ;
-        inline void set_zctr             (                      float to )                                              ;
-        inline void set_xlo              (                      float to )                                              ;
-        inline void set_ylo              (                      float to )                                              ;
-        inline void set_zlo              (                      float to )                                              ;
-        inline void set_xhi              (                      float to )                                              ;
-        inline void set_yhi              (                      float to )                                              ;
-        inline void set_zhi              (                      float to )                                              ;
-        inline void set_x0               (                      float to )           ;  //  center of spherical expansion
-        inline void set_y0               (                      float to )                                              ;
-        inline void set_z0               (                      float to )                                              ;
-        inline void set_v_temporal_pole  (                     Vertex to )                                              ;
-        inline void set_v_frontal_pole   (                     Vertex to )                                              ;
-        inline void set_v_occipital_pole (                     Vertex to )                                              ;
-        inline void set_max_curv         (                      float to )                                              ;
-        inline void set_min_curv         (                      float to )                                              ;
-        inline void set_total_area       (                      float to )                                              ;
-        inline void set_avg_vertex_area  (                     double to )                                              ;
-        inline void set_avg_vertex_dist  (                     double to )    ;  //  set by MRIScomputeAvgInterVertexDist
-        inline void set_std_vertex_dist  (                     double to )                                              ;
-        inline void set_orig_area        (                      float to )                                              ;
-        inline void set_neg_area         (                      float to )                                              ;
-        inline void set_neg_orig_area    (                      float to )     ;  //  amount of original surface in folds
-        inline void set_zeros            (                        int to )                                              ;
-        inline void set_hemisphere       (                        int to )                        ;  //  which hemisphere
-        inline void set_Hmin             (                      float to )                      ;  //  min mean curvature
-        inline void set_Hmax             (                      float to )                      ;  //  max mean curvature
-        inline void set_Kmin             (                      float to )                  ;  //  min Gaussian curvature
-        inline void set_Kmax             (                      float to )                  ;  //  max Gaussian curvature
-        inline void set_Ktotal           (                     double to )                ;  //  total Gaussian curvature
-        inline void set_nlabels          (                        int to )                                              ;
-        inline void set_labels           (           PMRIS_AREA_LABEL to )          ;  //  nlabels of these (may be null)
-        inline void set_vp               (                     p_void to )                           ;  //  for misc. use
-        inline void set_alpha            (                      float to )                  ;  //  rotation around z-axis
-        inline void set_beta             (                      float to )                  ;  //  rotation around y-axis
-        inline void set_gamma            (                      float to )                  ;  //  rotation around x-axis
-        inline void set_da               (                      float to )                                              ;
-        inline void set_db               (                      float to )                                              ;
-        inline void set_dg               (                      float to )                              ;  //  old deltas
+        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1
+        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;
+        inline int                   ncmds                    (           ) const ;
+        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group
+        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex
+        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces
+        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here
+        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel
+        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for
+        inline p_void                mht                      (           ) const ;
+        inline p_void                temps                    (           ) const ;
+        
+        inline void set_strips           ( size_t i,            STRIP to ) ;
+        inline void set_xctr             (                      float to ) ;
+        inline void set_yctr             (                      float to ) ;
+        inline void set_zctr             (                      float to ) ;
+        inline void set_xlo              (                      float to ) ;
+        inline void set_ylo              (                      float to ) ;
+        inline void set_zlo              (                      float to ) ;
+        inline void set_xhi              (                      float to ) ;
+        inline void set_yhi              (                      float to ) ;
+        inline void set_zhi              (                      float to ) ;
+        inline void set_x0               (                      float to ) ;  //  center of spherical expansion
+        inline void set_y0               (                      float to ) ;
+        inline void set_z0               (                      float to ) ;
+        inline void set_v_temporal_pole  (                     Vertex to ) ;
+        inline void set_v_frontal_pole   (                     Vertex to ) ;
+        inline void set_v_occipital_pole (                     Vertex to ) ;
+        inline void set_max_curv         (                      float to ) ;
+        inline void set_min_curv         (                      float to ) ;
+        inline void set_total_area       (                      float to ) ;
+        inline void set_avg_vertex_area  (                     double to ) ;
+        inline void set_avg_vertex_dist  (                     double to ) ;  //  set by MRIScomputeAvgInterVertexDist
+        inline void set_std_vertex_dist  (                     double to ) ;
+        inline void set_orig_area        (                      float to ) ;
+        inline void set_neg_area         (                      float to ) ;
+        inline void set_neg_orig_area    (                      float to ) ;  //  amount of original surface in folds
+        inline void set_zeros            (                        int to ) ;
+        inline void set_hemisphere       (                        int to ) ;  //  which hemisphere
+        inline void set_Hmin             (                      float to ) ;  //  min mean curvature
+        inline void set_Hmax             (                      float to ) ;  //  max mean curvature
+        inline void set_Kmin             (                      float to ) ;  //  min Gaussian curvature
+        inline void set_Kmax             (                      float to ) ;  //  max Gaussian curvature
+        inline void set_Ktotal           (                     double to ) ;  //  total Gaussian curvature
+        inline void set_nlabels          (                        int to ) ;
+        inline void set_labels           (           PMRIS_AREA_LABEL to ) ;  //  nlabels of these (may be null)
+        inline void set_vp               (                     p_void to ) ;  //  for misc. use
+        inline void set_alpha            (                      float to ) ;  //  rotation around z-axis
+        inline void set_beta             (                      float to ) ;  //  rotation around y-axis
+        inline void set_gamma            (                      float to ) ;  //  rotation around x-axis
+        inline void set_da               (                      float to ) ;
+        inline void set_db               (                      float to ) ;
+        inline void set_dg               (                      float to ) ;  //  old deltas
         inline void set_type             (                        int to ) ;  //  what type of surface was this initially
     };
 

--- a/include/mrisurf_SurfaceFromMRIS_generated_XYZPositionM.h
+++ b/include/mrisurf_SurfaceFromMRIS_generated_XYZPositionM.h
@@ -1,146 +1,147 @@
     namespace XYZPositionM {
-    struct Face : public MRIS_Elt {
-        inline Face                        (                        );
-        inline Face (                        Face const & src       );
-        inline Face (                        MRIS* mris, size_t idx );
-        inline Face (                        AllM::Face const & src );
+    struct Face : public Repr_Elt {
+        inline Face                        (                                            );
+        inline Face (                        Face const & src                           );
+        inline Face (                        Representation* representation, size_t idx );
+        inline Face (                        AllM::Face const & src                     );
         int fno     () const { return idx; }
 
         inline Vertex v        ( size_t i  ) const ;
         inline char   ripflag  (           ) const ;
         inline char   oripflag (           ) const ;
         inline int    marked   (           ) const ;
-                   
+        
         inline void set_ripflag  (  char to ) ;
         inline void set_oripflag (  char to ) ;
         inline void set_marked   (   int to ) ;
     };
 
-    struct Vertex : public MRIS_Elt {
-        inline Vertex (                                                 );
-        inline Vertex (                        Vertex const & src       );
-        inline Vertex (                        MRIS* mris, size_t idx   );
-        inline Vertex (                        AllM::Vertex const & src );
+    struct Vertex : public Repr_Elt {
+        inline Vertex (                                                                   );
+        inline Vertex (                        Vertex const & src                         );
+        inline Vertex (                        Representation* representation, size_t idx );
+        inline Vertex (                        AllM::Vertex const & src                   );
         int vno       () const { return idx; }
 
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces            
-        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex           
-        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                                          
+        inline Face   f                  ( size_t i  ) const ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
+        inline size_t n                  ( size_t i  ) const ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
+        inline int    e                  ( size_t i  ) const ;  //  edge state for neighboring vertices                      
         inline Vertex v                  ( size_t i  ) const ;  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i,                     
-        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                                              
-        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                                             
-        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur                                  
-        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                                       
-        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc                              
-        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                                         
-        inline uchar  num                (           ) const ;  //  number of neighboring faces                                                  
+        inline short  vnum               (           ) const ;  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
+        inline short  v2num              (           ) const ;  //  number of 1, or 2-hop neighbors                          
+        inline short  v3num              (           ) const ;  //  number of 1,2,or 3-hop neighbors                         
+        inline short  vtotal             (           ) const ;  //  total # of neighbors. copy of vnum.nsizeCur              
+        inline short  nsizeMaxClock      (           ) const ;  //  copy of mris->nsizeMaxClock when v#num                   
+        inline uchar  nsizeMax           (           ) const ;  //  the max nsize that was used to fill in vnum etc          
+        inline uchar  nsizeCur           (           ) const ;  //  index of the current v#num in vtotal                     
+        inline uchar  num                (           ) const ;  //  number of neighboring faces                              
         // managed by MRISfreeDists[_orig] and MRISmakeDists[_orig]
-        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz           
-        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz        
-        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements                               
-        //           
-        inline float  x                  (           ) const ;  //  current coordinates	                                                         
-        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set                                                      
-        inline float  z                  (           ) const ;                                                                                   
-        //           
-        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status                          
-        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(,                                                     
-        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set                                          
-        inline float  cx                 (           ) const ;                                                                                   
-        inline float  cy                 (           ) const ;                                                                                   
-        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system                                   
-        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache     
+        inline float  dist               ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on  xyz   
+        inline float  dist_orig          ( size_t i  ) const ;  // size() is vtotal.    distance to neighboring vertices based on origxyz
+        inline int    dist_capacity      (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        inline int    dist_orig_capacity (           ) const ;  //  -- should contain at least vtx_vtotal elements   
+        // 
+        inline float  x                  (           ) const ;  //  current coordinates	
+        inline float  y                  (           ) const ;  //  use MRISsetXYZ() to set
+        inline float  z                  (           ) const ;
+        // 
+        inline float  origx              (           ) const ;  //  original coordinates, see also MRIS::origxyz_status
+        inline float  origy              (           ) const ;  //  use MRISsetOriginalXYZ(, 
+        inline float  origz              (           ) const ;  //  or MRISsetOriginalXYZfromXYZ to set
+        inline float  cx                 (           ) const ;
+        inline float  cy                 (           ) const ;
+        inline float  cz                 (           ) const ;  //  coordinates in canonical coordinate system
+        inline char   ripflag            (           ) const ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void   which_coords       (int which, float *x, float *y, float *z) const ;
         // put the pointers before the ints, before the shorts, before uchars, to reduce size
         // the whole fits in much less than one cache line, so further ordering is no use
-                   
+        
         inline void set_f       ( size_t i,   Face to ) ;  // size() is num.    array[v->num] the fno's of the neighboring faces         
         inline void set_n       ( size_t i, size_t to ) ;  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        inline void set_e       ( size_t i,    int to )                  ;  //  edge state for neighboring vertices                      
-        //         
-        inline void set_x       (            float to )                                                       ;  //  current coordinates	
-        inline void set_y       (            float to )                                                    ;  //  use MRISsetXYZ() to set
-        inline void set_z       (            float to )                                                                                 ;
-        inline void set_cx      (            float to )                                                                                 ;
-        inline void set_cy      (            float to )                                                                                 ;
-        inline void set_cz      (            float to )                                 ;  //  coordinates in canonical coordinate system
-        inline void set_ripflag (             char to )   ;  //  vertex no longer exists - placed last to load the next vertex into cache
+        inline void set_e       ( size_t i,    int to ) ;  //  edge state for neighboring vertices                      
+        // 
+        inline void set_x       (            float to ) ;  //  current coordinates	
+        inline void set_y       (            float to ) ;  //  use MRISsetXYZ() to set
+        inline void set_z       (            float to ) ;
+        inline void set_cx      (            float to ) ;
+        inline void set_cy      (            float to ) ;
+        inline void set_cz      (            float to ) ;  //  coordinates in canonical coordinate system
+        inline void set_ripflag (             char to ) ;  //  vertex no longer exists - placed last to load the next vertex into cache
     };
 
-    struct Surface : public MRIS_Elt {
-        inline Surface (                           );
-        inline Surface ( Surface const & src       );
-        inline Surface ( MRIS* mris                );
-        inline Surface ( AllM::Surface const & src );
+    struct Surface : public Repr_Elt {
+        inline Surface (                                );
+        inline Surface ( Surface const & src            );
+        inline Surface ( Representation* representation );
+        inline Surface ( AllM::Surface const & src      );
 
         // Fields being maintained by specialist functions
-        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen                                                                                     
-        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al                                          
-        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al                                             
-        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons                                                             
-        inline int                   nedges                   (           ) const ;  //  # of edges on surface                                                                                                  
-        inline int                   nstrips                  (           ) const ;                                                                                                                             
-        inline Vertex                vertices                 ( size_t i  ) const ;                                                                                                                             
-        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored                          
-        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored                     
-        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use                                                
-        inline Face                  faces                    ( size_t i  ) const ;                                                                                                                             
-        inline MRI_EDGE              edges                    ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;                                                                                                                             
-        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;                                                                                                                             
-        inline int                   initialized              (           ) const ;                                                                                                                             
-        inline PLTA                  lta                      (           ) const ;                                                                                                                             
-        inline PMATRIX               SRASToTalSRAS_           (           ) const ;                                                                                                                             
-        inline PMATRIX               TalSRASToSRAS_           (           ) const ;                                                                                                                             
-        inline int                   free_transform           (           ) const ;                                                                                                                             
-        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)                                                                                        
-        inline float                 a                        (           ) const ;                                                                                                                             
-        inline float                 b                        (           ) const ;                                                                                                                             
-        inline float                 c                        (           ) const ;  //  ellipsoid parameters                                                                                                   
-        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from                                                                                     
-        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)                                                                                   
-        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from                                              
-        inline int                   patch                    (           ) const ;  //  if a patch of the surface                                                                                              
-        inline p_void                vp                       (           ) const ;  //  for misc. use                                                                                                          
-        inline float                 alpha                    (           ) const ;  //  rotation around z-axis                                                                                                 
-        inline float                 beta                     (           ) const ;  //  rotation around y-axis                                                                                                 
-        inline float                 gamma                    (           ) const ;  //  rotation around x-axis                                                                                                 
-        inline float                 da                       (           ) const ;                                                                                                                             
-        inline float                 db                       (           ) const ;                                                                                                                             
-        inline float                 dg                       (           ) const ;  //  old deltas                                                                                                             
-        inline int                   type                     (           ) const ;  //  what type of surface was this initially                                                                                
-        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces                                               
-        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces                                               
-        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject                                                                                                    
-        inline float                 canon_area               (           ) const ;                                                                                                                             
-        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true                                                                                    
-        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)                                                                          
-        inline float                 dy2                      ( size_t i  ) const ;                                                                                                                             
-        inline float                 dz2                      ( size_t i  ) const ;                                                                                                                             
-        inline PCOLOR_TABLE          ct                       (           ) const ;                                                                                                                             
+        inline int                   nverticesFrozen          (           ) const ;  //  # of vertices on surface is frozen
+        inline int                   nvertices                (           ) const ;  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline int                   nfaces                   (           ) const ;  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
+        inline bool                  faceAttachmentDeferred   (           ) const ;  //  defer connecting faces to vertices for performance reasons
+        inline int                   nedges                   (           ) const ;  //  # of edges on surface
+        inline int                   nstrips                  (           ) const ;
+        inline Vertex                vertices                 ( size_t i  ) const ;
+        inline p_p_void              dist_storage             (           ) const ;  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
+        inline p_p_void              dist_orig_storage        (           ) const ;  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
+        inline int                   tempsAssigned            (           ) const ;  //  State of various temp fields that can be borrowed if not already in use
+        inline Face                  faces                    ( size_t i  ) const ;
+        inline MRI_EDGE              edges                    ( size_t i  ) const ;
+        inline FaceNormCacheEntry    faceNormCacheEntries     ( size_t i  ) const ;
+        inline FaceNormDeferredEntry faceNormDeferredEntries  ( size_t i  ) const ;
+        inline int                   initialized              (           ) const ;
+        inline PLTA                  lta                      (           ) const ;
+        inline PMATRIX               SRASToTalSRAS_           (           ) const ;
+        inline PMATRIX               TalSRASToSRAS_           (           ) const ;
+        inline int                   free_transform           (           ) const ;
+        inline double                radius                   (           ) const ;  //  radius (if status==MRIS_SPHERE)
+        inline float                 a                        (           ) const ;
+        inline float                 b                        (           ) const ;
+        inline float                 c                        (           ) const ;  //  ellipsoid parameters
+        inline MRIS_fname_t          fname                    (           ) const ;  //  file it was originally loaded from
+        inline MRIS_Status           status                   (           ) const ;  //  type of surface (e.g. sphere, plane)
+        inline MRIS_Status           origxyz_status           (           ) const ;  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
+        inline int                   patch                    (           ) const ;  //  if a patch of the surface
+        inline p_void                vp                       (           ) const ;  //  for misc. use
+        inline float                 alpha                    (           ) const ;  //  rotation around z-axis
+        inline float                 beta                     (           ) const ;  //  rotation around y-axis
+        inline float                 gamma                    (           ) const ;  //  rotation around x-axis
+        inline float                 da                       (           ) const ;
+        inline float                 db                       (           ) const ;
+        inline float                 dg                       (           ) const ;  //  old deltas
+        inline int                   type                     (           ) const ;  //  what type of surface was this initially
+        inline int                   max_vertices             (           ) const ;  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
+        inline int                   max_faces                (           ) const ;  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
+        inline MRIS_subject_name_t   subject_name             (           ) const ;  //  name of the subject
+        inline float                 canon_area               (           ) const ;
+        inline int                   noscale                  (           ) const ;  //  don't scale by surface area if true
+        inline float                 dx2                      ( size_t i  ) const ;  //  an extra set of gradient (not always alloced)
+        inline float                 dy2                      ( size_t i  ) const ;
+        inline float                 dz2                      ( size_t i  ) const ;
+        inline PCOLOR_TABLE          ct                       (           ) const ;
         inline int                   useRealRAS               (           ) const ;  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1                                                 
-        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;                                                                                                                             
-        inline int                   ncmds                    (           ) const ;                                                                                                                             
-        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group                                                                                
-        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex                                                                           
-        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces                                                                                                      
-        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here                                                                               
-        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel                                                                                    
-        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for                                                                                    
-        inline p_void                mht                      (           ) const ;                                                                                                                             
-        inline p_void                temps                    (           ) const ;                                                                                                                             
-                   
-        inline void set_vp    (  p_void to )                           ;  //  for misc. use
-        inline void set_alpha (   float to )                  ;  //  rotation around z-axis
-        inline void set_beta  (   float to )                  ;  //  rotation around y-axis
-        inline void set_gamma (   float to )                  ;  //  rotation around x-axis
-        inline void set_da    (   float to )                                              ;
-        inline void set_db    (   float to )                                              ;
-        inline void set_dg    (   float to )                              ;  //  old deltas
+        inline VOL_GEOM              vg                       (           ) const ;  //  volume info from which this surface is created. valid iff vg.valid = 1
+        inline MRIS_cmdlines_t       cmdlines                 (           ) const ;
+        inline int                   ncmds                    (           ) const ;
+        inline float                 group_avg_surface_area   (           ) const ;  //  average of total surface area for group
+        inline int                   group_avg_vtxarea_loaded (           ) const ;  //  average vertex area for group at each vertex
+        inline int                   triangle_links_removed   (           ) const ;  //  for quad surfaces
+        inline p_void                user_parms               (           ) const ;  //  for whatever the user wants to hang here
+        inline PMATRIX               m_sras2vox               (           ) const ;  //  for converting surface ras to voxel
+        inline PMRI                  mri_sras2vox             (           ) const ;  //  volume that the above matrix is for
+        inline p_void                mht                      (           ) const ;
+        inline p_void                temps                    (           ) const ;
+        
+        inline void set_vp    (  p_void to ) ;  //  for misc. use
+        inline void set_alpha (   float to ) ;  //  rotation around z-axis
+        inline void set_beta  (   float to ) ;  //  rotation around y-axis
+        inline void set_gamma (   float to ) ;  //  rotation around x-axis
+        inline void set_da    (   float to ) ;
+        inline void set_db    (   float to ) ;
+        inline void set_dg    (   float to ) ;  //  old deltas
         inline void set_type  (     int to ) ;  //  what type of surface was this initially
     };
 

--- a/include/mrisurf_SurfaceFromMRIS_generated_prefix.h
+++ b/include/mrisurf_SurfaceFromMRIS_generated_prefix.h
@@ -2,8 +2,8 @@
 // GENERATED SOURCE - DO NOT DIRECTLY EDIT
 // 
 // =======================================
-#define SEPARATE_VERTEX_TOPOLOGY
 namespace SurfaceFromMRIS {
+    typedef MRIS Representation;
 
 
     namespace Existence {
@@ -95,14 +95,15 @@ namespace SurfaceFromMRIS {
         struct Vertex;
         struct Surface;
     } // namespace AllM
-    struct MRIS_Elt { 
-        bool operator==(MRIS_Elt const & rhs) const { return mris == rhs.mris && idx == rhs.idx; }
-        bool operator!=(MRIS_Elt const & rhs) const { return mris != rhs.mris || idx != rhs.idx; }
+    
+    struct Repr_Elt { 
+        bool operator==(Repr_Elt const & rhs) const { return repr == rhs.repr && idx == rhs.idx; }
+        bool operator!=(Repr_Elt const & rhs) const { return repr != rhs.repr || idx != rhs.idx; }
     protected: 
-        MRIS* mris; size_t idx; 
-        MRIS_Elt() : mris(nullptr), idx(0) {}
-        MRIS_Elt(MRIS* mris, size_t idx) : mris(mris), idx(idx) {}
-        MRIS_Elt(MRIS_Elt const & src) : mris(src.mris), idx(src.idx) {}
+        Representation* repr; size_t idx; 
+        Repr_Elt() : repr(nullptr), idx(0) {}
+        Repr_Elt(Representation* repr, size_t idx) : repr(repr), idx(idx) {}
+        Repr_Elt(Repr_Elt const & src) : repr(src.repr), idx(src.idx) {}
 
         friend struct SurfaceFromMRIS::ExistenceM::Face;
         friend struct SurfaceFromMRIS::ExistenceM::Vertex;
@@ -144,4 +145,4 @@ namespace SurfaceFromMRIS {
         friend struct SurfaceFromMRIS::AllM::Vertex;
         friend struct SurfaceFromMRIS::AllM::Surface;
     };
-} // namespace SurfaceFromMRIS
+} // SurfaceFromMRIS

--- a/include/mrisurf_SurfaceFromMRIS_generated_suffix.h
+++ b/include/mrisurf_SurfaceFromMRIS_generated_suffix.h
@@ -2,187 +2,190 @@
 // GENERATED SOURCE - DO NOT DIRECTLY EDIT
 // 
 // =======================================
-#define SEPARATE_VERTEX_TOPOLOGY
 namespace SurfaceFromMRIS {
+    typedef MRIS Representation;
 
 
     namespace Existence {
-    Face::Face (                                                                 ) {}
-    Face::Face ( MRIS* mris, size_t idx                     ) : MRIS_Elt(mris,idx) {}
-    Face::Face ( Face const & src                           ) : MRIS_Elt(src) {}     
-    Face::Face ( TopologyM::Face const & src                ) : MRIS_Elt(src) {}     
-    Face::Face ( Topology::Face const & src                 ) : MRIS_Elt(src) {}     
-    Face::Face ( XYZPositionM::Face const & src             ) : MRIS_Elt(src) {}     
-    Face::Face ( XYZPosition::Face const & src              ) : MRIS_Elt(src) {}     
-    Face::Face ( XYZPositionConsequencesM::Face const & src ) : MRIS_Elt(src) {}     
-    Face::Face ( XYZPositionConsequences::Face const & src  ) : MRIS_Elt(src) {}     
-    Face::Face ( DistortM::Face const & src                 ) : MRIS_Elt(src) {}     
-    Face::Face ( Distort::Face const & src                  ) : MRIS_Elt(src) {}     
-    Face::Face ( AnalysisM::Face const & src                ) : MRIS_Elt(src) {}     
-    Face::Face ( Analysis::Face const & src                 ) : MRIS_Elt(src) {}     
-    Face::Face ( AllM::Face const & src                     ) : MRIS_Elt(src) {}     
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( TopologyM::Face const & src                ) : Repr_Elt(src) {}
+    Face::Face ( Topology::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( XYZPositionM::Face const & src             ) : Repr_Elt(src) {}
+    Face::Face ( XYZPosition::Face const & src              ) : Repr_Elt(src) {}
+    Face::Face ( XYZPositionConsequencesM::Face const & src ) : Repr_Elt(src) {}
+    Face::Face ( XYZPositionConsequences::Face const & src  ) : Repr_Elt(src) {}
+    Face::Face ( DistortM::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( Distort::Face const & src                  ) : Repr_Elt(src) {}
+    Face::Face ( AnalysisM::Face const & src                ) : Repr_Elt(src) {}
+    Face::Face ( Analysis::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
     char Face::ripflag() const {
-        return mris->faces[idx].ripflag;
+        return repr->faces[idx].ripflag;
     }
     char Face::oripflag() const {
-        return mris->faces[idx].oripflag;
+        return repr->faces[idx].oripflag;
     }
     int Face::marked() const {
-        return mris->faces[idx].marked;
+        return repr->faces[idx].marked;
     }
     
     void Face::set_ripflag(char to) {
-        mris->faces[idx].ripflag = to;
+        repr->faces[idx].ripflag = to;
     }
     void Face::set_oripflag(char to) {
-        mris->faces[idx].oripflag = to;
+        repr->faces[idx].oripflag = to;
     }
     void Face::set_marked(int to) {
-        mris->faces[idx].marked = to;
+        repr->faces[idx].marked = to;
     }
 
 
-    Vertex::Vertex (                                              ) {}                     
-    Vertex::Vertex ( MRIS* mris, size_t idx                       ) : MRIS_Elt(mris,idx) {}
-    Vertex::Vertex ( Vertex const & src                           ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( TopologyM::Vertex const & src                ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( Topology::Vertex const & src                 ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( XYZPositionM::Vertex const & src             ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( XYZPosition::Vertex const & src              ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( XYZPositionConsequencesM::Vertex const & src ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( XYZPositionConsequences::Vertex const & src  ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( DistortM::Vertex const & src                 ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( Distort::Vertex const & src                  ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( AnalysisM::Vertex const & src                ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( Analysis::Vertex const & src                 ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( AllM::Vertex const & src                     ) : MRIS_Elt(src) {}     
+    Vertex::Vertex (                                              ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx   ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                           ) : Repr_Elt(src) {}
+    Vertex::Vertex ( TopologyM::Vertex const & src                ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Topology::Vertex const & src                 ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPositionM::Vertex const & src             ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPosition::Vertex const & src              ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPositionConsequencesM::Vertex const & src ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPositionConsequences::Vertex const & src  ) : Repr_Elt(src) {}
+    Vertex::Vertex ( DistortM::Vertex const & src                 ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Distort::Vertex const & src                  ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AnalysisM::Vertex const & src                ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Analysis::Vertex const & src                 ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                     ) : Repr_Elt(src) {}
 
     char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
-        return mris->vertices[idx].ripflag;
+        return repr->vertices[idx].ripflag;
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+         MRISvertexCoord2XYZ_float(&repr->vertices[idx], which, x, y, z);
     }
     
     void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
-        mris->vertices[idx].ripflag = to;
+        repr->vertices[idx].ripflag = to;
     }
 
 
-    Surface::Surface (                                               ) {}                   
-    Surface::Surface ( MRIS* mris                                    ) : MRIS_Elt(mris,0) {}
-    Surface::Surface ( Surface const & src                           ) : MRIS_Elt(src) {}   
-    Surface::Surface ( TopologyM::Surface const & src                ) : MRIS_Elt(src) {}   
-    Surface::Surface ( Topology::Surface const & src                 ) : MRIS_Elt(src) {}   
-    Surface::Surface ( XYZPositionM::Surface const & src             ) : MRIS_Elt(src) {}   
-    Surface::Surface ( XYZPosition::Surface const & src              ) : MRIS_Elt(src) {}   
-    Surface::Surface ( XYZPositionConsequencesM::Surface const & src ) : MRIS_Elt(src) {}   
-    Surface::Surface ( XYZPositionConsequences::Surface const & src  ) : MRIS_Elt(src) {}   
-    Surface::Surface ( DistortM::Surface const & src                 ) : MRIS_Elt(src) {}   
-    Surface::Surface ( Distort::Surface const & src                  ) : MRIS_Elt(src) {}   
-    Surface::Surface ( AnalysisM::Surface const & src                ) : MRIS_Elt(src) {}   
-    Surface::Surface ( Analysis::Surface const & src                 ) : MRIS_Elt(src) {}   
-    Surface::Surface ( AllM::Surface const & src                     ) : MRIS_Elt(src) {}   
+    Surface::Surface (                                               ) {}
+    Surface::Surface ( Representation* representation                ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src                           ) : Repr_Elt(src) {}
+    Surface::Surface ( TopologyM::Surface const & src                ) : Repr_Elt(src) {}
+    Surface::Surface ( Topology::Surface const & src                 ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPositionM::Surface const & src             ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPosition::Surface const & src              ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPositionConsequencesM::Surface const & src ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPositionConsequences::Surface const & src  ) : Repr_Elt(src) {}
+    Surface::Surface ( DistortM::Surface const & src                 ) : Repr_Elt(src) {}
+    Surface::Surface ( Distort::Surface const & src                  ) : Repr_Elt(src) {}
+    Surface::Surface ( AnalysisM::Surface const & src                ) : Repr_Elt(src) {}
+    Surface::Surface ( Analysis::Surface const & src                 ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src                     ) : Repr_Elt(src) {}
 
     int Surface::initialized() const {
-        return mris->initialized;
+        return repr->initialized;
     }
     PLTA Surface::lta() const {
-        return mris->lta;
+        return repr->lta;
     }
     PMATRIX Surface::SRASToTalSRAS_() const {
-        return mris->SRASToTalSRAS_;
+        return repr->SRASToTalSRAS_;
     }
     PMATRIX Surface::TalSRASToSRAS_() const {
-        return mris->TalSRASToSRAS_;
+        return repr->TalSRASToSRAS_;
     }
     int Surface::free_transform() const {
-        return mris->free_transform;
+        return repr->free_transform;
     }
     double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
-        return mris->radius;
+        return repr->radius;
     }
     float Surface::a() const {
-        return mris->a;
+        return repr->a;
     }
     float Surface::b() const {
-        return mris->b;
+        return repr->b;
     }
     float Surface::c() const {  //  ellipsoid parameters
-        return mris->c;
+        return repr->c;
     }
     MRIS_fname_t Surface::fname() const {  //  file it was originally loaded from
-        return mris->fname;
+        return repr->fname;
     }
     MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
-        return mris->status;
+        return repr->status;
     }
     MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-        return mris->origxyz_status;
+        return repr->origxyz_status;
     }
     int Surface::patch() const {  //  if a patch of the surface
-        return mris->patch;
+        return repr->patch;
     }
     int Surface::max_vertices() const {  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
-        return mris->max_vertices;
+        return repr->max_vertices;
     }
     int Surface::max_faces() const {  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
-        return mris->max_faces;
+        return repr->max_faces;
     }
     MRIS_subject_name_t Surface::subject_name() const {  //  name of the subject
-        return mris->subject_name;
+        return repr->subject_name;
     }
     float Surface::canon_area() const {
-        return mris->canon_area;
+        return repr->canon_area;
     }
     int Surface::noscale() const {  //  don't scale by surface area if true
-        return mris->noscale;
+        return repr->noscale;
     }
     float Surface::dx2(size_t i) const {  //  an extra set of gradient (not always alloced)
-        return mris->dx2[i];
+        return repr->dx2[i];
     }
     float Surface::dy2(size_t i) const {
-        return mris->dy2[i];
+        return repr->dy2[i];
     }
     float Surface::dz2(size_t i) const {
-        return mris->dz2[i];
+        return repr->dz2[i];
     }
     PCOLOR_TABLE Surface::ct() const {
-        return mris->ct;
+        return repr->ct;
     }
     int Surface::useRealRAS() const {  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        return mris->useRealRAS;
+        return repr->useRealRAS;
     }
     VOL_GEOM Surface::vg() const {  //  volume info from which this surface is created. valid iff vg.valid = 1
-        return mris->vg;
+        return repr->vg;
     }
     MRIS_cmdlines_t Surface::cmdlines() const {
-        return mris->cmdlines;
+        return repr->cmdlines;
     }
     int Surface::ncmds() const {
-        return mris->ncmds;
+        return repr->ncmds;
     }
     float Surface::group_avg_surface_area() const {  //  average of total surface area for group
-        return mris->group_avg_surface_area;
+        return repr->group_avg_surface_area;
     }
     int Surface::group_avg_vtxarea_loaded() const {  //  average vertex area for group at each vertex
-        return mris->group_avg_vtxarea_loaded;
+        return repr->group_avg_vtxarea_loaded;
     }
     int Surface::triangle_links_removed() const {  //  for quad surfaces
-        return mris->triangle_links_removed;
+        return repr->triangle_links_removed;
     }
     p_void Surface::user_parms() const {  //  for whatever the user wants to hang here
-        return mris->user_parms;
+        return repr->user_parms;
     }
     PMATRIX Surface::m_sras2vox() const {  //  for converting surface ras to voxel
-        return mris->m_sras2vox;
+        return repr->m_sras2vox;
     }
     PMRI Surface::mri_sras2vox() const {  //  volume that the above matrix is for
-        return mris->mri_sras2vox;
+        return repr->mri_sras2vox;
     }
     p_void Surface::mht() const {
-        return mris->mht;
+        return repr->mht;
     }
     p_void Surface::temps() const {
-        return mris->temps;
+        return repr->temps;
     }
 
 
@@ -190,266 +193,269 @@ namespace SurfaceFromMRIS {
 
 
     namespace Topology {
-    Face::Face (                                            ) {}                     
-    Face::Face ( MRIS* mris, size_t idx                     ) : MRIS_Elt(mris,idx) {}
-    Face::Face ( Face const & src                           ) : MRIS_Elt(src) {}     
-    Face::Face ( XYZPositionM::Face const & src             ) : MRIS_Elt(src) {}     
-    Face::Face ( XYZPosition::Face const & src              ) : MRIS_Elt(src) {}     
-    Face::Face ( XYZPositionConsequencesM::Face const & src ) : MRIS_Elt(src) {}     
-    Face::Face ( XYZPositionConsequences::Face const & src  ) : MRIS_Elt(src) {}     
-    Face::Face ( DistortM::Face const & src                 ) : MRIS_Elt(src) {}     
-    Face::Face ( Distort::Face const & src                  ) : MRIS_Elt(src) {}     
-    Face::Face ( AnalysisM::Face const & src                ) : MRIS_Elt(src) {}     
-    Face::Face ( Analysis::Face const & src                 ) : MRIS_Elt(src) {}     
-    Face::Face ( AllM::Face const & src                     ) : MRIS_Elt(src) {}     
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( XYZPositionM::Face const & src             ) : Repr_Elt(src) {}
+    Face::Face ( XYZPosition::Face const & src              ) : Repr_Elt(src) {}
+    Face::Face ( XYZPositionConsequencesM::Face const & src ) : Repr_Elt(src) {}
+    Face::Face ( XYZPositionConsequences::Face const & src  ) : Repr_Elt(src) {}
+    Face::Face ( DistortM::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( Distort::Face const & src                  ) : Repr_Elt(src) {}
+    Face::Face ( AnalysisM::Face const & src                ) : Repr_Elt(src) {}
+    Face::Face ( Analysis::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
     Vertex Face::v(size_t i) const {
-        return Vertex(mris,mris->faces[idx].v[i]);
+        return Vertex(repr,repr->faces[idx].v[i]);
     }
     char Face::ripflag() const {
-        return mris->faces[idx].ripflag;
+        return repr->faces[idx].ripflag;
     }
     char Face::oripflag() const {
-        return mris->faces[idx].oripflag;
+        return repr->faces[idx].oripflag;
     }
     int Face::marked() const {
-        return mris->faces[idx].marked;
+        return repr->faces[idx].marked;
     }
     
     void Face::set_ripflag(char to) {
-        mris->faces[idx].ripflag = to;
+        repr->faces[idx].ripflag = to;
     }
     void Face::set_oripflag(char to) {
-        mris->faces[idx].oripflag = to;
+        repr->faces[idx].oripflag = to;
     }
     void Face::set_marked(int to) {
-        mris->faces[idx].marked = to;
+        repr->faces[idx].marked = to;
     }
 
 
-    Vertex::Vertex (                                              ) {}                     
-    Vertex::Vertex ( MRIS* mris, size_t idx                       ) : MRIS_Elt(mris,idx) {}
-    Vertex::Vertex ( Vertex const & src                           ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( XYZPositionM::Vertex const & src             ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( XYZPosition::Vertex const & src              ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( XYZPositionConsequencesM::Vertex const & src ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( XYZPositionConsequences::Vertex const & src  ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( DistortM::Vertex const & src                 ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( Distort::Vertex const & src                  ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( AnalysisM::Vertex const & src                ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( Analysis::Vertex const & src                 ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( AllM::Vertex const & src                     ) : MRIS_Elt(src) {}     
+    Vertex::Vertex (                                              ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx   ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                           ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPositionM::Vertex const & src             ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPosition::Vertex const & src              ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPositionConsequencesM::Vertex const & src ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPositionConsequences::Vertex const & src  ) : Repr_Elt(src) {}
+    Vertex::Vertex ( DistortM::Vertex const & src                 ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Distort::Vertex const & src                  ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AnalysisM::Vertex const & src                ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Analysis::Vertex const & src                 ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                     ) : Repr_Elt(src) {}
 
     Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        return Face(mris,mris->vertices_topology[idx].f[i]);
+        return Face(repr,repr->vertices_topology[idx].f[i]);
     }
     size_t Vertex::n(size_t i) const {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        return size_t(mris->vertices_topology[idx].n[i]);
+        return size_t(repr->vertices_topology[idx].n[i]);
     }
     int Vertex::e(size_t i) const {  //  edge state for neighboring vertices                      
-        return mris->vertices_topology[idx].e[i];
+        return repr->vertices_topology[idx].e[i];
     }
     Vertex Vertex::v(size_t i) const {  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        return Vertex(mris,mris->vertices_topology[idx].v[i]);
+        return Vertex(repr,repr->vertices_topology[idx].v[i]);
     }
     short Vertex::vnum() const {  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
-        return mris->vertices_topology[idx].vnum;
+        return repr->vertices_topology[idx].vnum;
     }
     short Vertex::v2num() const {  //  number of 1, or 2-hop neighbors                          
-        return mris->vertices_topology[idx].v2num;
+        return repr->vertices_topology[idx].v2num;
     }
     short Vertex::v3num() const {  //  number of 1,2,or 3-hop neighbors                         
-        return mris->vertices_topology[idx].v3num;
+        return repr->vertices_topology[idx].v3num;
     }
     short Vertex::vtotal() const {  //  total # of neighbors. copy of vnum.nsizeCur              
-        return mris->vertices_topology[idx].vtotal;
+        return repr->vertices_topology[idx].vtotal;
     }
     short Vertex::nsizeMaxClock() const {  //  copy of mris->nsizeMaxClock when v#num                   
-        return mris->vertices_topology[idx].nsizeMaxClock;
+        return repr->vertices_topology[idx].nsizeMaxClock;
     }
     uchar Vertex::nsizeMax() const {  //  the max nsize that was used to fill in vnum etc          
-        return mris->vertices_topology[idx].nsizeMax;
+        return repr->vertices_topology[idx].nsizeMax;
     }
     uchar Vertex::nsizeCur() const {  //  index of the current v#num in vtotal                     
-        return mris->vertices_topology[idx].nsizeCur;
+        return repr->vertices_topology[idx].nsizeCur;
     }
     uchar Vertex::num() const {  //  number of neighboring faces                              
-        return mris->vertices_topology[idx].num;
+        return repr->vertices_topology[idx].num;
     }
     char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
-        return mris->vertices[idx].ripflag;
+        return repr->vertices[idx].ripflag;
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+         MRISvertexCoord2XYZ_float(&repr->vertices[idx], which, x, y, z);
     }
     
     void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        cheapAssert(mris == to.mris); mris->vertices_topology[idx].f[i] = to.idx;
+        cheapAssert(repr == to.repr); repr->vertices_topology[idx].f[i] = to.idx;
     }
     void Vertex::set_n(size_t i, size_t to) {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        mris->vertices_topology[idx].n[i] = uchar(to);
+        repr->vertices_topology[idx].n[i] = uchar(to);
     }
     void Vertex::set_e(size_t i, int to) {  //  edge state for neighboring vertices                      
-        mris->vertices_topology[idx].e[i] = to;
+        repr->vertices_topology[idx].e[i] = to;
     }
     void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
-        mris->vertices[idx].ripflag = to;
+        repr->vertices[idx].ripflag = to;
     }
 
 
-    Surface::Surface (                                               ) {}                   
-    Surface::Surface ( MRIS* mris                                    ) : MRIS_Elt(mris,0) {}
-    Surface::Surface ( Surface const & src                           ) : MRIS_Elt(src) {}   
-    Surface::Surface ( XYZPositionM::Surface const & src             ) : MRIS_Elt(src) {}   
-    Surface::Surface ( XYZPosition::Surface const & src              ) : MRIS_Elt(src) {}   
-    Surface::Surface ( XYZPositionConsequencesM::Surface const & src ) : MRIS_Elt(src) {}   
-    Surface::Surface ( XYZPositionConsequences::Surface const & src  ) : MRIS_Elt(src) {}   
-    Surface::Surface ( DistortM::Surface const & src                 ) : MRIS_Elt(src) {}   
-    Surface::Surface ( Distort::Surface const & src                  ) : MRIS_Elt(src) {}   
-    Surface::Surface ( AnalysisM::Surface const & src                ) : MRIS_Elt(src) {}   
-    Surface::Surface ( Analysis::Surface const & src                 ) : MRIS_Elt(src) {}   
-    Surface::Surface ( AllM::Surface const & src                     ) : MRIS_Elt(src) {}   
+    Surface::Surface (                                               ) {}
+    Surface::Surface ( Representation* representation                ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src                           ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPositionM::Surface const & src             ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPosition::Surface const & src              ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPositionConsequencesM::Surface const & src ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPositionConsequences::Surface const & src  ) : Repr_Elt(src) {}
+    Surface::Surface ( DistortM::Surface const & src                 ) : Repr_Elt(src) {}
+    Surface::Surface ( Distort::Surface const & src                  ) : Repr_Elt(src) {}
+    Surface::Surface ( AnalysisM::Surface const & src                ) : Repr_Elt(src) {}
+    Surface::Surface ( Analysis::Surface const & src                 ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src                     ) : Repr_Elt(src) {}
 
     int Surface::nverticesFrozen() const {  //  # of vertices on surface is frozen
-        return mris->nverticesFrozen;
+        return repr->nverticesFrozen;
     }
     int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nvertices;
+        return repr->nvertices;
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nfaces;
+        return repr->nfaces;
     }
     bool Surface::faceAttachmentDeferred() const {  //  defer connecting faces to vertices for performance reasons
-        return mris->faceAttachmentDeferred;
+        return repr->faceAttachmentDeferred;
     }
     int Surface::nedges() const {  //  # of edges on surface
-        return mris->nedges;
+        return repr->nedges;
     }
     int Surface::nstrips() const {
-        return mris->nstrips;
+        return repr->nstrips;
     }
     Vertex Surface::vertices(size_t i) const {
-        return Vertex(mris,i);
+        return Vertex(repr,i);
     }
     p_p_void Surface::dist_storage() const {  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
-        return mris->dist_storage;
+        return repr->dist_storage;
     }
     p_p_void Surface::dist_orig_storage() const {  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
-        return mris->dist_orig_storage;
+        return repr->dist_orig_storage;
     }
     int Surface::tempsAssigned() const {  //  State of various temp fields that can be borrowed if not already in use
-        return mris->tempsAssigned;
+        return repr->tempsAssigned;
     }
     Face Surface::faces(size_t i) const {
-        return Face(mris,i);
+        return Face(repr,i);
     }
     MRI_EDGE Surface::edges(size_t i) const {
-        return mris->edges[i];
+        return repr->edges[i];
     }
     FaceNormCacheEntry Surface::faceNormCacheEntries(size_t i) const {
-        return mris->faceNormCacheEntries[i];
+        return repr->faceNormCacheEntries[i];
     }
     FaceNormDeferredEntry Surface::faceNormDeferredEntries(size_t i) const {
-        return mris->faceNormDeferredEntries[i];
+        return repr->faceNormDeferredEntries[i];
     }
     int Surface::initialized() const {
-        return mris->initialized;
+        return repr->initialized;
     }
     PLTA Surface::lta() const {
-        return mris->lta;
+        return repr->lta;
     }
     PMATRIX Surface::SRASToTalSRAS_() const {
-        return mris->SRASToTalSRAS_;
+        return repr->SRASToTalSRAS_;
     }
     PMATRIX Surface::TalSRASToSRAS_() const {
-        return mris->TalSRASToSRAS_;
+        return repr->TalSRASToSRAS_;
     }
     int Surface::free_transform() const {
-        return mris->free_transform;
+        return repr->free_transform;
     }
     double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
-        return mris->radius;
+        return repr->radius;
     }
     float Surface::a() const {
-        return mris->a;
+        return repr->a;
     }
     float Surface::b() const {
-        return mris->b;
+        return repr->b;
     }
     float Surface::c() const {  //  ellipsoid parameters
-        return mris->c;
+        return repr->c;
     }
     MRIS_fname_t Surface::fname() const {  //  file it was originally loaded from
-        return mris->fname;
+        return repr->fname;
     }
     MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
-        return mris->status;
+        return repr->status;
     }
     MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-        return mris->origxyz_status;
+        return repr->origxyz_status;
     }
     int Surface::patch() const {  //  if a patch of the surface
-        return mris->patch;
+        return repr->patch;
     }
     int Surface::max_vertices() const {  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
-        return mris->max_vertices;
+        return repr->max_vertices;
     }
     int Surface::max_faces() const {  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
-        return mris->max_faces;
+        return repr->max_faces;
     }
     MRIS_subject_name_t Surface::subject_name() const {  //  name of the subject
-        return mris->subject_name;
+        return repr->subject_name;
     }
     float Surface::canon_area() const {
-        return mris->canon_area;
+        return repr->canon_area;
     }
     int Surface::noscale() const {  //  don't scale by surface area if true
-        return mris->noscale;
+        return repr->noscale;
     }
     float Surface::dx2(size_t i) const {  //  an extra set of gradient (not always alloced)
-        return mris->dx2[i];
+        return repr->dx2[i];
     }
     float Surface::dy2(size_t i) const {
-        return mris->dy2[i];
+        return repr->dy2[i];
     }
     float Surface::dz2(size_t i) const {
-        return mris->dz2[i];
+        return repr->dz2[i];
     }
     PCOLOR_TABLE Surface::ct() const {
-        return mris->ct;
+        return repr->ct;
     }
     int Surface::useRealRAS() const {  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        return mris->useRealRAS;
+        return repr->useRealRAS;
     }
     VOL_GEOM Surface::vg() const {  //  volume info from which this surface is created. valid iff vg.valid = 1
-        return mris->vg;
+        return repr->vg;
     }
     MRIS_cmdlines_t Surface::cmdlines() const {
-        return mris->cmdlines;
+        return repr->cmdlines;
     }
     int Surface::ncmds() const {
-        return mris->ncmds;
+        return repr->ncmds;
     }
     float Surface::group_avg_surface_area() const {  //  average of total surface area for group
-        return mris->group_avg_surface_area;
+        return repr->group_avg_surface_area;
     }
     int Surface::group_avg_vtxarea_loaded() const {  //  average vertex area for group at each vertex
-        return mris->group_avg_vtxarea_loaded;
+        return repr->group_avg_vtxarea_loaded;
     }
     int Surface::triangle_links_removed() const {  //  for quad surfaces
-        return mris->triangle_links_removed;
+        return repr->triangle_links_removed;
     }
     p_void Surface::user_parms() const {  //  for whatever the user wants to hang here
-        return mris->user_parms;
+        return repr->user_parms;
     }
     PMATRIX Surface::m_sras2vox() const {  //  for converting surface ras to voxel
-        return mris->m_sras2vox;
+        return repr->m_sras2vox;
     }
     PMRI Surface::mri_sras2vox() const {  //  volume that the above matrix is for
-        return mris->mri_sras2vox;
+        return repr->mri_sras2vox;
     }
     p_void Surface::mht() const {
-        return mris->mht;
+        return repr->mht;
     }
     p_void Surface::temps() const {
-        return mris->temps;
+        return repr->temps;
     }
 
 
@@ -457,357 +463,360 @@ namespace SurfaceFromMRIS {
 
 
     namespace XYZPosition {
-    Face::Face (                                            ) {}                     
-    Face::Face ( MRIS* mris, size_t idx                     ) : MRIS_Elt(mris,idx) {}
-    Face::Face ( Face const & src                           ) : MRIS_Elt(src) {}     
-    Face::Face ( XYZPositionConsequencesM::Face const & src ) : MRIS_Elt(src) {}     
-    Face::Face ( XYZPositionConsequences::Face const & src  ) : MRIS_Elt(src) {}     
-    Face::Face ( DistortM::Face const & src                 ) : MRIS_Elt(src) {}     
-    Face::Face ( Distort::Face const & src                  ) : MRIS_Elt(src) {}     
-    Face::Face ( AnalysisM::Face const & src                ) : MRIS_Elt(src) {}     
-    Face::Face ( Analysis::Face const & src                 ) : MRIS_Elt(src) {}     
-    Face::Face ( AllM::Face const & src                     ) : MRIS_Elt(src) {}     
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( XYZPositionConsequencesM::Face const & src ) : Repr_Elt(src) {}
+    Face::Face ( XYZPositionConsequences::Face const & src  ) : Repr_Elt(src) {}
+    Face::Face ( DistortM::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( Distort::Face const & src                  ) : Repr_Elt(src) {}
+    Face::Face ( AnalysisM::Face const & src                ) : Repr_Elt(src) {}
+    Face::Face ( Analysis::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
     Vertex Face::v(size_t i) const {
-        return Vertex(mris,mris->faces[idx].v[i]);
+        return Vertex(repr,repr->faces[idx].v[i]);
     }
     char Face::ripflag() const {
-        return mris->faces[idx].ripflag;
+        return repr->faces[idx].ripflag;
     }
     char Face::oripflag() const {
-        return mris->faces[idx].oripflag;
+        return repr->faces[idx].oripflag;
     }
     int Face::marked() const {
-        return mris->faces[idx].marked;
+        return repr->faces[idx].marked;
     }
     
     void Face::set_ripflag(char to) {
-        mris->faces[idx].ripflag = to;
+        repr->faces[idx].ripflag = to;
     }
     void Face::set_oripflag(char to) {
-        mris->faces[idx].oripflag = to;
+        repr->faces[idx].oripflag = to;
     }
     void Face::set_marked(int to) {
-        mris->faces[idx].marked = to;
+        repr->faces[idx].marked = to;
     }
 
 
-    Vertex::Vertex (                                              ) {}                     
-    Vertex::Vertex ( MRIS* mris, size_t idx                       ) : MRIS_Elt(mris,idx) {}
-    Vertex::Vertex ( Vertex const & src                           ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( XYZPositionConsequencesM::Vertex const & src ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( XYZPositionConsequences::Vertex const & src  ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( DistortM::Vertex const & src                 ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( Distort::Vertex const & src                  ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( AnalysisM::Vertex const & src                ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( Analysis::Vertex const & src                 ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( AllM::Vertex const & src                     ) : MRIS_Elt(src) {}     
+    Vertex::Vertex (                                              ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx   ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                           ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPositionConsequencesM::Vertex const & src ) : Repr_Elt(src) {}
+    Vertex::Vertex ( XYZPositionConsequences::Vertex const & src  ) : Repr_Elt(src) {}
+    Vertex::Vertex ( DistortM::Vertex const & src                 ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Distort::Vertex const & src                  ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AnalysisM::Vertex const & src                ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Analysis::Vertex const & src                 ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                     ) : Repr_Elt(src) {}
 
     Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        return Face(mris,mris->vertices_topology[idx].f[i]);
+        return Face(repr,repr->vertices_topology[idx].f[i]);
     }
     size_t Vertex::n(size_t i) const {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        return size_t(mris->vertices_topology[idx].n[i]);
+        return size_t(repr->vertices_topology[idx].n[i]);
     }
     int Vertex::e(size_t i) const {  //  edge state for neighboring vertices                      
-        return mris->vertices_topology[idx].e[i];
+        return repr->vertices_topology[idx].e[i];
     }
     Vertex Vertex::v(size_t i) const {  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        return Vertex(mris,mris->vertices_topology[idx].v[i]);
+        return Vertex(repr,repr->vertices_topology[idx].v[i]);
     }
     short Vertex::vnum() const {  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
-        return mris->vertices_topology[idx].vnum;
+        return repr->vertices_topology[idx].vnum;
     }
     short Vertex::v2num() const {  //  number of 1, or 2-hop neighbors                          
-        return mris->vertices_topology[idx].v2num;
+        return repr->vertices_topology[idx].v2num;
     }
     short Vertex::v3num() const {  //  number of 1,2,or 3-hop neighbors                         
-        return mris->vertices_topology[idx].v3num;
+        return repr->vertices_topology[idx].v3num;
     }
     short Vertex::vtotal() const {  //  total # of neighbors. copy of vnum.nsizeCur              
-        return mris->vertices_topology[idx].vtotal;
+        return repr->vertices_topology[idx].vtotal;
     }
     short Vertex::nsizeMaxClock() const {  //  copy of mris->nsizeMaxClock when v#num                   
-        return mris->vertices_topology[idx].nsizeMaxClock;
+        return repr->vertices_topology[idx].nsizeMaxClock;
     }
     uchar Vertex::nsizeMax() const {  //  the max nsize that was used to fill in vnum etc          
-        return mris->vertices_topology[idx].nsizeMax;
+        return repr->vertices_topology[idx].nsizeMax;
     }
     uchar Vertex::nsizeCur() const {  //  index of the current v#num in vtotal                     
-        return mris->vertices_topology[idx].nsizeCur;
+        return repr->vertices_topology[idx].nsizeCur;
     }
     uchar Vertex::num() const {  //  number of neighboring faces                              
-        return mris->vertices_topology[idx].num;
+        return repr->vertices_topology[idx].num;
     }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
-        return mris->vertices[idx].dist[i];
+        return repr->vertices[idx].dist[i];
     }
     float Vertex::dist_orig(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on origxyz
-        return mris->vertices[idx].dist_orig[i];
+        return repr->vertices[idx].dist_orig[i];
     }
     int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_capacity;
+        return repr->vertices[idx].dist_capacity;
     }
     int Vertex::dist_orig_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_orig_capacity;
+        return repr->vertices[idx].dist_orig_capacity;
     }
     float Vertex::x() const {  //  current coordinates	
-        return mris->vertices[idx].x;
+        return repr->vertices[idx].x;
     }
     float Vertex::y() const {  //  use MRISsetXYZ() to set
-        return mris->vertices[idx].y;
+        return repr->vertices[idx].y;
     }
     float Vertex::z() const {
-        return mris->vertices[idx].z;
+        return repr->vertices[idx].z;
     }
     float Vertex::origx() const {  //  original coordinates, see also MRIS::origxyz_status
-        return mris->vertices[idx].origx;
+        return repr->vertices[idx].origx;
     }
     float Vertex::origy() const {  //  use MRISsetOriginalXYZ(, 
-        return mris->vertices[idx].origy;
+        return repr->vertices[idx].origy;
     }
     float Vertex::origz() const {  //  or MRISsetOriginalXYZfromXYZ to set
-        return mris->vertices[idx].origz;
+        return repr->vertices[idx].origz;
     }
     float Vertex::cx() const {
-        return mris->vertices[idx].cx;
+        return repr->vertices[idx].cx;
     }
     float Vertex::cy() const {
-        return mris->vertices[idx].cy;
+        return repr->vertices[idx].cy;
     }
     float Vertex::cz() const {  //  coordinates in canonical coordinate system
-        return mris->vertices[idx].cz;
+        return repr->vertices[idx].cz;
     }
     char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
-        return mris->vertices[idx].ripflag;
+        return repr->vertices[idx].ripflag;
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+         MRISvertexCoord2XYZ_float(&repr->vertices[idx], which, x, y, z);
     }
     
     void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        cheapAssert(mris == to.mris); mris->vertices_topology[idx].f[i] = to.idx;
+        cheapAssert(repr == to.repr); repr->vertices_topology[idx].f[i] = to.idx;
     }
     void Vertex::set_n(size_t i, size_t to) {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        mris->vertices_topology[idx].n[i] = uchar(to);
+        repr->vertices_topology[idx].n[i] = uchar(to);
     }
     void Vertex::set_e(size_t i, int to) {  //  edge state for neighboring vertices                      
-        mris->vertices_topology[idx].e[i] = to;
+        repr->vertices_topology[idx].e[i] = to;
     }
     void Vertex::set_cx(float to) {
-        mris->vertices[idx].cx = to;
+        repr->vertices[idx].cx = to;
     }
     void Vertex::set_cy(float to) {
-        mris->vertices[idx].cy = to;
+        repr->vertices[idx].cy = to;
     }
     void Vertex::set_cz(float to) {  //  coordinates in canonical coordinate system
-        mris->vertices[idx].cz = to;
+        repr->vertices[idx].cz = to;
     }
     void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
-        mris->vertices[idx].ripflag = to;
+        repr->vertices[idx].ripflag = to;
     }
 
 
-    Surface::Surface (                                               ) {}                   
-    Surface::Surface ( MRIS* mris                                    ) : MRIS_Elt(mris,0) {}
-    Surface::Surface ( Surface const & src                           ) : MRIS_Elt(src) {}   
-    Surface::Surface ( XYZPositionConsequencesM::Surface const & src ) : MRIS_Elt(src) {}   
-    Surface::Surface ( XYZPositionConsequences::Surface const & src  ) : MRIS_Elt(src) {}   
-    Surface::Surface ( DistortM::Surface const & src                 ) : MRIS_Elt(src) {}   
-    Surface::Surface ( Distort::Surface const & src                  ) : MRIS_Elt(src) {}   
-    Surface::Surface ( AnalysisM::Surface const & src                ) : MRIS_Elt(src) {}   
-    Surface::Surface ( Analysis::Surface const & src                 ) : MRIS_Elt(src) {}   
-    Surface::Surface ( AllM::Surface const & src                     ) : MRIS_Elt(src) {}   
+    Surface::Surface (                                               ) {}
+    Surface::Surface ( Representation* representation                ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src                           ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPositionConsequencesM::Surface const & src ) : Repr_Elt(src) {}
+    Surface::Surface ( XYZPositionConsequences::Surface const & src  ) : Repr_Elt(src) {}
+    Surface::Surface ( DistortM::Surface const & src                 ) : Repr_Elt(src) {}
+    Surface::Surface ( Distort::Surface const & src                  ) : Repr_Elt(src) {}
+    Surface::Surface ( AnalysisM::Surface const & src                ) : Repr_Elt(src) {}
+    Surface::Surface ( Analysis::Surface const & src                 ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src                     ) : Repr_Elt(src) {}
 
     int Surface::nverticesFrozen() const {  //  # of vertices on surface is frozen
-        return mris->nverticesFrozen;
+        return repr->nverticesFrozen;
     }
     int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nvertices;
+        return repr->nvertices;
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nfaces;
+        return repr->nfaces;
     }
     bool Surface::faceAttachmentDeferred() const {  //  defer connecting faces to vertices for performance reasons
-        return mris->faceAttachmentDeferred;
+        return repr->faceAttachmentDeferred;
     }
     int Surface::nedges() const {  //  # of edges on surface
-        return mris->nedges;
+        return repr->nedges;
     }
     int Surface::nstrips() const {
-        return mris->nstrips;
+        return repr->nstrips;
     }
     Vertex Surface::vertices(size_t i) const {
-        return Vertex(mris,i);
+        return Vertex(repr,i);
     }
     p_p_void Surface::dist_storage() const {  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
-        return mris->dist_storage;
+        return repr->dist_storage;
     }
     p_p_void Surface::dist_orig_storage() const {  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
-        return mris->dist_orig_storage;
+        return repr->dist_orig_storage;
     }
     int Surface::tempsAssigned() const {  //  State of various temp fields that can be borrowed if not already in use
-        return mris->tempsAssigned;
+        return repr->tempsAssigned;
     }
     Face Surface::faces(size_t i) const {
-        return Face(mris,i);
+        return Face(repr,i);
     }
     MRI_EDGE Surface::edges(size_t i) const {
-        return mris->edges[i];
+        return repr->edges[i];
     }
     FaceNormCacheEntry Surface::faceNormCacheEntries(size_t i) const {
-        return mris->faceNormCacheEntries[i];
+        return repr->faceNormCacheEntries[i];
     }
     FaceNormDeferredEntry Surface::faceNormDeferredEntries(size_t i) const {
-        return mris->faceNormDeferredEntries[i];
+        return repr->faceNormDeferredEntries[i];
     }
     int Surface::initialized() const {
-        return mris->initialized;
+        return repr->initialized;
     }
     PLTA Surface::lta() const {
-        return mris->lta;
+        return repr->lta;
     }
     PMATRIX Surface::SRASToTalSRAS_() const {
-        return mris->SRASToTalSRAS_;
+        return repr->SRASToTalSRAS_;
     }
     PMATRIX Surface::TalSRASToSRAS_() const {
-        return mris->TalSRASToSRAS_;
+        return repr->TalSRASToSRAS_;
     }
     int Surface::free_transform() const {
-        return mris->free_transform;
+        return repr->free_transform;
     }
     double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
-        return mris->radius;
+        return repr->radius;
     }
     float Surface::a() const {
-        return mris->a;
+        return repr->a;
     }
     float Surface::b() const {
-        return mris->b;
+        return repr->b;
     }
     float Surface::c() const {  //  ellipsoid parameters
-        return mris->c;
+        return repr->c;
     }
     MRIS_fname_t Surface::fname() const {  //  file it was originally loaded from
-        return mris->fname;
+        return repr->fname;
     }
     MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
-        return mris->status;
+        return repr->status;
     }
     MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-        return mris->origxyz_status;
+        return repr->origxyz_status;
     }
     int Surface::patch() const {  //  if a patch of the surface
-        return mris->patch;
+        return repr->patch;
     }
     p_void Surface::vp() const {  //  for misc. use
-        return mris->vp;
+        return repr->vp;
     }
     float Surface::alpha() const {  //  rotation around z-axis
-        return mris->alpha;
+        return repr->alpha;
     }
     float Surface::beta() const {  //  rotation around y-axis
-        return mris->beta;
+        return repr->beta;
     }
     float Surface::gamma() const {  //  rotation around x-axis
-        return mris->gamma;
+        return repr->gamma;
     }
     float Surface::da() const {
-        return mris->da;
+        return repr->da;
     }
     float Surface::db() const {
-        return mris->db;
+        return repr->db;
     }
     float Surface::dg() const {  //  old deltas
-        return mris->dg;
+        return repr->dg;
     }
     int Surface::type() const {  //  what type of surface was this initially
-        return mris->type;
+        return repr->type;
     }
     int Surface::max_vertices() const {  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
-        return mris->max_vertices;
+        return repr->max_vertices;
     }
     int Surface::max_faces() const {  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
-        return mris->max_faces;
+        return repr->max_faces;
     }
     MRIS_subject_name_t Surface::subject_name() const {  //  name of the subject
-        return mris->subject_name;
+        return repr->subject_name;
     }
     float Surface::canon_area() const {
-        return mris->canon_area;
+        return repr->canon_area;
     }
     int Surface::noscale() const {  //  don't scale by surface area if true
-        return mris->noscale;
+        return repr->noscale;
     }
     float Surface::dx2(size_t i) const {  //  an extra set of gradient (not always alloced)
-        return mris->dx2[i];
+        return repr->dx2[i];
     }
     float Surface::dy2(size_t i) const {
-        return mris->dy2[i];
+        return repr->dy2[i];
     }
     float Surface::dz2(size_t i) const {
-        return mris->dz2[i];
+        return repr->dz2[i];
     }
     PCOLOR_TABLE Surface::ct() const {
-        return mris->ct;
+        return repr->ct;
     }
     int Surface::useRealRAS() const {  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        return mris->useRealRAS;
+        return repr->useRealRAS;
     }
     VOL_GEOM Surface::vg() const {  //  volume info from which this surface is created. valid iff vg.valid = 1
-        return mris->vg;
+        return repr->vg;
     }
     MRIS_cmdlines_t Surface::cmdlines() const {
-        return mris->cmdlines;
+        return repr->cmdlines;
     }
     int Surface::ncmds() const {
-        return mris->ncmds;
+        return repr->ncmds;
     }
     float Surface::group_avg_surface_area() const {  //  average of total surface area for group
-        return mris->group_avg_surface_area;
+        return repr->group_avg_surface_area;
     }
     int Surface::group_avg_vtxarea_loaded() const {  //  average vertex area for group at each vertex
-        return mris->group_avg_vtxarea_loaded;
+        return repr->group_avg_vtxarea_loaded;
     }
     int Surface::triangle_links_removed() const {  //  for quad surfaces
-        return mris->triangle_links_removed;
+        return repr->triangle_links_removed;
     }
     p_void Surface::user_parms() const {  //  for whatever the user wants to hang here
-        return mris->user_parms;
+        return repr->user_parms;
     }
     PMATRIX Surface::m_sras2vox() const {  //  for converting surface ras to voxel
-        return mris->m_sras2vox;
+        return repr->m_sras2vox;
     }
     PMRI Surface::mri_sras2vox() const {  //  volume that the above matrix is for
-        return mris->mri_sras2vox;
+        return repr->mri_sras2vox;
     }
     p_void Surface::mht() const {
-        return mris->mht;
+        return repr->mht;
     }
     p_void Surface::temps() const {
-        return mris->temps;
+        return repr->temps;
     }
     
     void Surface::set_vp(p_void to) {  //  for misc. use
-        mris->vp = to;
+        repr->vp = to;
     }
     void Surface::set_alpha(float to) {  //  rotation around z-axis
-        mris->alpha = to;
+        repr->alpha = to;
     }
     void Surface::set_beta(float to) {  //  rotation around y-axis
-        mris->beta = to;
+        repr->beta = to;
     }
     void Surface::set_gamma(float to) {  //  rotation around x-axis
-        mris->gamma = to;
+        repr->gamma = to;
     }
     void Surface::set_da(float to) {
-        mris->da = to;
+        repr->da = to;
     }
     void Surface::set_db(float to) {
-        mris->db = to;
+        repr->db = to;
     }
     void Surface::set_dg(float to) {  //  old deltas
-        mris->dg = to;
+        repr->dg = to;
     }
     void Surface::set_type(int to) {  //  what type of surface was this initially
-        mris->type = to;
+        repr->type = to;
     }
 
 
@@ -815,579 +824,582 @@ namespace SurfaceFromMRIS {
 
 
     namespace XYZPositionConsequences {
-    Face::Face (                             ) {}                     
-    Face::Face ( MRIS* mris, size_t idx      ) : MRIS_Elt(mris,idx) {}
-    Face::Face ( Face const & src            ) : MRIS_Elt(src) {}     
-    Face::Face ( DistortM::Face const & src  ) : MRIS_Elt(src) {}     
-    Face::Face ( Distort::Face const & src   ) : MRIS_Elt(src) {}     
-    Face::Face ( AnalysisM::Face const & src ) : MRIS_Elt(src) {}     
-    Face::Face ( Analysis::Face const & src  ) : MRIS_Elt(src) {}     
-    Face::Face ( AllM::Face const & src      ) : MRIS_Elt(src) {}     
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( DistortM::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( Distort::Face const & src                  ) : Repr_Elt(src) {}
+    Face::Face ( AnalysisM::Face const & src                ) : Repr_Elt(src) {}
+    Face::Face ( Analysis::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
     Vertex Face::v(size_t i) const {
-        return Vertex(mris,mris->faces[idx].v[i]);
+        return Vertex(repr,repr->faces[idx].v[i]);
     }
     float Face::area() const {
-        return mris->faces[idx].area;
+        return repr->faces[idx].area;
     }
     angles_per_triangle_t Face::angle() const {
-        return mris->faces[idx].angle;
+        return repr->faces[idx].angle;
     }
     angles_per_triangle_t Face::orig_angle() const {
-        return mris->faces[idx].orig_angle;
+        return repr->faces[idx].orig_angle;
     }
     char Face::ripflag() const {
-        return mris->faces[idx].ripflag;
+        return repr->faces[idx].ripflag;
     }
     char Face::oripflag() const {
-        return mris->faces[idx].oripflag;
+        return repr->faces[idx].oripflag;
     }
     int Face::marked() const {
-        return mris->faces[idx].marked;
+        return repr->faces[idx].marked;
     }
     PDMATRIX Face::norm() const {
-        return mris->faces[idx].norm;
+        return repr->faces[idx].norm;
     }
     A3PDMATRIX Face::gradNorm() const {
-        return mris->faces[idx].gradNorm;
+        return repr->faces[idx].gradNorm;
     }
     
     void Face::set_orig_angle(angles_per_triangle_t to) {
-        mris->faces[idx].orig_angle = to;
+        repr->faces[idx].orig_angle = to;
     }
     void Face::set_ripflag(char to) {
-        mris->faces[idx].ripflag = to;
+        repr->faces[idx].ripflag = to;
     }
     void Face::set_oripflag(char to) {
-        mris->faces[idx].oripflag = to;
+        repr->faces[idx].oripflag = to;
     }
     void Face::set_marked(int to) {
-        mris->faces[idx].marked = to;
+        repr->faces[idx].marked = to;
     }
 
 
-    Vertex::Vertex (                               ) {}                     
-    Vertex::Vertex ( MRIS* mris, size_t idx        ) : MRIS_Elt(mris,idx) {}
-    Vertex::Vertex ( Vertex const & src            ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( DistortM::Vertex const & src  ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( Distort::Vertex const & src   ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( AnalysisM::Vertex const & src ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( Analysis::Vertex const & src  ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( AllM::Vertex const & src      ) : MRIS_Elt(src) {}     
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( DistortM::Vertex const & src               ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Distort::Vertex const & src                ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AnalysisM::Vertex const & src              ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Analysis::Vertex const & src               ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
 
     Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        return Face(mris,mris->vertices_topology[idx].f[i]);
+        return Face(repr,repr->vertices_topology[idx].f[i]);
     }
     size_t Vertex::n(size_t i) const {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        return size_t(mris->vertices_topology[idx].n[i]);
+        return size_t(repr->vertices_topology[idx].n[i]);
     }
     int Vertex::e(size_t i) const {  //  edge state for neighboring vertices                      
-        return mris->vertices_topology[idx].e[i];
+        return repr->vertices_topology[idx].e[i];
     }
     Vertex Vertex::v(size_t i) const {  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        return Vertex(mris,mris->vertices_topology[idx].v[i]);
+        return Vertex(repr,repr->vertices_topology[idx].v[i]);
     }
     short Vertex::vnum() const {  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
-        return mris->vertices_topology[idx].vnum;
+        return repr->vertices_topology[idx].vnum;
     }
     short Vertex::v2num() const {  //  number of 1, or 2-hop neighbors                          
-        return mris->vertices_topology[idx].v2num;
+        return repr->vertices_topology[idx].v2num;
     }
     short Vertex::v3num() const {  //  number of 1,2,or 3-hop neighbors                         
-        return mris->vertices_topology[idx].v3num;
+        return repr->vertices_topology[idx].v3num;
     }
     short Vertex::vtotal() const {  //  total # of neighbors. copy of vnum.nsizeCur              
-        return mris->vertices_topology[idx].vtotal;
+        return repr->vertices_topology[idx].vtotal;
     }
     short Vertex::nsizeMaxClock() const {  //  copy of mris->nsizeMaxClock when v#num                   
-        return mris->vertices_topology[idx].nsizeMaxClock;
+        return repr->vertices_topology[idx].nsizeMaxClock;
     }
     uchar Vertex::nsizeMax() const {  //  the max nsize that was used to fill in vnum etc          
-        return mris->vertices_topology[idx].nsizeMax;
+        return repr->vertices_topology[idx].nsizeMax;
     }
     uchar Vertex::nsizeCur() const {  //  index of the current v#num in vtotal                     
-        return mris->vertices_topology[idx].nsizeCur;
+        return repr->vertices_topology[idx].nsizeCur;
     }
     uchar Vertex::num() const {  //  number of neighboring faces                              
-        return mris->vertices_topology[idx].num;
+        return repr->vertices_topology[idx].num;
     }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
-        return mris->vertices[idx].dist[i];
+        return repr->vertices[idx].dist[i];
     }
     float Vertex::dist_orig(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on origxyz
-        return mris->vertices[idx].dist_orig[i];
+        return repr->vertices[idx].dist_orig[i];
     }
     int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_capacity;
+        return repr->vertices[idx].dist_capacity;
     }
     int Vertex::dist_orig_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_orig_capacity;
+        return repr->vertices[idx].dist_orig_capacity;
     }
     float Vertex::x() const {  //  current coordinates	
-        return mris->vertices[idx].x;
+        return repr->vertices[idx].x;
     }
     float Vertex::y() const {  //  use MRISsetXYZ() to set
-        return mris->vertices[idx].y;
+        return repr->vertices[idx].y;
     }
     float Vertex::z() const {
-        return mris->vertices[idx].z;
+        return repr->vertices[idx].z;
     }
     float Vertex::origx() const {  //  original coordinates, see also MRIS::origxyz_status
-        return mris->vertices[idx].origx;
+        return repr->vertices[idx].origx;
     }
     float Vertex::origy() const {  //  use MRISsetOriginalXYZ(, 
-        return mris->vertices[idx].origy;
+        return repr->vertices[idx].origy;
     }
     float Vertex::origz() const {  //  or MRISsetOriginalXYZfromXYZ to set
-        return mris->vertices[idx].origz;
+        return repr->vertices[idx].origz;
     }
     float Vertex::nx() const {
-        return mris->vertices[idx].nx;
+        return repr->vertices[idx].nx;
     }
     float Vertex::ny() const {
-        return mris->vertices[idx].ny;
+        return repr->vertices[idx].ny;
     }
     float Vertex::nz() const {  //  curr normal
-        return mris->vertices[idx].nz;
+        return repr->vertices[idx].nz;
     }
     float Vertex::cx() const {
-        return mris->vertices[idx].cx;
+        return repr->vertices[idx].cx;
     }
     float Vertex::cy() const {
-        return mris->vertices[idx].cy;
+        return repr->vertices[idx].cy;
     }
     float Vertex::cz() const {  //  coordinates in canonical coordinate system
-        return mris->vertices[idx].cz;
+        return repr->vertices[idx].cz;
     }
     float Vertex::area() const {
-        return mris->vertices[idx].area;
+        return repr->vertices[idx].area;
     }
     char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
-        return mris->vertices[idx].ripflag;
+        return repr->vertices[idx].ripflag;
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+         MRISvertexCoord2XYZ_float(&repr->vertices[idx], which, x, y, z);
     }
     
     void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        cheapAssert(mris == to.mris); mris->vertices_topology[idx].f[i] = to.idx;
+        cheapAssert(repr == to.repr); repr->vertices_topology[idx].f[i] = to.idx;
     }
     void Vertex::set_n(size_t i, size_t to) {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        mris->vertices_topology[idx].n[i] = uchar(to);
+        repr->vertices_topology[idx].n[i] = uchar(to);
     }
     void Vertex::set_e(size_t i, int to) {  //  edge state for neighboring vertices                      
-        mris->vertices_topology[idx].e[i] = to;
+        repr->vertices_topology[idx].e[i] = to;
     }
     void Vertex::set_nx(float to) {
-        mris->vertices[idx].nx = to;
+        repr->vertices[idx].nx = to;
     }
     void Vertex::set_ny(float to) {
-        mris->vertices[idx].ny = to;
+        repr->vertices[idx].ny = to;
     }
     void Vertex::set_nz(float to) {  //  curr normal
-        mris->vertices[idx].nz = to;
+        repr->vertices[idx].nz = to;
     }
     void Vertex::set_cx(float to) {
-        mris->vertices[idx].cx = to;
+        repr->vertices[idx].cx = to;
     }
     void Vertex::set_cy(float to) {
-        mris->vertices[idx].cy = to;
+        repr->vertices[idx].cy = to;
     }
     void Vertex::set_cz(float to) {  //  coordinates in canonical coordinate system
-        mris->vertices[idx].cz = to;
+        repr->vertices[idx].cz = to;
     }
     void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
-        mris->vertices[idx].ripflag = to;
+        repr->vertices[idx].ripflag = to;
     }
 
 
-    Surface::Surface (                                ) {}                   
-    Surface::Surface ( MRIS* mris                     ) : MRIS_Elt(mris,0) {}
-    Surface::Surface ( Surface const & src            ) : MRIS_Elt(src) {}   
-    Surface::Surface ( DistortM::Surface const & src  ) : MRIS_Elt(src) {}   
-    Surface::Surface ( Distort::Surface const & src   ) : MRIS_Elt(src) {}   
-    Surface::Surface ( AnalysisM::Surface const & src ) : MRIS_Elt(src) {}   
-    Surface::Surface ( Analysis::Surface const & src  ) : MRIS_Elt(src) {}   
-    Surface::Surface ( AllM::Surface const & src      ) : MRIS_Elt(src) {}   
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( DistortM::Surface const & src  ) : Repr_Elt(src) {}
+    Surface::Surface ( Distort::Surface const & src   ) : Repr_Elt(src) {}
+    Surface::Surface ( AnalysisM::Surface const & src ) : Repr_Elt(src) {}
+    Surface::Surface ( Analysis::Surface const & src  ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
 
     int Surface::nverticesFrozen() const {  //  # of vertices on surface is frozen
-        return mris->nverticesFrozen;
+        return repr->nverticesFrozen;
     }
     int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nvertices;
+        return repr->nvertices;
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nfaces;
+        return repr->nfaces;
     }
     bool Surface::faceAttachmentDeferred() const {  //  defer connecting faces to vertices for performance reasons
-        return mris->faceAttachmentDeferred;
+        return repr->faceAttachmentDeferred;
     }
     int Surface::nedges() const {  //  # of edges on surface
-        return mris->nedges;
+        return repr->nedges;
     }
     int Surface::nstrips() const {
-        return mris->nstrips;
+        return repr->nstrips;
     }
     Vertex Surface::vertices(size_t i) const {
-        return Vertex(mris,i);
+        return Vertex(repr,i);
     }
     p_p_void Surface::dist_storage() const {  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
-        return mris->dist_storage;
+        return repr->dist_storage;
     }
     p_p_void Surface::dist_orig_storage() const {  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
-        return mris->dist_orig_storage;
+        return repr->dist_orig_storage;
     }
     int Surface::tempsAssigned() const {  //  State of various temp fields that can be borrowed if not already in use
-        return mris->tempsAssigned;
+        return repr->tempsAssigned;
     }
     Face Surface::faces(size_t i) const {
-        return Face(mris,i);
+        return Face(repr,i);
     }
     MRI_EDGE Surface::edges(size_t i) const {
-        return mris->edges[i];
+        return repr->edges[i];
     }
     FaceNormCacheEntry Surface::faceNormCacheEntries(size_t i) const {
-        return mris->faceNormCacheEntries[i];
+        return repr->faceNormCacheEntries[i];
     }
     FaceNormDeferredEntry Surface::faceNormDeferredEntries(size_t i) const {
-        return mris->faceNormDeferredEntries[i];
+        return repr->faceNormDeferredEntries[i];
     }
     STRIP Surface::strips(size_t i) const {
-        return mris->strips[i];
+        return repr->strips[i];
     }
     float Surface::xctr() const {
-        return mris->xctr;
+        return repr->xctr;
     }
     float Surface::yctr() const {
-        return mris->yctr;
+        return repr->yctr;
     }
     float Surface::zctr() const {
-        return mris->zctr;
+        return repr->zctr;
     }
     float Surface::xlo() const {
-        return mris->xlo;
+        return repr->xlo;
     }
     float Surface::ylo() const {
-        return mris->ylo;
+        return repr->ylo;
     }
     float Surface::zlo() const {
-        return mris->zlo;
+        return repr->zlo;
     }
     float Surface::xhi() const {
-        return mris->xhi;
+        return repr->xhi;
     }
     float Surface::yhi() const {
-        return mris->yhi;
+        return repr->yhi;
     }
     float Surface::zhi() const {
-        return mris->zhi;
+        return repr->zhi;
     }
     float Surface::x0() const {  //  center of spherical expansion
-        return mris->x0;
+        return repr->x0;
     }
     float Surface::y0() const {
-        return mris->y0;
+        return repr->y0;
     }
     float Surface::z0() const {
-        return mris->z0;
+        return repr->z0;
     }
     Vertex Surface::v_temporal_pole() const {
-        return Vertex(mris,mris->v_temporal_pole - mris->vertices);
+        return Vertex(repr,repr->v_temporal_pole - repr->vertices);
     }
     Vertex Surface::v_frontal_pole() const {
-        return Vertex(mris,mris->v_frontal_pole - mris->vertices);
+        return Vertex(repr,repr->v_frontal_pole - repr->vertices);
     }
     Vertex Surface::v_occipital_pole() const {
-        return Vertex(mris,mris->v_occipital_pole - mris->vertices);
+        return Vertex(repr,repr->v_occipital_pole - repr->vertices);
     }
     float Surface::max_curv() const {
-        return mris->max_curv;
+        return repr->max_curv;
     }
     float Surface::min_curv() const {
-        return mris->min_curv;
+        return repr->min_curv;
     }
     float Surface::total_area() const {
-        return mris->total_area;
+        return repr->total_area;
     }
     double Surface::avg_vertex_area() const {
-        return mris->avg_vertex_area;
+        return repr->avg_vertex_area;
     }
     double Surface::avg_vertex_dist() const {  //  set by MRIScomputeAvgInterVertexDist
-        return mris->avg_vertex_dist;
+        return repr->avg_vertex_dist;
     }
     double Surface::std_vertex_dist() const {
-        return mris->std_vertex_dist;
+        return repr->std_vertex_dist;
     }
     float Surface::orig_area() const {
-        return mris->orig_area;
+        return repr->orig_area;
     }
     float Surface::neg_area() const {
-        return mris->neg_area;
+        return repr->neg_area;
     }
     float Surface::neg_orig_area() const {  //  amount of original surface in folds
-        return mris->neg_orig_area;
+        return repr->neg_orig_area;
     }
     int Surface::zeros() const {
-        return mris->zeros;
+        return repr->zeros;
     }
     int Surface::hemisphere() const {  //  which hemisphere
-        return mris->hemisphere;
+        return repr->hemisphere;
     }
     int Surface::initialized() const {
-        return mris->initialized;
+        return repr->initialized;
     }
     PLTA Surface::lta() const {
-        return mris->lta;
+        return repr->lta;
     }
     PMATRIX Surface::SRASToTalSRAS_() const {
-        return mris->SRASToTalSRAS_;
+        return repr->SRASToTalSRAS_;
     }
     PMATRIX Surface::TalSRASToSRAS_() const {
-        return mris->TalSRASToSRAS_;
+        return repr->TalSRASToSRAS_;
     }
     int Surface::free_transform() const {
-        return mris->free_transform;
+        return repr->free_transform;
     }
     double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
-        return mris->radius;
+        return repr->radius;
     }
     float Surface::a() const {
-        return mris->a;
+        return repr->a;
     }
     float Surface::b() const {
-        return mris->b;
+        return repr->b;
     }
     float Surface::c() const {  //  ellipsoid parameters
-        return mris->c;
+        return repr->c;
     }
     MRIS_fname_t Surface::fname() const {  //  file it was originally loaded from
-        return mris->fname;
+        return repr->fname;
     }
     float Surface::Hmin() const {  //  min mean curvature
-        return mris->Hmin;
+        return repr->Hmin;
     }
     float Surface::Hmax() const {  //  max mean curvature
-        return mris->Hmax;
+        return repr->Hmax;
     }
     float Surface::Kmin() const {  //  min Gaussian curvature
-        return mris->Kmin;
+        return repr->Kmin;
     }
     float Surface::Kmax() const {  //  max Gaussian curvature
-        return mris->Kmax;
+        return repr->Kmax;
     }
     double Surface::Ktotal() const {  //  total Gaussian curvature
-        return mris->Ktotal;
+        return repr->Ktotal;
     }
     MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
-        return mris->status;
+        return repr->status;
     }
     MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-        return mris->origxyz_status;
+        return repr->origxyz_status;
     }
     int Surface::patch() const {  //  if a patch of the surface
-        return mris->patch;
+        return repr->patch;
     }
     int Surface::nlabels() const {
-        return mris->nlabels;
+        return repr->nlabels;
     }
     PMRIS_AREA_LABEL Surface::labels() const {  //  nlabels of these (may be null)
-        return mris->labels;
+        return repr->labels;
     }
     p_void Surface::vp() const {  //  for misc. use
-        return mris->vp;
+        return repr->vp;
     }
     float Surface::alpha() const {  //  rotation around z-axis
-        return mris->alpha;
+        return repr->alpha;
     }
     float Surface::beta() const {  //  rotation around y-axis
-        return mris->beta;
+        return repr->beta;
     }
     float Surface::gamma() const {  //  rotation around x-axis
-        return mris->gamma;
+        return repr->gamma;
     }
     float Surface::da() const {
-        return mris->da;
+        return repr->da;
     }
     float Surface::db() const {
-        return mris->db;
+        return repr->db;
     }
     float Surface::dg() const {  //  old deltas
-        return mris->dg;
+        return repr->dg;
     }
     int Surface::type() const {  //  what type of surface was this initially
-        return mris->type;
+        return repr->type;
     }
     int Surface::max_vertices() const {  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
-        return mris->max_vertices;
+        return repr->max_vertices;
     }
     int Surface::max_faces() const {  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
-        return mris->max_faces;
+        return repr->max_faces;
     }
     MRIS_subject_name_t Surface::subject_name() const {  //  name of the subject
-        return mris->subject_name;
+        return repr->subject_name;
     }
     float Surface::canon_area() const {
-        return mris->canon_area;
+        return repr->canon_area;
     }
     int Surface::noscale() const {  //  don't scale by surface area if true
-        return mris->noscale;
+        return repr->noscale;
     }
     float Surface::dx2(size_t i) const {  //  an extra set of gradient (not always alloced)
-        return mris->dx2[i];
+        return repr->dx2[i];
     }
     float Surface::dy2(size_t i) const {
-        return mris->dy2[i];
+        return repr->dy2[i];
     }
     float Surface::dz2(size_t i) const {
-        return mris->dz2[i];
+        return repr->dz2[i];
     }
     PCOLOR_TABLE Surface::ct() const {
-        return mris->ct;
+        return repr->ct;
     }
     int Surface::useRealRAS() const {  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        return mris->useRealRAS;
+        return repr->useRealRAS;
     }
     VOL_GEOM Surface::vg() const {  //  volume info from which this surface is created. valid iff vg.valid = 1
-        return mris->vg;
+        return repr->vg;
     }
     MRIS_cmdlines_t Surface::cmdlines() const {
-        return mris->cmdlines;
+        return repr->cmdlines;
     }
     int Surface::ncmds() const {
-        return mris->ncmds;
+        return repr->ncmds;
     }
     float Surface::group_avg_surface_area() const {  //  average of total surface area for group
-        return mris->group_avg_surface_area;
+        return repr->group_avg_surface_area;
     }
     int Surface::group_avg_vtxarea_loaded() const {  //  average vertex area for group at each vertex
-        return mris->group_avg_vtxarea_loaded;
+        return repr->group_avg_vtxarea_loaded;
     }
     int Surface::triangle_links_removed() const {  //  for quad surfaces
-        return mris->triangle_links_removed;
+        return repr->triangle_links_removed;
     }
     p_void Surface::user_parms() const {  //  for whatever the user wants to hang here
-        return mris->user_parms;
+        return repr->user_parms;
     }
     PMATRIX Surface::m_sras2vox() const {  //  for converting surface ras to voxel
-        return mris->m_sras2vox;
+        return repr->m_sras2vox;
     }
     PMRI Surface::mri_sras2vox() const {  //  volume that the above matrix is for
-        return mris->mri_sras2vox;
+        return repr->mri_sras2vox;
     }
     p_void Surface::mht() const {
-        return mris->mht;
+        return repr->mht;
     }
     p_void Surface::temps() const {
-        return mris->temps;
+        return repr->temps;
     }
     
     void Surface::set_strips(size_t i, STRIP to) {
-        mris->strips[i] = to;
+        repr->strips[i] = to;
     }
     void Surface::set_xctr(float to) {
-        mris->xctr = to;
+        repr->xctr = to;
     }
     void Surface::set_yctr(float to) {
-        mris->yctr = to;
+        repr->yctr = to;
     }
     void Surface::set_zctr(float to) {
-        mris->zctr = to;
+        repr->zctr = to;
     }
     void Surface::set_xlo(float to) {
-        mris->xlo = to;
+        repr->xlo = to;
     }
     void Surface::set_ylo(float to) {
-        mris->ylo = to;
+        repr->ylo = to;
     }
     void Surface::set_zlo(float to) {
-        mris->zlo = to;
+        repr->zlo = to;
     }
     void Surface::set_xhi(float to) {
-        mris->xhi = to;
+        repr->xhi = to;
     }
     void Surface::set_yhi(float to) {
-        mris->yhi = to;
+        repr->yhi = to;
     }
     void Surface::set_zhi(float to) {
-        mris->zhi = to;
+        repr->zhi = to;
     }
     void Surface::set_x0(float to) {  //  center of spherical expansion
-        mris->x0 = to;
+        repr->x0 = to;
     }
     void Surface::set_y0(float to) {
-        mris->y0 = to;
+        repr->y0 = to;
     }
     void Surface::set_z0(float to) {
-        mris->z0 = to;
+        repr->z0 = to;
     }
     void Surface::set_v_temporal_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_temporal_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_temporal_pole = repr->vertices + to.idx;
     }
     void Surface::set_v_frontal_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_frontal_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_frontal_pole = repr->vertices + to.idx;
     }
     void Surface::set_v_occipital_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_occipital_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_occipital_pole = repr->vertices + to.idx;
     }
     void Surface::set_max_curv(float to) {
-        mris->max_curv = to;
+        repr->max_curv = to;
     }
     void Surface::set_min_curv(float to) {
-        mris->min_curv = to;
+        repr->min_curv = to;
     }
     void Surface::set_total_area(float to) {
-        mris->total_area = to;
+        repr->total_area = to;
     }
     void Surface::set_avg_vertex_area(double to) {
-        mris->avg_vertex_area = to;
+        repr->avg_vertex_area = to;
     }
     void Surface::set_zeros(int to) {
-        mris->zeros = to;
+        repr->zeros = to;
     }
     void Surface::set_hemisphere(int to) {  //  which hemisphere
-        mris->hemisphere = to;
+        repr->hemisphere = to;
     }
     void Surface::set_Hmin(float to) {  //  min mean curvature
-        mris->Hmin = to;
+        repr->Hmin = to;
     }
     void Surface::set_Hmax(float to) {  //  max mean curvature
-        mris->Hmax = to;
+        repr->Hmax = to;
     }
     void Surface::set_Kmin(float to) {  //  min Gaussian curvature
-        mris->Kmin = to;
+        repr->Kmin = to;
     }
     void Surface::set_Kmax(float to) {  //  max Gaussian curvature
-        mris->Kmax = to;
+        repr->Kmax = to;
     }
     void Surface::set_Ktotal(double to) {  //  total Gaussian curvature
-        mris->Ktotal = to;
+        repr->Ktotal = to;
     }
     void Surface::set_nlabels(int to) {
-        mris->nlabels = to;
+        repr->nlabels = to;
     }
     void Surface::set_labels(PMRIS_AREA_LABEL to) {  //  nlabels of these (may be null)
-        mris->labels = to;
+        repr->labels = to;
     }
     void Surface::set_vp(p_void to) {  //  for misc. use
-        mris->vp = to;
+        repr->vp = to;
     }
     void Surface::set_alpha(float to) {  //  rotation around z-axis
-        mris->alpha = to;
+        repr->alpha = to;
     }
     void Surface::set_beta(float to) {  //  rotation around y-axis
-        mris->beta = to;
+        repr->beta = to;
     }
     void Surface::set_gamma(float to) {  //  rotation around x-axis
-        mris->gamma = to;
+        repr->gamma = to;
     }
     void Surface::set_da(float to) {
-        mris->da = to;
+        repr->da = to;
     }
     void Surface::set_db(float to) {
-        mris->db = to;
+        repr->db = to;
     }
     void Surface::set_dg(float to) {  //  old deltas
-        mris->dg = to;
+        repr->dg = to;
     }
     void Surface::set_type(int to) {  //  what type of surface was this initially
-        mris->type = to;
+        repr->type = to;
     }
 
 
@@ -1395,1161 +1407,1164 @@ namespace SurfaceFromMRIS {
 
 
     namespace Distort {
-    Face::Face (                             ) {}                     
-    Face::Face ( MRIS* mris, size_t idx      ) : MRIS_Elt(mris,idx) {}
-    Face::Face ( Face const & src            ) : MRIS_Elt(src) {}     
-    Face::Face ( AnalysisM::Face const & src ) : MRIS_Elt(src) {}     
-    Face::Face ( Analysis::Face const & src  ) : MRIS_Elt(src) {}     
-    Face::Face ( AllM::Face const & src      ) : MRIS_Elt(src) {}     
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( AnalysisM::Face const & src                ) : Repr_Elt(src) {}
+    Face::Face ( Analysis::Face const & src                 ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
     Vertex Face::v(size_t i) const {
-        return Vertex(mris,mris->faces[idx].v[i]);
+        return Vertex(repr,repr->faces[idx].v[i]);
     }
     float Face::area() const {
-        return mris->faces[idx].area;
+        return repr->faces[idx].area;
     }
     angles_per_triangle_t Face::angle() const {
-        return mris->faces[idx].angle;
+        return repr->faces[idx].angle;
     }
     angles_per_triangle_t Face::orig_angle() const {
-        return mris->faces[idx].orig_angle;
+        return repr->faces[idx].orig_angle;
     }
     char Face::ripflag() const {
-        return mris->faces[idx].ripflag;
+        return repr->faces[idx].ripflag;
     }
     char Face::oripflag() const {
-        return mris->faces[idx].oripflag;
+        return repr->faces[idx].oripflag;
     }
     int Face::marked() const {
-        return mris->faces[idx].marked;
+        return repr->faces[idx].marked;
     }
     PDMATRIX Face::norm() const {
-        return mris->faces[idx].norm;
+        return repr->faces[idx].norm;
     }
     A3PDMATRIX Face::gradNorm() const {
-        return mris->faces[idx].gradNorm;
+        return repr->faces[idx].gradNorm;
     }
     
     void Face::set_orig_angle(angles_per_triangle_t to) {
-        mris->faces[idx].orig_angle = to;
+        repr->faces[idx].orig_angle = to;
     }
     void Face::set_ripflag(char to) {
-        mris->faces[idx].ripflag = to;
+        repr->faces[idx].ripflag = to;
     }
     void Face::set_oripflag(char to) {
-        mris->faces[idx].oripflag = to;
+        repr->faces[idx].oripflag = to;
     }
     void Face::set_marked(int to) {
-        mris->faces[idx].marked = to;
+        repr->faces[idx].marked = to;
     }
 
 
-    Vertex::Vertex (                               ) {}                     
-    Vertex::Vertex ( MRIS* mris, size_t idx        ) : MRIS_Elt(mris,idx) {}
-    Vertex::Vertex ( Vertex const & src            ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( AnalysisM::Vertex const & src ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( Analysis::Vertex const & src  ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( AllM::Vertex const & src      ) : MRIS_Elt(src) {}     
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AnalysisM::Vertex const & src              ) : Repr_Elt(src) {}
+    Vertex::Vertex ( Analysis::Vertex const & src               ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
 
     Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        return Face(mris,mris->vertices_topology[idx].f[i]);
+        return Face(repr,repr->vertices_topology[idx].f[i]);
     }
     size_t Vertex::n(size_t i) const {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        return size_t(mris->vertices_topology[idx].n[i]);
+        return size_t(repr->vertices_topology[idx].n[i]);
     }
     int Vertex::e(size_t i) const {  //  edge state for neighboring vertices                      
-        return mris->vertices_topology[idx].e[i];
+        return repr->vertices_topology[idx].e[i];
     }
     Vertex Vertex::v(size_t i) const {  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        return Vertex(mris,mris->vertices_topology[idx].v[i]);
+        return Vertex(repr,repr->vertices_topology[idx].v[i]);
     }
     short Vertex::vnum() const {  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
-        return mris->vertices_topology[idx].vnum;
+        return repr->vertices_topology[idx].vnum;
     }
     short Vertex::v2num() const {  //  number of 1, or 2-hop neighbors                          
-        return mris->vertices_topology[idx].v2num;
+        return repr->vertices_topology[idx].v2num;
     }
     short Vertex::v3num() const {  //  number of 1,2,or 3-hop neighbors                         
-        return mris->vertices_topology[idx].v3num;
+        return repr->vertices_topology[idx].v3num;
     }
     short Vertex::vtotal() const {  //  total # of neighbors. copy of vnum.nsizeCur              
-        return mris->vertices_topology[idx].vtotal;
+        return repr->vertices_topology[idx].vtotal;
     }
     short Vertex::nsizeMaxClock() const {  //  copy of mris->nsizeMaxClock when v#num                   
-        return mris->vertices_topology[idx].nsizeMaxClock;
+        return repr->vertices_topology[idx].nsizeMaxClock;
     }
     uchar Vertex::nsizeMax() const {  //  the max nsize that was used to fill in vnum etc          
-        return mris->vertices_topology[idx].nsizeMax;
+        return repr->vertices_topology[idx].nsizeMax;
     }
     uchar Vertex::nsizeCur() const {  //  index of the current v#num in vtotal                     
-        return mris->vertices_topology[idx].nsizeCur;
+        return repr->vertices_topology[idx].nsizeCur;
     }
     uchar Vertex::num() const {  //  number of neighboring faces                              
-        return mris->vertices_topology[idx].num;
+        return repr->vertices_topology[idx].num;
     }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
-        return mris->vertices[idx].dist[i];
+        return repr->vertices[idx].dist[i];
     }
     float Vertex::dist_orig(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on origxyz
-        return mris->vertices[idx].dist_orig[i];
+        return repr->vertices[idx].dist_orig[i];
     }
     int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_capacity;
+        return repr->vertices[idx].dist_capacity;
     }
     int Vertex::dist_orig_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_orig_capacity;
+        return repr->vertices[idx].dist_orig_capacity;
     }
     float Vertex::x() const {  //  current coordinates	
-        return mris->vertices[idx].x;
+        return repr->vertices[idx].x;
     }
     float Vertex::y() const {  //  use MRISsetXYZ() to set
-        return mris->vertices[idx].y;
+        return repr->vertices[idx].y;
     }
     float Vertex::z() const {
-        return mris->vertices[idx].z;
+        return repr->vertices[idx].z;
     }
     float Vertex::origx() const {  //  original coordinates, see also MRIS::origxyz_status
-        return mris->vertices[idx].origx;
+        return repr->vertices[idx].origx;
     }
     float Vertex::origy() const {  //  use MRISsetOriginalXYZ(, 
-        return mris->vertices[idx].origy;
+        return repr->vertices[idx].origy;
     }
     float Vertex::origz() const {  //  or MRISsetOriginalXYZfromXYZ to set
-        return mris->vertices[idx].origz;
+        return repr->vertices[idx].origz;
     }
     float Vertex::nx() const {
-        return mris->vertices[idx].nx;
+        return repr->vertices[idx].nx;
     }
     float Vertex::ny() const {
-        return mris->vertices[idx].ny;
+        return repr->vertices[idx].ny;
     }
     float Vertex::nz() const {  //  curr normal
-        return mris->vertices[idx].nz;
+        return repr->vertices[idx].nz;
     }
     float Vertex::pnx() const {
-        return mris->vertices[idx].pnx;
+        return repr->vertices[idx].pnx;
     }
     float Vertex::pny() const {
-        return mris->vertices[idx].pny;
+        return repr->vertices[idx].pny;
     }
     float Vertex::pnz() const {  //  pial normal
-        return mris->vertices[idx].pnz;
+        return repr->vertices[idx].pnz;
     }
     float Vertex::wnx() const {
-        return mris->vertices[idx].wnx;
+        return repr->vertices[idx].wnx;
     }
     float Vertex::wny() const {
-        return mris->vertices[idx].wny;
+        return repr->vertices[idx].wny;
     }
     float Vertex::wnz() const {  //  white normal
-        return mris->vertices[idx].wnz;
+        return repr->vertices[idx].wnz;
     }
     float Vertex::onx() const {
-        return mris->vertices[idx].onx;
+        return repr->vertices[idx].onx;
     }
     float Vertex::ony() const {
-        return mris->vertices[idx].ony;
+        return repr->vertices[idx].ony;
     }
     float Vertex::onz() const {  //  original normal
-        return mris->vertices[idx].onz;
+        return repr->vertices[idx].onz;
     }
     float Vertex::dx() const {
-        return mris->vertices[idx].dx;
+        return repr->vertices[idx].dx;
     }
     float Vertex::dy() const {
-        return mris->vertices[idx].dy;
+        return repr->vertices[idx].dy;
     }
     float Vertex::dz() const {  //  current change in position
-        return mris->vertices[idx].dz;
+        return repr->vertices[idx].dz;
     }
     float Vertex::odx() const {
-        return mris->vertices[idx].odx;
+        return repr->vertices[idx].odx;
     }
     float Vertex::ody() const {
-        return mris->vertices[idx].ody;
+        return repr->vertices[idx].ody;
     }
     float Vertex::odz() const {  //  last change of position (for momentum, 
-        return mris->vertices[idx].odz;
+        return repr->vertices[idx].odz;
     }
     float Vertex::tdx() const {
-        return mris->vertices[idx].tdx;
+        return repr->vertices[idx].tdx;
     }
     float Vertex::tdy() const {
-        return mris->vertices[idx].tdy;
+        return repr->vertices[idx].tdy;
     }
     float Vertex::tdz() const {  //  temporary storage for averaging gradient
-        return mris->vertices[idx].tdz;
+        return repr->vertices[idx].tdz;
     }
     float Vertex::curv() const {  //  curr curvature
-        return mris->vertices[idx].curv;
+        return repr->vertices[idx].curv;
     }
     float Vertex::curvbak() const {
-        return mris->vertices[idx].curvbak;
+        return repr->vertices[idx].curvbak;
     }
     float Vertex::val() const {  //  scalar data value (file: rh.val, sig2-rh.w)
-        return mris->vertices[idx].val;
+        return repr->vertices[idx].val;
     }
     float Vertex::imag_val() const {  //  imaginary part of complex data value
-        return mris->vertices[idx].imag_val;
+        return repr->vertices[idx].imag_val;
     }
     float Vertex::cx() const {
-        return mris->vertices[idx].cx;
+        return repr->vertices[idx].cx;
     }
     float Vertex::cy() const {
-        return mris->vertices[idx].cy;
+        return repr->vertices[idx].cy;
     }
     float Vertex::cz() const {  //  coordinates in canonical coordinate system
-        return mris->vertices[idx].cz;
+        return repr->vertices[idx].cz;
     }
     float Vertex::tx() const {
-        return mris->vertices[idx].tx;
+        return repr->vertices[idx].tx;
     }
     float Vertex::ty() const {
-        return mris->vertices[idx].ty;
+        return repr->vertices[idx].ty;
     }
     float Vertex::tz() const {  //  tmp coordinate storage
-        return mris->vertices[idx].tz;
+        return repr->vertices[idx].tz;
     }
-    float Vertex::tx2() const {
-        return mris->vertices[idx].tx2;
+    float Vertex::t2x() const {
+        return repr->vertices[idx].t2x;
     }
-    float Vertex::ty2() const {
-        return mris->vertices[idx].ty2;
+    float Vertex::t2y() const {
+        return repr->vertices[idx].t2y;
     }
-    float Vertex::tz2() const {  //  tmp coordinate storage
-        return mris->vertices[idx].tz2;
+    float Vertex::t2z() const {  //  another tmp coordinate storage
+        return repr->vertices[idx].t2z;
     }
     float Vertex::targx() const {
-        return mris->vertices[idx].targx;
+        return repr->vertices[idx].targx;
     }
     float Vertex::targy() const {
-        return mris->vertices[idx].targy;
+        return repr->vertices[idx].targy;
     }
     float Vertex::targz() const {  //  target coordinates
-        return mris->vertices[idx].targz;
+        return repr->vertices[idx].targz;
     }
     float Vertex::pialx() const {
-        return mris->vertices[idx].pialx;
+        return repr->vertices[idx].pialx;
     }
     float Vertex::pialy() const {
-        return mris->vertices[idx].pialy;
+        return repr->vertices[idx].pialy;
     }
     float Vertex::pialz() const {  //  pial surface coordinates
-        return mris->vertices[idx].pialz;
+        return repr->vertices[idx].pialz;
     }
     float Vertex::whitex() const {
-        return mris->vertices[idx].whitex;
+        return repr->vertices[idx].whitex;
     }
     float Vertex::whitey() const {
-        return mris->vertices[idx].whitey;
+        return repr->vertices[idx].whitey;
     }
     float Vertex::whitez() const {  //  white surface coordinates
-        return mris->vertices[idx].whitez;
+        return repr->vertices[idx].whitez;
     }
     float Vertex::l4x() const {
-        return mris->vertices[idx].l4x;
+        return repr->vertices[idx].l4x;
     }
     float Vertex::l4y() const {
-        return mris->vertices[idx].l4y;
+        return repr->vertices[idx].l4y;
     }
     float Vertex::l4z() const {  //  layerIV surface coordinates
-        return mris->vertices[idx].l4z;
+        return repr->vertices[idx].l4z;
     }
     float Vertex::infx() const {
-        return mris->vertices[idx].infx;
+        return repr->vertices[idx].infx;
     }
     float Vertex::infy() const {
-        return mris->vertices[idx].infy;
+        return repr->vertices[idx].infy;
     }
     float Vertex::infz() const {  //  inflated coordinates
-        return mris->vertices[idx].infz;
+        return repr->vertices[idx].infz;
     }
     float Vertex::fx() const {
-        return mris->vertices[idx].fx;
+        return repr->vertices[idx].fx;
     }
     float Vertex::fy() const {
-        return mris->vertices[idx].fy;
+        return repr->vertices[idx].fy;
     }
     float Vertex::fz() const {  //  flattened coordinates
-        return mris->vertices[idx].fz;
+        return repr->vertices[idx].fz;
     }
     int Vertex::px() const {
-        return mris->vertices[idx].px;
+        return repr->vertices[idx].px;
     }
     int Vertex::qx() const {
-        return mris->vertices[idx].qx;
+        return repr->vertices[idx].qx;
     }
     int Vertex::py() const {
-        return mris->vertices[idx].py;
+        return repr->vertices[idx].py;
     }
     int Vertex::qy() const {
-        return mris->vertices[idx].qy;
+        return repr->vertices[idx].qy;
     }
     int Vertex::pz() const {
-        return mris->vertices[idx].pz;
+        return repr->vertices[idx].pz;
     }
     int Vertex::qz() const {  //  rational coordinates for exact calculations
-        return mris->vertices[idx].qz;
+        return repr->vertices[idx].qz;
     }
     float Vertex::e1x() const {
-        return mris->vertices[idx].e1x;
+        return repr->vertices[idx].e1x;
     }
     float Vertex::e1y() const {
-        return mris->vertices[idx].e1y;
+        return repr->vertices[idx].e1y;
     }
     float Vertex::e1z() const {  //  1st basis vector for the local tangent plane
-        return mris->vertices[idx].e1z;
+        return repr->vertices[idx].e1z;
     }
     float Vertex::e2x() const {
-        return mris->vertices[idx].e2x;
+        return repr->vertices[idx].e2x;
     }
     float Vertex::e2y() const {
-        return mris->vertices[idx].e2y;
+        return repr->vertices[idx].e2y;
     }
     float Vertex::e2z() const {  //  2nd basis vector for the local tangent plane
-        return mris->vertices[idx].e2z;
+        return repr->vertices[idx].e2z;
     }
     float Vertex::pe1x() const {
-        return mris->vertices[idx].pe1x;
+        return repr->vertices[idx].pe1x;
     }
     float Vertex::pe1y() const {
-        return mris->vertices[idx].pe1y;
+        return repr->vertices[idx].pe1y;
     }
     float Vertex::pe1z() const {  //  1st basis vector for the local tangent plane
-        return mris->vertices[idx].pe1z;
+        return repr->vertices[idx].pe1z;
     }
     float Vertex::pe2x() const {
-        return mris->vertices[idx].pe2x;
+        return repr->vertices[idx].pe2x;
     }
     float Vertex::pe2y() const {
-        return mris->vertices[idx].pe2y;
+        return repr->vertices[idx].pe2y;
     }
     float Vertex::pe2z() const {  //  2nd basis vector for the local tangent plane
-        return mris->vertices[idx].pe2z;
+        return repr->vertices[idx].pe2z;
     }
     float Vertex::nc() const {  //  curr length normal comp 
-        return mris->vertices[idx].nc;
+        return repr->vertices[idx].nc;
     }
     float Vertex::val2() const {  //  complex comp data value (file: sig3-rh.w) 
-        return mris->vertices[idx].val2;
+        return repr->vertices[idx].val2;
     }
     float Vertex::valbak() const {  //  scalar data stack 
-        return mris->vertices[idx].valbak;
+        return repr->vertices[idx].valbak;
     }
     float Vertex::val2bak() const {  //  complex comp data stack 
-        return mris->vertices[idx].val2bak;
+        return repr->vertices[idx].val2bak;
     }
     float Vertex::stat() const {  //  statistic 
-        return mris->vertices[idx].stat;
+        return repr->vertices[idx].stat;
     }
     int Vertex::undefval() const {  //  [previously dist=0] 
-        return mris->vertices[idx].undefval;
+        return repr->vertices[idx].undefval;
     }
     int Vertex::old_undefval() const {  //  for smooth_val_sparse 
-        return mris->vertices[idx].old_undefval;
+        return repr->vertices[idx].old_undefval;
     }
     int Vertex::fixedval() const {  //  [previously val=0] 
-        return mris->vertices[idx].fixedval;
+        return repr->vertices[idx].fixedval;
     }
     float Vertex::fieldsign() const {  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
-        return mris->vertices[idx].fieldsign;
+        return repr->vertices[idx].fieldsign;
     }
     float Vertex::fsmask() const {  //  significance mask (file: rh.fm) 
-        return mris->vertices[idx].fsmask;
+        return repr->vertices[idx].fsmask;
     }
     float Vertex::d() const {  //  for distance calculations 
-        return mris->vertices[idx].d;
+        return repr->vertices[idx].d;
     }
     int Vertex::annotation() const {  //  area label (defunct--now from label file name!) 
-        return mris->vertices[idx].annotation;
+        return repr->vertices[idx].annotation;
     }
     char Vertex::oripflag() const {
-        return mris->vertices[idx].oripflag;
+        return repr->vertices[idx].oripflag;
     }
     char Vertex::origripflag() const {  //  cuts flags 
-        return mris->vertices[idx].origripflag;
+        return repr->vertices[idx].origripflag;
     }
     p_void Vertex::vp() const {  //  to store user's information 
-        return mris->vertices[idx].vp;
+        return repr->vertices[idx].vp;
     }
     float Vertex::theta() const {
-        return mris->vertices[idx].theta;
+        return repr->vertices[idx].theta;
     }
     float Vertex::phi() const {  //  parameterization 
-        return mris->vertices[idx].phi;
+        return repr->vertices[idx].phi;
     }
     float Vertex::area() const {
-        return mris->vertices[idx].area;
+        return repr->vertices[idx].area;
     }
     float Vertex::origarea() const {
-        return mris->vertices[idx].origarea;
+        return repr->vertices[idx].origarea;
     }
     float Vertex::group_avg_area() const {
-        return mris->vertices[idx].group_avg_area;
+        return repr->vertices[idx].group_avg_area;
     }
     float Vertex::K() const {  //  Gaussian curvature 
-        return mris->vertices[idx].K;
+        return repr->vertices[idx].K;
     }
     float Vertex::H() const {  //  mean curvature 
-        return mris->vertices[idx].H;
+        return repr->vertices[idx].H;
     }
     float Vertex::k1() const {
-        return mris->vertices[idx].k1;
+        return repr->vertices[idx].k1;
     }
     float Vertex::k2() const {  //  the principal curvatures 
-        return mris->vertices[idx].k2;
+        return repr->vertices[idx].k2;
     }
     float Vertex::mean() const {
-        return mris->vertices[idx].mean;
+        return repr->vertices[idx].mean;
     }
     float Vertex::mean_imag() const {  //  imaginary part of complex statistic 
-        return mris->vertices[idx].mean_imag;
+        return repr->vertices[idx].mean_imag;
     }
     float Vertex::std_error() const {
-        return mris->vertices[idx].std_error;
+        return repr->vertices[idx].std_error;
     }
     uint Vertex::flags() const {
-        return mris->vertices[idx].flags;
+        return repr->vertices[idx].flags;
     }
     int Vertex::fno() const {  //  face that this vertex is in 
-        return mris->vertices[idx].fno;
+        return repr->vertices[idx].fno;
     }
     int Vertex::cropped() const {
-        return mris->vertices[idx].cropped;
+        return repr->vertices[idx].cropped;
     }
     short Vertex::marked() const {  //  for a variety of uses 
-        return mris->vertices[idx].marked;
+        return repr->vertices[idx].marked;
     }
     short Vertex::marked2() const {
-        return mris->vertices[idx].marked2;
+        return repr->vertices[idx].marked2;
     }
     short Vertex::marked3() const {
-        return mris->vertices[idx].marked3;
+        return repr->vertices[idx].marked3;
     }
     char Vertex::neg() const {  //  1 if the normal vector is inverted 
-        return mris->vertices[idx].neg;
+        return repr->vertices[idx].neg;
     }
     char Vertex::border() const {  //  flag 
-        return mris->vertices[idx].border;
+        return repr->vertices[idx].border;
     }
     char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
-        return mris->vertices[idx].ripflag;
+        return repr->vertices[idx].ripflag;
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+         MRISvertexCoord2XYZ_float(&repr->vertices[idx], which, x, y, z);
     }
     
     void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        cheapAssert(mris == to.mris); mris->vertices_topology[idx].f[i] = to.idx;
+        cheapAssert(repr == to.repr); repr->vertices_topology[idx].f[i] = to.idx;
     }
     void Vertex::set_n(size_t i, size_t to) {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        mris->vertices_topology[idx].n[i] = uchar(to);
+        repr->vertices_topology[idx].n[i] = uchar(to);
     }
     void Vertex::set_e(size_t i, int to) {  //  edge state for neighboring vertices                      
-        mris->vertices_topology[idx].e[i] = to;
+        repr->vertices_topology[idx].e[i] = to;
     }
     void Vertex::set_nx(float to) {
-        mris->vertices[idx].nx = to;
+        repr->vertices[idx].nx = to;
     }
     void Vertex::set_ny(float to) {
-        mris->vertices[idx].ny = to;
+        repr->vertices[idx].ny = to;
     }
     void Vertex::set_nz(float to) {  //  curr normal
-        mris->vertices[idx].nz = to;
+        repr->vertices[idx].nz = to;
     }
     void Vertex::set_pnx(float to) {
-        mris->vertices[idx].pnx = to;
+        repr->vertices[idx].pnx = to;
     }
     void Vertex::set_pny(float to) {
-        mris->vertices[idx].pny = to;
+        repr->vertices[idx].pny = to;
     }
     void Vertex::set_pnz(float to) {  //  pial normal
-        mris->vertices[idx].pnz = to;
+        repr->vertices[idx].pnz = to;
     }
     void Vertex::set_wnx(float to) {
-        mris->vertices[idx].wnx = to;
+        repr->vertices[idx].wnx = to;
     }
     void Vertex::set_wny(float to) {
-        mris->vertices[idx].wny = to;
+        repr->vertices[idx].wny = to;
     }
     void Vertex::set_wnz(float to) {  //  white normal
-        mris->vertices[idx].wnz = to;
+        repr->vertices[idx].wnz = to;
     }
     void Vertex::set_onx(float to) {
-        mris->vertices[idx].onx = to;
+        repr->vertices[idx].onx = to;
     }
     void Vertex::set_ony(float to) {
-        mris->vertices[idx].ony = to;
+        repr->vertices[idx].ony = to;
     }
     void Vertex::set_onz(float to) {  //  original normal
-        mris->vertices[idx].onz = to;
+        repr->vertices[idx].onz = to;
     }
     void Vertex::set_dx(float to) {
-        mris->vertices[idx].dx = to;
+        repr->vertices[idx].dx = to;
     }
     void Vertex::set_dy(float to) {
-        mris->vertices[idx].dy = to;
+        repr->vertices[idx].dy = to;
     }
     void Vertex::set_dz(float to) {  //  current change in position
-        mris->vertices[idx].dz = to;
+        repr->vertices[idx].dz = to;
     }
     void Vertex::set_odx(float to) {
-        mris->vertices[idx].odx = to;
+        repr->vertices[idx].odx = to;
     }
     void Vertex::set_ody(float to) {
-        mris->vertices[idx].ody = to;
+        repr->vertices[idx].ody = to;
     }
     void Vertex::set_odz(float to) {  //  last change of position (for momentum, 
-        mris->vertices[idx].odz = to;
+        repr->vertices[idx].odz = to;
     }
     void Vertex::set_tdx(float to) {
-        mris->vertices[idx].tdx = to;
+        repr->vertices[idx].tdx = to;
     }
     void Vertex::set_tdy(float to) {
-        mris->vertices[idx].tdy = to;
+        repr->vertices[idx].tdy = to;
     }
     void Vertex::set_tdz(float to) {  //  temporary storage for averaging gradient
-        mris->vertices[idx].tdz = to;
+        repr->vertices[idx].tdz = to;
     }
     void Vertex::set_curv(float to) {  //  curr curvature
-        mris->vertices[idx].curv = to;
+        repr->vertices[idx].curv = to;
     }
     void Vertex::set_curvbak(float to) {
-        mris->vertices[idx].curvbak = to;
+        repr->vertices[idx].curvbak = to;
     }
     void Vertex::set_val(float to) {  //  scalar data value (file: rh.val, sig2-rh.w)
-        mris->vertices[idx].val = to;
+        repr->vertices[idx].val = to;
     }
     void Vertex::set_imag_val(float to) {  //  imaginary part of complex data value
-        mris->vertices[idx].imag_val = to;
+        repr->vertices[idx].imag_val = to;
     }
     void Vertex::set_cx(float to) {
-        mris->vertices[idx].cx = to;
+        repr->vertices[idx].cx = to;
     }
     void Vertex::set_cy(float to) {
-        mris->vertices[idx].cy = to;
+        repr->vertices[idx].cy = to;
     }
     void Vertex::set_cz(float to) {  //  coordinates in canonical coordinate system
-        mris->vertices[idx].cz = to;
+        repr->vertices[idx].cz = to;
     }
     void Vertex::set_tx(float to) {
-        mris->vertices[idx].tx = to;
+        repr->vertices[idx].tx = to;
     }
     void Vertex::set_ty(float to) {
-        mris->vertices[idx].ty = to;
+        repr->vertices[idx].ty = to;
     }
     void Vertex::set_tz(float to) {  //  tmp coordinate storage
-        mris->vertices[idx].tz = to;
+        repr->vertices[idx].tz = to;
     }
-    void Vertex::set_tx2(float to) {
-        mris->vertices[idx].tx2 = to;
+    void Vertex::set_t2x(float to) {
+        repr->vertices[idx].t2x = to;
     }
-    void Vertex::set_ty2(float to) {
-        mris->vertices[idx].ty2 = to;
+    void Vertex::set_t2y(float to) {
+        repr->vertices[idx].t2y = to;
     }
-    void Vertex::set_tz2(float to) {  //  tmp coordinate storage
-        mris->vertices[idx].tz2 = to;
+    void Vertex::set_t2z(float to) {  //  another tmp coordinate storage
+        repr->vertices[idx].t2z = to;
     }
     void Vertex::set_targx(float to) {
-        mris->vertices[idx].targx = to;
+        repr->vertices[idx].targx = to;
     }
     void Vertex::set_targy(float to) {
-        mris->vertices[idx].targy = to;
+        repr->vertices[idx].targy = to;
     }
     void Vertex::set_targz(float to) {  //  target coordinates
-        mris->vertices[idx].targz = to;
+        repr->vertices[idx].targz = to;
     }
     void Vertex::set_pialx(float to) {
-        mris->vertices[idx].pialx = to;
+        repr->vertices[idx].pialx = to;
     }
     void Vertex::set_pialy(float to) {
-        mris->vertices[idx].pialy = to;
+        repr->vertices[idx].pialy = to;
     }
     void Vertex::set_pialz(float to) {  //  pial surface coordinates
-        mris->vertices[idx].pialz = to;
+        repr->vertices[idx].pialz = to;
     }
     void Vertex::set_whitex(float to) {
-        mris->vertices[idx].whitex = to;
+        repr->vertices[idx].whitex = to;
     }
     void Vertex::set_whitey(float to) {
-        mris->vertices[idx].whitey = to;
+        repr->vertices[idx].whitey = to;
     }
     void Vertex::set_whitez(float to) {  //  white surface coordinates
-        mris->vertices[idx].whitez = to;
+        repr->vertices[idx].whitez = to;
     }
     void Vertex::set_l4x(float to) {
-        mris->vertices[idx].l4x = to;
+        repr->vertices[idx].l4x = to;
     }
     void Vertex::set_l4y(float to) {
-        mris->vertices[idx].l4y = to;
+        repr->vertices[idx].l4y = to;
     }
     void Vertex::set_l4z(float to) {  //  layerIV surface coordinates
-        mris->vertices[idx].l4z = to;
+        repr->vertices[idx].l4z = to;
     }
     void Vertex::set_infx(float to) {
-        mris->vertices[idx].infx = to;
+        repr->vertices[idx].infx = to;
     }
     void Vertex::set_infy(float to) {
-        mris->vertices[idx].infy = to;
+        repr->vertices[idx].infy = to;
     }
     void Vertex::set_infz(float to) {  //  inflated coordinates
-        mris->vertices[idx].infz = to;
+        repr->vertices[idx].infz = to;
     }
     void Vertex::set_fx(float to) {
-        mris->vertices[idx].fx = to;
+        repr->vertices[idx].fx = to;
     }
     void Vertex::set_fy(float to) {
-        mris->vertices[idx].fy = to;
+        repr->vertices[idx].fy = to;
     }
     void Vertex::set_fz(float to) {  //  flattened coordinates
-        mris->vertices[idx].fz = to;
+        repr->vertices[idx].fz = to;
     }
     void Vertex::set_px(int to) {
-        mris->vertices[idx].px = to;
+        repr->vertices[idx].px = to;
     }
     void Vertex::set_qx(int to) {
-        mris->vertices[idx].qx = to;
+        repr->vertices[idx].qx = to;
     }
     void Vertex::set_py(int to) {
-        mris->vertices[idx].py = to;
+        repr->vertices[idx].py = to;
     }
     void Vertex::set_qy(int to) {
-        mris->vertices[idx].qy = to;
+        repr->vertices[idx].qy = to;
     }
     void Vertex::set_pz(int to) {
-        mris->vertices[idx].pz = to;
+        repr->vertices[idx].pz = to;
     }
     void Vertex::set_qz(int to) {  //  rational coordinates for exact calculations
-        mris->vertices[idx].qz = to;
+        repr->vertices[idx].qz = to;
     }
     void Vertex::set_e1x(float to) {
-        mris->vertices[idx].e1x = to;
+        repr->vertices[idx].e1x = to;
     }
     void Vertex::set_e1y(float to) {
-        mris->vertices[idx].e1y = to;
+        repr->vertices[idx].e1y = to;
     }
     void Vertex::set_e1z(float to) {  //  1st basis vector for the local tangent plane
-        mris->vertices[idx].e1z = to;
+        repr->vertices[idx].e1z = to;
     }
     void Vertex::set_e2x(float to) {
-        mris->vertices[idx].e2x = to;
+        repr->vertices[idx].e2x = to;
     }
     void Vertex::set_e2y(float to) {
-        mris->vertices[idx].e2y = to;
+        repr->vertices[idx].e2y = to;
     }
     void Vertex::set_e2z(float to) {  //  2nd basis vector for the local tangent plane
-        mris->vertices[idx].e2z = to;
+        repr->vertices[idx].e2z = to;
     }
     void Vertex::set_pe1x(float to) {
-        mris->vertices[idx].pe1x = to;
+        repr->vertices[idx].pe1x = to;
     }
     void Vertex::set_pe1y(float to) {
-        mris->vertices[idx].pe1y = to;
+        repr->vertices[idx].pe1y = to;
     }
     void Vertex::set_pe1z(float to) {  //  1st basis vector for the local tangent plane
-        mris->vertices[idx].pe1z = to;
+        repr->vertices[idx].pe1z = to;
     }
     void Vertex::set_pe2x(float to) {
-        mris->vertices[idx].pe2x = to;
+        repr->vertices[idx].pe2x = to;
     }
     void Vertex::set_pe2y(float to) {
-        mris->vertices[idx].pe2y = to;
+        repr->vertices[idx].pe2y = to;
     }
     void Vertex::set_pe2z(float to) {  //  2nd basis vector for the local tangent plane
-        mris->vertices[idx].pe2z = to;
+        repr->vertices[idx].pe2z = to;
     }
     void Vertex::set_nc(float to) {  //  curr length normal comp 
-        mris->vertices[idx].nc = to;
+        repr->vertices[idx].nc = to;
     }
     void Vertex::set_val2(float to) {  //  complex comp data value (file: sig3-rh.w) 
-        mris->vertices[idx].val2 = to;
+        repr->vertices[idx].val2 = to;
     }
     void Vertex::set_valbak(float to) {  //  scalar data stack 
-        mris->vertices[idx].valbak = to;
+        repr->vertices[idx].valbak = to;
     }
     void Vertex::set_val2bak(float to) {  //  complex comp data stack 
-        mris->vertices[idx].val2bak = to;
+        repr->vertices[idx].val2bak = to;
     }
     void Vertex::set_stat(float to) {  //  statistic 
-        mris->vertices[idx].stat = to;
+        repr->vertices[idx].stat = to;
     }
     void Vertex::set_undefval(int to) {  //  [previously dist=0] 
-        mris->vertices[idx].undefval = to;
+        repr->vertices[idx].undefval = to;
     }
     void Vertex::set_old_undefval(int to) {  //  for smooth_val_sparse 
-        mris->vertices[idx].old_undefval = to;
+        repr->vertices[idx].old_undefval = to;
     }
     void Vertex::set_fixedval(int to) {  //  [previously val=0] 
-        mris->vertices[idx].fixedval = to;
+        repr->vertices[idx].fixedval = to;
     }
     void Vertex::set_fieldsign(float to) {  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
-        mris->vertices[idx].fieldsign = to;
+        repr->vertices[idx].fieldsign = to;
     }
     void Vertex::set_fsmask(float to) {  //  significance mask (file: rh.fm) 
-        mris->vertices[idx].fsmask = to;
+        repr->vertices[idx].fsmask = to;
     }
     void Vertex::set_d(float to) {  //  for distance calculations 
-        mris->vertices[idx].d = to;
+        repr->vertices[idx].d = to;
     }
     void Vertex::set_annotation(int to) {  //  area label (defunct--now from label file name!) 
-        mris->vertices[idx].annotation = to;
+        repr->vertices[idx].annotation = to;
     }
     void Vertex::set_oripflag(char to) {
-        mris->vertices[idx].oripflag = to;
+        repr->vertices[idx].oripflag = to;
     }
     void Vertex::set_origripflag(char to) {  //  cuts flags 
-        mris->vertices[idx].origripflag = to;
+        repr->vertices[idx].origripflag = to;
     }
     void Vertex::set_vp(p_void to) {  //  to store user's information 
-        mris->vertices[idx].vp = to;
+        repr->vertices[idx].vp = to;
     }
     void Vertex::set_theta(float to) {
-        mris->vertices[idx].theta = to;
+        repr->vertices[idx].theta = to;
     }
     void Vertex::set_phi(float to) {  //  parameterization 
-        mris->vertices[idx].phi = to;
+        repr->vertices[idx].phi = to;
     }
     void Vertex::set_origarea(float to) {
-        mris->vertices[idx].origarea = to;
+        repr->vertices[idx].origarea = to;
     }
     void Vertex::set_group_avg_area(float to) {
-        mris->vertices[idx].group_avg_area = to;
+        repr->vertices[idx].group_avg_area = to;
     }
     void Vertex::set_K(float to) {  //  Gaussian curvature 
-        mris->vertices[idx].K = to;
+        repr->vertices[idx].K = to;
     }
     void Vertex::set_H(float to) {  //  mean curvature 
-        mris->vertices[idx].H = to;
+        repr->vertices[idx].H = to;
     }
     void Vertex::set_k1(float to) {
-        mris->vertices[idx].k1 = to;
+        repr->vertices[idx].k1 = to;
     }
     void Vertex::set_k2(float to) {  //  the principal curvatures 
-        mris->vertices[idx].k2 = to;
+        repr->vertices[idx].k2 = to;
     }
     void Vertex::set_mean(float to) {
-        mris->vertices[idx].mean = to;
+        repr->vertices[idx].mean = to;
     }
     void Vertex::set_mean_imag(float to) {  //  imaginary part of complex statistic 
-        mris->vertices[idx].mean_imag = to;
+        repr->vertices[idx].mean_imag = to;
     }
     void Vertex::set_std_error(float to) {
-        mris->vertices[idx].std_error = to;
+        repr->vertices[idx].std_error = to;
     }
     void Vertex::set_flags(uint to) {
-        mris->vertices[idx].flags = to;
+        repr->vertices[idx].flags = to;
     }
     void Vertex::set_fno(int to) {  //  face that this vertex is in 
-        mris->vertices[idx].fno = to;
+        repr->vertices[idx].fno = to;
     }
     void Vertex::set_cropped(int to) {
-        mris->vertices[idx].cropped = to;
+        repr->vertices[idx].cropped = to;
     }
     void Vertex::set_marked(short to) {  //  for a variety of uses 
-        mris->vertices[idx].marked = to;
+        repr->vertices[idx].marked = to;
     }
     void Vertex::set_marked2(short to) {
-        mris->vertices[idx].marked2 = to;
+        repr->vertices[idx].marked2 = to;
     }
     void Vertex::set_marked3(short to) {
-        mris->vertices[idx].marked3 = to;
+        repr->vertices[idx].marked3 = to;
     }
     void Vertex::set_neg(char to) {  //  1 if the normal vector is inverted 
-        mris->vertices[idx].neg = to;
+        repr->vertices[idx].neg = to;
     }
     void Vertex::set_border(char to) {  //  flag 
-        mris->vertices[idx].border = to;
+        repr->vertices[idx].border = to;
     }
     void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
-        mris->vertices[idx].ripflag = to;
+        repr->vertices[idx].ripflag = to;
     }
 
 
-    Surface::Surface (                                ) {}                   
-    Surface::Surface ( MRIS* mris                     ) : MRIS_Elt(mris,0) {}
-    Surface::Surface ( Surface const & src            ) : MRIS_Elt(src) {}   
-    Surface::Surface ( AnalysisM::Surface const & src ) : MRIS_Elt(src) {}   
-    Surface::Surface ( Analysis::Surface const & src  ) : MRIS_Elt(src) {}   
-    Surface::Surface ( AllM::Surface const & src      ) : MRIS_Elt(src) {}   
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( AnalysisM::Surface const & src ) : Repr_Elt(src) {}
+    Surface::Surface ( Analysis::Surface const & src  ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
 
     int Surface::nverticesFrozen() const {  //  # of vertices on surface is frozen
-        return mris->nverticesFrozen;
+        return repr->nverticesFrozen;
     }
     int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nvertices;
+        return repr->nvertices;
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nfaces;
+        return repr->nfaces;
     }
     bool Surface::faceAttachmentDeferred() const {  //  defer connecting faces to vertices for performance reasons
-        return mris->faceAttachmentDeferred;
+        return repr->faceAttachmentDeferred;
     }
     int Surface::nedges() const {  //  # of edges on surface
-        return mris->nedges;
+        return repr->nedges;
     }
     int Surface::nstrips() const {
-        return mris->nstrips;
+        return repr->nstrips;
     }
     Vertex Surface::vertices(size_t i) const {
-        return Vertex(mris,i);
+        return Vertex(repr,i);
     }
     p_p_void Surface::dist_storage() const {  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
-        return mris->dist_storage;
+        return repr->dist_storage;
     }
     p_p_void Surface::dist_orig_storage() const {  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
-        return mris->dist_orig_storage;
+        return repr->dist_orig_storage;
     }
     int Surface::tempsAssigned() const {  //  State of various temp fields that can be borrowed if not already in use
-        return mris->tempsAssigned;
+        return repr->tempsAssigned;
     }
     Face Surface::faces(size_t i) const {
-        return Face(mris,i);
+        return Face(repr,i);
     }
     MRI_EDGE Surface::edges(size_t i) const {
-        return mris->edges[i];
+        return repr->edges[i];
     }
     FaceNormCacheEntry Surface::faceNormCacheEntries(size_t i) const {
-        return mris->faceNormCacheEntries[i];
+        return repr->faceNormCacheEntries[i];
     }
     FaceNormDeferredEntry Surface::faceNormDeferredEntries(size_t i) const {
-        return mris->faceNormDeferredEntries[i];
+        return repr->faceNormDeferredEntries[i];
     }
     STRIP Surface::strips(size_t i) const {
-        return mris->strips[i];
+        return repr->strips[i];
     }
     float Surface::xctr() const {
-        return mris->xctr;
+        return repr->xctr;
     }
     float Surface::yctr() const {
-        return mris->yctr;
+        return repr->yctr;
     }
     float Surface::zctr() const {
-        return mris->zctr;
+        return repr->zctr;
     }
     float Surface::xlo() const {
-        return mris->xlo;
+        return repr->xlo;
     }
     float Surface::ylo() const {
-        return mris->ylo;
+        return repr->ylo;
     }
     float Surface::zlo() const {
-        return mris->zlo;
+        return repr->zlo;
     }
     float Surface::xhi() const {
-        return mris->xhi;
+        return repr->xhi;
     }
     float Surface::yhi() const {
-        return mris->yhi;
+        return repr->yhi;
     }
     float Surface::zhi() const {
-        return mris->zhi;
+        return repr->zhi;
     }
     float Surface::x0() const {  //  center of spherical expansion
-        return mris->x0;
+        return repr->x0;
     }
     float Surface::y0() const {
-        return mris->y0;
+        return repr->y0;
     }
     float Surface::z0() const {
-        return mris->z0;
+        return repr->z0;
     }
     Vertex Surface::v_temporal_pole() const {
-        return Vertex(mris,mris->v_temporal_pole - mris->vertices);
+        return Vertex(repr,repr->v_temporal_pole - repr->vertices);
     }
     Vertex Surface::v_frontal_pole() const {
-        return Vertex(mris,mris->v_frontal_pole - mris->vertices);
+        return Vertex(repr,repr->v_frontal_pole - repr->vertices);
     }
     Vertex Surface::v_occipital_pole() const {
-        return Vertex(mris,mris->v_occipital_pole - mris->vertices);
+        return Vertex(repr,repr->v_occipital_pole - repr->vertices);
     }
     float Surface::max_curv() const {
-        return mris->max_curv;
+        return repr->max_curv;
     }
     float Surface::min_curv() const {
-        return mris->min_curv;
+        return repr->min_curv;
     }
     float Surface::total_area() const {
-        return mris->total_area;
+        return repr->total_area;
     }
     double Surface::avg_vertex_area() const {
-        return mris->avg_vertex_area;
+        return repr->avg_vertex_area;
     }
     double Surface::avg_vertex_dist() const {  //  set by MRIScomputeAvgInterVertexDist
-        return mris->avg_vertex_dist;
+        return repr->avg_vertex_dist;
     }
     double Surface::std_vertex_dist() const {
-        return mris->std_vertex_dist;
+        return repr->std_vertex_dist;
     }
     float Surface::orig_area() const {
-        return mris->orig_area;
+        return repr->orig_area;
     }
     float Surface::neg_area() const {
-        return mris->neg_area;
+        return repr->neg_area;
     }
     float Surface::neg_orig_area() const {  //  amount of original surface in folds
-        return mris->neg_orig_area;
+        return repr->neg_orig_area;
     }
     int Surface::zeros() const {
-        return mris->zeros;
+        return repr->zeros;
     }
     int Surface::hemisphere() const {  //  which hemisphere
-        return mris->hemisphere;
+        return repr->hemisphere;
     }
     int Surface::initialized() const {
-        return mris->initialized;
+        return repr->initialized;
     }
     PLTA Surface::lta() const {
-        return mris->lta;
+        return repr->lta;
     }
     PMATRIX Surface::SRASToTalSRAS_() const {
-        return mris->SRASToTalSRAS_;
+        return repr->SRASToTalSRAS_;
     }
     PMATRIX Surface::TalSRASToSRAS_() const {
-        return mris->TalSRASToSRAS_;
+        return repr->TalSRASToSRAS_;
     }
     int Surface::free_transform() const {
-        return mris->free_transform;
+        return repr->free_transform;
     }
     double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
-        return mris->radius;
+        return repr->radius;
     }
     float Surface::a() const {
-        return mris->a;
+        return repr->a;
     }
     float Surface::b() const {
-        return mris->b;
+        return repr->b;
     }
     float Surface::c() const {  //  ellipsoid parameters
-        return mris->c;
+        return repr->c;
     }
     MRIS_fname_t Surface::fname() const {  //  file it was originally loaded from
-        return mris->fname;
+        return repr->fname;
     }
     float Surface::Hmin() const {  //  min mean curvature
-        return mris->Hmin;
+        return repr->Hmin;
     }
     float Surface::Hmax() const {  //  max mean curvature
-        return mris->Hmax;
+        return repr->Hmax;
     }
     float Surface::Kmin() const {  //  min Gaussian curvature
-        return mris->Kmin;
+        return repr->Kmin;
     }
     float Surface::Kmax() const {  //  max Gaussian curvature
-        return mris->Kmax;
+        return repr->Kmax;
     }
     double Surface::Ktotal() const {  //  total Gaussian curvature
-        return mris->Ktotal;
+        return repr->Ktotal;
     }
     MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
-        return mris->status;
+        return repr->status;
     }
     MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-        return mris->origxyz_status;
+        return repr->origxyz_status;
     }
     int Surface::patch() const {  //  if a patch of the surface
-        return mris->patch;
+        return repr->patch;
     }
     int Surface::nlabels() const {
-        return mris->nlabels;
+        return repr->nlabels;
     }
     PMRIS_AREA_LABEL Surface::labels() const {  //  nlabels of these (may be null)
-        return mris->labels;
+        return repr->labels;
     }
     p_void Surface::vp() const {  //  for misc. use
-        return mris->vp;
+        return repr->vp;
     }
     float Surface::alpha() const {  //  rotation around z-axis
-        return mris->alpha;
+        return repr->alpha;
     }
     float Surface::beta() const {  //  rotation around y-axis
-        return mris->beta;
+        return repr->beta;
     }
     float Surface::gamma() const {  //  rotation around x-axis
-        return mris->gamma;
+        return repr->gamma;
     }
     float Surface::da() const {
-        return mris->da;
+        return repr->da;
     }
     float Surface::db() const {
-        return mris->db;
+        return repr->db;
     }
     float Surface::dg() const {  //  old deltas
-        return mris->dg;
+        return repr->dg;
     }
     int Surface::type() const {  //  what type of surface was this initially
-        return mris->type;
+        return repr->type;
     }
     int Surface::max_vertices() const {  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
-        return mris->max_vertices;
+        return repr->max_vertices;
     }
     int Surface::max_faces() const {  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
-        return mris->max_faces;
+        return repr->max_faces;
     }
     MRIS_subject_name_t Surface::subject_name() const {  //  name of the subject
-        return mris->subject_name;
+        return repr->subject_name;
     }
     float Surface::canon_area() const {
-        return mris->canon_area;
+        return repr->canon_area;
     }
     int Surface::noscale() const {  //  don't scale by surface area if true
-        return mris->noscale;
+        return repr->noscale;
     }
     float Surface::dx2(size_t i) const {  //  an extra set of gradient (not always alloced)
-        return mris->dx2[i];
+        return repr->dx2[i];
     }
     float Surface::dy2(size_t i) const {
-        return mris->dy2[i];
+        return repr->dy2[i];
     }
     float Surface::dz2(size_t i) const {
-        return mris->dz2[i];
+        return repr->dz2[i];
     }
     PCOLOR_TABLE Surface::ct() const {
-        return mris->ct;
+        return repr->ct;
     }
     int Surface::useRealRAS() const {  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        return mris->useRealRAS;
+        return repr->useRealRAS;
     }
     VOL_GEOM Surface::vg() const {  //  volume info from which this surface is created. valid iff vg.valid = 1
-        return mris->vg;
+        return repr->vg;
     }
     MRIS_cmdlines_t Surface::cmdlines() const {
-        return mris->cmdlines;
+        return repr->cmdlines;
     }
     int Surface::ncmds() const {
-        return mris->ncmds;
+        return repr->ncmds;
     }
     float Surface::group_avg_surface_area() const {  //  average of total surface area for group
-        return mris->group_avg_surface_area;
+        return repr->group_avg_surface_area;
     }
     int Surface::group_avg_vtxarea_loaded() const {  //  average vertex area for group at each vertex
-        return mris->group_avg_vtxarea_loaded;
+        return repr->group_avg_vtxarea_loaded;
     }
     int Surface::triangle_links_removed() const {  //  for quad surfaces
-        return mris->triangle_links_removed;
+        return repr->triangle_links_removed;
     }
     p_void Surface::user_parms() const {  //  for whatever the user wants to hang here
-        return mris->user_parms;
+        return repr->user_parms;
     }
     PMATRIX Surface::m_sras2vox() const {  //  for converting surface ras to voxel
-        return mris->m_sras2vox;
+        return repr->m_sras2vox;
     }
     PMRI Surface::mri_sras2vox() const {  //  volume that the above matrix is for
-        return mris->mri_sras2vox;
+        return repr->mri_sras2vox;
     }
     p_void Surface::mht() const {
-        return mris->mht;
+        return repr->mht;
     }
     p_void Surface::temps() const {
-        return mris->temps;
+        return repr->temps;
     }
     
     void Surface::set_strips(size_t i, STRIP to) {
-        mris->strips[i] = to;
+        repr->strips[i] = to;
     }
     void Surface::set_xctr(float to) {
-        mris->xctr = to;
+        repr->xctr = to;
     }
     void Surface::set_yctr(float to) {
-        mris->yctr = to;
+        repr->yctr = to;
     }
     void Surface::set_zctr(float to) {
-        mris->zctr = to;
+        repr->zctr = to;
     }
     void Surface::set_xlo(float to) {
-        mris->xlo = to;
+        repr->xlo = to;
     }
     void Surface::set_ylo(float to) {
-        mris->ylo = to;
+        repr->ylo = to;
     }
     void Surface::set_zlo(float to) {
-        mris->zlo = to;
+        repr->zlo = to;
     }
     void Surface::set_xhi(float to) {
-        mris->xhi = to;
+        repr->xhi = to;
     }
     void Surface::set_yhi(float to) {
-        mris->yhi = to;
+        repr->yhi = to;
     }
     void Surface::set_zhi(float to) {
-        mris->zhi = to;
+        repr->zhi = to;
     }
     void Surface::set_x0(float to) {  //  center of spherical expansion
-        mris->x0 = to;
+        repr->x0 = to;
     }
     void Surface::set_y0(float to) {
-        mris->y0 = to;
+        repr->y0 = to;
     }
     void Surface::set_z0(float to) {
-        mris->z0 = to;
+        repr->z0 = to;
     }
     void Surface::set_v_temporal_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_temporal_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_temporal_pole = repr->vertices + to.idx;
     }
     void Surface::set_v_frontal_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_frontal_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_frontal_pole = repr->vertices + to.idx;
     }
     void Surface::set_v_occipital_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_occipital_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_occipital_pole = repr->vertices + to.idx;
     }
     void Surface::set_max_curv(float to) {
-        mris->max_curv = to;
+        repr->max_curv = to;
     }
     void Surface::set_min_curv(float to) {
-        mris->min_curv = to;
+        repr->min_curv = to;
     }
     void Surface::set_total_area(float to) {
-        mris->total_area = to;
+        repr->total_area = to;
     }
     void Surface::set_avg_vertex_area(double to) {
-        mris->avg_vertex_area = to;
+        repr->avg_vertex_area = to;
     }
     void Surface::set_zeros(int to) {
-        mris->zeros = to;
+        repr->zeros = to;
     }
     void Surface::set_hemisphere(int to) {  //  which hemisphere
-        mris->hemisphere = to;
+        repr->hemisphere = to;
     }
     void Surface::set_Hmin(float to) {  //  min mean curvature
-        mris->Hmin = to;
+        repr->Hmin = to;
     }
     void Surface::set_Hmax(float to) {  //  max mean curvature
-        mris->Hmax = to;
+        repr->Hmax = to;
     }
     void Surface::set_Kmin(float to) {  //  min Gaussian curvature
-        mris->Kmin = to;
+        repr->Kmin = to;
     }
     void Surface::set_Kmax(float to) {  //  max Gaussian curvature
-        mris->Kmax = to;
+        repr->Kmax = to;
     }
     void Surface::set_Ktotal(double to) {  //  total Gaussian curvature
-        mris->Ktotal = to;
+        repr->Ktotal = to;
     }
     void Surface::set_nlabels(int to) {
-        mris->nlabels = to;
+        repr->nlabels = to;
     }
     void Surface::set_labels(PMRIS_AREA_LABEL to) {  //  nlabels of these (may be null)
-        mris->labels = to;
+        repr->labels = to;
     }
     void Surface::set_vp(p_void to) {  //  for misc. use
-        mris->vp = to;
+        repr->vp = to;
     }
     void Surface::set_alpha(float to) {  //  rotation around z-axis
-        mris->alpha = to;
+        repr->alpha = to;
     }
     void Surface::set_beta(float to) {  //  rotation around y-axis
-        mris->beta = to;
+        repr->beta = to;
     }
     void Surface::set_gamma(float to) {  //  rotation around x-axis
-        mris->gamma = to;
+        repr->gamma = to;
     }
     void Surface::set_da(float to) {
-        mris->da = to;
+        repr->da = to;
     }
     void Surface::set_db(float to) {
-        mris->db = to;
+        repr->db = to;
     }
     void Surface::set_dg(float to) {  //  old deltas
-        mris->dg = to;
+        repr->dg = to;
     }
     void Surface::set_type(int to) {  //  what type of surface was this initially
-        mris->type = to;
+        repr->type = to;
     }
 
 
@@ -2557,1155 +2572,1158 @@ namespace SurfaceFromMRIS {
 
 
     namespace Analysis {
-    Face::Face (                        ) {}                     
-    Face::Face ( MRIS* mris, size_t idx ) : MRIS_Elt(mris,idx) {}
-    Face::Face ( Face const & src       ) : MRIS_Elt(src) {}     
-    Face::Face ( AllM::Face const & src ) : MRIS_Elt(src) {}     
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
     Vertex Face::v(size_t i) const {
-        return Vertex(mris,mris->faces[idx].v[i]);
+        return Vertex(repr,repr->faces[idx].v[i]);
     }
     float Face::area() const {
-        return mris->faces[idx].area;
+        return repr->faces[idx].area;
     }
     angles_per_triangle_t Face::angle() const {
-        return mris->faces[idx].angle;
+        return repr->faces[idx].angle;
     }
     angles_per_triangle_t Face::orig_angle() const {
-        return mris->faces[idx].orig_angle;
+        return repr->faces[idx].orig_angle;
     }
     char Face::ripflag() const {
-        return mris->faces[idx].ripflag;
+        return repr->faces[idx].ripflag;
     }
     char Face::oripflag() const {
-        return mris->faces[idx].oripflag;
+        return repr->faces[idx].oripflag;
     }
     int Face::marked() const {
-        return mris->faces[idx].marked;
+        return repr->faces[idx].marked;
     }
     PDMATRIX Face::norm() const {
-        return mris->faces[idx].norm;
+        return repr->faces[idx].norm;
     }
     A3PDMATRIX Face::gradNorm() const {
-        return mris->faces[idx].gradNorm;
+        return repr->faces[idx].gradNorm;
     }
     
     void Face::set_orig_angle(angles_per_triangle_t to) {
-        mris->faces[idx].orig_angle = to;
+        repr->faces[idx].orig_angle = to;
     }
     void Face::set_ripflag(char to) {
-        mris->faces[idx].ripflag = to;
+        repr->faces[idx].ripflag = to;
     }
     void Face::set_oripflag(char to) {
-        mris->faces[idx].oripflag = to;
+        repr->faces[idx].oripflag = to;
     }
     void Face::set_marked(int to) {
-        mris->faces[idx].marked = to;
+        repr->faces[idx].marked = to;
     }
 
 
-    Vertex::Vertex (                          ) {}                     
-    Vertex::Vertex ( MRIS* mris, size_t idx   ) : MRIS_Elt(mris,idx) {}
-    Vertex::Vertex ( Vertex const & src       ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( AllM::Vertex const & src ) : MRIS_Elt(src) {}     
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
 
     Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        return Face(mris,mris->vertices_topology[idx].f[i]);
+        return Face(repr,repr->vertices_topology[idx].f[i]);
     }
     size_t Vertex::n(size_t i) const {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        return size_t(mris->vertices_topology[idx].n[i]);
+        return size_t(repr->vertices_topology[idx].n[i]);
     }
     int Vertex::e(size_t i) const {  //  edge state for neighboring vertices                      
-        return mris->vertices_topology[idx].e[i];
+        return repr->vertices_topology[idx].e[i];
     }
     Vertex Vertex::v(size_t i) const {  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        return Vertex(mris,mris->vertices_topology[idx].v[i]);
+        return Vertex(repr,repr->vertices_topology[idx].v[i]);
     }
     short Vertex::vnum() const {  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
-        return mris->vertices_topology[idx].vnum;
+        return repr->vertices_topology[idx].vnum;
     }
     short Vertex::v2num() const {  //  number of 1, or 2-hop neighbors                          
-        return mris->vertices_topology[idx].v2num;
+        return repr->vertices_topology[idx].v2num;
     }
     short Vertex::v3num() const {  //  number of 1,2,or 3-hop neighbors                         
-        return mris->vertices_topology[idx].v3num;
+        return repr->vertices_topology[idx].v3num;
     }
     short Vertex::vtotal() const {  //  total # of neighbors. copy of vnum.nsizeCur              
-        return mris->vertices_topology[idx].vtotal;
+        return repr->vertices_topology[idx].vtotal;
     }
     short Vertex::nsizeMaxClock() const {  //  copy of mris->nsizeMaxClock when v#num                   
-        return mris->vertices_topology[idx].nsizeMaxClock;
+        return repr->vertices_topology[idx].nsizeMaxClock;
     }
     uchar Vertex::nsizeMax() const {  //  the max nsize that was used to fill in vnum etc          
-        return mris->vertices_topology[idx].nsizeMax;
+        return repr->vertices_topology[idx].nsizeMax;
     }
     uchar Vertex::nsizeCur() const {  //  index of the current v#num in vtotal                     
-        return mris->vertices_topology[idx].nsizeCur;
+        return repr->vertices_topology[idx].nsizeCur;
     }
     uchar Vertex::num() const {  //  number of neighboring faces                              
-        return mris->vertices_topology[idx].num;
+        return repr->vertices_topology[idx].num;
     }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
-        return mris->vertices[idx].dist[i];
+        return repr->vertices[idx].dist[i];
     }
     float Vertex::dist_orig(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on origxyz
-        return mris->vertices[idx].dist_orig[i];
+        return repr->vertices[idx].dist_orig[i];
     }
     int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_capacity;
+        return repr->vertices[idx].dist_capacity;
     }
     int Vertex::dist_orig_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_orig_capacity;
+        return repr->vertices[idx].dist_orig_capacity;
     }
     float Vertex::x() const {  //  current coordinates	
-        return mris->vertices[idx].x;
+        return repr->vertices[idx].x;
     }
     float Vertex::y() const {  //  use MRISsetXYZ() to set
-        return mris->vertices[idx].y;
+        return repr->vertices[idx].y;
     }
     float Vertex::z() const {
-        return mris->vertices[idx].z;
+        return repr->vertices[idx].z;
     }
     float Vertex::origx() const {  //  original coordinates, see also MRIS::origxyz_status
-        return mris->vertices[idx].origx;
+        return repr->vertices[idx].origx;
     }
     float Vertex::origy() const {  //  use MRISsetOriginalXYZ(, 
-        return mris->vertices[idx].origy;
+        return repr->vertices[idx].origy;
     }
     float Vertex::origz() const {  //  or MRISsetOriginalXYZfromXYZ to set
-        return mris->vertices[idx].origz;
+        return repr->vertices[idx].origz;
     }
     float Vertex::nx() const {
-        return mris->vertices[idx].nx;
+        return repr->vertices[idx].nx;
     }
     float Vertex::ny() const {
-        return mris->vertices[idx].ny;
+        return repr->vertices[idx].ny;
     }
     float Vertex::nz() const {  //  curr normal
-        return mris->vertices[idx].nz;
+        return repr->vertices[idx].nz;
     }
     float Vertex::pnx() const {
-        return mris->vertices[idx].pnx;
+        return repr->vertices[idx].pnx;
     }
     float Vertex::pny() const {
-        return mris->vertices[idx].pny;
+        return repr->vertices[idx].pny;
     }
     float Vertex::pnz() const {  //  pial normal
-        return mris->vertices[idx].pnz;
+        return repr->vertices[idx].pnz;
     }
     float Vertex::wnx() const {
-        return mris->vertices[idx].wnx;
+        return repr->vertices[idx].wnx;
     }
     float Vertex::wny() const {
-        return mris->vertices[idx].wny;
+        return repr->vertices[idx].wny;
     }
     float Vertex::wnz() const {  //  white normal
-        return mris->vertices[idx].wnz;
+        return repr->vertices[idx].wnz;
     }
     float Vertex::onx() const {
-        return mris->vertices[idx].onx;
+        return repr->vertices[idx].onx;
     }
     float Vertex::ony() const {
-        return mris->vertices[idx].ony;
+        return repr->vertices[idx].ony;
     }
     float Vertex::onz() const {  //  original normal
-        return mris->vertices[idx].onz;
+        return repr->vertices[idx].onz;
     }
     float Vertex::dx() const {
-        return mris->vertices[idx].dx;
+        return repr->vertices[idx].dx;
     }
     float Vertex::dy() const {
-        return mris->vertices[idx].dy;
+        return repr->vertices[idx].dy;
     }
     float Vertex::dz() const {  //  current change in position
-        return mris->vertices[idx].dz;
+        return repr->vertices[idx].dz;
     }
     float Vertex::odx() const {
-        return mris->vertices[idx].odx;
+        return repr->vertices[idx].odx;
     }
     float Vertex::ody() const {
-        return mris->vertices[idx].ody;
+        return repr->vertices[idx].ody;
     }
     float Vertex::odz() const {  //  last change of position (for momentum, 
-        return mris->vertices[idx].odz;
+        return repr->vertices[idx].odz;
     }
     float Vertex::tdx() const {
-        return mris->vertices[idx].tdx;
+        return repr->vertices[idx].tdx;
     }
     float Vertex::tdy() const {
-        return mris->vertices[idx].tdy;
+        return repr->vertices[idx].tdy;
     }
     float Vertex::tdz() const {  //  temporary storage for averaging gradient
-        return mris->vertices[idx].tdz;
+        return repr->vertices[idx].tdz;
     }
     float Vertex::curv() const {  //  curr curvature
-        return mris->vertices[idx].curv;
+        return repr->vertices[idx].curv;
     }
     float Vertex::curvbak() const {
-        return mris->vertices[idx].curvbak;
+        return repr->vertices[idx].curvbak;
     }
     float Vertex::val() const {  //  scalar data value (file: rh.val, sig2-rh.w)
-        return mris->vertices[idx].val;
+        return repr->vertices[idx].val;
     }
     float Vertex::imag_val() const {  //  imaginary part of complex data value
-        return mris->vertices[idx].imag_val;
+        return repr->vertices[idx].imag_val;
     }
     float Vertex::cx() const {
-        return mris->vertices[idx].cx;
+        return repr->vertices[idx].cx;
     }
     float Vertex::cy() const {
-        return mris->vertices[idx].cy;
+        return repr->vertices[idx].cy;
     }
     float Vertex::cz() const {  //  coordinates in canonical coordinate system
-        return mris->vertices[idx].cz;
+        return repr->vertices[idx].cz;
     }
     float Vertex::tx() const {
-        return mris->vertices[idx].tx;
+        return repr->vertices[idx].tx;
     }
     float Vertex::ty() const {
-        return mris->vertices[idx].ty;
+        return repr->vertices[idx].ty;
     }
     float Vertex::tz() const {  //  tmp coordinate storage
-        return mris->vertices[idx].tz;
+        return repr->vertices[idx].tz;
     }
-    float Vertex::tx2() const {
-        return mris->vertices[idx].tx2;
+    float Vertex::t2x() const {
+        return repr->vertices[idx].t2x;
     }
-    float Vertex::ty2() const {
-        return mris->vertices[idx].ty2;
+    float Vertex::t2y() const {
+        return repr->vertices[idx].t2y;
     }
-    float Vertex::tz2() const {  //  tmp coordinate storage
-        return mris->vertices[idx].tz2;
+    float Vertex::t2z() const {  //  another tmp coordinate storage
+        return repr->vertices[idx].t2z;
     }
     float Vertex::targx() const {
-        return mris->vertices[idx].targx;
+        return repr->vertices[idx].targx;
     }
     float Vertex::targy() const {
-        return mris->vertices[idx].targy;
+        return repr->vertices[idx].targy;
     }
     float Vertex::targz() const {  //  target coordinates
-        return mris->vertices[idx].targz;
+        return repr->vertices[idx].targz;
     }
     float Vertex::pialx() const {
-        return mris->vertices[idx].pialx;
+        return repr->vertices[idx].pialx;
     }
     float Vertex::pialy() const {
-        return mris->vertices[idx].pialy;
+        return repr->vertices[idx].pialy;
     }
     float Vertex::pialz() const {  //  pial surface coordinates
-        return mris->vertices[idx].pialz;
+        return repr->vertices[idx].pialz;
     }
     float Vertex::whitex() const {
-        return mris->vertices[idx].whitex;
+        return repr->vertices[idx].whitex;
     }
     float Vertex::whitey() const {
-        return mris->vertices[idx].whitey;
+        return repr->vertices[idx].whitey;
     }
     float Vertex::whitez() const {  //  white surface coordinates
-        return mris->vertices[idx].whitez;
+        return repr->vertices[idx].whitez;
     }
     float Vertex::l4x() const {
-        return mris->vertices[idx].l4x;
+        return repr->vertices[idx].l4x;
     }
     float Vertex::l4y() const {
-        return mris->vertices[idx].l4y;
+        return repr->vertices[idx].l4y;
     }
     float Vertex::l4z() const {  //  layerIV surface coordinates
-        return mris->vertices[idx].l4z;
+        return repr->vertices[idx].l4z;
     }
     float Vertex::infx() const {
-        return mris->vertices[idx].infx;
+        return repr->vertices[idx].infx;
     }
     float Vertex::infy() const {
-        return mris->vertices[idx].infy;
+        return repr->vertices[idx].infy;
     }
     float Vertex::infz() const {  //  inflated coordinates
-        return mris->vertices[idx].infz;
+        return repr->vertices[idx].infz;
     }
     float Vertex::fx() const {
-        return mris->vertices[idx].fx;
+        return repr->vertices[idx].fx;
     }
     float Vertex::fy() const {
-        return mris->vertices[idx].fy;
+        return repr->vertices[idx].fy;
     }
     float Vertex::fz() const {  //  flattened coordinates
-        return mris->vertices[idx].fz;
+        return repr->vertices[idx].fz;
     }
     int Vertex::px() const {
-        return mris->vertices[idx].px;
+        return repr->vertices[idx].px;
     }
     int Vertex::qx() const {
-        return mris->vertices[idx].qx;
+        return repr->vertices[idx].qx;
     }
     int Vertex::py() const {
-        return mris->vertices[idx].py;
+        return repr->vertices[idx].py;
     }
     int Vertex::qy() const {
-        return mris->vertices[idx].qy;
+        return repr->vertices[idx].qy;
     }
     int Vertex::pz() const {
-        return mris->vertices[idx].pz;
+        return repr->vertices[idx].pz;
     }
     int Vertex::qz() const {  //  rational coordinates for exact calculations
-        return mris->vertices[idx].qz;
+        return repr->vertices[idx].qz;
     }
     float Vertex::e1x() const {
-        return mris->vertices[idx].e1x;
+        return repr->vertices[idx].e1x;
     }
     float Vertex::e1y() const {
-        return mris->vertices[idx].e1y;
+        return repr->vertices[idx].e1y;
     }
     float Vertex::e1z() const {  //  1st basis vector for the local tangent plane
-        return mris->vertices[idx].e1z;
+        return repr->vertices[idx].e1z;
     }
     float Vertex::e2x() const {
-        return mris->vertices[idx].e2x;
+        return repr->vertices[idx].e2x;
     }
     float Vertex::e2y() const {
-        return mris->vertices[idx].e2y;
+        return repr->vertices[idx].e2y;
     }
     float Vertex::e2z() const {  //  2nd basis vector for the local tangent plane
-        return mris->vertices[idx].e2z;
+        return repr->vertices[idx].e2z;
     }
     float Vertex::pe1x() const {
-        return mris->vertices[idx].pe1x;
+        return repr->vertices[idx].pe1x;
     }
     float Vertex::pe1y() const {
-        return mris->vertices[idx].pe1y;
+        return repr->vertices[idx].pe1y;
     }
     float Vertex::pe1z() const {  //  1st basis vector for the local tangent plane
-        return mris->vertices[idx].pe1z;
+        return repr->vertices[idx].pe1z;
     }
     float Vertex::pe2x() const {
-        return mris->vertices[idx].pe2x;
+        return repr->vertices[idx].pe2x;
     }
     float Vertex::pe2y() const {
-        return mris->vertices[idx].pe2y;
+        return repr->vertices[idx].pe2y;
     }
     float Vertex::pe2z() const {  //  2nd basis vector for the local tangent plane
-        return mris->vertices[idx].pe2z;
+        return repr->vertices[idx].pe2z;
     }
     float Vertex::nc() const {  //  curr length normal comp 
-        return mris->vertices[idx].nc;
+        return repr->vertices[idx].nc;
     }
     float Vertex::val2() const {  //  complex comp data value (file: sig3-rh.w) 
-        return mris->vertices[idx].val2;
+        return repr->vertices[idx].val2;
     }
     float Vertex::valbak() const {  //  scalar data stack 
-        return mris->vertices[idx].valbak;
+        return repr->vertices[idx].valbak;
     }
     float Vertex::val2bak() const {  //  complex comp data stack 
-        return mris->vertices[idx].val2bak;
+        return repr->vertices[idx].val2bak;
     }
     float Vertex::stat() const {  //  statistic 
-        return mris->vertices[idx].stat;
+        return repr->vertices[idx].stat;
     }
     int Vertex::undefval() const {  //  [previously dist=0] 
-        return mris->vertices[idx].undefval;
+        return repr->vertices[idx].undefval;
     }
     int Vertex::old_undefval() const {  //  for smooth_val_sparse 
-        return mris->vertices[idx].old_undefval;
+        return repr->vertices[idx].old_undefval;
     }
     int Vertex::fixedval() const {  //  [previously val=0] 
-        return mris->vertices[idx].fixedval;
+        return repr->vertices[idx].fixedval;
     }
     float Vertex::fieldsign() const {  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
-        return mris->vertices[idx].fieldsign;
+        return repr->vertices[idx].fieldsign;
     }
     float Vertex::fsmask() const {  //  significance mask (file: rh.fm) 
-        return mris->vertices[idx].fsmask;
+        return repr->vertices[idx].fsmask;
     }
     float Vertex::d() const {  //  for distance calculations 
-        return mris->vertices[idx].d;
+        return repr->vertices[idx].d;
     }
     int Vertex::annotation() const {  //  area label (defunct--now from label file name!) 
-        return mris->vertices[idx].annotation;
+        return repr->vertices[idx].annotation;
     }
     char Vertex::oripflag() const {
-        return mris->vertices[idx].oripflag;
+        return repr->vertices[idx].oripflag;
     }
     char Vertex::origripflag() const {  //  cuts flags 
-        return mris->vertices[idx].origripflag;
+        return repr->vertices[idx].origripflag;
     }
     p_void Vertex::vp() const {  //  to store user's information 
-        return mris->vertices[idx].vp;
+        return repr->vertices[idx].vp;
     }
     float Vertex::theta() const {
-        return mris->vertices[idx].theta;
+        return repr->vertices[idx].theta;
     }
     float Vertex::phi() const {  //  parameterization 
-        return mris->vertices[idx].phi;
+        return repr->vertices[idx].phi;
     }
     float Vertex::area() const {
-        return mris->vertices[idx].area;
+        return repr->vertices[idx].area;
     }
     float Vertex::origarea() const {
-        return mris->vertices[idx].origarea;
+        return repr->vertices[idx].origarea;
     }
     float Vertex::group_avg_area() const {
-        return mris->vertices[idx].group_avg_area;
+        return repr->vertices[idx].group_avg_area;
     }
     float Vertex::K() const {  //  Gaussian curvature 
-        return mris->vertices[idx].K;
+        return repr->vertices[idx].K;
     }
     float Vertex::H() const {  //  mean curvature 
-        return mris->vertices[idx].H;
+        return repr->vertices[idx].H;
     }
     float Vertex::k1() const {
-        return mris->vertices[idx].k1;
+        return repr->vertices[idx].k1;
     }
     float Vertex::k2() const {  //  the principal curvatures 
-        return mris->vertices[idx].k2;
+        return repr->vertices[idx].k2;
     }
     float Vertex::mean() const {
-        return mris->vertices[idx].mean;
+        return repr->vertices[idx].mean;
     }
     float Vertex::mean_imag() const {  //  imaginary part of complex statistic 
-        return mris->vertices[idx].mean_imag;
+        return repr->vertices[idx].mean_imag;
     }
     float Vertex::std_error() const {
-        return mris->vertices[idx].std_error;
+        return repr->vertices[idx].std_error;
     }
     uint Vertex::flags() const {
-        return mris->vertices[idx].flags;
+        return repr->vertices[idx].flags;
     }
     int Vertex::fno() const {  //  face that this vertex is in 
-        return mris->vertices[idx].fno;
+        return repr->vertices[idx].fno;
     }
     int Vertex::cropped() const {
-        return mris->vertices[idx].cropped;
+        return repr->vertices[idx].cropped;
     }
     short Vertex::marked() const {  //  for a variety of uses 
-        return mris->vertices[idx].marked;
+        return repr->vertices[idx].marked;
     }
     short Vertex::marked2() const {
-        return mris->vertices[idx].marked2;
+        return repr->vertices[idx].marked2;
     }
     short Vertex::marked3() const {
-        return mris->vertices[idx].marked3;
+        return repr->vertices[idx].marked3;
     }
     char Vertex::neg() const {  //  1 if the normal vector is inverted 
-        return mris->vertices[idx].neg;
+        return repr->vertices[idx].neg;
     }
     char Vertex::border() const {  //  flag 
-        return mris->vertices[idx].border;
+        return repr->vertices[idx].border;
     }
     char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
-        return mris->vertices[idx].ripflag;
+        return repr->vertices[idx].ripflag;
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+         MRISvertexCoord2XYZ_float(&repr->vertices[idx], which, x, y, z);
     }
     
     void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        cheapAssert(mris == to.mris); mris->vertices_topology[idx].f[i] = to.idx;
+        cheapAssert(repr == to.repr); repr->vertices_topology[idx].f[i] = to.idx;
     }
     void Vertex::set_n(size_t i, size_t to) {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        mris->vertices_topology[idx].n[i] = uchar(to);
+        repr->vertices_topology[idx].n[i] = uchar(to);
     }
     void Vertex::set_e(size_t i, int to) {  //  edge state for neighboring vertices                      
-        mris->vertices_topology[idx].e[i] = to;
+        repr->vertices_topology[idx].e[i] = to;
     }
     void Vertex::set_nx(float to) {
-        mris->vertices[idx].nx = to;
+        repr->vertices[idx].nx = to;
     }
     void Vertex::set_ny(float to) {
-        mris->vertices[idx].ny = to;
+        repr->vertices[idx].ny = to;
     }
     void Vertex::set_nz(float to) {  //  curr normal
-        mris->vertices[idx].nz = to;
+        repr->vertices[idx].nz = to;
     }
     void Vertex::set_pnx(float to) {
-        mris->vertices[idx].pnx = to;
+        repr->vertices[idx].pnx = to;
     }
     void Vertex::set_pny(float to) {
-        mris->vertices[idx].pny = to;
+        repr->vertices[idx].pny = to;
     }
     void Vertex::set_pnz(float to) {  //  pial normal
-        mris->vertices[idx].pnz = to;
+        repr->vertices[idx].pnz = to;
     }
     void Vertex::set_wnx(float to) {
-        mris->vertices[idx].wnx = to;
+        repr->vertices[idx].wnx = to;
     }
     void Vertex::set_wny(float to) {
-        mris->vertices[idx].wny = to;
+        repr->vertices[idx].wny = to;
     }
     void Vertex::set_wnz(float to) {  //  white normal
-        mris->vertices[idx].wnz = to;
+        repr->vertices[idx].wnz = to;
     }
     void Vertex::set_onx(float to) {
-        mris->vertices[idx].onx = to;
+        repr->vertices[idx].onx = to;
     }
     void Vertex::set_ony(float to) {
-        mris->vertices[idx].ony = to;
+        repr->vertices[idx].ony = to;
     }
     void Vertex::set_onz(float to) {  //  original normal
-        mris->vertices[idx].onz = to;
+        repr->vertices[idx].onz = to;
     }
     void Vertex::set_dx(float to) {
-        mris->vertices[idx].dx = to;
+        repr->vertices[idx].dx = to;
     }
     void Vertex::set_dy(float to) {
-        mris->vertices[idx].dy = to;
+        repr->vertices[idx].dy = to;
     }
     void Vertex::set_dz(float to) {  //  current change in position
-        mris->vertices[idx].dz = to;
+        repr->vertices[idx].dz = to;
     }
     void Vertex::set_odx(float to) {
-        mris->vertices[idx].odx = to;
+        repr->vertices[idx].odx = to;
     }
     void Vertex::set_ody(float to) {
-        mris->vertices[idx].ody = to;
+        repr->vertices[idx].ody = to;
     }
     void Vertex::set_odz(float to) {  //  last change of position (for momentum, 
-        mris->vertices[idx].odz = to;
+        repr->vertices[idx].odz = to;
     }
     void Vertex::set_tdx(float to) {
-        mris->vertices[idx].tdx = to;
+        repr->vertices[idx].tdx = to;
     }
     void Vertex::set_tdy(float to) {
-        mris->vertices[idx].tdy = to;
+        repr->vertices[idx].tdy = to;
     }
     void Vertex::set_tdz(float to) {  //  temporary storage for averaging gradient
-        mris->vertices[idx].tdz = to;
+        repr->vertices[idx].tdz = to;
     }
     void Vertex::set_curv(float to) {  //  curr curvature
-        mris->vertices[idx].curv = to;
+        repr->vertices[idx].curv = to;
     }
     void Vertex::set_curvbak(float to) {
-        mris->vertices[idx].curvbak = to;
+        repr->vertices[idx].curvbak = to;
     }
     void Vertex::set_val(float to) {  //  scalar data value (file: rh.val, sig2-rh.w)
-        mris->vertices[idx].val = to;
+        repr->vertices[idx].val = to;
     }
     void Vertex::set_imag_val(float to) {  //  imaginary part of complex data value
-        mris->vertices[idx].imag_val = to;
+        repr->vertices[idx].imag_val = to;
     }
     void Vertex::set_cx(float to) {
-        mris->vertices[idx].cx = to;
+        repr->vertices[idx].cx = to;
     }
     void Vertex::set_cy(float to) {
-        mris->vertices[idx].cy = to;
+        repr->vertices[idx].cy = to;
     }
     void Vertex::set_cz(float to) {  //  coordinates in canonical coordinate system
-        mris->vertices[idx].cz = to;
+        repr->vertices[idx].cz = to;
     }
     void Vertex::set_tx(float to) {
-        mris->vertices[idx].tx = to;
+        repr->vertices[idx].tx = to;
     }
     void Vertex::set_ty(float to) {
-        mris->vertices[idx].ty = to;
+        repr->vertices[idx].ty = to;
     }
     void Vertex::set_tz(float to) {  //  tmp coordinate storage
-        mris->vertices[idx].tz = to;
+        repr->vertices[idx].tz = to;
     }
-    void Vertex::set_tx2(float to) {
-        mris->vertices[idx].tx2 = to;
+    void Vertex::set_t2x(float to) {
+        repr->vertices[idx].t2x = to;
     }
-    void Vertex::set_ty2(float to) {
-        mris->vertices[idx].ty2 = to;
+    void Vertex::set_t2y(float to) {
+        repr->vertices[idx].t2y = to;
     }
-    void Vertex::set_tz2(float to) {  //  tmp coordinate storage
-        mris->vertices[idx].tz2 = to;
+    void Vertex::set_t2z(float to) {  //  another tmp coordinate storage
+        repr->vertices[idx].t2z = to;
     }
     void Vertex::set_targx(float to) {
-        mris->vertices[idx].targx = to;
+        repr->vertices[idx].targx = to;
     }
     void Vertex::set_targy(float to) {
-        mris->vertices[idx].targy = to;
+        repr->vertices[idx].targy = to;
     }
     void Vertex::set_targz(float to) {  //  target coordinates
-        mris->vertices[idx].targz = to;
+        repr->vertices[idx].targz = to;
     }
     void Vertex::set_pialx(float to) {
-        mris->vertices[idx].pialx = to;
+        repr->vertices[idx].pialx = to;
     }
     void Vertex::set_pialy(float to) {
-        mris->vertices[idx].pialy = to;
+        repr->vertices[idx].pialy = to;
     }
     void Vertex::set_pialz(float to) {  //  pial surface coordinates
-        mris->vertices[idx].pialz = to;
+        repr->vertices[idx].pialz = to;
     }
     void Vertex::set_whitex(float to) {
-        mris->vertices[idx].whitex = to;
+        repr->vertices[idx].whitex = to;
     }
     void Vertex::set_whitey(float to) {
-        mris->vertices[idx].whitey = to;
+        repr->vertices[idx].whitey = to;
     }
     void Vertex::set_whitez(float to) {  //  white surface coordinates
-        mris->vertices[idx].whitez = to;
+        repr->vertices[idx].whitez = to;
     }
     void Vertex::set_l4x(float to) {
-        mris->vertices[idx].l4x = to;
+        repr->vertices[idx].l4x = to;
     }
     void Vertex::set_l4y(float to) {
-        mris->vertices[idx].l4y = to;
+        repr->vertices[idx].l4y = to;
     }
     void Vertex::set_l4z(float to) {  //  layerIV surface coordinates
-        mris->vertices[idx].l4z = to;
+        repr->vertices[idx].l4z = to;
     }
     void Vertex::set_infx(float to) {
-        mris->vertices[idx].infx = to;
+        repr->vertices[idx].infx = to;
     }
     void Vertex::set_infy(float to) {
-        mris->vertices[idx].infy = to;
+        repr->vertices[idx].infy = to;
     }
     void Vertex::set_infz(float to) {  //  inflated coordinates
-        mris->vertices[idx].infz = to;
+        repr->vertices[idx].infz = to;
     }
     void Vertex::set_fx(float to) {
-        mris->vertices[idx].fx = to;
+        repr->vertices[idx].fx = to;
     }
     void Vertex::set_fy(float to) {
-        mris->vertices[idx].fy = to;
+        repr->vertices[idx].fy = to;
     }
     void Vertex::set_fz(float to) {  //  flattened coordinates
-        mris->vertices[idx].fz = to;
+        repr->vertices[idx].fz = to;
     }
     void Vertex::set_px(int to) {
-        mris->vertices[idx].px = to;
+        repr->vertices[idx].px = to;
     }
     void Vertex::set_qx(int to) {
-        mris->vertices[idx].qx = to;
+        repr->vertices[idx].qx = to;
     }
     void Vertex::set_py(int to) {
-        mris->vertices[idx].py = to;
+        repr->vertices[idx].py = to;
     }
     void Vertex::set_qy(int to) {
-        mris->vertices[idx].qy = to;
+        repr->vertices[idx].qy = to;
     }
     void Vertex::set_pz(int to) {
-        mris->vertices[idx].pz = to;
+        repr->vertices[idx].pz = to;
     }
     void Vertex::set_qz(int to) {  //  rational coordinates for exact calculations
-        mris->vertices[idx].qz = to;
+        repr->vertices[idx].qz = to;
     }
     void Vertex::set_e1x(float to) {
-        mris->vertices[idx].e1x = to;
+        repr->vertices[idx].e1x = to;
     }
     void Vertex::set_e1y(float to) {
-        mris->vertices[idx].e1y = to;
+        repr->vertices[idx].e1y = to;
     }
     void Vertex::set_e1z(float to) {  //  1st basis vector for the local tangent plane
-        mris->vertices[idx].e1z = to;
+        repr->vertices[idx].e1z = to;
     }
     void Vertex::set_e2x(float to) {
-        mris->vertices[idx].e2x = to;
+        repr->vertices[idx].e2x = to;
     }
     void Vertex::set_e2y(float to) {
-        mris->vertices[idx].e2y = to;
+        repr->vertices[idx].e2y = to;
     }
     void Vertex::set_e2z(float to) {  //  2nd basis vector for the local tangent plane
-        mris->vertices[idx].e2z = to;
+        repr->vertices[idx].e2z = to;
     }
     void Vertex::set_pe1x(float to) {
-        mris->vertices[idx].pe1x = to;
+        repr->vertices[idx].pe1x = to;
     }
     void Vertex::set_pe1y(float to) {
-        mris->vertices[idx].pe1y = to;
+        repr->vertices[idx].pe1y = to;
     }
     void Vertex::set_pe1z(float to) {  //  1st basis vector for the local tangent plane
-        mris->vertices[idx].pe1z = to;
+        repr->vertices[idx].pe1z = to;
     }
     void Vertex::set_pe2x(float to) {
-        mris->vertices[idx].pe2x = to;
+        repr->vertices[idx].pe2x = to;
     }
     void Vertex::set_pe2y(float to) {
-        mris->vertices[idx].pe2y = to;
+        repr->vertices[idx].pe2y = to;
     }
     void Vertex::set_pe2z(float to) {  //  2nd basis vector for the local tangent plane
-        mris->vertices[idx].pe2z = to;
+        repr->vertices[idx].pe2z = to;
     }
     void Vertex::set_nc(float to) {  //  curr length normal comp 
-        mris->vertices[idx].nc = to;
+        repr->vertices[idx].nc = to;
     }
     void Vertex::set_val2(float to) {  //  complex comp data value (file: sig3-rh.w) 
-        mris->vertices[idx].val2 = to;
+        repr->vertices[idx].val2 = to;
     }
     void Vertex::set_valbak(float to) {  //  scalar data stack 
-        mris->vertices[idx].valbak = to;
+        repr->vertices[idx].valbak = to;
     }
     void Vertex::set_val2bak(float to) {  //  complex comp data stack 
-        mris->vertices[idx].val2bak = to;
+        repr->vertices[idx].val2bak = to;
     }
     void Vertex::set_stat(float to) {  //  statistic 
-        mris->vertices[idx].stat = to;
+        repr->vertices[idx].stat = to;
     }
     void Vertex::set_undefval(int to) {  //  [previously dist=0] 
-        mris->vertices[idx].undefval = to;
+        repr->vertices[idx].undefval = to;
     }
     void Vertex::set_old_undefval(int to) {  //  for smooth_val_sparse 
-        mris->vertices[idx].old_undefval = to;
+        repr->vertices[idx].old_undefval = to;
     }
     void Vertex::set_fixedval(int to) {  //  [previously val=0] 
-        mris->vertices[idx].fixedval = to;
+        repr->vertices[idx].fixedval = to;
     }
     void Vertex::set_fieldsign(float to) {  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
-        mris->vertices[idx].fieldsign = to;
+        repr->vertices[idx].fieldsign = to;
     }
     void Vertex::set_fsmask(float to) {  //  significance mask (file: rh.fm) 
-        mris->vertices[idx].fsmask = to;
+        repr->vertices[idx].fsmask = to;
     }
     void Vertex::set_d(float to) {  //  for distance calculations 
-        mris->vertices[idx].d = to;
+        repr->vertices[idx].d = to;
     }
     void Vertex::set_annotation(int to) {  //  area label (defunct--now from label file name!) 
-        mris->vertices[idx].annotation = to;
+        repr->vertices[idx].annotation = to;
     }
     void Vertex::set_oripflag(char to) {
-        mris->vertices[idx].oripflag = to;
+        repr->vertices[idx].oripflag = to;
     }
     void Vertex::set_origripflag(char to) {  //  cuts flags 
-        mris->vertices[idx].origripflag = to;
+        repr->vertices[idx].origripflag = to;
     }
     void Vertex::set_vp(p_void to) {  //  to store user's information 
-        mris->vertices[idx].vp = to;
+        repr->vertices[idx].vp = to;
     }
     void Vertex::set_theta(float to) {
-        mris->vertices[idx].theta = to;
+        repr->vertices[idx].theta = to;
     }
     void Vertex::set_phi(float to) {  //  parameterization 
-        mris->vertices[idx].phi = to;
+        repr->vertices[idx].phi = to;
     }
     void Vertex::set_origarea(float to) {
-        mris->vertices[idx].origarea = to;
+        repr->vertices[idx].origarea = to;
     }
     void Vertex::set_group_avg_area(float to) {
-        mris->vertices[idx].group_avg_area = to;
+        repr->vertices[idx].group_avg_area = to;
     }
     void Vertex::set_K(float to) {  //  Gaussian curvature 
-        mris->vertices[idx].K = to;
+        repr->vertices[idx].K = to;
     }
     void Vertex::set_H(float to) {  //  mean curvature 
-        mris->vertices[idx].H = to;
+        repr->vertices[idx].H = to;
     }
     void Vertex::set_k1(float to) {
-        mris->vertices[idx].k1 = to;
+        repr->vertices[idx].k1 = to;
     }
     void Vertex::set_k2(float to) {  //  the principal curvatures 
-        mris->vertices[idx].k2 = to;
+        repr->vertices[idx].k2 = to;
     }
     void Vertex::set_mean(float to) {
-        mris->vertices[idx].mean = to;
+        repr->vertices[idx].mean = to;
     }
     void Vertex::set_mean_imag(float to) {  //  imaginary part of complex statistic 
-        mris->vertices[idx].mean_imag = to;
+        repr->vertices[idx].mean_imag = to;
     }
     void Vertex::set_std_error(float to) {
-        mris->vertices[idx].std_error = to;
+        repr->vertices[idx].std_error = to;
     }
     void Vertex::set_flags(uint to) {
-        mris->vertices[idx].flags = to;
+        repr->vertices[idx].flags = to;
     }
     void Vertex::set_fno(int to) {  //  face that this vertex is in 
-        mris->vertices[idx].fno = to;
+        repr->vertices[idx].fno = to;
     }
     void Vertex::set_cropped(int to) {
-        mris->vertices[idx].cropped = to;
+        repr->vertices[idx].cropped = to;
     }
     void Vertex::set_marked(short to) {  //  for a variety of uses 
-        mris->vertices[idx].marked = to;
+        repr->vertices[idx].marked = to;
     }
     void Vertex::set_marked2(short to) {
-        mris->vertices[idx].marked2 = to;
+        repr->vertices[idx].marked2 = to;
     }
     void Vertex::set_marked3(short to) {
-        mris->vertices[idx].marked3 = to;
+        repr->vertices[idx].marked3 = to;
     }
     void Vertex::set_neg(char to) {  //  1 if the normal vector is inverted 
-        mris->vertices[idx].neg = to;
+        repr->vertices[idx].neg = to;
     }
     void Vertex::set_border(char to) {  //  flag 
-        mris->vertices[idx].border = to;
+        repr->vertices[idx].border = to;
     }
     void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
-        mris->vertices[idx].ripflag = to;
+        repr->vertices[idx].ripflag = to;
     }
 
 
-    Surface::Surface (                           ) {}                   
-    Surface::Surface ( MRIS* mris                ) : MRIS_Elt(mris,0) {}
-    Surface::Surface ( Surface const & src       ) : MRIS_Elt(src) {}   
-    Surface::Surface ( AllM::Surface const & src ) : MRIS_Elt(src) {}   
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
 
     int Surface::nverticesFrozen() const {  //  # of vertices on surface is frozen
-        return mris->nverticesFrozen;
+        return repr->nverticesFrozen;
     }
     int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nvertices;
+        return repr->nvertices;
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nfaces;
+        return repr->nfaces;
     }
     bool Surface::faceAttachmentDeferred() const {  //  defer connecting faces to vertices for performance reasons
-        return mris->faceAttachmentDeferred;
+        return repr->faceAttachmentDeferred;
     }
     int Surface::nedges() const {  //  # of edges on surface
-        return mris->nedges;
+        return repr->nedges;
     }
     int Surface::nstrips() const {
-        return mris->nstrips;
+        return repr->nstrips;
     }
     Vertex Surface::vertices(size_t i) const {
-        return Vertex(mris,i);
+        return Vertex(repr,i);
     }
     p_p_void Surface::dist_storage() const {  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
-        return mris->dist_storage;
+        return repr->dist_storage;
     }
     p_p_void Surface::dist_orig_storage() const {  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
-        return mris->dist_orig_storage;
+        return repr->dist_orig_storage;
     }
     int Surface::tempsAssigned() const {  //  State of various temp fields that can be borrowed if not already in use
-        return mris->tempsAssigned;
+        return repr->tempsAssigned;
     }
     Face Surface::faces(size_t i) const {
-        return Face(mris,i);
+        return Face(repr,i);
     }
     MRI_EDGE Surface::edges(size_t i) const {
-        return mris->edges[i];
+        return repr->edges[i];
     }
     FaceNormCacheEntry Surface::faceNormCacheEntries(size_t i) const {
-        return mris->faceNormCacheEntries[i];
+        return repr->faceNormCacheEntries[i];
     }
     FaceNormDeferredEntry Surface::faceNormDeferredEntries(size_t i) const {
-        return mris->faceNormDeferredEntries[i];
+        return repr->faceNormDeferredEntries[i];
     }
     STRIP Surface::strips(size_t i) const {
-        return mris->strips[i];
+        return repr->strips[i];
     }
     float Surface::xctr() const {
-        return mris->xctr;
+        return repr->xctr;
     }
     float Surface::yctr() const {
-        return mris->yctr;
+        return repr->yctr;
     }
     float Surface::zctr() const {
-        return mris->zctr;
+        return repr->zctr;
     }
     float Surface::xlo() const {
-        return mris->xlo;
+        return repr->xlo;
     }
     float Surface::ylo() const {
-        return mris->ylo;
+        return repr->ylo;
     }
     float Surface::zlo() const {
-        return mris->zlo;
+        return repr->zlo;
     }
     float Surface::xhi() const {
-        return mris->xhi;
+        return repr->xhi;
     }
     float Surface::yhi() const {
-        return mris->yhi;
+        return repr->yhi;
     }
     float Surface::zhi() const {
-        return mris->zhi;
+        return repr->zhi;
     }
     float Surface::x0() const {  //  center of spherical expansion
-        return mris->x0;
+        return repr->x0;
     }
     float Surface::y0() const {
-        return mris->y0;
+        return repr->y0;
     }
     float Surface::z0() const {
-        return mris->z0;
+        return repr->z0;
     }
     Vertex Surface::v_temporal_pole() const {
-        return Vertex(mris,mris->v_temporal_pole - mris->vertices);
+        return Vertex(repr,repr->v_temporal_pole - repr->vertices);
     }
     Vertex Surface::v_frontal_pole() const {
-        return Vertex(mris,mris->v_frontal_pole - mris->vertices);
+        return Vertex(repr,repr->v_frontal_pole - repr->vertices);
     }
     Vertex Surface::v_occipital_pole() const {
-        return Vertex(mris,mris->v_occipital_pole - mris->vertices);
+        return Vertex(repr,repr->v_occipital_pole - repr->vertices);
     }
     float Surface::max_curv() const {
-        return mris->max_curv;
+        return repr->max_curv;
     }
     float Surface::min_curv() const {
-        return mris->min_curv;
+        return repr->min_curv;
     }
     float Surface::total_area() const {
-        return mris->total_area;
+        return repr->total_area;
     }
     double Surface::avg_vertex_area() const {
-        return mris->avg_vertex_area;
+        return repr->avg_vertex_area;
     }
     double Surface::avg_vertex_dist() const {  //  set by MRIScomputeAvgInterVertexDist
-        return mris->avg_vertex_dist;
+        return repr->avg_vertex_dist;
     }
     double Surface::std_vertex_dist() const {
-        return mris->std_vertex_dist;
+        return repr->std_vertex_dist;
     }
     float Surface::orig_area() const {
-        return mris->orig_area;
+        return repr->orig_area;
     }
     float Surface::neg_area() const {
-        return mris->neg_area;
+        return repr->neg_area;
     }
     float Surface::neg_orig_area() const {  //  amount of original surface in folds
-        return mris->neg_orig_area;
+        return repr->neg_orig_area;
     }
     int Surface::zeros() const {
-        return mris->zeros;
+        return repr->zeros;
     }
     int Surface::hemisphere() const {  //  which hemisphere
-        return mris->hemisphere;
+        return repr->hemisphere;
     }
     int Surface::initialized() const {
-        return mris->initialized;
+        return repr->initialized;
     }
     PLTA Surface::lta() const {
-        return mris->lta;
+        return repr->lta;
     }
     PMATRIX Surface::SRASToTalSRAS_() const {
-        return mris->SRASToTalSRAS_;
+        return repr->SRASToTalSRAS_;
     }
     PMATRIX Surface::TalSRASToSRAS_() const {
-        return mris->TalSRASToSRAS_;
+        return repr->TalSRASToSRAS_;
     }
     int Surface::free_transform() const {
-        return mris->free_transform;
+        return repr->free_transform;
     }
     double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
-        return mris->radius;
+        return repr->radius;
     }
     float Surface::a() const {
-        return mris->a;
+        return repr->a;
     }
     float Surface::b() const {
-        return mris->b;
+        return repr->b;
     }
     float Surface::c() const {  //  ellipsoid parameters
-        return mris->c;
+        return repr->c;
     }
     MRIS_fname_t Surface::fname() const {  //  file it was originally loaded from
-        return mris->fname;
+        return repr->fname;
     }
     float Surface::Hmin() const {  //  min mean curvature
-        return mris->Hmin;
+        return repr->Hmin;
     }
     float Surface::Hmax() const {  //  max mean curvature
-        return mris->Hmax;
+        return repr->Hmax;
     }
     float Surface::Kmin() const {  //  min Gaussian curvature
-        return mris->Kmin;
+        return repr->Kmin;
     }
     float Surface::Kmax() const {  //  max Gaussian curvature
-        return mris->Kmax;
+        return repr->Kmax;
     }
     double Surface::Ktotal() const {  //  total Gaussian curvature
-        return mris->Ktotal;
+        return repr->Ktotal;
     }
     MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
-        return mris->status;
+        return repr->status;
     }
     MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-        return mris->origxyz_status;
+        return repr->origxyz_status;
     }
     int Surface::patch() const {  //  if a patch of the surface
-        return mris->patch;
+        return repr->patch;
     }
     int Surface::nlabels() const {
-        return mris->nlabels;
+        return repr->nlabels;
     }
     PMRIS_AREA_LABEL Surface::labels() const {  //  nlabels of these (may be null)
-        return mris->labels;
+        return repr->labels;
     }
     p_void Surface::vp() const {  //  for misc. use
-        return mris->vp;
+        return repr->vp;
     }
     float Surface::alpha() const {  //  rotation around z-axis
-        return mris->alpha;
+        return repr->alpha;
     }
     float Surface::beta() const {  //  rotation around y-axis
-        return mris->beta;
+        return repr->beta;
     }
     float Surface::gamma() const {  //  rotation around x-axis
-        return mris->gamma;
+        return repr->gamma;
     }
     float Surface::da() const {
-        return mris->da;
+        return repr->da;
     }
     float Surface::db() const {
-        return mris->db;
+        return repr->db;
     }
     float Surface::dg() const {  //  old deltas
-        return mris->dg;
+        return repr->dg;
     }
     int Surface::type() const {  //  what type of surface was this initially
-        return mris->type;
+        return repr->type;
     }
     int Surface::max_vertices() const {  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
-        return mris->max_vertices;
+        return repr->max_vertices;
     }
     int Surface::max_faces() const {  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
-        return mris->max_faces;
+        return repr->max_faces;
     }
     MRIS_subject_name_t Surface::subject_name() const {  //  name of the subject
-        return mris->subject_name;
+        return repr->subject_name;
     }
     float Surface::canon_area() const {
-        return mris->canon_area;
+        return repr->canon_area;
     }
     int Surface::noscale() const {  //  don't scale by surface area if true
-        return mris->noscale;
+        return repr->noscale;
     }
     float Surface::dx2(size_t i) const {  //  an extra set of gradient (not always alloced)
-        return mris->dx2[i];
+        return repr->dx2[i];
     }
     float Surface::dy2(size_t i) const {
-        return mris->dy2[i];
+        return repr->dy2[i];
     }
     float Surface::dz2(size_t i) const {
-        return mris->dz2[i];
+        return repr->dz2[i];
     }
     PCOLOR_TABLE Surface::ct() const {
-        return mris->ct;
+        return repr->ct;
     }
     int Surface::useRealRAS() const {  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        return mris->useRealRAS;
+        return repr->useRealRAS;
     }
     VOL_GEOM Surface::vg() const {  //  volume info from which this surface is created. valid iff vg.valid = 1
-        return mris->vg;
+        return repr->vg;
     }
     MRIS_cmdlines_t Surface::cmdlines() const {
-        return mris->cmdlines;
+        return repr->cmdlines;
     }
     int Surface::ncmds() const {
-        return mris->ncmds;
+        return repr->ncmds;
     }
     float Surface::group_avg_surface_area() const {  //  average of total surface area for group
-        return mris->group_avg_surface_area;
+        return repr->group_avg_surface_area;
     }
     int Surface::group_avg_vtxarea_loaded() const {  //  average vertex area for group at each vertex
-        return mris->group_avg_vtxarea_loaded;
+        return repr->group_avg_vtxarea_loaded;
     }
     int Surface::triangle_links_removed() const {  //  for quad surfaces
-        return mris->triangle_links_removed;
+        return repr->triangle_links_removed;
     }
     p_void Surface::user_parms() const {  //  for whatever the user wants to hang here
-        return mris->user_parms;
+        return repr->user_parms;
     }
     PMATRIX Surface::m_sras2vox() const {  //  for converting surface ras to voxel
-        return mris->m_sras2vox;
+        return repr->m_sras2vox;
     }
     PMRI Surface::mri_sras2vox() const {  //  volume that the above matrix is for
-        return mris->mri_sras2vox;
+        return repr->mri_sras2vox;
     }
     p_void Surface::mht() const {
-        return mris->mht;
+        return repr->mht;
     }
     p_void Surface::temps() const {
-        return mris->temps;
+        return repr->temps;
     }
     
     void Surface::set_strips(size_t i, STRIP to) {
-        mris->strips[i] = to;
+        repr->strips[i] = to;
     }
     void Surface::set_xctr(float to) {
-        mris->xctr = to;
+        repr->xctr = to;
     }
     void Surface::set_yctr(float to) {
-        mris->yctr = to;
+        repr->yctr = to;
     }
     void Surface::set_zctr(float to) {
-        mris->zctr = to;
+        repr->zctr = to;
     }
     void Surface::set_xlo(float to) {
-        mris->xlo = to;
+        repr->xlo = to;
     }
     void Surface::set_ylo(float to) {
-        mris->ylo = to;
+        repr->ylo = to;
     }
     void Surface::set_zlo(float to) {
-        mris->zlo = to;
+        repr->zlo = to;
     }
     void Surface::set_xhi(float to) {
-        mris->xhi = to;
+        repr->xhi = to;
     }
     void Surface::set_yhi(float to) {
-        mris->yhi = to;
+        repr->yhi = to;
     }
     void Surface::set_zhi(float to) {
-        mris->zhi = to;
+        repr->zhi = to;
     }
     void Surface::set_x0(float to) {  //  center of spherical expansion
-        mris->x0 = to;
+        repr->x0 = to;
     }
     void Surface::set_y0(float to) {
-        mris->y0 = to;
+        repr->y0 = to;
     }
     void Surface::set_z0(float to) {
-        mris->z0 = to;
+        repr->z0 = to;
     }
     void Surface::set_v_temporal_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_temporal_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_temporal_pole = repr->vertices + to.idx;
     }
     void Surface::set_v_frontal_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_frontal_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_frontal_pole = repr->vertices + to.idx;
     }
     void Surface::set_v_occipital_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_occipital_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_occipital_pole = repr->vertices + to.idx;
     }
     void Surface::set_max_curv(float to) {
-        mris->max_curv = to;
+        repr->max_curv = to;
     }
     void Surface::set_min_curv(float to) {
-        mris->min_curv = to;
+        repr->min_curv = to;
     }
     void Surface::set_total_area(float to) {
-        mris->total_area = to;
+        repr->total_area = to;
     }
     void Surface::set_avg_vertex_area(double to) {
-        mris->avg_vertex_area = to;
+        repr->avg_vertex_area = to;
     }
     void Surface::set_zeros(int to) {
-        mris->zeros = to;
+        repr->zeros = to;
     }
     void Surface::set_hemisphere(int to) {  //  which hemisphere
-        mris->hemisphere = to;
+        repr->hemisphere = to;
     }
     void Surface::set_Hmin(float to) {  //  min mean curvature
-        mris->Hmin = to;
+        repr->Hmin = to;
     }
     void Surface::set_Hmax(float to) {  //  max mean curvature
-        mris->Hmax = to;
+        repr->Hmax = to;
     }
     void Surface::set_Kmin(float to) {  //  min Gaussian curvature
-        mris->Kmin = to;
+        repr->Kmin = to;
     }
     void Surface::set_Kmax(float to) {  //  max Gaussian curvature
-        mris->Kmax = to;
+        repr->Kmax = to;
     }
     void Surface::set_Ktotal(double to) {  //  total Gaussian curvature
-        mris->Ktotal = to;
+        repr->Ktotal = to;
     }
     void Surface::set_nlabels(int to) {
-        mris->nlabels = to;
+        repr->nlabels = to;
     }
     void Surface::set_labels(PMRIS_AREA_LABEL to) {  //  nlabels of these (may be null)
-        mris->labels = to;
+        repr->labels = to;
     }
     void Surface::set_vp(p_void to) {  //  for misc. use
-        mris->vp = to;
+        repr->vp = to;
     }
     void Surface::set_alpha(float to) {  //  rotation around z-axis
-        mris->alpha = to;
+        repr->alpha = to;
     }
     void Surface::set_beta(float to) {  //  rotation around y-axis
-        mris->beta = to;
+        repr->beta = to;
     }
     void Surface::set_gamma(float to) {  //  rotation around x-axis
-        mris->gamma = to;
+        repr->gamma = to;
     }
     void Surface::set_da(float to) {
-        mris->da = to;
+        repr->da = to;
     }
     void Surface::set_db(float to) {
-        mris->db = to;
+        repr->db = to;
     }
     void Surface::set_dg(float to) {  //  old deltas
-        mris->dg = to;
+        repr->dg = to;
     }
     void Surface::set_type(int to) {  //  what type of surface was this initially
-        mris->type = to;
+        repr->type = to;
     }
 
 
@@ -3713,165 +3731,168 @@ namespace SurfaceFromMRIS {
 
 
     namespace ExistenceM {
-    Face::Face (                        ) {}                     
-    Face::Face ( MRIS* mris, size_t idx ) : MRIS_Elt(mris,idx) {}
-    Face::Face ( Face const & src       ) : MRIS_Elt(src) {}     
-    Face::Face ( AllM::Face const & src ) : MRIS_Elt(src) {}     
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
     char Face::ripflag() const {
-        return mris->faces[idx].ripflag;
+        return repr->faces[idx].ripflag;
     }
     char Face::oripflag() const {
-        return mris->faces[idx].oripflag;
+        return repr->faces[idx].oripflag;
     }
     int Face::marked() const {
-        return mris->faces[idx].marked;
+        return repr->faces[idx].marked;
     }
     
     void Face::set_ripflag(char to) {
-        mris->faces[idx].ripflag = to;
+        repr->faces[idx].ripflag = to;
     }
     void Face::set_oripflag(char to) {
-        mris->faces[idx].oripflag = to;
+        repr->faces[idx].oripflag = to;
     }
     void Face::set_marked(int to) {
-        mris->faces[idx].marked = to;
+        repr->faces[idx].marked = to;
     }
 
 
-    Vertex::Vertex (                          ) {}                     
-    Vertex::Vertex ( MRIS* mris, size_t idx   ) : MRIS_Elt(mris,idx) {}
-    Vertex::Vertex ( Vertex const & src       ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( AllM::Vertex const & src ) : MRIS_Elt(src) {}     
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
 
     char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
-        return mris->vertices[idx].ripflag;
+        return repr->vertices[idx].ripflag;
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+         MRISvertexCoord2XYZ_float(&repr->vertices[idx], which, x, y, z);
     }
     
     void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
-        mris->vertices[idx].ripflag = to;
+        repr->vertices[idx].ripflag = to;
     }
 
 
-    Surface::Surface (                           ) {}                   
-    Surface::Surface ( MRIS* mris                ) : MRIS_Elt(mris,0) {}
-    Surface::Surface ( Surface const & src       ) : MRIS_Elt(src) {}   
-    Surface::Surface ( AllM::Surface const & src ) : MRIS_Elt(src) {}   
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
 
     int Surface::initialized() const {
-        return mris->initialized;
+        return repr->initialized;
     }
     PLTA Surface::lta() const {
-        return mris->lta;
+        return repr->lta;
     }
     PMATRIX Surface::SRASToTalSRAS_() const {
-        return mris->SRASToTalSRAS_;
+        return repr->SRASToTalSRAS_;
     }
     PMATRIX Surface::TalSRASToSRAS_() const {
-        return mris->TalSRASToSRAS_;
+        return repr->TalSRASToSRAS_;
     }
     int Surface::free_transform() const {
-        return mris->free_transform;
+        return repr->free_transform;
     }
     double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
-        return mris->radius;
+        return repr->radius;
     }
     float Surface::a() const {
-        return mris->a;
+        return repr->a;
     }
     float Surface::b() const {
-        return mris->b;
+        return repr->b;
     }
     float Surface::c() const {  //  ellipsoid parameters
-        return mris->c;
+        return repr->c;
     }
     MRIS_fname_t Surface::fname() const {  //  file it was originally loaded from
-        return mris->fname;
+        return repr->fname;
     }
     MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
-        return mris->status;
+        return repr->status;
     }
     MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-        return mris->origxyz_status;
+        return repr->origxyz_status;
     }
     int Surface::patch() const {  //  if a patch of the surface
-        return mris->patch;
+        return repr->patch;
     }
     int Surface::max_vertices() const {  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
-        return mris->max_vertices;
+        return repr->max_vertices;
     }
     int Surface::max_faces() const {  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
-        return mris->max_faces;
+        return repr->max_faces;
     }
     MRIS_subject_name_t Surface::subject_name() const {  //  name of the subject
-        return mris->subject_name;
+        return repr->subject_name;
     }
     float Surface::canon_area() const {
-        return mris->canon_area;
+        return repr->canon_area;
     }
     int Surface::noscale() const {  //  don't scale by surface area if true
-        return mris->noscale;
+        return repr->noscale;
     }
     float Surface::dx2(size_t i) const {  //  an extra set of gradient (not always alloced)
-        return mris->dx2[i];
+        return repr->dx2[i];
     }
     float Surface::dy2(size_t i) const {
-        return mris->dy2[i];
+        return repr->dy2[i];
     }
     float Surface::dz2(size_t i) const {
-        return mris->dz2[i];
+        return repr->dz2[i];
     }
     PCOLOR_TABLE Surface::ct() const {
-        return mris->ct;
+        return repr->ct;
     }
     int Surface::useRealRAS() const {  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        return mris->useRealRAS;
+        return repr->useRealRAS;
     }
     VOL_GEOM Surface::vg() const {  //  volume info from which this surface is created. valid iff vg.valid = 1
-        return mris->vg;
+        return repr->vg;
     }
     MRIS_cmdlines_t Surface::cmdlines() const {
-        return mris->cmdlines;
+        return repr->cmdlines;
     }
     int Surface::ncmds() const {
-        return mris->ncmds;
+        return repr->ncmds;
     }
     float Surface::group_avg_surface_area() const {  //  average of total surface area for group
-        return mris->group_avg_surface_area;
+        return repr->group_avg_surface_area;
     }
     int Surface::group_avg_vtxarea_loaded() const {  //  average vertex area for group at each vertex
-        return mris->group_avg_vtxarea_loaded;
+        return repr->group_avg_vtxarea_loaded;
     }
     int Surface::triangle_links_removed() const {  //  for quad surfaces
-        return mris->triangle_links_removed;
+        return repr->triangle_links_removed;
     }
     p_void Surface::user_parms() const {  //  for whatever the user wants to hang here
-        return mris->user_parms;
+        return repr->user_parms;
     }
     PMATRIX Surface::m_sras2vox() const {  //  for converting surface ras to voxel
-        return mris->m_sras2vox;
+        return repr->m_sras2vox;
     }
     PMRI Surface::mri_sras2vox() const {  //  volume that the above matrix is for
-        return mris->mri_sras2vox;
+        return repr->mri_sras2vox;
     }
     p_void Surface::mht() const {
-        return mris->mht;
+        return repr->mht;
     }
     p_void Surface::temps() const {
-        return mris->temps;
+        return repr->temps;
     }
     
     void Surface::set_fname(MRIS_fname_t to) {  //  file it was originally loaded from
-        mris->fname = to;
+        repr->fname = to;
     }
     void Surface::set_status(MRIS_Status to) {  //  type of surface (e.g. sphere, plane)
-        mris->status = to;
+        repr->status = to;
     }
     void Surface::set_origxyz_status(MRIS_Status to) {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-        mris->origxyz_status = to;
+        repr->origxyz_status = to;
     }
     void Surface::set_patch(int to) {  //  if a patch of the surface
-        mris->patch = to;
+        repr->patch = to;
     }
 
 
@@ -3879,272 +3900,275 @@ namespace SurfaceFromMRIS {
 
 
     namespace TopologyM {
-    Face::Face (                        ) {}                     
-    Face::Face ( MRIS* mris, size_t idx ) : MRIS_Elt(mris,idx) {}
-    Face::Face ( Face const & src       ) : MRIS_Elt(src) {}     
-    Face::Face ( AllM::Face const & src ) : MRIS_Elt(src) {}     
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
     Vertex Face::v(size_t i) const {
-        return Vertex(mris,mris->faces[idx].v[i]);
+        return Vertex(repr,repr->faces[idx].v[i]);
     }
     char Face::ripflag() const {
-        return mris->faces[idx].ripflag;
+        return repr->faces[idx].ripflag;
     }
     char Face::oripflag() const {
-        return mris->faces[idx].oripflag;
+        return repr->faces[idx].oripflag;
     }
     int Face::marked() const {
-        return mris->faces[idx].marked;
+        return repr->faces[idx].marked;
     }
     
     void Face::set_v(size_t i, Vertex to) {
-        cheapAssert(mris == to.mris); mris->faces[idx].v[i] = to.idx;
+        cheapAssert(repr == to.repr); repr->faces[idx].v[i] = to.idx;
     }
     void Face::set_ripflag(char to) {
-        mris->faces[idx].ripflag = to;
+        repr->faces[idx].ripflag = to;
     }
     void Face::set_oripflag(char to) {
-        mris->faces[idx].oripflag = to;
+        repr->faces[idx].oripflag = to;
     }
     void Face::set_marked(int to) {
-        mris->faces[idx].marked = to;
+        repr->faces[idx].marked = to;
     }
 
 
-    Vertex::Vertex (                          ) {}                     
-    Vertex::Vertex ( MRIS* mris, size_t idx   ) : MRIS_Elt(mris,idx) {}
-    Vertex::Vertex ( Vertex const & src       ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( AllM::Vertex const & src ) : MRIS_Elt(src) {}     
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
 
     Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        return Face(mris,mris->vertices_topology[idx].f[i]);
+        return Face(repr,repr->vertices_topology[idx].f[i]);
     }
     size_t Vertex::n(size_t i) const {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        return size_t(mris->vertices_topology[idx].n[i]);
+        return size_t(repr->vertices_topology[idx].n[i]);
     }
     int Vertex::e(size_t i) const {  //  edge state for neighboring vertices                      
-        return mris->vertices_topology[idx].e[i];
+        return repr->vertices_topology[idx].e[i];
     }
     Vertex Vertex::v(size_t i) const {  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        return Vertex(mris,mris->vertices_topology[idx].v[i]);
+        return Vertex(repr,repr->vertices_topology[idx].v[i]);
     }
     short Vertex::vnum() const {  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
-        return mris->vertices_topology[idx].vnum;
+        return repr->vertices_topology[idx].vnum;
     }
     short Vertex::v2num() const {  //  number of 1, or 2-hop neighbors                          
-        return mris->vertices_topology[idx].v2num;
+        return repr->vertices_topology[idx].v2num;
     }
     short Vertex::v3num() const {  //  number of 1,2,or 3-hop neighbors                         
-        return mris->vertices_topology[idx].v3num;
+        return repr->vertices_topology[idx].v3num;
     }
     short Vertex::vtotal() const {  //  total # of neighbors. copy of vnum.nsizeCur              
-        return mris->vertices_topology[idx].vtotal;
+        return repr->vertices_topology[idx].vtotal;
     }
     short Vertex::nsizeMaxClock() const {  //  copy of mris->nsizeMaxClock when v#num                   
-        return mris->vertices_topology[idx].nsizeMaxClock;
+        return repr->vertices_topology[idx].nsizeMaxClock;
     }
     uchar Vertex::nsizeMax() const {  //  the max nsize that was used to fill in vnum etc          
-        return mris->vertices_topology[idx].nsizeMax;
+        return repr->vertices_topology[idx].nsizeMax;
     }
     uchar Vertex::nsizeCur() const {  //  index of the current v#num in vtotal                     
-        return mris->vertices_topology[idx].nsizeCur;
+        return repr->vertices_topology[idx].nsizeCur;
     }
     uchar Vertex::num() const {  //  number of neighboring faces                              
-        return mris->vertices_topology[idx].num;
+        return repr->vertices_topology[idx].num;
     }
     char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
-        return mris->vertices[idx].ripflag;
+        return repr->vertices[idx].ripflag;
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+         MRISvertexCoord2XYZ_float(&repr->vertices[idx], which, x, y, z);
     }
     
     void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        cheapAssert(mris == to.mris); mris->vertices_topology[idx].f[i] = to.idx;
+        cheapAssert(repr == to.repr); repr->vertices_topology[idx].f[i] = to.idx;
     }
     void Vertex::set_n(size_t i, size_t to) {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        mris->vertices_topology[idx].n[i] = uchar(to);
+        repr->vertices_topology[idx].n[i] = uchar(to);
     }
     void Vertex::set_e(size_t i, int to) {  //  edge state for neighboring vertices                      
-        mris->vertices_topology[idx].e[i] = to;
+        repr->vertices_topology[idx].e[i] = to;
     }
     void Vertex::set_v(size_t i, Vertex to) {  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        cheapAssert(mris == to.mris); mris->vertices_topology[idx].v[i] = to.idx;
+        cheapAssert(repr == to.repr); repr->vertices_topology[idx].v[i] = to.idx;
     }
     void Vertex::set_vnum(short to) {  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
-        mris->vertices_topology[idx].vnum = to;
+        repr->vertices_topology[idx].vnum = to;
     }
     void Vertex::set_v2num(short to) {  //  number of 1, or 2-hop neighbors                          
-        mris->vertices_topology[idx].v2num = to;
+        repr->vertices_topology[idx].v2num = to;
     }
     void Vertex::set_v3num(short to) {  //  number of 1,2,or 3-hop neighbors                         
-        mris->vertices_topology[idx].v3num = to;
+        repr->vertices_topology[idx].v3num = to;
     }
     void Vertex::set_vtotal(short to) {  //  total # of neighbors. copy of vnum.nsizeCur              
-        mris->vertices_topology[idx].vtotal = to;
+        repr->vertices_topology[idx].vtotal = to;
     }
     void Vertex::set_nsizeMaxClock(short to) {  //  copy of mris->nsizeMaxClock when v#num                   
-        mris->vertices_topology[idx].nsizeMaxClock = to;
+        repr->vertices_topology[idx].nsizeMaxClock = to;
     }
     void Vertex::set_nsizeMax(uchar to) {  //  the max nsize that was used to fill in vnum etc          
-        mris->vertices_topology[idx].nsizeMax = to;
+        repr->vertices_topology[idx].nsizeMax = to;
     }
     void Vertex::set_nsizeCur(uchar to) {  //  index of the current v#num in vtotal                     
-        mris->vertices_topology[idx].nsizeCur = to;
+        repr->vertices_topology[idx].nsizeCur = to;
     }
     void Vertex::set_num(uchar to) {  //  number of neighboring faces                              
-        mris->vertices_topology[idx].num = to;
+        repr->vertices_topology[idx].num = to;
     }
     void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
-        mris->vertices[idx].ripflag = to;
+        repr->vertices[idx].ripflag = to;
     }
 
 
-    Surface::Surface (                           ) {}                   
-    Surface::Surface ( MRIS* mris                ) : MRIS_Elt(mris,0) {}
-    Surface::Surface ( Surface const & src       ) : MRIS_Elt(src) {}   
-    Surface::Surface ( AllM::Surface const & src ) : MRIS_Elt(src) {}   
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
 
     int Surface::nverticesFrozen() const {  //  # of vertices on surface is frozen
-        return mris->nverticesFrozen;
+        return repr->nverticesFrozen;
     }
     int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nvertices;
+        return repr->nvertices;
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nfaces;
+        return repr->nfaces;
     }
     bool Surface::faceAttachmentDeferred() const {  //  defer connecting faces to vertices for performance reasons
-        return mris->faceAttachmentDeferred;
+        return repr->faceAttachmentDeferred;
     }
     int Surface::nedges() const {  //  # of edges on surface
-        return mris->nedges;
+        return repr->nedges;
     }
     int Surface::nstrips() const {
-        return mris->nstrips;
+        return repr->nstrips;
     }
     Vertex Surface::vertices(size_t i) const {
-        return Vertex(mris,i);
+        return Vertex(repr,i);
     }
     p_p_void Surface::dist_storage() const {  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
-        return mris->dist_storage;
+        return repr->dist_storage;
     }
     p_p_void Surface::dist_orig_storage() const {  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
-        return mris->dist_orig_storage;
+        return repr->dist_orig_storage;
     }
     int Surface::tempsAssigned() const {  //  State of various temp fields that can be borrowed if not already in use
-        return mris->tempsAssigned;
+        return repr->tempsAssigned;
     }
     Face Surface::faces(size_t i) const {
-        return Face(mris,i);
+        return Face(repr,i);
     }
     MRI_EDGE Surface::edges(size_t i) const {
-        return mris->edges[i];
+        return repr->edges[i];
     }
     FaceNormCacheEntry Surface::faceNormCacheEntries(size_t i) const {
-        return mris->faceNormCacheEntries[i];
+        return repr->faceNormCacheEntries[i];
     }
     FaceNormDeferredEntry Surface::faceNormDeferredEntries(size_t i) const {
-        return mris->faceNormDeferredEntries[i];
+        return repr->faceNormDeferredEntries[i];
     }
     int Surface::initialized() const {
-        return mris->initialized;
+        return repr->initialized;
     }
     PLTA Surface::lta() const {
-        return mris->lta;
+        return repr->lta;
     }
     PMATRIX Surface::SRASToTalSRAS_() const {
-        return mris->SRASToTalSRAS_;
+        return repr->SRASToTalSRAS_;
     }
     PMATRIX Surface::TalSRASToSRAS_() const {
-        return mris->TalSRASToSRAS_;
+        return repr->TalSRASToSRAS_;
     }
     int Surface::free_transform() const {
-        return mris->free_transform;
+        return repr->free_transform;
     }
     double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
-        return mris->radius;
+        return repr->radius;
     }
     float Surface::a() const {
-        return mris->a;
+        return repr->a;
     }
     float Surface::b() const {
-        return mris->b;
+        return repr->b;
     }
     float Surface::c() const {  //  ellipsoid parameters
-        return mris->c;
+        return repr->c;
     }
     MRIS_fname_t Surface::fname() const {  //  file it was originally loaded from
-        return mris->fname;
+        return repr->fname;
     }
     MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
-        return mris->status;
+        return repr->status;
     }
     MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-        return mris->origxyz_status;
+        return repr->origxyz_status;
     }
     int Surface::patch() const {  //  if a patch of the surface
-        return mris->patch;
+        return repr->patch;
     }
     int Surface::max_vertices() const {  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
-        return mris->max_vertices;
+        return repr->max_vertices;
     }
     int Surface::max_faces() const {  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
-        return mris->max_faces;
+        return repr->max_faces;
     }
     MRIS_subject_name_t Surface::subject_name() const {  //  name of the subject
-        return mris->subject_name;
+        return repr->subject_name;
     }
     float Surface::canon_area() const {
-        return mris->canon_area;
+        return repr->canon_area;
     }
     int Surface::noscale() const {  //  don't scale by surface area if true
-        return mris->noscale;
+        return repr->noscale;
     }
     float Surface::dx2(size_t i) const {  //  an extra set of gradient (not always alloced)
-        return mris->dx2[i];
+        return repr->dx2[i];
     }
     float Surface::dy2(size_t i) const {
-        return mris->dy2[i];
+        return repr->dy2[i];
     }
     float Surface::dz2(size_t i) const {
-        return mris->dz2[i];
+        return repr->dz2[i];
     }
     PCOLOR_TABLE Surface::ct() const {
-        return mris->ct;
+        return repr->ct;
     }
     int Surface::useRealRAS() const {  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        return mris->useRealRAS;
+        return repr->useRealRAS;
     }
     VOL_GEOM Surface::vg() const {  //  volume info from which this surface is created. valid iff vg.valid = 1
-        return mris->vg;
+        return repr->vg;
     }
     MRIS_cmdlines_t Surface::cmdlines() const {
-        return mris->cmdlines;
+        return repr->cmdlines;
     }
     int Surface::ncmds() const {
-        return mris->ncmds;
+        return repr->ncmds;
     }
     float Surface::group_avg_surface_area() const {  //  average of total surface area for group
-        return mris->group_avg_surface_area;
+        return repr->group_avg_surface_area;
     }
     int Surface::group_avg_vtxarea_loaded() const {  //  average vertex area for group at each vertex
-        return mris->group_avg_vtxarea_loaded;
+        return repr->group_avg_vtxarea_loaded;
     }
     int Surface::triangle_links_removed() const {  //  for quad surfaces
-        return mris->triangle_links_removed;
+        return repr->triangle_links_removed;
     }
     p_void Surface::user_parms() const {  //  for whatever the user wants to hang here
-        return mris->user_parms;
+        return repr->user_parms;
     }
     PMATRIX Surface::m_sras2vox() const {  //  for converting surface ras to voxel
-        return mris->m_sras2vox;
+        return repr->m_sras2vox;
     }
     PMRI Surface::mri_sras2vox() const {  //  volume that the above matrix is for
-        return mris->mri_sras2vox;
+        return repr->mri_sras2vox;
     }
     p_void Surface::mht() const {
-        return mris->mht;
+        return repr->mht;
     }
     p_void Surface::temps() const {
-        return mris->temps;
+        return repr->temps;
     }
 
 
@@ -4152,348 +4176,351 @@ namespace SurfaceFromMRIS {
 
 
     namespace XYZPositionM {
-    Face::Face (                        ) {}                     
-    Face::Face ( MRIS* mris, size_t idx ) : MRIS_Elt(mris,idx) {}
-    Face::Face ( Face const & src       ) : MRIS_Elt(src) {}     
-    Face::Face ( AllM::Face const & src ) : MRIS_Elt(src) {}     
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
     Vertex Face::v(size_t i) const {
-        return Vertex(mris,mris->faces[idx].v[i]);
+        return Vertex(repr,repr->faces[idx].v[i]);
     }
     char Face::ripflag() const {
-        return mris->faces[idx].ripflag;
+        return repr->faces[idx].ripflag;
     }
     char Face::oripflag() const {
-        return mris->faces[idx].oripflag;
+        return repr->faces[idx].oripflag;
     }
     int Face::marked() const {
-        return mris->faces[idx].marked;
+        return repr->faces[idx].marked;
     }
     
     void Face::set_ripflag(char to) {
-        mris->faces[idx].ripflag = to;
+        repr->faces[idx].ripflag = to;
     }
     void Face::set_oripflag(char to) {
-        mris->faces[idx].oripflag = to;
+        repr->faces[idx].oripflag = to;
     }
     void Face::set_marked(int to) {
-        mris->faces[idx].marked = to;
+        repr->faces[idx].marked = to;
     }
 
 
-    Vertex::Vertex (                          ) {}                     
-    Vertex::Vertex ( MRIS* mris, size_t idx   ) : MRIS_Elt(mris,idx) {}
-    Vertex::Vertex ( Vertex const & src       ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( AllM::Vertex const & src ) : MRIS_Elt(src) {}     
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
 
     Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        return Face(mris,mris->vertices_topology[idx].f[i]);
+        return Face(repr,repr->vertices_topology[idx].f[i]);
     }
     size_t Vertex::n(size_t i) const {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        return size_t(mris->vertices_topology[idx].n[i]);
+        return size_t(repr->vertices_topology[idx].n[i]);
     }
     int Vertex::e(size_t i) const {  //  edge state for neighboring vertices                      
-        return mris->vertices_topology[idx].e[i];
+        return repr->vertices_topology[idx].e[i];
     }
     Vertex Vertex::v(size_t i) const {  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        return Vertex(mris,mris->vertices_topology[idx].v[i]);
+        return Vertex(repr,repr->vertices_topology[idx].v[i]);
     }
     short Vertex::vnum() const {  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
-        return mris->vertices_topology[idx].vnum;
+        return repr->vertices_topology[idx].vnum;
     }
     short Vertex::v2num() const {  //  number of 1, or 2-hop neighbors                          
-        return mris->vertices_topology[idx].v2num;
+        return repr->vertices_topology[idx].v2num;
     }
     short Vertex::v3num() const {  //  number of 1,2,or 3-hop neighbors                         
-        return mris->vertices_topology[idx].v3num;
+        return repr->vertices_topology[idx].v3num;
     }
     short Vertex::vtotal() const {  //  total # of neighbors. copy of vnum.nsizeCur              
-        return mris->vertices_topology[idx].vtotal;
+        return repr->vertices_topology[idx].vtotal;
     }
     short Vertex::nsizeMaxClock() const {  //  copy of mris->nsizeMaxClock when v#num                   
-        return mris->vertices_topology[idx].nsizeMaxClock;
+        return repr->vertices_topology[idx].nsizeMaxClock;
     }
     uchar Vertex::nsizeMax() const {  //  the max nsize that was used to fill in vnum etc          
-        return mris->vertices_topology[idx].nsizeMax;
+        return repr->vertices_topology[idx].nsizeMax;
     }
     uchar Vertex::nsizeCur() const {  //  index of the current v#num in vtotal                     
-        return mris->vertices_topology[idx].nsizeCur;
+        return repr->vertices_topology[idx].nsizeCur;
     }
     uchar Vertex::num() const {  //  number of neighboring faces                              
-        return mris->vertices_topology[idx].num;
+        return repr->vertices_topology[idx].num;
     }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
-        return mris->vertices[idx].dist[i];
+        return repr->vertices[idx].dist[i];
     }
     float Vertex::dist_orig(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on origxyz
-        return mris->vertices[idx].dist_orig[i];
+        return repr->vertices[idx].dist_orig[i];
     }
     int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_capacity;
+        return repr->vertices[idx].dist_capacity;
     }
     int Vertex::dist_orig_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_orig_capacity;
+        return repr->vertices[idx].dist_orig_capacity;
     }
     float Vertex::x() const {  //  current coordinates	
-        return mris->vertices[idx].x;
+        return repr->vertices[idx].x;
     }
     float Vertex::y() const {  //  use MRISsetXYZ() to set
-        return mris->vertices[idx].y;
+        return repr->vertices[idx].y;
     }
     float Vertex::z() const {
-        return mris->vertices[idx].z;
+        return repr->vertices[idx].z;
     }
     float Vertex::origx() const {  //  original coordinates, see also MRIS::origxyz_status
-        return mris->vertices[idx].origx;
+        return repr->vertices[idx].origx;
     }
     float Vertex::origy() const {  //  use MRISsetOriginalXYZ(, 
-        return mris->vertices[idx].origy;
+        return repr->vertices[idx].origy;
     }
     float Vertex::origz() const {  //  or MRISsetOriginalXYZfromXYZ to set
-        return mris->vertices[idx].origz;
+        return repr->vertices[idx].origz;
     }
     float Vertex::cx() const {
-        return mris->vertices[idx].cx;
+        return repr->vertices[idx].cx;
     }
     float Vertex::cy() const {
-        return mris->vertices[idx].cy;
+        return repr->vertices[idx].cy;
     }
     float Vertex::cz() const {  //  coordinates in canonical coordinate system
-        return mris->vertices[idx].cz;
+        return repr->vertices[idx].cz;
     }
     char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
-        return mris->vertices[idx].ripflag;
+        return repr->vertices[idx].ripflag;
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+         MRISvertexCoord2XYZ_float(&repr->vertices[idx], which, x, y, z);
     }
     
     void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        cheapAssert(mris == to.mris); mris->vertices_topology[idx].f[i] = to.idx;
+        cheapAssert(repr == to.repr); repr->vertices_topology[idx].f[i] = to.idx;
     }
     void Vertex::set_n(size_t i, size_t to) {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        mris->vertices_topology[idx].n[i] = uchar(to);
+        repr->vertices_topology[idx].n[i] = uchar(to);
     }
     void Vertex::set_e(size_t i, int to) {  //  edge state for neighboring vertices                      
-        mris->vertices_topology[idx].e[i] = to;
+        repr->vertices_topology[idx].e[i] = to;
     }
     void Vertex::set_x(float to) {  //  current coordinates	
-        mris->vertices[idx].x = to;
+        repr->vertices[idx].x = to;
     }
     void Vertex::set_y(float to) {  //  use MRISsetXYZ() to set
-        mris->vertices[idx].y = to;
+        repr->vertices[idx].y = to;
     }
     void Vertex::set_z(float to) {
-        mris->vertices[idx].z = to;
+        repr->vertices[idx].z = to;
     }
     void Vertex::set_cx(float to) {
-        mris->vertices[idx].cx = to;
+        repr->vertices[idx].cx = to;
     }
     void Vertex::set_cy(float to) {
-        mris->vertices[idx].cy = to;
+        repr->vertices[idx].cy = to;
     }
     void Vertex::set_cz(float to) {  //  coordinates in canonical coordinate system
-        mris->vertices[idx].cz = to;
+        repr->vertices[idx].cz = to;
     }
     void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
-        mris->vertices[idx].ripflag = to;
+        repr->vertices[idx].ripflag = to;
     }
 
 
-    Surface::Surface (                           ) {}                   
-    Surface::Surface ( MRIS* mris                ) : MRIS_Elt(mris,0) {}
-    Surface::Surface ( Surface const & src       ) : MRIS_Elt(src) {}   
-    Surface::Surface ( AllM::Surface const & src ) : MRIS_Elt(src) {}   
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
 
     int Surface::nverticesFrozen() const {  //  # of vertices on surface is frozen
-        return mris->nverticesFrozen;
+        return repr->nverticesFrozen;
     }
     int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nvertices;
+        return repr->nvertices;
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nfaces;
+        return repr->nfaces;
     }
     bool Surface::faceAttachmentDeferred() const {  //  defer connecting faces to vertices for performance reasons
-        return mris->faceAttachmentDeferred;
+        return repr->faceAttachmentDeferred;
     }
     int Surface::nedges() const {  //  # of edges on surface
-        return mris->nedges;
+        return repr->nedges;
     }
     int Surface::nstrips() const {
-        return mris->nstrips;
+        return repr->nstrips;
     }
     Vertex Surface::vertices(size_t i) const {
-        return Vertex(mris,i);
+        return Vertex(repr,i);
     }
     p_p_void Surface::dist_storage() const {  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
-        return mris->dist_storage;
+        return repr->dist_storage;
     }
     p_p_void Surface::dist_orig_storage() const {  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
-        return mris->dist_orig_storage;
+        return repr->dist_orig_storage;
     }
     int Surface::tempsAssigned() const {  //  State of various temp fields that can be borrowed if not already in use
-        return mris->tempsAssigned;
+        return repr->tempsAssigned;
     }
     Face Surface::faces(size_t i) const {
-        return Face(mris,i);
+        return Face(repr,i);
     }
     MRI_EDGE Surface::edges(size_t i) const {
-        return mris->edges[i];
+        return repr->edges[i];
     }
     FaceNormCacheEntry Surface::faceNormCacheEntries(size_t i) const {
-        return mris->faceNormCacheEntries[i];
+        return repr->faceNormCacheEntries[i];
     }
     FaceNormDeferredEntry Surface::faceNormDeferredEntries(size_t i) const {
-        return mris->faceNormDeferredEntries[i];
+        return repr->faceNormDeferredEntries[i];
     }
     int Surface::initialized() const {
-        return mris->initialized;
+        return repr->initialized;
     }
     PLTA Surface::lta() const {
-        return mris->lta;
+        return repr->lta;
     }
     PMATRIX Surface::SRASToTalSRAS_() const {
-        return mris->SRASToTalSRAS_;
+        return repr->SRASToTalSRAS_;
     }
     PMATRIX Surface::TalSRASToSRAS_() const {
-        return mris->TalSRASToSRAS_;
+        return repr->TalSRASToSRAS_;
     }
     int Surface::free_transform() const {
-        return mris->free_transform;
+        return repr->free_transform;
     }
     double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
-        return mris->radius;
+        return repr->radius;
     }
     float Surface::a() const {
-        return mris->a;
+        return repr->a;
     }
     float Surface::b() const {
-        return mris->b;
+        return repr->b;
     }
     float Surface::c() const {  //  ellipsoid parameters
-        return mris->c;
+        return repr->c;
     }
     MRIS_fname_t Surface::fname() const {  //  file it was originally loaded from
-        return mris->fname;
+        return repr->fname;
     }
     MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
-        return mris->status;
+        return repr->status;
     }
     MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-        return mris->origxyz_status;
+        return repr->origxyz_status;
     }
     int Surface::patch() const {  //  if a patch of the surface
-        return mris->patch;
+        return repr->patch;
     }
     p_void Surface::vp() const {  //  for misc. use
-        return mris->vp;
+        return repr->vp;
     }
     float Surface::alpha() const {  //  rotation around z-axis
-        return mris->alpha;
+        return repr->alpha;
     }
     float Surface::beta() const {  //  rotation around y-axis
-        return mris->beta;
+        return repr->beta;
     }
     float Surface::gamma() const {  //  rotation around x-axis
-        return mris->gamma;
+        return repr->gamma;
     }
     float Surface::da() const {
-        return mris->da;
+        return repr->da;
     }
     float Surface::db() const {
-        return mris->db;
+        return repr->db;
     }
     float Surface::dg() const {  //  old deltas
-        return mris->dg;
+        return repr->dg;
     }
     int Surface::type() const {  //  what type of surface was this initially
-        return mris->type;
+        return repr->type;
     }
     int Surface::max_vertices() const {  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
-        return mris->max_vertices;
+        return repr->max_vertices;
     }
     int Surface::max_faces() const {  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
-        return mris->max_faces;
+        return repr->max_faces;
     }
     MRIS_subject_name_t Surface::subject_name() const {  //  name of the subject
-        return mris->subject_name;
+        return repr->subject_name;
     }
     float Surface::canon_area() const {
-        return mris->canon_area;
+        return repr->canon_area;
     }
     int Surface::noscale() const {  //  don't scale by surface area if true
-        return mris->noscale;
+        return repr->noscale;
     }
     float Surface::dx2(size_t i) const {  //  an extra set of gradient (not always alloced)
-        return mris->dx2[i];
+        return repr->dx2[i];
     }
     float Surface::dy2(size_t i) const {
-        return mris->dy2[i];
+        return repr->dy2[i];
     }
     float Surface::dz2(size_t i) const {
-        return mris->dz2[i];
+        return repr->dz2[i];
     }
     PCOLOR_TABLE Surface::ct() const {
-        return mris->ct;
+        return repr->ct;
     }
     int Surface::useRealRAS() const {  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        return mris->useRealRAS;
+        return repr->useRealRAS;
     }
     VOL_GEOM Surface::vg() const {  //  volume info from which this surface is created. valid iff vg.valid = 1
-        return mris->vg;
+        return repr->vg;
     }
     MRIS_cmdlines_t Surface::cmdlines() const {
-        return mris->cmdlines;
+        return repr->cmdlines;
     }
     int Surface::ncmds() const {
-        return mris->ncmds;
+        return repr->ncmds;
     }
     float Surface::group_avg_surface_area() const {  //  average of total surface area for group
-        return mris->group_avg_surface_area;
+        return repr->group_avg_surface_area;
     }
     int Surface::group_avg_vtxarea_loaded() const {  //  average vertex area for group at each vertex
-        return mris->group_avg_vtxarea_loaded;
+        return repr->group_avg_vtxarea_loaded;
     }
     int Surface::triangle_links_removed() const {  //  for quad surfaces
-        return mris->triangle_links_removed;
+        return repr->triangle_links_removed;
     }
     p_void Surface::user_parms() const {  //  for whatever the user wants to hang here
-        return mris->user_parms;
+        return repr->user_parms;
     }
     PMATRIX Surface::m_sras2vox() const {  //  for converting surface ras to voxel
-        return mris->m_sras2vox;
+        return repr->m_sras2vox;
     }
     PMRI Surface::mri_sras2vox() const {  //  volume that the above matrix is for
-        return mris->mri_sras2vox;
+        return repr->mri_sras2vox;
     }
     p_void Surface::mht() const {
-        return mris->mht;
+        return repr->mht;
     }
     p_void Surface::temps() const {
-        return mris->temps;
+        return repr->temps;
     }
     
     void Surface::set_vp(p_void to) {  //  for misc. use
-        mris->vp = to;
+        repr->vp = to;
     }
     void Surface::set_alpha(float to) {  //  rotation around z-axis
-        mris->alpha = to;
+        repr->alpha = to;
     }
     void Surface::set_beta(float to) {  //  rotation around y-axis
-        mris->beta = to;
+        repr->beta = to;
     }
     void Surface::set_gamma(float to) {  //  rotation around x-axis
-        mris->gamma = to;
+        repr->gamma = to;
     }
     void Surface::set_da(float to) {
-        mris->da = to;
+        repr->da = to;
     }
     void Surface::set_db(float to) {
-        mris->db = to;
+        repr->db = to;
     }
     void Surface::set_dg(float to) {  //  old deltas
-        mris->dg = to;
+        repr->dg = to;
     }
     void Surface::set_type(int to) {  //  what type of surface was this initially
-        mris->type = to;
+        repr->type = to;
     }
 
 
@@ -4501,597 +4528,600 @@ namespace SurfaceFromMRIS {
 
 
     namespace XYZPositionConsequencesM {
-    Face::Face (                        ) {}                     
-    Face::Face ( MRIS* mris, size_t idx ) : MRIS_Elt(mris,idx) {}
-    Face::Face ( Face const & src       ) : MRIS_Elt(src) {}     
-    Face::Face ( AllM::Face const & src ) : MRIS_Elt(src) {}     
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
     Vertex Face::v(size_t i) const {
-        return Vertex(mris,mris->faces[idx].v[i]);
+        return Vertex(repr,repr->faces[idx].v[i]);
     }
     float Face::area() const {
-        return mris->faces[idx].area;
+        return repr->faces[idx].area;
     }
     angles_per_triangle_t Face::angle() const {
-        return mris->faces[idx].angle;
+        return repr->faces[idx].angle;
     }
     angles_per_triangle_t Face::orig_angle() const {
-        return mris->faces[idx].orig_angle;
+        return repr->faces[idx].orig_angle;
     }
     char Face::ripflag() const {
-        return mris->faces[idx].ripflag;
+        return repr->faces[idx].ripflag;
     }
     char Face::oripflag() const {
-        return mris->faces[idx].oripflag;
+        return repr->faces[idx].oripflag;
     }
     int Face::marked() const {
-        return mris->faces[idx].marked;
+        return repr->faces[idx].marked;
     }
     PDMATRIX Face::norm() const {
-        return mris->faces[idx].norm;
+        return repr->faces[idx].norm;
     }
     A3PDMATRIX Face::gradNorm() const {
-        return mris->faces[idx].gradNorm;
+        return repr->faces[idx].gradNorm;
     }
     
     void Face::set_area(float to) {
-        mris->faces[idx].area = to;
+        repr->faces[idx].area = to;
     }
     void Face::set_angle(angles_per_triangle_t to) {
-        mris->faces[idx].angle = to;
+        repr->faces[idx].angle = to;
     }
     void Face::set_orig_angle(angles_per_triangle_t to) {
-        mris->faces[idx].orig_angle = to;
+        repr->faces[idx].orig_angle = to;
     }
     void Face::set_ripflag(char to) {
-        mris->faces[idx].ripflag = to;
+        repr->faces[idx].ripflag = to;
     }
     void Face::set_oripflag(char to) {
-        mris->faces[idx].oripflag = to;
+        repr->faces[idx].oripflag = to;
     }
     void Face::set_marked(int to) {
-        mris->faces[idx].marked = to;
+        repr->faces[idx].marked = to;
     }
     void Face::set_norm(PDMATRIX to) {
-        mris->faces[idx].norm = to;
+        repr->faces[idx].norm = to;
     }
     void Face::set_gradNorm(A3PDMATRIX to) {
-        mris->faces[idx].gradNorm = to;
+        repr->faces[idx].gradNorm = to;
     }
 
 
-    Vertex::Vertex (                          ) {}                     
-    Vertex::Vertex ( MRIS* mris, size_t idx   ) : MRIS_Elt(mris,idx) {}
-    Vertex::Vertex ( Vertex const & src       ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( AllM::Vertex const & src ) : MRIS_Elt(src) {}     
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
 
     Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        return Face(mris,mris->vertices_topology[idx].f[i]);
+        return Face(repr,repr->vertices_topology[idx].f[i]);
     }
     size_t Vertex::n(size_t i) const {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        return size_t(mris->vertices_topology[idx].n[i]);
+        return size_t(repr->vertices_topology[idx].n[i]);
     }
     int Vertex::e(size_t i) const {  //  edge state for neighboring vertices                      
-        return mris->vertices_topology[idx].e[i];
+        return repr->vertices_topology[idx].e[i];
     }
     Vertex Vertex::v(size_t i) const {  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        return Vertex(mris,mris->vertices_topology[idx].v[i]);
+        return Vertex(repr,repr->vertices_topology[idx].v[i]);
     }
     short Vertex::vnum() const {  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
-        return mris->vertices_topology[idx].vnum;
+        return repr->vertices_topology[idx].vnum;
     }
     short Vertex::v2num() const {  //  number of 1, or 2-hop neighbors                          
-        return mris->vertices_topology[idx].v2num;
+        return repr->vertices_topology[idx].v2num;
     }
     short Vertex::v3num() const {  //  number of 1,2,or 3-hop neighbors                         
-        return mris->vertices_topology[idx].v3num;
+        return repr->vertices_topology[idx].v3num;
     }
     short Vertex::vtotal() const {  //  total # of neighbors. copy of vnum.nsizeCur              
-        return mris->vertices_topology[idx].vtotal;
+        return repr->vertices_topology[idx].vtotal;
     }
     short Vertex::nsizeMaxClock() const {  //  copy of mris->nsizeMaxClock when v#num                   
-        return mris->vertices_topology[idx].nsizeMaxClock;
+        return repr->vertices_topology[idx].nsizeMaxClock;
     }
     uchar Vertex::nsizeMax() const {  //  the max nsize that was used to fill in vnum etc          
-        return mris->vertices_topology[idx].nsizeMax;
+        return repr->vertices_topology[idx].nsizeMax;
     }
     uchar Vertex::nsizeCur() const {  //  index of the current v#num in vtotal                     
-        return mris->vertices_topology[idx].nsizeCur;
+        return repr->vertices_topology[idx].nsizeCur;
     }
     uchar Vertex::num() const {  //  number of neighboring faces                              
-        return mris->vertices_topology[idx].num;
+        return repr->vertices_topology[idx].num;
     }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
-        return mris->vertices[idx].dist[i];
+        return repr->vertices[idx].dist[i];
     }
     float Vertex::dist_orig(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on origxyz
-        return mris->vertices[idx].dist_orig[i];
+        return repr->vertices[idx].dist_orig[i];
     }
     int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_capacity;
+        return repr->vertices[idx].dist_capacity;
     }
     int Vertex::dist_orig_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_orig_capacity;
+        return repr->vertices[idx].dist_orig_capacity;
     }
     float Vertex::x() const {  //  current coordinates	
-        return mris->vertices[idx].x;
+        return repr->vertices[idx].x;
     }
     float Vertex::y() const {  //  use MRISsetXYZ() to set
-        return mris->vertices[idx].y;
+        return repr->vertices[idx].y;
     }
     float Vertex::z() const {
-        return mris->vertices[idx].z;
+        return repr->vertices[idx].z;
     }
     float Vertex::origx() const {  //  original coordinates, see also MRIS::origxyz_status
-        return mris->vertices[idx].origx;
+        return repr->vertices[idx].origx;
     }
     float Vertex::origy() const {  //  use MRISsetOriginalXYZ(, 
-        return mris->vertices[idx].origy;
+        return repr->vertices[idx].origy;
     }
     float Vertex::origz() const {  //  or MRISsetOriginalXYZfromXYZ to set
-        return mris->vertices[idx].origz;
+        return repr->vertices[idx].origz;
     }
     float Vertex::nx() const {
-        return mris->vertices[idx].nx;
+        return repr->vertices[idx].nx;
     }
     float Vertex::ny() const {
-        return mris->vertices[idx].ny;
+        return repr->vertices[idx].ny;
     }
     float Vertex::nz() const {  //  curr normal
-        return mris->vertices[idx].nz;
+        return repr->vertices[idx].nz;
     }
     float Vertex::cx() const {
-        return mris->vertices[idx].cx;
+        return repr->vertices[idx].cx;
     }
     float Vertex::cy() const {
-        return mris->vertices[idx].cy;
+        return repr->vertices[idx].cy;
     }
     float Vertex::cz() const {  //  coordinates in canonical coordinate system
-        return mris->vertices[idx].cz;
+        return repr->vertices[idx].cz;
     }
     float Vertex::area() const {
-        return mris->vertices[idx].area;
+        return repr->vertices[idx].area;
     }
     char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
-        return mris->vertices[idx].ripflag;
+        return repr->vertices[idx].ripflag;
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+         MRISvertexCoord2XYZ_float(&repr->vertices[idx], which, x, y, z);
     }
     
     void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        cheapAssert(mris == to.mris); mris->vertices_topology[idx].f[i] = to.idx;
+        cheapAssert(repr == to.repr); repr->vertices_topology[idx].f[i] = to.idx;
     }
     void Vertex::set_n(size_t i, size_t to) {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        mris->vertices_topology[idx].n[i] = uchar(to);
+        repr->vertices_topology[idx].n[i] = uchar(to);
     }
     void Vertex::set_e(size_t i, int to) {  //  edge state for neighboring vertices                      
-        mris->vertices_topology[idx].e[i] = to;
+        repr->vertices_topology[idx].e[i] = to;
     }
     void Vertex::set_nx(float to) {
-        mris->vertices[idx].nx = to;
+        repr->vertices[idx].nx = to;
     }
     void Vertex::set_ny(float to) {
-        mris->vertices[idx].ny = to;
+        repr->vertices[idx].ny = to;
     }
     void Vertex::set_nz(float to) {  //  curr normal
-        mris->vertices[idx].nz = to;
+        repr->vertices[idx].nz = to;
     }
     void Vertex::set_cx(float to) {
-        mris->vertices[idx].cx = to;
+        repr->vertices[idx].cx = to;
     }
     void Vertex::set_cy(float to) {
-        mris->vertices[idx].cy = to;
+        repr->vertices[idx].cy = to;
     }
     void Vertex::set_cz(float to) {  //  coordinates in canonical coordinate system
-        mris->vertices[idx].cz = to;
+        repr->vertices[idx].cz = to;
     }
     void Vertex::set_area(float to) {
-        mris->vertices[idx].area = to;
+        repr->vertices[idx].area = to;
     }
     void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
-        mris->vertices[idx].ripflag = to;
+        repr->vertices[idx].ripflag = to;
     }
 
 
-    Surface::Surface (                           ) {}                   
-    Surface::Surface ( MRIS* mris                ) : MRIS_Elt(mris,0) {}
-    Surface::Surface ( Surface const & src       ) : MRIS_Elt(src) {}   
-    Surface::Surface ( AllM::Surface const & src ) : MRIS_Elt(src) {}   
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
 
     int Surface::nverticesFrozen() const {  //  # of vertices on surface is frozen
-        return mris->nverticesFrozen;
+        return repr->nverticesFrozen;
     }
     int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nvertices;
+        return repr->nvertices;
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nfaces;
+        return repr->nfaces;
     }
     bool Surface::faceAttachmentDeferred() const {  //  defer connecting faces to vertices for performance reasons
-        return mris->faceAttachmentDeferred;
+        return repr->faceAttachmentDeferred;
     }
     int Surface::nedges() const {  //  # of edges on surface
-        return mris->nedges;
+        return repr->nedges;
     }
     int Surface::nstrips() const {
-        return mris->nstrips;
+        return repr->nstrips;
     }
     Vertex Surface::vertices(size_t i) const {
-        return Vertex(mris,i);
+        return Vertex(repr,i);
     }
     p_p_void Surface::dist_storage() const {  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
-        return mris->dist_storage;
+        return repr->dist_storage;
     }
     p_p_void Surface::dist_orig_storage() const {  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
-        return mris->dist_orig_storage;
+        return repr->dist_orig_storage;
     }
     int Surface::tempsAssigned() const {  //  State of various temp fields that can be borrowed if not already in use
-        return mris->tempsAssigned;
+        return repr->tempsAssigned;
     }
     Face Surface::faces(size_t i) const {
-        return Face(mris,i);
+        return Face(repr,i);
     }
     MRI_EDGE Surface::edges(size_t i) const {
-        return mris->edges[i];
+        return repr->edges[i];
     }
     FaceNormCacheEntry Surface::faceNormCacheEntries(size_t i) const {
-        return mris->faceNormCacheEntries[i];
+        return repr->faceNormCacheEntries[i];
     }
     FaceNormDeferredEntry Surface::faceNormDeferredEntries(size_t i) const {
-        return mris->faceNormDeferredEntries[i];
+        return repr->faceNormDeferredEntries[i];
     }
     STRIP Surface::strips(size_t i) const {
-        return mris->strips[i];
+        return repr->strips[i];
     }
     float Surface::xctr() const {
-        return mris->xctr;
+        return repr->xctr;
     }
     float Surface::yctr() const {
-        return mris->yctr;
+        return repr->yctr;
     }
     float Surface::zctr() const {
-        return mris->zctr;
+        return repr->zctr;
     }
     float Surface::xlo() const {
-        return mris->xlo;
+        return repr->xlo;
     }
     float Surface::ylo() const {
-        return mris->ylo;
+        return repr->ylo;
     }
     float Surface::zlo() const {
-        return mris->zlo;
+        return repr->zlo;
     }
     float Surface::xhi() const {
-        return mris->xhi;
+        return repr->xhi;
     }
     float Surface::yhi() const {
-        return mris->yhi;
+        return repr->yhi;
     }
     float Surface::zhi() const {
-        return mris->zhi;
+        return repr->zhi;
     }
     float Surface::x0() const {  //  center of spherical expansion
-        return mris->x0;
+        return repr->x0;
     }
     float Surface::y0() const {
-        return mris->y0;
+        return repr->y0;
     }
     float Surface::z0() const {
-        return mris->z0;
+        return repr->z0;
     }
     Vertex Surface::v_temporal_pole() const {
-        return Vertex(mris,mris->v_temporal_pole - mris->vertices);
+        return Vertex(repr,repr->v_temporal_pole - repr->vertices);
     }
     Vertex Surface::v_frontal_pole() const {
-        return Vertex(mris,mris->v_frontal_pole - mris->vertices);
+        return Vertex(repr,repr->v_frontal_pole - repr->vertices);
     }
     Vertex Surface::v_occipital_pole() const {
-        return Vertex(mris,mris->v_occipital_pole - mris->vertices);
+        return Vertex(repr,repr->v_occipital_pole - repr->vertices);
     }
     float Surface::max_curv() const {
-        return mris->max_curv;
+        return repr->max_curv;
     }
     float Surface::min_curv() const {
-        return mris->min_curv;
+        return repr->min_curv;
     }
     float Surface::total_area() const {
-        return mris->total_area;
+        return repr->total_area;
     }
     double Surface::avg_vertex_area() const {
-        return mris->avg_vertex_area;
+        return repr->avg_vertex_area;
     }
     double Surface::avg_vertex_dist() const {  //  set by MRIScomputeAvgInterVertexDist
-        return mris->avg_vertex_dist;
+        return repr->avg_vertex_dist;
     }
     double Surface::std_vertex_dist() const {
-        return mris->std_vertex_dist;
+        return repr->std_vertex_dist;
     }
     float Surface::orig_area() const {
-        return mris->orig_area;
+        return repr->orig_area;
     }
     float Surface::neg_area() const {
-        return mris->neg_area;
+        return repr->neg_area;
     }
     float Surface::neg_orig_area() const {  //  amount of original surface in folds
-        return mris->neg_orig_area;
+        return repr->neg_orig_area;
     }
     int Surface::zeros() const {
-        return mris->zeros;
+        return repr->zeros;
     }
     int Surface::hemisphere() const {  //  which hemisphere
-        return mris->hemisphere;
+        return repr->hemisphere;
     }
     int Surface::initialized() const {
-        return mris->initialized;
+        return repr->initialized;
     }
     PLTA Surface::lta() const {
-        return mris->lta;
+        return repr->lta;
     }
     PMATRIX Surface::SRASToTalSRAS_() const {
-        return mris->SRASToTalSRAS_;
+        return repr->SRASToTalSRAS_;
     }
     PMATRIX Surface::TalSRASToSRAS_() const {
-        return mris->TalSRASToSRAS_;
+        return repr->TalSRASToSRAS_;
     }
     int Surface::free_transform() const {
-        return mris->free_transform;
+        return repr->free_transform;
     }
     double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
-        return mris->radius;
+        return repr->radius;
     }
     float Surface::a() const {
-        return mris->a;
+        return repr->a;
     }
     float Surface::b() const {
-        return mris->b;
+        return repr->b;
     }
     float Surface::c() const {  //  ellipsoid parameters
-        return mris->c;
+        return repr->c;
     }
     MRIS_fname_t Surface::fname() const {  //  file it was originally loaded from
-        return mris->fname;
+        return repr->fname;
     }
     float Surface::Hmin() const {  //  min mean curvature
-        return mris->Hmin;
+        return repr->Hmin;
     }
     float Surface::Hmax() const {  //  max mean curvature
-        return mris->Hmax;
+        return repr->Hmax;
     }
     float Surface::Kmin() const {  //  min Gaussian curvature
-        return mris->Kmin;
+        return repr->Kmin;
     }
     float Surface::Kmax() const {  //  max Gaussian curvature
-        return mris->Kmax;
+        return repr->Kmax;
     }
     double Surface::Ktotal() const {  //  total Gaussian curvature
-        return mris->Ktotal;
+        return repr->Ktotal;
     }
     MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
-        return mris->status;
+        return repr->status;
     }
     MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-        return mris->origxyz_status;
+        return repr->origxyz_status;
     }
     int Surface::patch() const {  //  if a patch of the surface
-        return mris->patch;
+        return repr->patch;
     }
     int Surface::nlabels() const {
-        return mris->nlabels;
+        return repr->nlabels;
     }
     PMRIS_AREA_LABEL Surface::labels() const {  //  nlabels of these (may be null)
-        return mris->labels;
+        return repr->labels;
     }
     p_void Surface::vp() const {  //  for misc. use
-        return mris->vp;
+        return repr->vp;
     }
     float Surface::alpha() const {  //  rotation around z-axis
-        return mris->alpha;
+        return repr->alpha;
     }
     float Surface::beta() const {  //  rotation around y-axis
-        return mris->beta;
+        return repr->beta;
     }
     float Surface::gamma() const {  //  rotation around x-axis
-        return mris->gamma;
+        return repr->gamma;
     }
     float Surface::da() const {
-        return mris->da;
+        return repr->da;
     }
     float Surface::db() const {
-        return mris->db;
+        return repr->db;
     }
     float Surface::dg() const {  //  old deltas
-        return mris->dg;
+        return repr->dg;
     }
     int Surface::type() const {  //  what type of surface was this initially
-        return mris->type;
+        return repr->type;
     }
     int Surface::max_vertices() const {  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
-        return mris->max_vertices;
+        return repr->max_vertices;
     }
     int Surface::max_faces() const {  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
-        return mris->max_faces;
+        return repr->max_faces;
     }
     MRIS_subject_name_t Surface::subject_name() const {  //  name of the subject
-        return mris->subject_name;
+        return repr->subject_name;
     }
     float Surface::canon_area() const {
-        return mris->canon_area;
+        return repr->canon_area;
     }
     int Surface::noscale() const {  //  don't scale by surface area if true
-        return mris->noscale;
+        return repr->noscale;
     }
     float Surface::dx2(size_t i) const {  //  an extra set of gradient (not always alloced)
-        return mris->dx2[i];
+        return repr->dx2[i];
     }
     float Surface::dy2(size_t i) const {
-        return mris->dy2[i];
+        return repr->dy2[i];
     }
     float Surface::dz2(size_t i) const {
-        return mris->dz2[i];
+        return repr->dz2[i];
     }
     PCOLOR_TABLE Surface::ct() const {
-        return mris->ct;
+        return repr->ct;
     }
     int Surface::useRealRAS() const {  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        return mris->useRealRAS;
+        return repr->useRealRAS;
     }
     VOL_GEOM Surface::vg() const {  //  volume info from which this surface is created. valid iff vg.valid = 1
-        return mris->vg;
+        return repr->vg;
     }
     MRIS_cmdlines_t Surface::cmdlines() const {
-        return mris->cmdlines;
+        return repr->cmdlines;
     }
     int Surface::ncmds() const {
-        return mris->ncmds;
+        return repr->ncmds;
     }
     float Surface::group_avg_surface_area() const {  //  average of total surface area for group
-        return mris->group_avg_surface_area;
+        return repr->group_avg_surface_area;
     }
     int Surface::group_avg_vtxarea_loaded() const {  //  average vertex area for group at each vertex
-        return mris->group_avg_vtxarea_loaded;
+        return repr->group_avg_vtxarea_loaded;
     }
     int Surface::triangle_links_removed() const {  //  for quad surfaces
-        return mris->triangle_links_removed;
+        return repr->triangle_links_removed;
     }
     p_void Surface::user_parms() const {  //  for whatever the user wants to hang here
-        return mris->user_parms;
+        return repr->user_parms;
     }
     PMATRIX Surface::m_sras2vox() const {  //  for converting surface ras to voxel
-        return mris->m_sras2vox;
+        return repr->m_sras2vox;
     }
     PMRI Surface::mri_sras2vox() const {  //  volume that the above matrix is for
-        return mris->mri_sras2vox;
+        return repr->mri_sras2vox;
     }
     p_void Surface::mht() const {
-        return mris->mht;
+        return repr->mht;
     }
     p_void Surface::temps() const {
-        return mris->temps;
+        return repr->temps;
     }
     
     void Surface::set_strips(size_t i, STRIP to) {
-        mris->strips[i] = to;
+        repr->strips[i] = to;
     }
     void Surface::set_xctr(float to) {
-        mris->xctr = to;
+        repr->xctr = to;
     }
     void Surface::set_yctr(float to) {
-        mris->yctr = to;
+        repr->yctr = to;
     }
     void Surface::set_zctr(float to) {
-        mris->zctr = to;
+        repr->zctr = to;
     }
     void Surface::set_xlo(float to) {
-        mris->xlo = to;
+        repr->xlo = to;
     }
     void Surface::set_ylo(float to) {
-        mris->ylo = to;
+        repr->ylo = to;
     }
     void Surface::set_zlo(float to) {
-        mris->zlo = to;
+        repr->zlo = to;
     }
     void Surface::set_xhi(float to) {
-        mris->xhi = to;
+        repr->xhi = to;
     }
     void Surface::set_yhi(float to) {
-        mris->yhi = to;
+        repr->yhi = to;
     }
     void Surface::set_zhi(float to) {
-        mris->zhi = to;
+        repr->zhi = to;
     }
     void Surface::set_x0(float to) {  //  center of spherical expansion
-        mris->x0 = to;
+        repr->x0 = to;
     }
     void Surface::set_y0(float to) {
-        mris->y0 = to;
+        repr->y0 = to;
     }
     void Surface::set_z0(float to) {
-        mris->z0 = to;
+        repr->z0 = to;
     }
     void Surface::set_v_temporal_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_temporal_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_temporal_pole = repr->vertices + to.idx;
     }
     void Surface::set_v_frontal_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_frontal_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_frontal_pole = repr->vertices + to.idx;
     }
     void Surface::set_v_occipital_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_occipital_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_occipital_pole = repr->vertices + to.idx;
     }
     void Surface::set_max_curv(float to) {
-        mris->max_curv = to;
+        repr->max_curv = to;
     }
     void Surface::set_min_curv(float to) {
-        mris->min_curv = to;
+        repr->min_curv = to;
     }
     void Surface::set_total_area(float to) {
-        mris->total_area = to;
+        repr->total_area = to;
     }
     void Surface::set_avg_vertex_area(double to) {
-        mris->avg_vertex_area = to;
+        repr->avg_vertex_area = to;
     }
     void Surface::set_avg_vertex_dist(double to) {  //  set by MRIScomputeAvgInterVertexDist
-        mris->avg_vertex_dist = to;
+        repr->avg_vertex_dist = to;
     }
     void Surface::set_std_vertex_dist(double to) {
-        mris->std_vertex_dist = to;
+        repr->std_vertex_dist = to;
     }
     void Surface::set_orig_area(float to) {
-        mris->orig_area = to;
+        repr->orig_area = to;
     }
     void Surface::set_neg_area(float to) {
-        mris->neg_area = to;
+        repr->neg_area = to;
     }
     void Surface::set_neg_orig_area(float to) {  //  amount of original surface in folds
-        mris->neg_orig_area = to;
+        repr->neg_orig_area = to;
     }
     void Surface::set_zeros(int to) {
-        mris->zeros = to;
+        repr->zeros = to;
     }
     void Surface::set_hemisphere(int to) {  //  which hemisphere
-        mris->hemisphere = to;
+        repr->hemisphere = to;
     }
     void Surface::set_Hmin(float to) {  //  min mean curvature
-        mris->Hmin = to;
+        repr->Hmin = to;
     }
     void Surface::set_Hmax(float to) {  //  max mean curvature
-        mris->Hmax = to;
+        repr->Hmax = to;
     }
     void Surface::set_Kmin(float to) {  //  min Gaussian curvature
-        mris->Kmin = to;
+        repr->Kmin = to;
     }
     void Surface::set_Kmax(float to) {  //  max Gaussian curvature
-        mris->Kmax = to;
+        repr->Kmax = to;
     }
     void Surface::set_Ktotal(double to) {  //  total Gaussian curvature
-        mris->Ktotal = to;
+        repr->Ktotal = to;
     }
     void Surface::set_nlabels(int to) {
-        mris->nlabels = to;
+        repr->nlabels = to;
     }
     void Surface::set_labels(PMRIS_AREA_LABEL to) {  //  nlabels of these (may be null)
-        mris->labels = to;
+        repr->labels = to;
     }
     void Surface::set_vp(p_void to) {  //  for misc. use
-        mris->vp = to;
+        repr->vp = to;
     }
     void Surface::set_alpha(float to) {  //  rotation around z-axis
-        mris->alpha = to;
+        repr->alpha = to;
     }
     void Surface::set_beta(float to) {  //  rotation around y-axis
-        mris->beta = to;
+        repr->beta = to;
     }
     void Surface::set_gamma(float to) {  //  rotation around x-axis
-        mris->gamma = to;
+        repr->gamma = to;
     }
     void Surface::set_da(float to) {
-        mris->da = to;
+        repr->da = to;
     }
     void Surface::set_db(float to) {
-        mris->db = to;
+        repr->db = to;
     }
     void Surface::set_dg(float to) {  //  old deltas
-        mris->dg = to;
+        repr->dg = to;
     }
     void Surface::set_type(int to) {  //  what type of surface was this initially
-        mris->type = to;
+        repr->type = to;
     }
 
 
@@ -5099,1155 +5129,1158 @@ namespace SurfaceFromMRIS {
 
 
     namespace DistortM {
-    Face::Face (                        ) {}                     
-    Face::Face ( MRIS* mris, size_t idx ) : MRIS_Elt(mris,idx) {}
-    Face::Face ( Face const & src       ) : MRIS_Elt(src) {}     
-    Face::Face ( AllM::Face const & src ) : MRIS_Elt(src) {}     
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
     Vertex Face::v(size_t i) const {
-        return Vertex(mris,mris->faces[idx].v[i]);
+        return Vertex(repr,repr->faces[idx].v[i]);
     }
     float Face::area() const {
-        return mris->faces[idx].area;
+        return repr->faces[idx].area;
     }
     angles_per_triangle_t Face::angle() const {
-        return mris->faces[idx].angle;
+        return repr->faces[idx].angle;
     }
     angles_per_triangle_t Face::orig_angle() const {
-        return mris->faces[idx].orig_angle;
+        return repr->faces[idx].orig_angle;
     }
     char Face::ripflag() const {
-        return mris->faces[idx].ripflag;
+        return repr->faces[idx].ripflag;
     }
     char Face::oripflag() const {
-        return mris->faces[idx].oripflag;
+        return repr->faces[idx].oripflag;
     }
     int Face::marked() const {
-        return mris->faces[idx].marked;
+        return repr->faces[idx].marked;
     }
     PDMATRIX Face::norm() const {
-        return mris->faces[idx].norm;
+        return repr->faces[idx].norm;
     }
     A3PDMATRIX Face::gradNorm() const {
-        return mris->faces[idx].gradNorm;
+        return repr->faces[idx].gradNorm;
     }
     
     void Face::set_orig_angle(angles_per_triangle_t to) {
-        mris->faces[idx].orig_angle = to;
+        repr->faces[idx].orig_angle = to;
     }
     void Face::set_ripflag(char to) {
-        mris->faces[idx].ripflag = to;
+        repr->faces[idx].ripflag = to;
     }
     void Face::set_oripflag(char to) {
-        mris->faces[idx].oripflag = to;
+        repr->faces[idx].oripflag = to;
     }
     void Face::set_marked(int to) {
-        mris->faces[idx].marked = to;
+        repr->faces[idx].marked = to;
     }
 
 
-    Vertex::Vertex (                          ) {}                     
-    Vertex::Vertex ( MRIS* mris, size_t idx   ) : MRIS_Elt(mris,idx) {}
-    Vertex::Vertex ( Vertex const & src       ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( AllM::Vertex const & src ) : MRIS_Elt(src) {}     
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
 
     Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        return Face(mris,mris->vertices_topology[idx].f[i]);
+        return Face(repr,repr->vertices_topology[idx].f[i]);
     }
     size_t Vertex::n(size_t i) const {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        return size_t(mris->vertices_topology[idx].n[i]);
+        return size_t(repr->vertices_topology[idx].n[i]);
     }
     int Vertex::e(size_t i) const {  //  edge state for neighboring vertices                      
-        return mris->vertices_topology[idx].e[i];
+        return repr->vertices_topology[idx].e[i];
     }
     Vertex Vertex::v(size_t i) const {  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        return Vertex(mris,mris->vertices_topology[idx].v[i]);
+        return Vertex(repr,repr->vertices_topology[idx].v[i]);
     }
     short Vertex::vnum() const {  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
-        return mris->vertices_topology[idx].vnum;
+        return repr->vertices_topology[idx].vnum;
     }
     short Vertex::v2num() const {  //  number of 1, or 2-hop neighbors                          
-        return mris->vertices_topology[idx].v2num;
+        return repr->vertices_topology[idx].v2num;
     }
     short Vertex::v3num() const {  //  number of 1,2,or 3-hop neighbors                         
-        return mris->vertices_topology[idx].v3num;
+        return repr->vertices_topology[idx].v3num;
     }
     short Vertex::vtotal() const {  //  total # of neighbors. copy of vnum.nsizeCur              
-        return mris->vertices_topology[idx].vtotal;
+        return repr->vertices_topology[idx].vtotal;
     }
     short Vertex::nsizeMaxClock() const {  //  copy of mris->nsizeMaxClock when v#num                   
-        return mris->vertices_topology[idx].nsizeMaxClock;
+        return repr->vertices_topology[idx].nsizeMaxClock;
     }
     uchar Vertex::nsizeMax() const {  //  the max nsize that was used to fill in vnum etc          
-        return mris->vertices_topology[idx].nsizeMax;
+        return repr->vertices_topology[idx].nsizeMax;
     }
     uchar Vertex::nsizeCur() const {  //  index of the current v#num in vtotal                     
-        return mris->vertices_topology[idx].nsizeCur;
+        return repr->vertices_topology[idx].nsizeCur;
     }
     uchar Vertex::num() const {  //  number of neighboring faces                              
-        return mris->vertices_topology[idx].num;
+        return repr->vertices_topology[idx].num;
     }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
-        return mris->vertices[idx].dist[i];
+        return repr->vertices[idx].dist[i];
     }
     float Vertex::dist_orig(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on origxyz
-        return mris->vertices[idx].dist_orig[i];
+        return repr->vertices[idx].dist_orig[i];
     }
     int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_capacity;
+        return repr->vertices[idx].dist_capacity;
     }
     int Vertex::dist_orig_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_orig_capacity;
+        return repr->vertices[idx].dist_orig_capacity;
     }
     float Vertex::x() const {  //  current coordinates	
-        return mris->vertices[idx].x;
+        return repr->vertices[idx].x;
     }
     float Vertex::y() const {  //  use MRISsetXYZ() to set
-        return mris->vertices[idx].y;
+        return repr->vertices[idx].y;
     }
     float Vertex::z() const {
-        return mris->vertices[idx].z;
+        return repr->vertices[idx].z;
     }
     float Vertex::origx() const {  //  original coordinates, see also MRIS::origxyz_status
-        return mris->vertices[idx].origx;
+        return repr->vertices[idx].origx;
     }
     float Vertex::origy() const {  //  use MRISsetOriginalXYZ(, 
-        return mris->vertices[idx].origy;
+        return repr->vertices[idx].origy;
     }
     float Vertex::origz() const {  //  or MRISsetOriginalXYZfromXYZ to set
-        return mris->vertices[idx].origz;
+        return repr->vertices[idx].origz;
     }
     float Vertex::nx() const {
-        return mris->vertices[idx].nx;
+        return repr->vertices[idx].nx;
     }
     float Vertex::ny() const {
-        return mris->vertices[idx].ny;
+        return repr->vertices[idx].ny;
     }
     float Vertex::nz() const {  //  curr normal
-        return mris->vertices[idx].nz;
+        return repr->vertices[idx].nz;
     }
     float Vertex::pnx() const {
-        return mris->vertices[idx].pnx;
+        return repr->vertices[idx].pnx;
     }
     float Vertex::pny() const {
-        return mris->vertices[idx].pny;
+        return repr->vertices[idx].pny;
     }
     float Vertex::pnz() const {  //  pial normal
-        return mris->vertices[idx].pnz;
+        return repr->vertices[idx].pnz;
     }
     float Vertex::wnx() const {
-        return mris->vertices[idx].wnx;
+        return repr->vertices[idx].wnx;
     }
     float Vertex::wny() const {
-        return mris->vertices[idx].wny;
+        return repr->vertices[idx].wny;
     }
     float Vertex::wnz() const {  //  white normal
-        return mris->vertices[idx].wnz;
+        return repr->vertices[idx].wnz;
     }
     float Vertex::onx() const {
-        return mris->vertices[idx].onx;
+        return repr->vertices[idx].onx;
     }
     float Vertex::ony() const {
-        return mris->vertices[idx].ony;
+        return repr->vertices[idx].ony;
     }
     float Vertex::onz() const {  //  original normal
-        return mris->vertices[idx].onz;
+        return repr->vertices[idx].onz;
     }
     float Vertex::dx() const {
-        return mris->vertices[idx].dx;
+        return repr->vertices[idx].dx;
     }
     float Vertex::dy() const {
-        return mris->vertices[idx].dy;
+        return repr->vertices[idx].dy;
     }
     float Vertex::dz() const {  //  current change in position
-        return mris->vertices[idx].dz;
+        return repr->vertices[idx].dz;
     }
     float Vertex::odx() const {
-        return mris->vertices[idx].odx;
+        return repr->vertices[idx].odx;
     }
     float Vertex::ody() const {
-        return mris->vertices[idx].ody;
+        return repr->vertices[idx].ody;
     }
     float Vertex::odz() const {  //  last change of position (for momentum, 
-        return mris->vertices[idx].odz;
+        return repr->vertices[idx].odz;
     }
     float Vertex::tdx() const {
-        return mris->vertices[idx].tdx;
+        return repr->vertices[idx].tdx;
     }
     float Vertex::tdy() const {
-        return mris->vertices[idx].tdy;
+        return repr->vertices[idx].tdy;
     }
     float Vertex::tdz() const {  //  temporary storage for averaging gradient
-        return mris->vertices[idx].tdz;
+        return repr->vertices[idx].tdz;
     }
     float Vertex::curv() const {  //  curr curvature
-        return mris->vertices[idx].curv;
+        return repr->vertices[idx].curv;
     }
     float Vertex::curvbak() const {
-        return mris->vertices[idx].curvbak;
+        return repr->vertices[idx].curvbak;
     }
     float Vertex::val() const {  //  scalar data value (file: rh.val, sig2-rh.w)
-        return mris->vertices[idx].val;
+        return repr->vertices[idx].val;
     }
     float Vertex::imag_val() const {  //  imaginary part of complex data value
-        return mris->vertices[idx].imag_val;
+        return repr->vertices[idx].imag_val;
     }
     float Vertex::cx() const {
-        return mris->vertices[idx].cx;
+        return repr->vertices[idx].cx;
     }
     float Vertex::cy() const {
-        return mris->vertices[idx].cy;
+        return repr->vertices[idx].cy;
     }
     float Vertex::cz() const {  //  coordinates in canonical coordinate system
-        return mris->vertices[idx].cz;
+        return repr->vertices[idx].cz;
     }
     float Vertex::tx() const {
-        return mris->vertices[idx].tx;
+        return repr->vertices[idx].tx;
     }
     float Vertex::ty() const {
-        return mris->vertices[idx].ty;
+        return repr->vertices[idx].ty;
     }
     float Vertex::tz() const {  //  tmp coordinate storage
-        return mris->vertices[idx].tz;
+        return repr->vertices[idx].tz;
     }
-    float Vertex::tx2() const {
-        return mris->vertices[idx].tx2;
+    float Vertex::t2x() const {
+        return repr->vertices[idx].t2x;
     }
-    float Vertex::ty2() const {
-        return mris->vertices[idx].ty2;
+    float Vertex::t2y() const {
+        return repr->vertices[idx].t2y;
     }
-    float Vertex::tz2() const {  //  tmp coordinate storage
-        return mris->vertices[idx].tz2;
+    float Vertex::t2z() const {  //  another tmp coordinate storage
+        return repr->vertices[idx].t2z;
     }
     float Vertex::targx() const {
-        return mris->vertices[idx].targx;
+        return repr->vertices[idx].targx;
     }
     float Vertex::targy() const {
-        return mris->vertices[idx].targy;
+        return repr->vertices[idx].targy;
     }
     float Vertex::targz() const {  //  target coordinates
-        return mris->vertices[idx].targz;
+        return repr->vertices[idx].targz;
     }
     float Vertex::pialx() const {
-        return mris->vertices[idx].pialx;
+        return repr->vertices[idx].pialx;
     }
     float Vertex::pialy() const {
-        return mris->vertices[idx].pialy;
+        return repr->vertices[idx].pialy;
     }
     float Vertex::pialz() const {  //  pial surface coordinates
-        return mris->vertices[idx].pialz;
+        return repr->vertices[idx].pialz;
     }
     float Vertex::whitex() const {
-        return mris->vertices[idx].whitex;
+        return repr->vertices[idx].whitex;
     }
     float Vertex::whitey() const {
-        return mris->vertices[idx].whitey;
+        return repr->vertices[idx].whitey;
     }
     float Vertex::whitez() const {  //  white surface coordinates
-        return mris->vertices[idx].whitez;
+        return repr->vertices[idx].whitez;
     }
     float Vertex::l4x() const {
-        return mris->vertices[idx].l4x;
+        return repr->vertices[idx].l4x;
     }
     float Vertex::l4y() const {
-        return mris->vertices[idx].l4y;
+        return repr->vertices[idx].l4y;
     }
     float Vertex::l4z() const {  //  layerIV surface coordinates
-        return mris->vertices[idx].l4z;
+        return repr->vertices[idx].l4z;
     }
     float Vertex::infx() const {
-        return mris->vertices[idx].infx;
+        return repr->vertices[idx].infx;
     }
     float Vertex::infy() const {
-        return mris->vertices[idx].infy;
+        return repr->vertices[idx].infy;
     }
     float Vertex::infz() const {  //  inflated coordinates
-        return mris->vertices[idx].infz;
+        return repr->vertices[idx].infz;
     }
     float Vertex::fx() const {
-        return mris->vertices[idx].fx;
+        return repr->vertices[idx].fx;
     }
     float Vertex::fy() const {
-        return mris->vertices[idx].fy;
+        return repr->vertices[idx].fy;
     }
     float Vertex::fz() const {  //  flattened coordinates
-        return mris->vertices[idx].fz;
+        return repr->vertices[idx].fz;
     }
     int Vertex::px() const {
-        return mris->vertices[idx].px;
+        return repr->vertices[idx].px;
     }
     int Vertex::qx() const {
-        return mris->vertices[idx].qx;
+        return repr->vertices[idx].qx;
     }
     int Vertex::py() const {
-        return mris->vertices[idx].py;
+        return repr->vertices[idx].py;
     }
     int Vertex::qy() const {
-        return mris->vertices[idx].qy;
+        return repr->vertices[idx].qy;
     }
     int Vertex::pz() const {
-        return mris->vertices[idx].pz;
+        return repr->vertices[idx].pz;
     }
     int Vertex::qz() const {  //  rational coordinates for exact calculations
-        return mris->vertices[idx].qz;
+        return repr->vertices[idx].qz;
     }
     float Vertex::e1x() const {
-        return mris->vertices[idx].e1x;
+        return repr->vertices[idx].e1x;
     }
     float Vertex::e1y() const {
-        return mris->vertices[idx].e1y;
+        return repr->vertices[idx].e1y;
     }
     float Vertex::e1z() const {  //  1st basis vector for the local tangent plane
-        return mris->vertices[idx].e1z;
+        return repr->vertices[idx].e1z;
     }
     float Vertex::e2x() const {
-        return mris->vertices[idx].e2x;
+        return repr->vertices[idx].e2x;
     }
     float Vertex::e2y() const {
-        return mris->vertices[idx].e2y;
+        return repr->vertices[idx].e2y;
     }
     float Vertex::e2z() const {  //  2nd basis vector for the local tangent plane
-        return mris->vertices[idx].e2z;
+        return repr->vertices[idx].e2z;
     }
     float Vertex::pe1x() const {
-        return mris->vertices[idx].pe1x;
+        return repr->vertices[idx].pe1x;
     }
     float Vertex::pe1y() const {
-        return mris->vertices[idx].pe1y;
+        return repr->vertices[idx].pe1y;
     }
     float Vertex::pe1z() const {  //  1st basis vector for the local tangent plane
-        return mris->vertices[idx].pe1z;
+        return repr->vertices[idx].pe1z;
     }
     float Vertex::pe2x() const {
-        return mris->vertices[idx].pe2x;
+        return repr->vertices[idx].pe2x;
     }
     float Vertex::pe2y() const {
-        return mris->vertices[idx].pe2y;
+        return repr->vertices[idx].pe2y;
     }
     float Vertex::pe2z() const {  //  2nd basis vector for the local tangent plane
-        return mris->vertices[idx].pe2z;
+        return repr->vertices[idx].pe2z;
     }
     float Vertex::nc() const {  //  curr length normal comp 
-        return mris->vertices[idx].nc;
+        return repr->vertices[idx].nc;
     }
     float Vertex::val2() const {  //  complex comp data value (file: sig3-rh.w) 
-        return mris->vertices[idx].val2;
+        return repr->vertices[idx].val2;
     }
     float Vertex::valbak() const {  //  scalar data stack 
-        return mris->vertices[idx].valbak;
+        return repr->vertices[idx].valbak;
     }
     float Vertex::val2bak() const {  //  complex comp data stack 
-        return mris->vertices[idx].val2bak;
+        return repr->vertices[idx].val2bak;
     }
     float Vertex::stat() const {  //  statistic 
-        return mris->vertices[idx].stat;
+        return repr->vertices[idx].stat;
     }
     int Vertex::undefval() const {  //  [previously dist=0] 
-        return mris->vertices[idx].undefval;
+        return repr->vertices[idx].undefval;
     }
     int Vertex::old_undefval() const {  //  for smooth_val_sparse 
-        return mris->vertices[idx].old_undefval;
+        return repr->vertices[idx].old_undefval;
     }
     int Vertex::fixedval() const {  //  [previously val=0] 
-        return mris->vertices[idx].fixedval;
+        return repr->vertices[idx].fixedval;
     }
     float Vertex::fieldsign() const {  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
-        return mris->vertices[idx].fieldsign;
+        return repr->vertices[idx].fieldsign;
     }
     float Vertex::fsmask() const {  //  significance mask (file: rh.fm) 
-        return mris->vertices[idx].fsmask;
+        return repr->vertices[idx].fsmask;
     }
     float Vertex::d() const {  //  for distance calculations 
-        return mris->vertices[idx].d;
+        return repr->vertices[idx].d;
     }
     int Vertex::annotation() const {  //  area label (defunct--now from label file name!) 
-        return mris->vertices[idx].annotation;
+        return repr->vertices[idx].annotation;
     }
     char Vertex::oripflag() const {
-        return mris->vertices[idx].oripflag;
+        return repr->vertices[idx].oripflag;
     }
     char Vertex::origripflag() const {  //  cuts flags 
-        return mris->vertices[idx].origripflag;
+        return repr->vertices[idx].origripflag;
     }
     p_void Vertex::vp() const {  //  to store user's information 
-        return mris->vertices[idx].vp;
+        return repr->vertices[idx].vp;
     }
     float Vertex::theta() const {
-        return mris->vertices[idx].theta;
+        return repr->vertices[idx].theta;
     }
     float Vertex::phi() const {  //  parameterization 
-        return mris->vertices[idx].phi;
+        return repr->vertices[idx].phi;
     }
     float Vertex::area() const {
-        return mris->vertices[idx].area;
+        return repr->vertices[idx].area;
     }
     float Vertex::origarea() const {
-        return mris->vertices[idx].origarea;
+        return repr->vertices[idx].origarea;
     }
     float Vertex::group_avg_area() const {
-        return mris->vertices[idx].group_avg_area;
+        return repr->vertices[idx].group_avg_area;
     }
     float Vertex::K() const {  //  Gaussian curvature 
-        return mris->vertices[idx].K;
+        return repr->vertices[idx].K;
     }
     float Vertex::H() const {  //  mean curvature 
-        return mris->vertices[idx].H;
+        return repr->vertices[idx].H;
     }
     float Vertex::k1() const {
-        return mris->vertices[idx].k1;
+        return repr->vertices[idx].k1;
     }
     float Vertex::k2() const {  //  the principal curvatures 
-        return mris->vertices[idx].k2;
+        return repr->vertices[idx].k2;
     }
     float Vertex::mean() const {
-        return mris->vertices[idx].mean;
+        return repr->vertices[idx].mean;
     }
     float Vertex::mean_imag() const {  //  imaginary part of complex statistic 
-        return mris->vertices[idx].mean_imag;
+        return repr->vertices[idx].mean_imag;
     }
     float Vertex::std_error() const {
-        return mris->vertices[idx].std_error;
+        return repr->vertices[idx].std_error;
     }
     uint Vertex::flags() const {
-        return mris->vertices[idx].flags;
+        return repr->vertices[idx].flags;
     }
     int Vertex::fno() const {  //  face that this vertex is in 
-        return mris->vertices[idx].fno;
+        return repr->vertices[idx].fno;
     }
     int Vertex::cropped() const {
-        return mris->vertices[idx].cropped;
+        return repr->vertices[idx].cropped;
     }
     short Vertex::marked() const {  //  for a variety of uses 
-        return mris->vertices[idx].marked;
+        return repr->vertices[idx].marked;
     }
     short Vertex::marked2() const {
-        return mris->vertices[idx].marked2;
+        return repr->vertices[idx].marked2;
     }
     short Vertex::marked3() const {
-        return mris->vertices[idx].marked3;
+        return repr->vertices[idx].marked3;
     }
     char Vertex::neg() const {  //  1 if the normal vector is inverted 
-        return mris->vertices[idx].neg;
+        return repr->vertices[idx].neg;
     }
     char Vertex::border() const {  //  flag 
-        return mris->vertices[idx].border;
+        return repr->vertices[idx].border;
     }
     char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
-        return mris->vertices[idx].ripflag;
+        return repr->vertices[idx].ripflag;
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+         MRISvertexCoord2XYZ_float(&repr->vertices[idx], which, x, y, z);
     }
     
     void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        cheapAssert(mris == to.mris); mris->vertices_topology[idx].f[i] = to.idx;
+        cheapAssert(repr == to.repr); repr->vertices_topology[idx].f[i] = to.idx;
     }
     void Vertex::set_n(size_t i, size_t to) {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        mris->vertices_topology[idx].n[i] = uchar(to);
+        repr->vertices_topology[idx].n[i] = uchar(to);
     }
     void Vertex::set_e(size_t i, int to) {  //  edge state for neighboring vertices                      
-        mris->vertices_topology[idx].e[i] = to;
+        repr->vertices_topology[idx].e[i] = to;
     }
     void Vertex::set_nx(float to) {
-        mris->vertices[idx].nx = to;
+        repr->vertices[idx].nx = to;
     }
     void Vertex::set_ny(float to) {
-        mris->vertices[idx].ny = to;
+        repr->vertices[idx].ny = to;
     }
     void Vertex::set_nz(float to) {  //  curr normal
-        mris->vertices[idx].nz = to;
+        repr->vertices[idx].nz = to;
     }
     void Vertex::set_pnx(float to) {
-        mris->vertices[idx].pnx = to;
+        repr->vertices[idx].pnx = to;
     }
     void Vertex::set_pny(float to) {
-        mris->vertices[idx].pny = to;
+        repr->vertices[idx].pny = to;
     }
     void Vertex::set_pnz(float to) {  //  pial normal
-        mris->vertices[idx].pnz = to;
+        repr->vertices[idx].pnz = to;
     }
     void Vertex::set_wnx(float to) {
-        mris->vertices[idx].wnx = to;
+        repr->vertices[idx].wnx = to;
     }
     void Vertex::set_wny(float to) {
-        mris->vertices[idx].wny = to;
+        repr->vertices[idx].wny = to;
     }
     void Vertex::set_wnz(float to) {  //  white normal
-        mris->vertices[idx].wnz = to;
+        repr->vertices[idx].wnz = to;
     }
     void Vertex::set_onx(float to) {
-        mris->vertices[idx].onx = to;
+        repr->vertices[idx].onx = to;
     }
     void Vertex::set_ony(float to) {
-        mris->vertices[idx].ony = to;
+        repr->vertices[idx].ony = to;
     }
     void Vertex::set_onz(float to) {  //  original normal
-        mris->vertices[idx].onz = to;
+        repr->vertices[idx].onz = to;
     }
     void Vertex::set_dx(float to) {
-        mris->vertices[idx].dx = to;
+        repr->vertices[idx].dx = to;
     }
     void Vertex::set_dy(float to) {
-        mris->vertices[idx].dy = to;
+        repr->vertices[idx].dy = to;
     }
     void Vertex::set_dz(float to) {  //  current change in position
-        mris->vertices[idx].dz = to;
+        repr->vertices[idx].dz = to;
     }
     void Vertex::set_odx(float to) {
-        mris->vertices[idx].odx = to;
+        repr->vertices[idx].odx = to;
     }
     void Vertex::set_ody(float to) {
-        mris->vertices[idx].ody = to;
+        repr->vertices[idx].ody = to;
     }
     void Vertex::set_odz(float to) {  //  last change of position (for momentum, 
-        mris->vertices[idx].odz = to;
+        repr->vertices[idx].odz = to;
     }
     void Vertex::set_tdx(float to) {
-        mris->vertices[idx].tdx = to;
+        repr->vertices[idx].tdx = to;
     }
     void Vertex::set_tdy(float to) {
-        mris->vertices[idx].tdy = to;
+        repr->vertices[idx].tdy = to;
     }
     void Vertex::set_tdz(float to) {  //  temporary storage for averaging gradient
-        mris->vertices[idx].tdz = to;
+        repr->vertices[idx].tdz = to;
     }
     void Vertex::set_curv(float to) {  //  curr curvature
-        mris->vertices[idx].curv = to;
+        repr->vertices[idx].curv = to;
     }
     void Vertex::set_curvbak(float to) {
-        mris->vertices[idx].curvbak = to;
+        repr->vertices[idx].curvbak = to;
     }
     void Vertex::set_val(float to) {  //  scalar data value (file: rh.val, sig2-rh.w)
-        mris->vertices[idx].val = to;
+        repr->vertices[idx].val = to;
     }
     void Vertex::set_imag_val(float to) {  //  imaginary part of complex data value
-        mris->vertices[idx].imag_val = to;
+        repr->vertices[idx].imag_val = to;
     }
     void Vertex::set_cx(float to) {
-        mris->vertices[idx].cx = to;
+        repr->vertices[idx].cx = to;
     }
     void Vertex::set_cy(float to) {
-        mris->vertices[idx].cy = to;
+        repr->vertices[idx].cy = to;
     }
     void Vertex::set_cz(float to) {  //  coordinates in canonical coordinate system
-        mris->vertices[idx].cz = to;
+        repr->vertices[idx].cz = to;
     }
     void Vertex::set_tx(float to) {
-        mris->vertices[idx].tx = to;
+        repr->vertices[idx].tx = to;
     }
     void Vertex::set_ty(float to) {
-        mris->vertices[idx].ty = to;
+        repr->vertices[idx].ty = to;
     }
     void Vertex::set_tz(float to) {  //  tmp coordinate storage
-        mris->vertices[idx].tz = to;
+        repr->vertices[idx].tz = to;
     }
-    void Vertex::set_tx2(float to) {
-        mris->vertices[idx].tx2 = to;
+    void Vertex::set_t2x(float to) {
+        repr->vertices[idx].t2x = to;
     }
-    void Vertex::set_ty2(float to) {
-        mris->vertices[idx].ty2 = to;
+    void Vertex::set_t2y(float to) {
+        repr->vertices[idx].t2y = to;
     }
-    void Vertex::set_tz2(float to) {  //  tmp coordinate storage
-        mris->vertices[idx].tz2 = to;
+    void Vertex::set_t2z(float to) {  //  another tmp coordinate storage
+        repr->vertices[idx].t2z = to;
     }
     void Vertex::set_targx(float to) {
-        mris->vertices[idx].targx = to;
+        repr->vertices[idx].targx = to;
     }
     void Vertex::set_targy(float to) {
-        mris->vertices[idx].targy = to;
+        repr->vertices[idx].targy = to;
     }
     void Vertex::set_targz(float to) {  //  target coordinates
-        mris->vertices[idx].targz = to;
+        repr->vertices[idx].targz = to;
     }
     void Vertex::set_pialx(float to) {
-        mris->vertices[idx].pialx = to;
+        repr->vertices[idx].pialx = to;
     }
     void Vertex::set_pialy(float to) {
-        mris->vertices[idx].pialy = to;
+        repr->vertices[idx].pialy = to;
     }
     void Vertex::set_pialz(float to) {  //  pial surface coordinates
-        mris->vertices[idx].pialz = to;
+        repr->vertices[idx].pialz = to;
     }
     void Vertex::set_whitex(float to) {
-        mris->vertices[idx].whitex = to;
+        repr->vertices[idx].whitex = to;
     }
     void Vertex::set_whitey(float to) {
-        mris->vertices[idx].whitey = to;
+        repr->vertices[idx].whitey = to;
     }
     void Vertex::set_whitez(float to) {  //  white surface coordinates
-        mris->vertices[idx].whitez = to;
+        repr->vertices[idx].whitez = to;
     }
     void Vertex::set_l4x(float to) {
-        mris->vertices[idx].l4x = to;
+        repr->vertices[idx].l4x = to;
     }
     void Vertex::set_l4y(float to) {
-        mris->vertices[idx].l4y = to;
+        repr->vertices[idx].l4y = to;
     }
     void Vertex::set_l4z(float to) {  //  layerIV surface coordinates
-        mris->vertices[idx].l4z = to;
+        repr->vertices[idx].l4z = to;
     }
     void Vertex::set_infx(float to) {
-        mris->vertices[idx].infx = to;
+        repr->vertices[idx].infx = to;
     }
     void Vertex::set_infy(float to) {
-        mris->vertices[idx].infy = to;
+        repr->vertices[idx].infy = to;
     }
     void Vertex::set_infz(float to) {  //  inflated coordinates
-        mris->vertices[idx].infz = to;
+        repr->vertices[idx].infz = to;
     }
     void Vertex::set_fx(float to) {
-        mris->vertices[idx].fx = to;
+        repr->vertices[idx].fx = to;
     }
     void Vertex::set_fy(float to) {
-        mris->vertices[idx].fy = to;
+        repr->vertices[idx].fy = to;
     }
     void Vertex::set_fz(float to) {  //  flattened coordinates
-        mris->vertices[idx].fz = to;
+        repr->vertices[idx].fz = to;
     }
     void Vertex::set_px(int to) {
-        mris->vertices[idx].px = to;
+        repr->vertices[idx].px = to;
     }
     void Vertex::set_qx(int to) {
-        mris->vertices[idx].qx = to;
+        repr->vertices[idx].qx = to;
     }
     void Vertex::set_py(int to) {
-        mris->vertices[idx].py = to;
+        repr->vertices[idx].py = to;
     }
     void Vertex::set_qy(int to) {
-        mris->vertices[idx].qy = to;
+        repr->vertices[idx].qy = to;
     }
     void Vertex::set_pz(int to) {
-        mris->vertices[idx].pz = to;
+        repr->vertices[idx].pz = to;
     }
     void Vertex::set_qz(int to) {  //  rational coordinates for exact calculations
-        mris->vertices[idx].qz = to;
+        repr->vertices[idx].qz = to;
     }
     void Vertex::set_e1x(float to) {
-        mris->vertices[idx].e1x = to;
+        repr->vertices[idx].e1x = to;
     }
     void Vertex::set_e1y(float to) {
-        mris->vertices[idx].e1y = to;
+        repr->vertices[idx].e1y = to;
     }
     void Vertex::set_e1z(float to) {  //  1st basis vector for the local tangent plane
-        mris->vertices[idx].e1z = to;
+        repr->vertices[idx].e1z = to;
     }
     void Vertex::set_e2x(float to) {
-        mris->vertices[idx].e2x = to;
+        repr->vertices[idx].e2x = to;
     }
     void Vertex::set_e2y(float to) {
-        mris->vertices[idx].e2y = to;
+        repr->vertices[idx].e2y = to;
     }
     void Vertex::set_e2z(float to) {  //  2nd basis vector for the local tangent plane
-        mris->vertices[idx].e2z = to;
+        repr->vertices[idx].e2z = to;
     }
     void Vertex::set_pe1x(float to) {
-        mris->vertices[idx].pe1x = to;
+        repr->vertices[idx].pe1x = to;
     }
     void Vertex::set_pe1y(float to) {
-        mris->vertices[idx].pe1y = to;
+        repr->vertices[idx].pe1y = to;
     }
     void Vertex::set_pe1z(float to) {  //  1st basis vector for the local tangent plane
-        mris->vertices[idx].pe1z = to;
+        repr->vertices[idx].pe1z = to;
     }
     void Vertex::set_pe2x(float to) {
-        mris->vertices[idx].pe2x = to;
+        repr->vertices[idx].pe2x = to;
     }
     void Vertex::set_pe2y(float to) {
-        mris->vertices[idx].pe2y = to;
+        repr->vertices[idx].pe2y = to;
     }
     void Vertex::set_pe2z(float to) {  //  2nd basis vector for the local tangent plane
-        mris->vertices[idx].pe2z = to;
+        repr->vertices[idx].pe2z = to;
     }
     void Vertex::set_nc(float to) {  //  curr length normal comp 
-        mris->vertices[idx].nc = to;
+        repr->vertices[idx].nc = to;
     }
     void Vertex::set_val2(float to) {  //  complex comp data value (file: sig3-rh.w) 
-        mris->vertices[idx].val2 = to;
+        repr->vertices[idx].val2 = to;
     }
     void Vertex::set_valbak(float to) {  //  scalar data stack 
-        mris->vertices[idx].valbak = to;
+        repr->vertices[idx].valbak = to;
     }
     void Vertex::set_val2bak(float to) {  //  complex comp data stack 
-        mris->vertices[idx].val2bak = to;
+        repr->vertices[idx].val2bak = to;
     }
     void Vertex::set_stat(float to) {  //  statistic 
-        mris->vertices[idx].stat = to;
+        repr->vertices[idx].stat = to;
     }
     void Vertex::set_undefval(int to) {  //  [previously dist=0] 
-        mris->vertices[idx].undefval = to;
+        repr->vertices[idx].undefval = to;
     }
     void Vertex::set_old_undefval(int to) {  //  for smooth_val_sparse 
-        mris->vertices[idx].old_undefval = to;
+        repr->vertices[idx].old_undefval = to;
     }
     void Vertex::set_fixedval(int to) {  //  [previously val=0] 
-        mris->vertices[idx].fixedval = to;
+        repr->vertices[idx].fixedval = to;
     }
     void Vertex::set_fieldsign(float to) {  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
-        mris->vertices[idx].fieldsign = to;
+        repr->vertices[idx].fieldsign = to;
     }
     void Vertex::set_fsmask(float to) {  //  significance mask (file: rh.fm) 
-        mris->vertices[idx].fsmask = to;
+        repr->vertices[idx].fsmask = to;
     }
     void Vertex::set_d(float to) {  //  for distance calculations 
-        mris->vertices[idx].d = to;
+        repr->vertices[idx].d = to;
     }
     void Vertex::set_annotation(int to) {  //  area label (defunct--now from label file name!) 
-        mris->vertices[idx].annotation = to;
+        repr->vertices[idx].annotation = to;
     }
     void Vertex::set_oripflag(char to) {
-        mris->vertices[idx].oripflag = to;
+        repr->vertices[idx].oripflag = to;
     }
     void Vertex::set_origripflag(char to) {  //  cuts flags 
-        mris->vertices[idx].origripflag = to;
+        repr->vertices[idx].origripflag = to;
     }
     void Vertex::set_vp(p_void to) {  //  to store user's information 
-        mris->vertices[idx].vp = to;
+        repr->vertices[idx].vp = to;
     }
     void Vertex::set_theta(float to) {
-        mris->vertices[idx].theta = to;
+        repr->vertices[idx].theta = to;
     }
     void Vertex::set_phi(float to) {  //  parameterization 
-        mris->vertices[idx].phi = to;
+        repr->vertices[idx].phi = to;
     }
     void Vertex::set_origarea(float to) {
-        mris->vertices[idx].origarea = to;
+        repr->vertices[idx].origarea = to;
     }
     void Vertex::set_group_avg_area(float to) {
-        mris->vertices[idx].group_avg_area = to;
+        repr->vertices[idx].group_avg_area = to;
     }
     void Vertex::set_K(float to) {  //  Gaussian curvature 
-        mris->vertices[idx].K = to;
+        repr->vertices[idx].K = to;
     }
     void Vertex::set_H(float to) {  //  mean curvature 
-        mris->vertices[idx].H = to;
+        repr->vertices[idx].H = to;
     }
     void Vertex::set_k1(float to) {
-        mris->vertices[idx].k1 = to;
+        repr->vertices[idx].k1 = to;
     }
     void Vertex::set_k2(float to) {  //  the principal curvatures 
-        mris->vertices[idx].k2 = to;
+        repr->vertices[idx].k2 = to;
     }
     void Vertex::set_mean(float to) {
-        mris->vertices[idx].mean = to;
+        repr->vertices[idx].mean = to;
     }
     void Vertex::set_mean_imag(float to) {  //  imaginary part of complex statistic 
-        mris->vertices[idx].mean_imag = to;
+        repr->vertices[idx].mean_imag = to;
     }
     void Vertex::set_std_error(float to) {
-        mris->vertices[idx].std_error = to;
+        repr->vertices[idx].std_error = to;
     }
     void Vertex::set_flags(uint to) {
-        mris->vertices[idx].flags = to;
+        repr->vertices[idx].flags = to;
     }
     void Vertex::set_fno(int to) {  //  face that this vertex is in 
-        mris->vertices[idx].fno = to;
+        repr->vertices[idx].fno = to;
     }
     void Vertex::set_cropped(int to) {
-        mris->vertices[idx].cropped = to;
+        repr->vertices[idx].cropped = to;
     }
     void Vertex::set_marked(short to) {  //  for a variety of uses 
-        mris->vertices[idx].marked = to;
+        repr->vertices[idx].marked = to;
     }
     void Vertex::set_marked2(short to) {
-        mris->vertices[idx].marked2 = to;
+        repr->vertices[idx].marked2 = to;
     }
     void Vertex::set_marked3(short to) {
-        mris->vertices[idx].marked3 = to;
+        repr->vertices[idx].marked3 = to;
     }
     void Vertex::set_neg(char to) {  //  1 if the normal vector is inverted 
-        mris->vertices[idx].neg = to;
+        repr->vertices[idx].neg = to;
     }
     void Vertex::set_border(char to) {  //  flag 
-        mris->vertices[idx].border = to;
+        repr->vertices[idx].border = to;
     }
     void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
-        mris->vertices[idx].ripflag = to;
+        repr->vertices[idx].ripflag = to;
     }
 
 
-    Surface::Surface (                           ) {}                   
-    Surface::Surface ( MRIS* mris                ) : MRIS_Elt(mris,0) {}
-    Surface::Surface ( Surface const & src       ) : MRIS_Elt(src) {}   
-    Surface::Surface ( AllM::Surface const & src ) : MRIS_Elt(src) {}   
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
 
     int Surface::nverticesFrozen() const {  //  # of vertices on surface is frozen
-        return mris->nverticesFrozen;
+        return repr->nverticesFrozen;
     }
     int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nvertices;
+        return repr->nvertices;
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nfaces;
+        return repr->nfaces;
     }
     bool Surface::faceAttachmentDeferred() const {  //  defer connecting faces to vertices for performance reasons
-        return mris->faceAttachmentDeferred;
+        return repr->faceAttachmentDeferred;
     }
     int Surface::nedges() const {  //  # of edges on surface
-        return mris->nedges;
+        return repr->nedges;
     }
     int Surface::nstrips() const {
-        return mris->nstrips;
+        return repr->nstrips;
     }
     Vertex Surface::vertices(size_t i) const {
-        return Vertex(mris,i);
+        return Vertex(repr,i);
     }
     p_p_void Surface::dist_storage() const {  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
-        return mris->dist_storage;
+        return repr->dist_storage;
     }
     p_p_void Surface::dist_orig_storage() const {  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
-        return mris->dist_orig_storage;
+        return repr->dist_orig_storage;
     }
     int Surface::tempsAssigned() const {  //  State of various temp fields that can be borrowed if not already in use
-        return mris->tempsAssigned;
+        return repr->tempsAssigned;
     }
     Face Surface::faces(size_t i) const {
-        return Face(mris,i);
+        return Face(repr,i);
     }
     MRI_EDGE Surface::edges(size_t i) const {
-        return mris->edges[i];
+        return repr->edges[i];
     }
     FaceNormCacheEntry Surface::faceNormCacheEntries(size_t i) const {
-        return mris->faceNormCacheEntries[i];
+        return repr->faceNormCacheEntries[i];
     }
     FaceNormDeferredEntry Surface::faceNormDeferredEntries(size_t i) const {
-        return mris->faceNormDeferredEntries[i];
+        return repr->faceNormDeferredEntries[i];
     }
     STRIP Surface::strips(size_t i) const {
-        return mris->strips[i];
+        return repr->strips[i];
     }
     float Surface::xctr() const {
-        return mris->xctr;
+        return repr->xctr;
     }
     float Surface::yctr() const {
-        return mris->yctr;
+        return repr->yctr;
     }
     float Surface::zctr() const {
-        return mris->zctr;
+        return repr->zctr;
     }
     float Surface::xlo() const {
-        return mris->xlo;
+        return repr->xlo;
     }
     float Surface::ylo() const {
-        return mris->ylo;
+        return repr->ylo;
     }
     float Surface::zlo() const {
-        return mris->zlo;
+        return repr->zlo;
     }
     float Surface::xhi() const {
-        return mris->xhi;
+        return repr->xhi;
     }
     float Surface::yhi() const {
-        return mris->yhi;
+        return repr->yhi;
     }
     float Surface::zhi() const {
-        return mris->zhi;
+        return repr->zhi;
     }
     float Surface::x0() const {  //  center of spherical expansion
-        return mris->x0;
+        return repr->x0;
     }
     float Surface::y0() const {
-        return mris->y0;
+        return repr->y0;
     }
     float Surface::z0() const {
-        return mris->z0;
+        return repr->z0;
     }
     Vertex Surface::v_temporal_pole() const {
-        return Vertex(mris,mris->v_temporal_pole - mris->vertices);
+        return Vertex(repr,repr->v_temporal_pole - repr->vertices);
     }
     Vertex Surface::v_frontal_pole() const {
-        return Vertex(mris,mris->v_frontal_pole - mris->vertices);
+        return Vertex(repr,repr->v_frontal_pole - repr->vertices);
     }
     Vertex Surface::v_occipital_pole() const {
-        return Vertex(mris,mris->v_occipital_pole - mris->vertices);
+        return Vertex(repr,repr->v_occipital_pole - repr->vertices);
     }
     float Surface::max_curv() const {
-        return mris->max_curv;
+        return repr->max_curv;
     }
     float Surface::min_curv() const {
-        return mris->min_curv;
+        return repr->min_curv;
     }
     float Surface::total_area() const {
-        return mris->total_area;
+        return repr->total_area;
     }
     double Surface::avg_vertex_area() const {
-        return mris->avg_vertex_area;
+        return repr->avg_vertex_area;
     }
     double Surface::avg_vertex_dist() const {  //  set by MRIScomputeAvgInterVertexDist
-        return mris->avg_vertex_dist;
+        return repr->avg_vertex_dist;
     }
     double Surface::std_vertex_dist() const {
-        return mris->std_vertex_dist;
+        return repr->std_vertex_dist;
     }
     float Surface::orig_area() const {
-        return mris->orig_area;
+        return repr->orig_area;
     }
     float Surface::neg_area() const {
-        return mris->neg_area;
+        return repr->neg_area;
     }
     float Surface::neg_orig_area() const {  //  amount of original surface in folds
-        return mris->neg_orig_area;
+        return repr->neg_orig_area;
     }
     int Surface::zeros() const {
-        return mris->zeros;
+        return repr->zeros;
     }
     int Surface::hemisphere() const {  //  which hemisphere
-        return mris->hemisphere;
+        return repr->hemisphere;
     }
     int Surface::initialized() const {
-        return mris->initialized;
+        return repr->initialized;
     }
     PLTA Surface::lta() const {
-        return mris->lta;
+        return repr->lta;
     }
     PMATRIX Surface::SRASToTalSRAS_() const {
-        return mris->SRASToTalSRAS_;
+        return repr->SRASToTalSRAS_;
     }
     PMATRIX Surface::TalSRASToSRAS_() const {
-        return mris->TalSRASToSRAS_;
+        return repr->TalSRASToSRAS_;
     }
     int Surface::free_transform() const {
-        return mris->free_transform;
+        return repr->free_transform;
     }
     double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
-        return mris->radius;
+        return repr->radius;
     }
     float Surface::a() const {
-        return mris->a;
+        return repr->a;
     }
     float Surface::b() const {
-        return mris->b;
+        return repr->b;
     }
     float Surface::c() const {  //  ellipsoid parameters
-        return mris->c;
+        return repr->c;
     }
     MRIS_fname_t Surface::fname() const {  //  file it was originally loaded from
-        return mris->fname;
+        return repr->fname;
     }
     float Surface::Hmin() const {  //  min mean curvature
-        return mris->Hmin;
+        return repr->Hmin;
     }
     float Surface::Hmax() const {  //  max mean curvature
-        return mris->Hmax;
+        return repr->Hmax;
     }
     float Surface::Kmin() const {  //  min Gaussian curvature
-        return mris->Kmin;
+        return repr->Kmin;
     }
     float Surface::Kmax() const {  //  max Gaussian curvature
-        return mris->Kmax;
+        return repr->Kmax;
     }
     double Surface::Ktotal() const {  //  total Gaussian curvature
-        return mris->Ktotal;
+        return repr->Ktotal;
     }
     MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
-        return mris->status;
+        return repr->status;
     }
     MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-        return mris->origxyz_status;
+        return repr->origxyz_status;
     }
     int Surface::patch() const {  //  if a patch of the surface
-        return mris->patch;
+        return repr->patch;
     }
     int Surface::nlabels() const {
-        return mris->nlabels;
+        return repr->nlabels;
     }
     PMRIS_AREA_LABEL Surface::labels() const {  //  nlabels of these (may be null)
-        return mris->labels;
+        return repr->labels;
     }
     p_void Surface::vp() const {  //  for misc. use
-        return mris->vp;
+        return repr->vp;
     }
     float Surface::alpha() const {  //  rotation around z-axis
-        return mris->alpha;
+        return repr->alpha;
     }
     float Surface::beta() const {  //  rotation around y-axis
-        return mris->beta;
+        return repr->beta;
     }
     float Surface::gamma() const {  //  rotation around x-axis
-        return mris->gamma;
+        return repr->gamma;
     }
     float Surface::da() const {
-        return mris->da;
+        return repr->da;
     }
     float Surface::db() const {
-        return mris->db;
+        return repr->db;
     }
     float Surface::dg() const {  //  old deltas
-        return mris->dg;
+        return repr->dg;
     }
     int Surface::type() const {  //  what type of surface was this initially
-        return mris->type;
+        return repr->type;
     }
     int Surface::max_vertices() const {  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
-        return mris->max_vertices;
+        return repr->max_vertices;
     }
     int Surface::max_faces() const {  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
-        return mris->max_faces;
+        return repr->max_faces;
     }
     MRIS_subject_name_t Surface::subject_name() const {  //  name of the subject
-        return mris->subject_name;
+        return repr->subject_name;
     }
     float Surface::canon_area() const {
-        return mris->canon_area;
+        return repr->canon_area;
     }
     int Surface::noscale() const {  //  don't scale by surface area if true
-        return mris->noscale;
+        return repr->noscale;
     }
     float Surface::dx2(size_t i) const {  //  an extra set of gradient (not always alloced)
-        return mris->dx2[i];
+        return repr->dx2[i];
     }
     float Surface::dy2(size_t i) const {
-        return mris->dy2[i];
+        return repr->dy2[i];
     }
     float Surface::dz2(size_t i) const {
-        return mris->dz2[i];
+        return repr->dz2[i];
     }
     PCOLOR_TABLE Surface::ct() const {
-        return mris->ct;
+        return repr->ct;
     }
     int Surface::useRealRAS() const {  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        return mris->useRealRAS;
+        return repr->useRealRAS;
     }
     VOL_GEOM Surface::vg() const {  //  volume info from which this surface is created. valid iff vg.valid = 1
-        return mris->vg;
+        return repr->vg;
     }
     MRIS_cmdlines_t Surface::cmdlines() const {
-        return mris->cmdlines;
+        return repr->cmdlines;
     }
     int Surface::ncmds() const {
-        return mris->ncmds;
+        return repr->ncmds;
     }
     float Surface::group_avg_surface_area() const {  //  average of total surface area for group
-        return mris->group_avg_surface_area;
+        return repr->group_avg_surface_area;
     }
     int Surface::group_avg_vtxarea_loaded() const {  //  average vertex area for group at each vertex
-        return mris->group_avg_vtxarea_loaded;
+        return repr->group_avg_vtxarea_loaded;
     }
     int Surface::triangle_links_removed() const {  //  for quad surfaces
-        return mris->triangle_links_removed;
+        return repr->triangle_links_removed;
     }
     p_void Surface::user_parms() const {  //  for whatever the user wants to hang here
-        return mris->user_parms;
+        return repr->user_parms;
     }
     PMATRIX Surface::m_sras2vox() const {  //  for converting surface ras to voxel
-        return mris->m_sras2vox;
+        return repr->m_sras2vox;
     }
     PMRI Surface::mri_sras2vox() const {  //  volume that the above matrix is for
-        return mris->mri_sras2vox;
+        return repr->mri_sras2vox;
     }
     p_void Surface::mht() const {
-        return mris->mht;
+        return repr->mht;
     }
     p_void Surface::temps() const {
-        return mris->temps;
+        return repr->temps;
     }
     
     void Surface::set_strips(size_t i, STRIP to) {
-        mris->strips[i] = to;
+        repr->strips[i] = to;
     }
     void Surface::set_xctr(float to) {
-        mris->xctr = to;
+        repr->xctr = to;
     }
     void Surface::set_yctr(float to) {
-        mris->yctr = to;
+        repr->yctr = to;
     }
     void Surface::set_zctr(float to) {
-        mris->zctr = to;
+        repr->zctr = to;
     }
     void Surface::set_xlo(float to) {
-        mris->xlo = to;
+        repr->xlo = to;
     }
     void Surface::set_ylo(float to) {
-        mris->ylo = to;
+        repr->ylo = to;
     }
     void Surface::set_zlo(float to) {
-        mris->zlo = to;
+        repr->zlo = to;
     }
     void Surface::set_xhi(float to) {
-        mris->xhi = to;
+        repr->xhi = to;
     }
     void Surface::set_yhi(float to) {
-        mris->yhi = to;
+        repr->yhi = to;
     }
     void Surface::set_zhi(float to) {
-        mris->zhi = to;
+        repr->zhi = to;
     }
     void Surface::set_x0(float to) {  //  center of spherical expansion
-        mris->x0 = to;
+        repr->x0 = to;
     }
     void Surface::set_y0(float to) {
-        mris->y0 = to;
+        repr->y0 = to;
     }
     void Surface::set_z0(float to) {
-        mris->z0 = to;
+        repr->z0 = to;
     }
     void Surface::set_v_temporal_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_temporal_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_temporal_pole = repr->vertices + to.idx;
     }
     void Surface::set_v_frontal_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_frontal_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_frontal_pole = repr->vertices + to.idx;
     }
     void Surface::set_v_occipital_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_occipital_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_occipital_pole = repr->vertices + to.idx;
     }
     void Surface::set_max_curv(float to) {
-        mris->max_curv = to;
+        repr->max_curv = to;
     }
     void Surface::set_min_curv(float to) {
-        mris->min_curv = to;
+        repr->min_curv = to;
     }
     void Surface::set_total_area(float to) {
-        mris->total_area = to;
+        repr->total_area = to;
     }
     void Surface::set_avg_vertex_area(double to) {
-        mris->avg_vertex_area = to;
+        repr->avg_vertex_area = to;
     }
     void Surface::set_zeros(int to) {
-        mris->zeros = to;
+        repr->zeros = to;
     }
     void Surface::set_hemisphere(int to) {  //  which hemisphere
-        mris->hemisphere = to;
+        repr->hemisphere = to;
     }
     void Surface::set_Hmin(float to) {  //  min mean curvature
-        mris->Hmin = to;
+        repr->Hmin = to;
     }
     void Surface::set_Hmax(float to) {  //  max mean curvature
-        mris->Hmax = to;
+        repr->Hmax = to;
     }
     void Surface::set_Kmin(float to) {  //  min Gaussian curvature
-        mris->Kmin = to;
+        repr->Kmin = to;
     }
     void Surface::set_Kmax(float to) {  //  max Gaussian curvature
-        mris->Kmax = to;
+        repr->Kmax = to;
     }
     void Surface::set_Ktotal(double to) {  //  total Gaussian curvature
-        mris->Ktotal = to;
+        repr->Ktotal = to;
     }
     void Surface::set_nlabels(int to) {
-        mris->nlabels = to;
+        repr->nlabels = to;
     }
     void Surface::set_labels(PMRIS_AREA_LABEL to) {  //  nlabels of these (may be null)
-        mris->labels = to;
+        repr->labels = to;
     }
     void Surface::set_vp(p_void to) {  //  for misc. use
-        mris->vp = to;
+        repr->vp = to;
     }
     void Surface::set_alpha(float to) {  //  rotation around z-axis
-        mris->alpha = to;
+        repr->alpha = to;
     }
     void Surface::set_beta(float to) {  //  rotation around y-axis
-        mris->beta = to;
+        repr->beta = to;
     }
     void Surface::set_gamma(float to) {  //  rotation around x-axis
-        mris->gamma = to;
+        repr->gamma = to;
     }
     void Surface::set_da(float to) {
-        mris->da = to;
+        repr->da = to;
     }
     void Surface::set_db(float to) {
-        mris->db = to;
+        repr->db = to;
     }
     void Surface::set_dg(float to) {  //  old deltas
-        mris->dg = to;
+        repr->dg = to;
     }
     void Surface::set_type(int to) {  //  what type of surface was this initially
-        mris->type = to;
+        repr->type = to;
     }
 
 
@@ -6255,1155 +6288,1158 @@ namespace SurfaceFromMRIS {
 
 
     namespace AnalysisM {
-    Face::Face (                        ) {}                     
-    Face::Face ( MRIS* mris, size_t idx ) : MRIS_Elt(mris,idx) {}
-    Face::Face ( Face const & src       ) : MRIS_Elt(src) {}     
-    Face::Face ( AllM::Face const & src ) : MRIS_Elt(src) {}     
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
+    Face::Face ( AllM::Face const & src                     ) : Repr_Elt(src) {}
 
     Vertex Face::v(size_t i) const {
-        return Vertex(mris,mris->faces[idx].v[i]);
+        return Vertex(repr,repr->faces[idx].v[i]);
     }
     float Face::area() const {
-        return mris->faces[idx].area;
+        return repr->faces[idx].area;
     }
     angles_per_triangle_t Face::angle() const {
-        return mris->faces[idx].angle;
+        return repr->faces[idx].angle;
     }
     angles_per_triangle_t Face::orig_angle() const {
-        return mris->faces[idx].orig_angle;
+        return repr->faces[idx].orig_angle;
     }
     char Face::ripflag() const {
-        return mris->faces[idx].ripflag;
+        return repr->faces[idx].ripflag;
     }
     char Face::oripflag() const {
-        return mris->faces[idx].oripflag;
+        return repr->faces[idx].oripflag;
     }
     int Face::marked() const {
-        return mris->faces[idx].marked;
+        return repr->faces[idx].marked;
     }
     PDMATRIX Face::norm() const {
-        return mris->faces[idx].norm;
+        return repr->faces[idx].norm;
     }
     A3PDMATRIX Face::gradNorm() const {
-        return mris->faces[idx].gradNorm;
+        return repr->faces[idx].gradNorm;
     }
     
     void Face::set_orig_angle(angles_per_triangle_t to) {
-        mris->faces[idx].orig_angle = to;
+        repr->faces[idx].orig_angle = to;
     }
     void Face::set_ripflag(char to) {
-        mris->faces[idx].ripflag = to;
+        repr->faces[idx].ripflag = to;
     }
     void Face::set_oripflag(char to) {
-        mris->faces[idx].oripflag = to;
+        repr->faces[idx].oripflag = to;
     }
     void Face::set_marked(int to) {
-        mris->faces[idx].marked = to;
+        repr->faces[idx].marked = to;
     }
 
 
-    Vertex::Vertex (                          ) {}                     
-    Vertex::Vertex ( MRIS* mris, size_t idx   ) : MRIS_Elt(mris,idx) {}
-    Vertex::Vertex ( Vertex const & src       ) : MRIS_Elt(src) {}     
-    Vertex::Vertex ( AllM::Vertex const & src ) : MRIS_Elt(src) {}     
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
+    Vertex::Vertex ( AllM::Vertex const & src                   ) : Repr_Elt(src) {}
 
     Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        return Face(mris,mris->vertices_topology[idx].f[i]);
+        return Face(repr,repr->vertices_topology[idx].f[i]);
     }
     size_t Vertex::n(size_t i) const {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        return size_t(mris->vertices_topology[idx].n[i]);
+        return size_t(repr->vertices_topology[idx].n[i]);
     }
     int Vertex::e(size_t i) const {  //  edge state for neighboring vertices                      
-        return mris->vertices_topology[idx].e[i];
+        return repr->vertices_topology[idx].e[i];
     }
     Vertex Vertex::v(size_t i) const {  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        return Vertex(mris,mris->vertices_topology[idx].v[i]);
+        return Vertex(repr,repr->vertices_topology[idx].v[i]);
     }
     short Vertex::vnum() const {  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
-        return mris->vertices_topology[idx].vnum;
+        return repr->vertices_topology[idx].vnum;
     }
     short Vertex::v2num() const {  //  number of 1, or 2-hop neighbors                          
-        return mris->vertices_topology[idx].v2num;
+        return repr->vertices_topology[idx].v2num;
     }
     short Vertex::v3num() const {  //  number of 1,2,or 3-hop neighbors                         
-        return mris->vertices_topology[idx].v3num;
+        return repr->vertices_topology[idx].v3num;
     }
     short Vertex::vtotal() const {  //  total # of neighbors. copy of vnum.nsizeCur              
-        return mris->vertices_topology[idx].vtotal;
+        return repr->vertices_topology[idx].vtotal;
     }
     short Vertex::nsizeMaxClock() const {  //  copy of mris->nsizeMaxClock when v#num                   
-        return mris->vertices_topology[idx].nsizeMaxClock;
+        return repr->vertices_topology[idx].nsizeMaxClock;
     }
     uchar Vertex::nsizeMax() const {  //  the max nsize that was used to fill in vnum etc          
-        return mris->vertices_topology[idx].nsizeMax;
+        return repr->vertices_topology[idx].nsizeMax;
     }
     uchar Vertex::nsizeCur() const {  //  index of the current v#num in vtotal                     
-        return mris->vertices_topology[idx].nsizeCur;
+        return repr->vertices_topology[idx].nsizeCur;
     }
     uchar Vertex::num() const {  //  number of neighboring faces                              
-        return mris->vertices_topology[idx].num;
+        return repr->vertices_topology[idx].num;
     }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
-        return mris->vertices[idx].dist[i];
+        return repr->vertices[idx].dist[i];
     }
     float Vertex::dist_orig(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on origxyz
-        return mris->vertices[idx].dist_orig[i];
+        return repr->vertices[idx].dist_orig[i];
     }
     int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_capacity;
+        return repr->vertices[idx].dist_capacity;
     }
     int Vertex::dist_orig_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_orig_capacity;
+        return repr->vertices[idx].dist_orig_capacity;
     }
     float Vertex::x() const {  //  current coordinates	
-        return mris->vertices[idx].x;
+        return repr->vertices[idx].x;
     }
     float Vertex::y() const {  //  use MRISsetXYZ() to set
-        return mris->vertices[idx].y;
+        return repr->vertices[idx].y;
     }
     float Vertex::z() const {
-        return mris->vertices[idx].z;
+        return repr->vertices[idx].z;
     }
     float Vertex::origx() const {  //  original coordinates, see also MRIS::origxyz_status
-        return mris->vertices[idx].origx;
+        return repr->vertices[idx].origx;
     }
     float Vertex::origy() const {  //  use MRISsetOriginalXYZ(, 
-        return mris->vertices[idx].origy;
+        return repr->vertices[idx].origy;
     }
     float Vertex::origz() const {  //  or MRISsetOriginalXYZfromXYZ to set
-        return mris->vertices[idx].origz;
+        return repr->vertices[idx].origz;
     }
     float Vertex::nx() const {
-        return mris->vertices[idx].nx;
+        return repr->vertices[idx].nx;
     }
     float Vertex::ny() const {
-        return mris->vertices[idx].ny;
+        return repr->vertices[idx].ny;
     }
     float Vertex::nz() const {  //  curr normal
-        return mris->vertices[idx].nz;
+        return repr->vertices[idx].nz;
     }
     float Vertex::pnx() const {
-        return mris->vertices[idx].pnx;
+        return repr->vertices[idx].pnx;
     }
     float Vertex::pny() const {
-        return mris->vertices[idx].pny;
+        return repr->vertices[idx].pny;
     }
     float Vertex::pnz() const {  //  pial normal
-        return mris->vertices[idx].pnz;
+        return repr->vertices[idx].pnz;
     }
     float Vertex::wnx() const {
-        return mris->vertices[idx].wnx;
+        return repr->vertices[idx].wnx;
     }
     float Vertex::wny() const {
-        return mris->vertices[idx].wny;
+        return repr->vertices[idx].wny;
     }
     float Vertex::wnz() const {  //  white normal
-        return mris->vertices[idx].wnz;
+        return repr->vertices[idx].wnz;
     }
     float Vertex::onx() const {
-        return mris->vertices[idx].onx;
+        return repr->vertices[idx].onx;
     }
     float Vertex::ony() const {
-        return mris->vertices[idx].ony;
+        return repr->vertices[idx].ony;
     }
     float Vertex::onz() const {  //  original normal
-        return mris->vertices[idx].onz;
+        return repr->vertices[idx].onz;
     }
     float Vertex::dx() const {
-        return mris->vertices[idx].dx;
+        return repr->vertices[idx].dx;
     }
     float Vertex::dy() const {
-        return mris->vertices[idx].dy;
+        return repr->vertices[idx].dy;
     }
     float Vertex::dz() const {  //  current change in position
-        return mris->vertices[idx].dz;
+        return repr->vertices[idx].dz;
     }
     float Vertex::odx() const {
-        return mris->vertices[idx].odx;
+        return repr->vertices[idx].odx;
     }
     float Vertex::ody() const {
-        return mris->vertices[idx].ody;
+        return repr->vertices[idx].ody;
     }
     float Vertex::odz() const {  //  last change of position (for momentum, 
-        return mris->vertices[idx].odz;
+        return repr->vertices[idx].odz;
     }
     float Vertex::tdx() const {
-        return mris->vertices[idx].tdx;
+        return repr->vertices[idx].tdx;
     }
     float Vertex::tdy() const {
-        return mris->vertices[idx].tdy;
+        return repr->vertices[idx].tdy;
     }
     float Vertex::tdz() const {  //  temporary storage for averaging gradient
-        return mris->vertices[idx].tdz;
+        return repr->vertices[idx].tdz;
     }
     float Vertex::curv() const {  //  curr curvature
-        return mris->vertices[idx].curv;
+        return repr->vertices[idx].curv;
     }
     float Vertex::curvbak() const {
-        return mris->vertices[idx].curvbak;
+        return repr->vertices[idx].curvbak;
     }
     float Vertex::val() const {  //  scalar data value (file: rh.val, sig2-rh.w)
-        return mris->vertices[idx].val;
+        return repr->vertices[idx].val;
     }
     float Vertex::imag_val() const {  //  imaginary part of complex data value
-        return mris->vertices[idx].imag_val;
+        return repr->vertices[idx].imag_val;
     }
     float Vertex::cx() const {
-        return mris->vertices[idx].cx;
+        return repr->vertices[idx].cx;
     }
     float Vertex::cy() const {
-        return mris->vertices[idx].cy;
+        return repr->vertices[idx].cy;
     }
     float Vertex::cz() const {  //  coordinates in canonical coordinate system
-        return mris->vertices[idx].cz;
+        return repr->vertices[idx].cz;
     }
     float Vertex::tx() const {
-        return mris->vertices[idx].tx;
+        return repr->vertices[idx].tx;
     }
     float Vertex::ty() const {
-        return mris->vertices[idx].ty;
+        return repr->vertices[idx].ty;
     }
     float Vertex::tz() const {  //  tmp coordinate storage
-        return mris->vertices[idx].tz;
+        return repr->vertices[idx].tz;
     }
-    float Vertex::tx2() const {
-        return mris->vertices[idx].tx2;
+    float Vertex::t2x() const {
+        return repr->vertices[idx].t2x;
     }
-    float Vertex::ty2() const {
-        return mris->vertices[idx].ty2;
+    float Vertex::t2y() const {
+        return repr->vertices[idx].t2y;
     }
-    float Vertex::tz2() const {  //  tmp coordinate storage
-        return mris->vertices[idx].tz2;
+    float Vertex::t2z() const {  //  another tmp coordinate storage
+        return repr->vertices[idx].t2z;
     }
     float Vertex::targx() const {
-        return mris->vertices[idx].targx;
+        return repr->vertices[idx].targx;
     }
     float Vertex::targy() const {
-        return mris->vertices[idx].targy;
+        return repr->vertices[idx].targy;
     }
     float Vertex::targz() const {  //  target coordinates
-        return mris->vertices[idx].targz;
+        return repr->vertices[idx].targz;
     }
     float Vertex::pialx() const {
-        return mris->vertices[idx].pialx;
+        return repr->vertices[idx].pialx;
     }
     float Vertex::pialy() const {
-        return mris->vertices[idx].pialy;
+        return repr->vertices[idx].pialy;
     }
     float Vertex::pialz() const {  //  pial surface coordinates
-        return mris->vertices[idx].pialz;
+        return repr->vertices[idx].pialz;
     }
     float Vertex::whitex() const {
-        return mris->vertices[idx].whitex;
+        return repr->vertices[idx].whitex;
     }
     float Vertex::whitey() const {
-        return mris->vertices[idx].whitey;
+        return repr->vertices[idx].whitey;
     }
     float Vertex::whitez() const {  //  white surface coordinates
-        return mris->vertices[idx].whitez;
+        return repr->vertices[idx].whitez;
     }
     float Vertex::l4x() const {
-        return mris->vertices[idx].l4x;
+        return repr->vertices[idx].l4x;
     }
     float Vertex::l4y() const {
-        return mris->vertices[idx].l4y;
+        return repr->vertices[idx].l4y;
     }
     float Vertex::l4z() const {  //  layerIV surface coordinates
-        return mris->vertices[idx].l4z;
+        return repr->vertices[idx].l4z;
     }
     float Vertex::infx() const {
-        return mris->vertices[idx].infx;
+        return repr->vertices[idx].infx;
     }
     float Vertex::infy() const {
-        return mris->vertices[idx].infy;
+        return repr->vertices[idx].infy;
     }
     float Vertex::infz() const {  //  inflated coordinates
-        return mris->vertices[idx].infz;
+        return repr->vertices[idx].infz;
     }
     float Vertex::fx() const {
-        return mris->vertices[idx].fx;
+        return repr->vertices[idx].fx;
     }
     float Vertex::fy() const {
-        return mris->vertices[idx].fy;
+        return repr->vertices[idx].fy;
     }
     float Vertex::fz() const {  //  flattened coordinates
-        return mris->vertices[idx].fz;
+        return repr->vertices[idx].fz;
     }
     int Vertex::px() const {
-        return mris->vertices[idx].px;
+        return repr->vertices[idx].px;
     }
     int Vertex::qx() const {
-        return mris->vertices[idx].qx;
+        return repr->vertices[idx].qx;
     }
     int Vertex::py() const {
-        return mris->vertices[idx].py;
+        return repr->vertices[idx].py;
     }
     int Vertex::qy() const {
-        return mris->vertices[idx].qy;
+        return repr->vertices[idx].qy;
     }
     int Vertex::pz() const {
-        return mris->vertices[idx].pz;
+        return repr->vertices[idx].pz;
     }
     int Vertex::qz() const {  //  rational coordinates for exact calculations
-        return mris->vertices[idx].qz;
+        return repr->vertices[idx].qz;
     }
     float Vertex::e1x() const {
-        return mris->vertices[idx].e1x;
+        return repr->vertices[idx].e1x;
     }
     float Vertex::e1y() const {
-        return mris->vertices[idx].e1y;
+        return repr->vertices[idx].e1y;
     }
     float Vertex::e1z() const {  //  1st basis vector for the local tangent plane
-        return mris->vertices[idx].e1z;
+        return repr->vertices[idx].e1z;
     }
     float Vertex::e2x() const {
-        return mris->vertices[idx].e2x;
+        return repr->vertices[idx].e2x;
     }
     float Vertex::e2y() const {
-        return mris->vertices[idx].e2y;
+        return repr->vertices[idx].e2y;
     }
     float Vertex::e2z() const {  //  2nd basis vector for the local tangent plane
-        return mris->vertices[idx].e2z;
+        return repr->vertices[idx].e2z;
     }
     float Vertex::pe1x() const {
-        return mris->vertices[idx].pe1x;
+        return repr->vertices[idx].pe1x;
     }
     float Vertex::pe1y() const {
-        return mris->vertices[idx].pe1y;
+        return repr->vertices[idx].pe1y;
     }
     float Vertex::pe1z() const {  //  1st basis vector for the local tangent plane
-        return mris->vertices[idx].pe1z;
+        return repr->vertices[idx].pe1z;
     }
     float Vertex::pe2x() const {
-        return mris->vertices[idx].pe2x;
+        return repr->vertices[idx].pe2x;
     }
     float Vertex::pe2y() const {
-        return mris->vertices[idx].pe2y;
+        return repr->vertices[idx].pe2y;
     }
     float Vertex::pe2z() const {  //  2nd basis vector for the local tangent plane
-        return mris->vertices[idx].pe2z;
+        return repr->vertices[idx].pe2z;
     }
     float Vertex::nc() const {  //  curr length normal comp 
-        return mris->vertices[idx].nc;
+        return repr->vertices[idx].nc;
     }
     float Vertex::val2() const {  //  complex comp data value (file: sig3-rh.w) 
-        return mris->vertices[idx].val2;
+        return repr->vertices[idx].val2;
     }
     float Vertex::valbak() const {  //  scalar data stack 
-        return mris->vertices[idx].valbak;
+        return repr->vertices[idx].valbak;
     }
     float Vertex::val2bak() const {  //  complex comp data stack 
-        return mris->vertices[idx].val2bak;
+        return repr->vertices[idx].val2bak;
     }
     float Vertex::stat() const {  //  statistic 
-        return mris->vertices[idx].stat;
+        return repr->vertices[idx].stat;
     }
     int Vertex::undefval() const {  //  [previously dist=0] 
-        return mris->vertices[idx].undefval;
+        return repr->vertices[idx].undefval;
     }
     int Vertex::old_undefval() const {  //  for smooth_val_sparse 
-        return mris->vertices[idx].old_undefval;
+        return repr->vertices[idx].old_undefval;
     }
     int Vertex::fixedval() const {  //  [previously val=0] 
-        return mris->vertices[idx].fixedval;
+        return repr->vertices[idx].fixedval;
     }
     float Vertex::fieldsign() const {  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
-        return mris->vertices[idx].fieldsign;
+        return repr->vertices[idx].fieldsign;
     }
     float Vertex::fsmask() const {  //  significance mask (file: rh.fm) 
-        return mris->vertices[idx].fsmask;
+        return repr->vertices[idx].fsmask;
     }
     float Vertex::d() const {  //  for distance calculations 
-        return mris->vertices[idx].d;
+        return repr->vertices[idx].d;
     }
     int Vertex::annotation() const {  //  area label (defunct--now from label file name!) 
-        return mris->vertices[idx].annotation;
+        return repr->vertices[idx].annotation;
     }
     char Vertex::oripflag() const {
-        return mris->vertices[idx].oripflag;
+        return repr->vertices[idx].oripflag;
     }
     char Vertex::origripflag() const {  //  cuts flags 
-        return mris->vertices[idx].origripflag;
+        return repr->vertices[idx].origripflag;
     }
     p_void Vertex::vp() const {  //  to store user's information 
-        return mris->vertices[idx].vp;
+        return repr->vertices[idx].vp;
     }
     float Vertex::theta() const {
-        return mris->vertices[idx].theta;
+        return repr->vertices[idx].theta;
     }
     float Vertex::phi() const {  //  parameterization 
-        return mris->vertices[idx].phi;
+        return repr->vertices[idx].phi;
     }
     float Vertex::area() const {
-        return mris->vertices[idx].area;
+        return repr->vertices[idx].area;
     }
     float Vertex::origarea() const {
-        return mris->vertices[idx].origarea;
+        return repr->vertices[idx].origarea;
     }
     float Vertex::group_avg_area() const {
-        return mris->vertices[idx].group_avg_area;
+        return repr->vertices[idx].group_avg_area;
     }
     float Vertex::K() const {  //  Gaussian curvature 
-        return mris->vertices[idx].K;
+        return repr->vertices[idx].K;
     }
     float Vertex::H() const {  //  mean curvature 
-        return mris->vertices[idx].H;
+        return repr->vertices[idx].H;
     }
     float Vertex::k1() const {
-        return mris->vertices[idx].k1;
+        return repr->vertices[idx].k1;
     }
     float Vertex::k2() const {  //  the principal curvatures 
-        return mris->vertices[idx].k2;
+        return repr->vertices[idx].k2;
     }
     float Vertex::mean() const {
-        return mris->vertices[idx].mean;
+        return repr->vertices[idx].mean;
     }
     float Vertex::mean_imag() const {  //  imaginary part of complex statistic 
-        return mris->vertices[idx].mean_imag;
+        return repr->vertices[idx].mean_imag;
     }
     float Vertex::std_error() const {
-        return mris->vertices[idx].std_error;
+        return repr->vertices[idx].std_error;
     }
     uint Vertex::flags() const {
-        return mris->vertices[idx].flags;
+        return repr->vertices[idx].flags;
     }
     int Vertex::fno() const {  //  face that this vertex is in 
-        return mris->vertices[idx].fno;
+        return repr->vertices[idx].fno;
     }
     int Vertex::cropped() const {
-        return mris->vertices[idx].cropped;
+        return repr->vertices[idx].cropped;
     }
     short Vertex::marked() const {  //  for a variety of uses 
-        return mris->vertices[idx].marked;
+        return repr->vertices[idx].marked;
     }
     short Vertex::marked2() const {
-        return mris->vertices[idx].marked2;
+        return repr->vertices[idx].marked2;
     }
     short Vertex::marked3() const {
-        return mris->vertices[idx].marked3;
+        return repr->vertices[idx].marked3;
     }
     char Vertex::neg() const {  //  1 if the normal vector is inverted 
-        return mris->vertices[idx].neg;
+        return repr->vertices[idx].neg;
     }
     char Vertex::border() const {  //  flag 
-        return mris->vertices[idx].border;
+        return repr->vertices[idx].border;
     }
     char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
-        return mris->vertices[idx].ripflag;
+        return repr->vertices[idx].ripflag;
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+         MRISvertexCoord2XYZ_float(&repr->vertices[idx], which, x, y, z);
     }
     
     void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        cheapAssert(mris == to.mris); mris->vertices_topology[idx].f[i] = to.idx;
+        cheapAssert(repr == to.repr); repr->vertices_topology[idx].f[i] = to.idx;
     }
     void Vertex::set_n(size_t i, size_t to) {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        mris->vertices_topology[idx].n[i] = uchar(to);
+        repr->vertices_topology[idx].n[i] = uchar(to);
     }
     void Vertex::set_e(size_t i, int to) {  //  edge state for neighboring vertices                      
-        mris->vertices_topology[idx].e[i] = to;
+        repr->vertices_topology[idx].e[i] = to;
     }
     void Vertex::set_nx(float to) {
-        mris->vertices[idx].nx = to;
+        repr->vertices[idx].nx = to;
     }
     void Vertex::set_ny(float to) {
-        mris->vertices[idx].ny = to;
+        repr->vertices[idx].ny = to;
     }
     void Vertex::set_nz(float to) {  //  curr normal
-        mris->vertices[idx].nz = to;
+        repr->vertices[idx].nz = to;
     }
     void Vertex::set_pnx(float to) {
-        mris->vertices[idx].pnx = to;
+        repr->vertices[idx].pnx = to;
     }
     void Vertex::set_pny(float to) {
-        mris->vertices[idx].pny = to;
+        repr->vertices[idx].pny = to;
     }
     void Vertex::set_pnz(float to) {  //  pial normal
-        mris->vertices[idx].pnz = to;
+        repr->vertices[idx].pnz = to;
     }
     void Vertex::set_wnx(float to) {
-        mris->vertices[idx].wnx = to;
+        repr->vertices[idx].wnx = to;
     }
     void Vertex::set_wny(float to) {
-        mris->vertices[idx].wny = to;
+        repr->vertices[idx].wny = to;
     }
     void Vertex::set_wnz(float to) {  //  white normal
-        mris->vertices[idx].wnz = to;
+        repr->vertices[idx].wnz = to;
     }
     void Vertex::set_onx(float to) {
-        mris->vertices[idx].onx = to;
+        repr->vertices[idx].onx = to;
     }
     void Vertex::set_ony(float to) {
-        mris->vertices[idx].ony = to;
+        repr->vertices[idx].ony = to;
     }
     void Vertex::set_onz(float to) {  //  original normal
-        mris->vertices[idx].onz = to;
+        repr->vertices[idx].onz = to;
     }
     void Vertex::set_dx(float to) {
-        mris->vertices[idx].dx = to;
+        repr->vertices[idx].dx = to;
     }
     void Vertex::set_dy(float to) {
-        mris->vertices[idx].dy = to;
+        repr->vertices[idx].dy = to;
     }
     void Vertex::set_dz(float to) {  //  current change in position
-        mris->vertices[idx].dz = to;
+        repr->vertices[idx].dz = to;
     }
     void Vertex::set_odx(float to) {
-        mris->vertices[idx].odx = to;
+        repr->vertices[idx].odx = to;
     }
     void Vertex::set_ody(float to) {
-        mris->vertices[idx].ody = to;
+        repr->vertices[idx].ody = to;
     }
     void Vertex::set_odz(float to) {  //  last change of position (for momentum, 
-        mris->vertices[idx].odz = to;
+        repr->vertices[idx].odz = to;
     }
     void Vertex::set_tdx(float to) {
-        mris->vertices[idx].tdx = to;
+        repr->vertices[idx].tdx = to;
     }
     void Vertex::set_tdy(float to) {
-        mris->vertices[idx].tdy = to;
+        repr->vertices[idx].tdy = to;
     }
     void Vertex::set_tdz(float to) {  //  temporary storage for averaging gradient
-        mris->vertices[idx].tdz = to;
+        repr->vertices[idx].tdz = to;
     }
     void Vertex::set_curv(float to) {  //  curr curvature
-        mris->vertices[idx].curv = to;
+        repr->vertices[idx].curv = to;
     }
     void Vertex::set_curvbak(float to) {
-        mris->vertices[idx].curvbak = to;
+        repr->vertices[idx].curvbak = to;
     }
     void Vertex::set_val(float to) {  //  scalar data value (file: rh.val, sig2-rh.w)
-        mris->vertices[idx].val = to;
+        repr->vertices[idx].val = to;
     }
     void Vertex::set_imag_val(float to) {  //  imaginary part of complex data value
-        mris->vertices[idx].imag_val = to;
+        repr->vertices[idx].imag_val = to;
     }
     void Vertex::set_cx(float to) {
-        mris->vertices[idx].cx = to;
+        repr->vertices[idx].cx = to;
     }
     void Vertex::set_cy(float to) {
-        mris->vertices[idx].cy = to;
+        repr->vertices[idx].cy = to;
     }
     void Vertex::set_cz(float to) {  //  coordinates in canonical coordinate system
-        mris->vertices[idx].cz = to;
+        repr->vertices[idx].cz = to;
     }
     void Vertex::set_tx(float to) {
-        mris->vertices[idx].tx = to;
+        repr->vertices[idx].tx = to;
     }
     void Vertex::set_ty(float to) {
-        mris->vertices[idx].ty = to;
+        repr->vertices[idx].ty = to;
     }
     void Vertex::set_tz(float to) {  //  tmp coordinate storage
-        mris->vertices[idx].tz = to;
+        repr->vertices[idx].tz = to;
     }
-    void Vertex::set_tx2(float to) {
-        mris->vertices[idx].tx2 = to;
+    void Vertex::set_t2x(float to) {
+        repr->vertices[idx].t2x = to;
     }
-    void Vertex::set_ty2(float to) {
-        mris->vertices[idx].ty2 = to;
+    void Vertex::set_t2y(float to) {
+        repr->vertices[idx].t2y = to;
     }
-    void Vertex::set_tz2(float to) {  //  tmp coordinate storage
-        mris->vertices[idx].tz2 = to;
+    void Vertex::set_t2z(float to) {  //  another tmp coordinate storage
+        repr->vertices[idx].t2z = to;
     }
     void Vertex::set_targx(float to) {
-        mris->vertices[idx].targx = to;
+        repr->vertices[idx].targx = to;
     }
     void Vertex::set_targy(float to) {
-        mris->vertices[idx].targy = to;
+        repr->vertices[idx].targy = to;
     }
     void Vertex::set_targz(float to) {  //  target coordinates
-        mris->vertices[idx].targz = to;
+        repr->vertices[idx].targz = to;
     }
     void Vertex::set_pialx(float to) {
-        mris->vertices[idx].pialx = to;
+        repr->vertices[idx].pialx = to;
     }
     void Vertex::set_pialy(float to) {
-        mris->vertices[idx].pialy = to;
+        repr->vertices[idx].pialy = to;
     }
     void Vertex::set_pialz(float to) {  //  pial surface coordinates
-        mris->vertices[idx].pialz = to;
+        repr->vertices[idx].pialz = to;
     }
     void Vertex::set_whitex(float to) {
-        mris->vertices[idx].whitex = to;
+        repr->vertices[idx].whitex = to;
     }
     void Vertex::set_whitey(float to) {
-        mris->vertices[idx].whitey = to;
+        repr->vertices[idx].whitey = to;
     }
     void Vertex::set_whitez(float to) {  //  white surface coordinates
-        mris->vertices[idx].whitez = to;
+        repr->vertices[idx].whitez = to;
     }
     void Vertex::set_l4x(float to) {
-        mris->vertices[idx].l4x = to;
+        repr->vertices[idx].l4x = to;
     }
     void Vertex::set_l4y(float to) {
-        mris->vertices[idx].l4y = to;
+        repr->vertices[idx].l4y = to;
     }
     void Vertex::set_l4z(float to) {  //  layerIV surface coordinates
-        mris->vertices[idx].l4z = to;
+        repr->vertices[idx].l4z = to;
     }
     void Vertex::set_infx(float to) {
-        mris->vertices[idx].infx = to;
+        repr->vertices[idx].infx = to;
     }
     void Vertex::set_infy(float to) {
-        mris->vertices[idx].infy = to;
+        repr->vertices[idx].infy = to;
     }
     void Vertex::set_infz(float to) {  //  inflated coordinates
-        mris->vertices[idx].infz = to;
+        repr->vertices[idx].infz = to;
     }
     void Vertex::set_fx(float to) {
-        mris->vertices[idx].fx = to;
+        repr->vertices[idx].fx = to;
     }
     void Vertex::set_fy(float to) {
-        mris->vertices[idx].fy = to;
+        repr->vertices[idx].fy = to;
     }
     void Vertex::set_fz(float to) {  //  flattened coordinates
-        mris->vertices[idx].fz = to;
+        repr->vertices[idx].fz = to;
     }
     void Vertex::set_px(int to) {
-        mris->vertices[idx].px = to;
+        repr->vertices[idx].px = to;
     }
     void Vertex::set_qx(int to) {
-        mris->vertices[idx].qx = to;
+        repr->vertices[idx].qx = to;
     }
     void Vertex::set_py(int to) {
-        mris->vertices[idx].py = to;
+        repr->vertices[idx].py = to;
     }
     void Vertex::set_qy(int to) {
-        mris->vertices[idx].qy = to;
+        repr->vertices[idx].qy = to;
     }
     void Vertex::set_pz(int to) {
-        mris->vertices[idx].pz = to;
+        repr->vertices[idx].pz = to;
     }
     void Vertex::set_qz(int to) {  //  rational coordinates for exact calculations
-        mris->vertices[idx].qz = to;
+        repr->vertices[idx].qz = to;
     }
     void Vertex::set_e1x(float to) {
-        mris->vertices[idx].e1x = to;
+        repr->vertices[idx].e1x = to;
     }
     void Vertex::set_e1y(float to) {
-        mris->vertices[idx].e1y = to;
+        repr->vertices[idx].e1y = to;
     }
     void Vertex::set_e1z(float to) {  //  1st basis vector for the local tangent plane
-        mris->vertices[idx].e1z = to;
+        repr->vertices[idx].e1z = to;
     }
     void Vertex::set_e2x(float to) {
-        mris->vertices[idx].e2x = to;
+        repr->vertices[idx].e2x = to;
     }
     void Vertex::set_e2y(float to) {
-        mris->vertices[idx].e2y = to;
+        repr->vertices[idx].e2y = to;
     }
     void Vertex::set_e2z(float to) {  //  2nd basis vector for the local tangent plane
-        mris->vertices[idx].e2z = to;
+        repr->vertices[idx].e2z = to;
     }
     void Vertex::set_pe1x(float to) {
-        mris->vertices[idx].pe1x = to;
+        repr->vertices[idx].pe1x = to;
     }
     void Vertex::set_pe1y(float to) {
-        mris->vertices[idx].pe1y = to;
+        repr->vertices[idx].pe1y = to;
     }
     void Vertex::set_pe1z(float to) {  //  1st basis vector for the local tangent plane
-        mris->vertices[idx].pe1z = to;
+        repr->vertices[idx].pe1z = to;
     }
     void Vertex::set_pe2x(float to) {
-        mris->vertices[idx].pe2x = to;
+        repr->vertices[idx].pe2x = to;
     }
     void Vertex::set_pe2y(float to) {
-        mris->vertices[idx].pe2y = to;
+        repr->vertices[idx].pe2y = to;
     }
     void Vertex::set_pe2z(float to) {  //  2nd basis vector for the local tangent plane
-        mris->vertices[idx].pe2z = to;
+        repr->vertices[idx].pe2z = to;
     }
     void Vertex::set_nc(float to) {  //  curr length normal comp 
-        mris->vertices[idx].nc = to;
+        repr->vertices[idx].nc = to;
     }
     void Vertex::set_val2(float to) {  //  complex comp data value (file: sig3-rh.w) 
-        mris->vertices[idx].val2 = to;
+        repr->vertices[idx].val2 = to;
     }
     void Vertex::set_valbak(float to) {  //  scalar data stack 
-        mris->vertices[idx].valbak = to;
+        repr->vertices[idx].valbak = to;
     }
     void Vertex::set_val2bak(float to) {  //  complex comp data stack 
-        mris->vertices[idx].val2bak = to;
+        repr->vertices[idx].val2bak = to;
     }
     void Vertex::set_stat(float to) {  //  statistic 
-        mris->vertices[idx].stat = to;
+        repr->vertices[idx].stat = to;
     }
     void Vertex::set_undefval(int to) {  //  [previously dist=0] 
-        mris->vertices[idx].undefval = to;
+        repr->vertices[idx].undefval = to;
     }
     void Vertex::set_old_undefval(int to) {  //  for smooth_val_sparse 
-        mris->vertices[idx].old_undefval = to;
+        repr->vertices[idx].old_undefval = to;
     }
     void Vertex::set_fixedval(int to) {  //  [previously val=0] 
-        mris->vertices[idx].fixedval = to;
+        repr->vertices[idx].fixedval = to;
     }
     void Vertex::set_fieldsign(float to) {  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
-        mris->vertices[idx].fieldsign = to;
+        repr->vertices[idx].fieldsign = to;
     }
     void Vertex::set_fsmask(float to) {  //  significance mask (file: rh.fm) 
-        mris->vertices[idx].fsmask = to;
+        repr->vertices[idx].fsmask = to;
     }
     void Vertex::set_d(float to) {  //  for distance calculations 
-        mris->vertices[idx].d = to;
+        repr->vertices[idx].d = to;
     }
     void Vertex::set_annotation(int to) {  //  area label (defunct--now from label file name!) 
-        mris->vertices[idx].annotation = to;
+        repr->vertices[idx].annotation = to;
     }
     void Vertex::set_oripflag(char to) {
-        mris->vertices[idx].oripflag = to;
+        repr->vertices[idx].oripflag = to;
     }
     void Vertex::set_origripflag(char to) {  //  cuts flags 
-        mris->vertices[idx].origripflag = to;
+        repr->vertices[idx].origripflag = to;
     }
     void Vertex::set_vp(p_void to) {  //  to store user's information 
-        mris->vertices[idx].vp = to;
+        repr->vertices[idx].vp = to;
     }
     void Vertex::set_theta(float to) {
-        mris->vertices[idx].theta = to;
+        repr->vertices[idx].theta = to;
     }
     void Vertex::set_phi(float to) {  //  parameterization 
-        mris->vertices[idx].phi = to;
+        repr->vertices[idx].phi = to;
     }
     void Vertex::set_origarea(float to) {
-        mris->vertices[idx].origarea = to;
+        repr->vertices[idx].origarea = to;
     }
     void Vertex::set_group_avg_area(float to) {
-        mris->vertices[idx].group_avg_area = to;
+        repr->vertices[idx].group_avg_area = to;
     }
     void Vertex::set_K(float to) {  //  Gaussian curvature 
-        mris->vertices[idx].K = to;
+        repr->vertices[idx].K = to;
     }
     void Vertex::set_H(float to) {  //  mean curvature 
-        mris->vertices[idx].H = to;
+        repr->vertices[idx].H = to;
     }
     void Vertex::set_k1(float to) {
-        mris->vertices[idx].k1 = to;
+        repr->vertices[idx].k1 = to;
     }
     void Vertex::set_k2(float to) {  //  the principal curvatures 
-        mris->vertices[idx].k2 = to;
+        repr->vertices[idx].k2 = to;
     }
     void Vertex::set_mean(float to) {
-        mris->vertices[idx].mean = to;
+        repr->vertices[idx].mean = to;
     }
     void Vertex::set_mean_imag(float to) {  //  imaginary part of complex statistic 
-        mris->vertices[idx].mean_imag = to;
+        repr->vertices[idx].mean_imag = to;
     }
     void Vertex::set_std_error(float to) {
-        mris->vertices[idx].std_error = to;
+        repr->vertices[idx].std_error = to;
     }
     void Vertex::set_flags(uint to) {
-        mris->vertices[idx].flags = to;
+        repr->vertices[idx].flags = to;
     }
     void Vertex::set_fno(int to) {  //  face that this vertex is in 
-        mris->vertices[idx].fno = to;
+        repr->vertices[idx].fno = to;
     }
     void Vertex::set_cropped(int to) {
-        mris->vertices[idx].cropped = to;
+        repr->vertices[idx].cropped = to;
     }
     void Vertex::set_marked(short to) {  //  for a variety of uses 
-        mris->vertices[idx].marked = to;
+        repr->vertices[idx].marked = to;
     }
     void Vertex::set_marked2(short to) {
-        mris->vertices[idx].marked2 = to;
+        repr->vertices[idx].marked2 = to;
     }
     void Vertex::set_marked3(short to) {
-        mris->vertices[idx].marked3 = to;
+        repr->vertices[idx].marked3 = to;
     }
     void Vertex::set_neg(char to) {  //  1 if the normal vector is inverted 
-        mris->vertices[idx].neg = to;
+        repr->vertices[idx].neg = to;
     }
     void Vertex::set_border(char to) {  //  flag 
-        mris->vertices[idx].border = to;
+        repr->vertices[idx].border = to;
     }
     void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
-        mris->vertices[idx].ripflag = to;
+        repr->vertices[idx].ripflag = to;
     }
 
 
-    Surface::Surface (                           ) {}                   
-    Surface::Surface ( MRIS* mris                ) : MRIS_Elt(mris,0) {}
-    Surface::Surface ( Surface const & src       ) : MRIS_Elt(src) {}   
-    Surface::Surface ( AllM::Surface const & src ) : MRIS_Elt(src) {}   
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
+    Surface::Surface ( AllM::Surface const & src      ) : Repr_Elt(src) {}
 
     int Surface::nverticesFrozen() const {  //  # of vertices on surface is frozen
-        return mris->nverticesFrozen;
+        return repr->nverticesFrozen;
     }
     int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nvertices;
+        return repr->nvertices;
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nfaces;
+        return repr->nfaces;
     }
     bool Surface::faceAttachmentDeferred() const {  //  defer connecting faces to vertices for performance reasons
-        return mris->faceAttachmentDeferred;
+        return repr->faceAttachmentDeferred;
     }
     int Surface::nedges() const {  //  # of edges on surface
-        return mris->nedges;
+        return repr->nedges;
     }
     int Surface::nstrips() const {
-        return mris->nstrips;
+        return repr->nstrips;
     }
     Vertex Surface::vertices(size_t i) const {
-        return Vertex(mris,i);
+        return Vertex(repr,i);
     }
     p_p_void Surface::dist_storage() const {  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
-        return mris->dist_storage;
+        return repr->dist_storage;
     }
     p_p_void Surface::dist_orig_storage() const {  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
-        return mris->dist_orig_storage;
+        return repr->dist_orig_storage;
     }
     int Surface::tempsAssigned() const {  //  State of various temp fields that can be borrowed if not already in use
-        return mris->tempsAssigned;
+        return repr->tempsAssigned;
     }
     Face Surface::faces(size_t i) const {
-        return Face(mris,i);
+        return Face(repr,i);
     }
     MRI_EDGE Surface::edges(size_t i) const {
-        return mris->edges[i];
+        return repr->edges[i];
     }
     FaceNormCacheEntry Surface::faceNormCacheEntries(size_t i) const {
-        return mris->faceNormCacheEntries[i];
+        return repr->faceNormCacheEntries[i];
     }
     FaceNormDeferredEntry Surface::faceNormDeferredEntries(size_t i) const {
-        return mris->faceNormDeferredEntries[i];
+        return repr->faceNormDeferredEntries[i];
     }
     STRIP Surface::strips(size_t i) const {
-        return mris->strips[i];
+        return repr->strips[i];
     }
     float Surface::xctr() const {
-        return mris->xctr;
+        return repr->xctr;
     }
     float Surface::yctr() const {
-        return mris->yctr;
+        return repr->yctr;
     }
     float Surface::zctr() const {
-        return mris->zctr;
+        return repr->zctr;
     }
     float Surface::xlo() const {
-        return mris->xlo;
+        return repr->xlo;
     }
     float Surface::ylo() const {
-        return mris->ylo;
+        return repr->ylo;
     }
     float Surface::zlo() const {
-        return mris->zlo;
+        return repr->zlo;
     }
     float Surface::xhi() const {
-        return mris->xhi;
+        return repr->xhi;
     }
     float Surface::yhi() const {
-        return mris->yhi;
+        return repr->yhi;
     }
     float Surface::zhi() const {
-        return mris->zhi;
+        return repr->zhi;
     }
     float Surface::x0() const {  //  center of spherical expansion
-        return mris->x0;
+        return repr->x0;
     }
     float Surface::y0() const {
-        return mris->y0;
+        return repr->y0;
     }
     float Surface::z0() const {
-        return mris->z0;
+        return repr->z0;
     }
     Vertex Surface::v_temporal_pole() const {
-        return Vertex(mris,mris->v_temporal_pole - mris->vertices);
+        return Vertex(repr,repr->v_temporal_pole - repr->vertices);
     }
     Vertex Surface::v_frontal_pole() const {
-        return Vertex(mris,mris->v_frontal_pole - mris->vertices);
+        return Vertex(repr,repr->v_frontal_pole - repr->vertices);
     }
     Vertex Surface::v_occipital_pole() const {
-        return Vertex(mris,mris->v_occipital_pole - mris->vertices);
+        return Vertex(repr,repr->v_occipital_pole - repr->vertices);
     }
     float Surface::max_curv() const {
-        return mris->max_curv;
+        return repr->max_curv;
     }
     float Surface::min_curv() const {
-        return mris->min_curv;
+        return repr->min_curv;
     }
     float Surface::total_area() const {
-        return mris->total_area;
+        return repr->total_area;
     }
     double Surface::avg_vertex_area() const {
-        return mris->avg_vertex_area;
+        return repr->avg_vertex_area;
     }
     double Surface::avg_vertex_dist() const {  //  set by MRIScomputeAvgInterVertexDist
-        return mris->avg_vertex_dist;
+        return repr->avg_vertex_dist;
     }
     double Surface::std_vertex_dist() const {
-        return mris->std_vertex_dist;
+        return repr->std_vertex_dist;
     }
     float Surface::orig_area() const {
-        return mris->orig_area;
+        return repr->orig_area;
     }
     float Surface::neg_area() const {
-        return mris->neg_area;
+        return repr->neg_area;
     }
     float Surface::neg_orig_area() const {  //  amount of original surface in folds
-        return mris->neg_orig_area;
+        return repr->neg_orig_area;
     }
     int Surface::zeros() const {
-        return mris->zeros;
+        return repr->zeros;
     }
     int Surface::hemisphere() const {  //  which hemisphere
-        return mris->hemisphere;
+        return repr->hemisphere;
     }
     int Surface::initialized() const {
-        return mris->initialized;
+        return repr->initialized;
     }
     PLTA Surface::lta() const {
-        return mris->lta;
+        return repr->lta;
     }
     PMATRIX Surface::SRASToTalSRAS_() const {
-        return mris->SRASToTalSRAS_;
+        return repr->SRASToTalSRAS_;
     }
     PMATRIX Surface::TalSRASToSRAS_() const {
-        return mris->TalSRASToSRAS_;
+        return repr->TalSRASToSRAS_;
     }
     int Surface::free_transform() const {
-        return mris->free_transform;
+        return repr->free_transform;
     }
     double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
-        return mris->radius;
+        return repr->radius;
     }
     float Surface::a() const {
-        return mris->a;
+        return repr->a;
     }
     float Surface::b() const {
-        return mris->b;
+        return repr->b;
     }
     float Surface::c() const {  //  ellipsoid parameters
-        return mris->c;
+        return repr->c;
     }
     MRIS_fname_t Surface::fname() const {  //  file it was originally loaded from
-        return mris->fname;
+        return repr->fname;
     }
     float Surface::Hmin() const {  //  min mean curvature
-        return mris->Hmin;
+        return repr->Hmin;
     }
     float Surface::Hmax() const {  //  max mean curvature
-        return mris->Hmax;
+        return repr->Hmax;
     }
     float Surface::Kmin() const {  //  min Gaussian curvature
-        return mris->Kmin;
+        return repr->Kmin;
     }
     float Surface::Kmax() const {  //  max Gaussian curvature
-        return mris->Kmax;
+        return repr->Kmax;
     }
     double Surface::Ktotal() const {  //  total Gaussian curvature
-        return mris->Ktotal;
+        return repr->Ktotal;
     }
     MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
-        return mris->status;
+        return repr->status;
     }
     MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-        return mris->origxyz_status;
+        return repr->origxyz_status;
     }
     int Surface::patch() const {  //  if a patch of the surface
-        return mris->patch;
+        return repr->patch;
     }
     int Surface::nlabels() const {
-        return mris->nlabels;
+        return repr->nlabels;
     }
     PMRIS_AREA_LABEL Surface::labels() const {  //  nlabels of these (may be null)
-        return mris->labels;
+        return repr->labels;
     }
     p_void Surface::vp() const {  //  for misc. use
-        return mris->vp;
+        return repr->vp;
     }
     float Surface::alpha() const {  //  rotation around z-axis
-        return mris->alpha;
+        return repr->alpha;
     }
     float Surface::beta() const {  //  rotation around y-axis
-        return mris->beta;
+        return repr->beta;
     }
     float Surface::gamma() const {  //  rotation around x-axis
-        return mris->gamma;
+        return repr->gamma;
     }
     float Surface::da() const {
-        return mris->da;
+        return repr->da;
     }
     float Surface::db() const {
-        return mris->db;
+        return repr->db;
     }
     float Surface::dg() const {  //  old deltas
-        return mris->dg;
+        return repr->dg;
     }
     int Surface::type() const {  //  what type of surface was this initially
-        return mris->type;
+        return repr->type;
     }
     int Surface::max_vertices() const {  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
-        return mris->max_vertices;
+        return repr->max_vertices;
     }
     int Surface::max_faces() const {  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
-        return mris->max_faces;
+        return repr->max_faces;
     }
     MRIS_subject_name_t Surface::subject_name() const {  //  name of the subject
-        return mris->subject_name;
+        return repr->subject_name;
     }
     float Surface::canon_area() const {
-        return mris->canon_area;
+        return repr->canon_area;
     }
     int Surface::noscale() const {  //  don't scale by surface area if true
-        return mris->noscale;
+        return repr->noscale;
     }
     float Surface::dx2(size_t i) const {  //  an extra set of gradient (not always alloced)
-        return mris->dx2[i];
+        return repr->dx2[i];
     }
     float Surface::dy2(size_t i) const {
-        return mris->dy2[i];
+        return repr->dy2[i];
     }
     float Surface::dz2(size_t i) const {
-        return mris->dz2[i];
+        return repr->dz2[i];
     }
     PCOLOR_TABLE Surface::ct() const {
-        return mris->ct;
+        return repr->ct;
     }
     int Surface::useRealRAS() const {  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        return mris->useRealRAS;
+        return repr->useRealRAS;
     }
     VOL_GEOM Surface::vg() const {  //  volume info from which this surface is created. valid iff vg.valid = 1
-        return mris->vg;
+        return repr->vg;
     }
     MRIS_cmdlines_t Surface::cmdlines() const {
-        return mris->cmdlines;
+        return repr->cmdlines;
     }
     int Surface::ncmds() const {
-        return mris->ncmds;
+        return repr->ncmds;
     }
     float Surface::group_avg_surface_area() const {  //  average of total surface area for group
-        return mris->group_avg_surface_area;
+        return repr->group_avg_surface_area;
     }
     int Surface::group_avg_vtxarea_loaded() const {  //  average vertex area for group at each vertex
-        return mris->group_avg_vtxarea_loaded;
+        return repr->group_avg_vtxarea_loaded;
     }
     int Surface::triangle_links_removed() const {  //  for quad surfaces
-        return mris->triangle_links_removed;
+        return repr->triangle_links_removed;
     }
     p_void Surface::user_parms() const {  //  for whatever the user wants to hang here
-        return mris->user_parms;
+        return repr->user_parms;
     }
     PMATRIX Surface::m_sras2vox() const {  //  for converting surface ras to voxel
-        return mris->m_sras2vox;
+        return repr->m_sras2vox;
     }
     PMRI Surface::mri_sras2vox() const {  //  volume that the above matrix is for
-        return mris->mri_sras2vox;
+        return repr->mri_sras2vox;
     }
     p_void Surface::mht() const {
-        return mris->mht;
+        return repr->mht;
     }
     p_void Surface::temps() const {
-        return mris->temps;
+        return repr->temps;
     }
     
     void Surface::set_strips(size_t i, STRIP to) {
-        mris->strips[i] = to;
+        repr->strips[i] = to;
     }
     void Surface::set_xctr(float to) {
-        mris->xctr = to;
+        repr->xctr = to;
     }
     void Surface::set_yctr(float to) {
-        mris->yctr = to;
+        repr->yctr = to;
     }
     void Surface::set_zctr(float to) {
-        mris->zctr = to;
+        repr->zctr = to;
     }
     void Surface::set_xlo(float to) {
-        mris->xlo = to;
+        repr->xlo = to;
     }
     void Surface::set_ylo(float to) {
-        mris->ylo = to;
+        repr->ylo = to;
     }
     void Surface::set_zlo(float to) {
-        mris->zlo = to;
+        repr->zlo = to;
     }
     void Surface::set_xhi(float to) {
-        mris->xhi = to;
+        repr->xhi = to;
     }
     void Surface::set_yhi(float to) {
-        mris->yhi = to;
+        repr->yhi = to;
     }
     void Surface::set_zhi(float to) {
-        mris->zhi = to;
+        repr->zhi = to;
     }
     void Surface::set_x0(float to) {  //  center of spherical expansion
-        mris->x0 = to;
+        repr->x0 = to;
     }
     void Surface::set_y0(float to) {
-        mris->y0 = to;
+        repr->y0 = to;
     }
     void Surface::set_z0(float to) {
-        mris->z0 = to;
+        repr->z0 = to;
     }
     void Surface::set_v_temporal_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_temporal_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_temporal_pole = repr->vertices + to.idx;
     }
     void Surface::set_v_frontal_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_frontal_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_frontal_pole = repr->vertices + to.idx;
     }
     void Surface::set_v_occipital_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_occipital_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_occipital_pole = repr->vertices + to.idx;
     }
     void Surface::set_max_curv(float to) {
-        mris->max_curv = to;
+        repr->max_curv = to;
     }
     void Surface::set_min_curv(float to) {
-        mris->min_curv = to;
+        repr->min_curv = to;
     }
     void Surface::set_total_area(float to) {
-        mris->total_area = to;
+        repr->total_area = to;
     }
     void Surface::set_avg_vertex_area(double to) {
-        mris->avg_vertex_area = to;
+        repr->avg_vertex_area = to;
     }
     void Surface::set_zeros(int to) {
-        mris->zeros = to;
+        repr->zeros = to;
     }
     void Surface::set_hemisphere(int to) {  //  which hemisphere
-        mris->hemisphere = to;
+        repr->hemisphere = to;
     }
     void Surface::set_Hmin(float to) {  //  min mean curvature
-        mris->Hmin = to;
+        repr->Hmin = to;
     }
     void Surface::set_Hmax(float to) {  //  max mean curvature
-        mris->Hmax = to;
+        repr->Hmax = to;
     }
     void Surface::set_Kmin(float to) {  //  min Gaussian curvature
-        mris->Kmin = to;
+        repr->Kmin = to;
     }
     void Surface::set_Kmax(float to) {  //  max Gaussian curvature
-        mris->Kmax = to;
+        repr->Kmax = to;
     }
     void Surface::set_Ktotal(double to) {  //  total Gaussian curvature
-        mris->Ktotal = to;
+        repr->Ktotal = to;
     }
     void Surface::set_nlabels(int to) {
-        mris->nlabels = to;
+        repr->nlabels = to;
     }
     void Surface::set_labels(PMRIS_AREA_LABEL to) {  //  nlabels of these (may be null)
-        mris->labels = to;
+        repr->labels = to;
     }
     void Surface::set_vp(p_void to) {  //  for misc. use
-        mris->vp = to;
+        repr->vp = to;
     }
     void Surface::set_alpha(float to) {  //  rotation around z-axis
-        mris->alpha = to;
+        repr->alpha = to;
     }
     void Surface::set_beta(float to) {  //  rotation around y-axis
-        mris->beta = to;
+        repr->beta = to;
     }
     void Surface::set_gamma(float to) {  //  rotation around x-axis
-        mris->gamma = to;
+        repr->gamma = to;
     }
     void Surface::set_da(float to) {
-        mris->da = to;
+        repr->da = to;
     }
     void Surface::set_db(float to) {
-        mris->db = to;
+        repr->db = to;
     }
     void Surface::set_dg(float to) {  //  old deltas
-        mris->dg = to;
+        repr->dg = to;
     }
     void Surface::set_type(int to) {  //  what type of surface was this initially
-        mris->type = to;
+        repr->type = to;
     }
 
 
@@ -7411,1235 +7447,1238 @@ namespace SurfaceFromMRIS {
 
 
     namespace AllM {
-    Face::Face (                        ) {}                     
-    Face::Face ( MRIS* mris, size_t idx ) : MRIS_Elt(mris,idx) {}
-    Face::Face ( Face const & src       ) : MRIS_Elt(src) {}     
+    Face::Face (                                            ) {}
+    Face::Face ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Face::Face ( Face const & src                           ) : Repr_Elt(src) {}
 
     Vertex Face::v(size_t i) const {
-        return Vertex(mris,mris->faces[idx].v[i]);
+        return Vertex(repr,repr->faces[idx].v[i]);
     }
     float Face::area() const {
-        return mris->faces[idx].area;
+        return repr->faces[idx].area;
     }
     angles_per_triangle_t Face::angle() const {
-        return mris->faces[idx].angle;
+        return repr->faces[idx].angle;
     }
     angles_per_triangle_t Face::orig_angle() const {
-        return mris->faces[idx].orig_angle;
+        return repr->faces[idx].orig_angle;
     }
     char Face::ripflag() const {
-        return mris->faces[idx].ripflag;
+        return repr->faces[idx].ripflag;
     }
     char Face::oripflag() const {
-        return mris->faces[idx].oripflag;
+        return repr->faces[idx].oripflag;
     }
     int Face::marked() const {
-        return mris->faces[idx].marked;
+        return repr->faces[idx].marked;
     }
     PDMATRIX Face::norm() const {
-        return mris->faces[idx].norm;
+        return repr->faces[idx].norm;
     }
     A3PDMATRIX Face::gradNorm() const {
-        return mris->faces[idx].gradNorm;
+        return repr->faces[idx].gradNorm;
     }
     
     void Face::set_v(size_t i, Vertex to) {
-        cheapAssert(mris == to.mris); mris->faces[idx].v[i] = to.idx;
+        cheapAssert(repr == to.repr); repr->faces[idx].v[i] = to.idx;
     }
     void Face::set_area(float to) {
-        mris->faces[idx].area = to;
+        repr->faces[idx].area = to;
     }
     void Face::set_angle(angles_per_triangle_t to) {
-        mris->faces[idx].angle = to;
+        repr->faces[idx].angle = to;
     }
     void Face::set_orig_angle(angles_per_triangle_t to) {
-        mris->faces[idx].orig_angle = to;
+        repr->faces[idx].orig_angle = to;
     }
     void Face::set_ripflag(char to) {
-        mris->faces[idx].ripflag = to;
+        repr->faces[idx].ripflag = to;
     }
     void Face::set_oripflag(char to) {
-        mris->faces[idx].oripflag = to;
+        repr->faces[idx].oripflag = to;
     }
     void Face::set_marked(int to) {
-        mris->faces[idx].marked = to;
+        repr->faces[idx].marked = to;
     }
     void Face::set_norm(PDMATRIX to) {
-        mris->faces[idx].norm = to;
+        repr->faces[idx].norm = to;
     }
     void Face::set_gradNorm(A3PDMATRIX to) {
-        mris->faces[idx].gradNorm = to;
+        repr->faces[idx].gradNorm = to;
     }
 
 
-    Vertex::Vertex (                        ) {}                     
-    Vertex::Vertex ( MRIS* mris, size_t idx ) : MRIS_Elt(mris,idx) {}
-    Vertex::Vertex ( Vertex const & src     ) : MRIS_Elt(src) {}     
+    Vertex::Vertex (                                            ) {}
+    Vertex::Vertex ( Representation* representation, size_t idx ) : Repr_Elt(representation,idx) {}
+    Vertex::Vertex ( Vertex const & src                         ) : Repr_Elt(src) {}
 
     Face Vertex::f(size_t i) const {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        return Face(mris,mris->vertices_topology[idx].f[i]);
+        return Face(repr,repr->vertices_topology[idx].f[i]);
     }
     size_t Vertex::n(size_t i) const {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        return size_t(mris->vertices_topology[idx].n[i]);
+        return size_t(repr->vertices_topology[idx].n[i]);
     }
     int Vertex::e(size_t i) const {  //  edge state for neighboring vertices                      
-        return mris->vertices_topology[idx].e[i];
+        return repr->vertices_topology[idx].e[i];
     }
     Vertex Vertex::v(size_t i) const {  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        return Vertex(mris,mris->vertices_topology[idx].v[i]);
+        return Vertex(repr,repr->vertices_topology[idx].v[i]);
     }
     short Vertex::vnum() const {  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
-        return mris->vertices_topology[idx].vnum;
+        return repr->vertices_topology[idx].vnum;
     }
     short Vertex::v2num() const {  //  number of 1, or 2-hop neighbors                          
-        return mris->vertices_topology[idx].v2num;
+        return repr->vertices_topology[idx].v2num;
     }
     short Vertex::v3num() const {  //  number of 1,2,or 3-hop neighbors                         
-        return mris->vertices_topology[idx].v3num;
+        return repr->vertices_topology[idx].v3num;
     }
     short Vertex::vtotal() const {  //  total # of neighbors. copy of vnum.nsizeCur              
-        return mris->vertices_topology[idx].vtotal;
+        return repr->vertices_topology[idx].vtotal;
     }
     short Vertex::nsizeMaxClock() const {  //  copy of mris->nsizeMaxClock when v#num                   
-        return mris->vertices_topology[idx].nsizeMaxClock;
+        return repr->vertices_topology[idx].nsizeMaxClock;
     }
     uchar Vertex::nsizeMax() const {  //  the max nsize that was used to fill in vnum etc          
-        return mris->vertices_topology[idx].nsizeMax;
+        return repr->vertices_topology[idx].nsizeMax;
     }
     uchar Vertex::nsizeCur() const {  //  index of the current v#num in vtotal                     
-        return mris->vertices_topology[idx].nsizeCur;
+        return repr->vertices_topology[idx].nsizeCur;
     }
     uchar Vertex::num() const {  //  number of neighboring faces                              
-        return mris->vertices_topology[idx].num;
+        return repr->vertices_topology[idx].num;
     }
     float Vertex::dist(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on  xyz   
-        return mris->vertices[idx].dist[i];
+        return repr->vertices[idx].dist[i];
     }
     float Vertex::dist_orig(size_t i) const {  // size() is vtotal.    distance to neighboring vertices based on origxyz
-        return mris->vertices[idx].dist_orig[i];
+        return repr->vertices[idx].dist_orig[i];
     }
     int Vertex::dist_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_capacity;
+        return repr->vertices[idx].dist_capacity;
     }
     int Vertex::dist_orig_capacity() const {  //  -- should contain at least vtx_vtotal elements   
-        return mris->vertices[idx].dist_orig_capacity;
+        return repr->vertices[idx].dist_orig_capacity;
     }
     float Vertex::x() const {  //  current coordinates	
-        return mris->vertices[idx].x;
+        return repr->vertices[idx].x;
     }
     float Vertex::y() const {  //  use MRISsetXYZ() to set
-        return mris->vertices[idx].y;
+        return repr->vertices[idx].y;
     }
     float Vertex::z() const {
-        return mris->vertices[idx].z;
+        return repr->vertices[idx].z;
     }
     float Vertex::origx() const {  //  original coordinates, see also MRIS::origxyz_status
-        return mris->vertices[idx].origx;
+        return repr->vertices[idx].origx;
     }
     float Vertex::origy() const {  //  use MRISsetOriginalXYZ(, 
-        return mris->vertices[idx].origy;
+        return repr->vertices[idx].origy;
     }
     float Vertex::origz() const {  //  or MRISsetOriginalXYZfromXYZ to set
-        return mris->vertices[idx].origz;
+        return repr->vertices[idx].origz;
     }
     float Vertex::nx() const {
-        return mris->vertices[idx].nx;
+        return repr->vertices[idx].nx;
     }
     float Vertex::ny() const {
-        return mris->vertices[idx].ny;
+        return repr->vertices[idx].ny;
     }
     float Vertex::nz() const {  //  curr normal
-        return mris->vertices[idx].nz;
+        return repr->vertices[idx].nz;
     }
     float Vertex::pnx() const {
-        return mris->vertices[idx].pnx;
+        return repr->vertices[idx].pnx;
     }
     float Vertex::pny() const {
-        return mris->vertices[idx].pny;
+        return repr->vertices[idx].pny;
     }
     float Vertex::pnz() const {  //  pial normal
-        return mris->vertices[idx].pnz;
+        return repr->vertices[idx].pnz;
     }
     float Vertex::wnx() const {
-        return mris->vertices[idx].wnx;
+        return repr->vertices[idx].wnx;
     }
     float Vertex::wny() const {
-        return mris->vertices[idx].wny;
+        return repr->vertices[idx].wny;
     }
     float Vertex::wnz() const {  //  white normal
-        return mris->vertices[idx].wnz;
+        return repr->vertices[idx].wnz;
     }
     float Vertex::onx() const {
-        return mris->vertices[idx].onx;
+        return repr->vertices[idx].onx;
     }
     float Vertex::ony() const {
-        return mris->vertices[idx].ony;
+        return repr->vertices[idx].ony;
     }
     float Vertex::onz() const {  //  original normal
-        return mris->vertices[idx].onz;
+        return repr->vertices[idx].onz;
     }
     float Vertex::dx() const {
-        return mris->vertices[idx].dx;
+        return repr->vertices[idx].dx;
     }
     float Vertex::dy() const {
-        return mris->vertices[idx].dy;
+        return repr->vertices[idx].dy;
     }
     float Vertex::dz() const {  //  current change in position
-        return mris->vertices[idx].dz;
+        return repr->vertices[idx].dz;
     }
     float Vertex::odx() const {
-        return mris->vertices[idx].odx;
+        return repr->vertices[idx].odx;
     }
     float Vertex::ody() const {
-        return mris->vertices[idx].ody;
+        return repr->vertices[idx].ody;
     }
     float Vertex::odz() const {  //  last change of position (for momentum, 
-        return mris->vertices[idx].odz;
+        return repr->vertices[idx].odz;
     }
     float Vertex::tdx() const {
-        return mris->vertices[idx].tdx;
+        return repr->vertices[idx].tdx;
     }
     float Vertex::tdy() const {
-        return mris->vertices[idx].tdy;
+        return repr->vertices[idx].tdy;
     }
     float Vertex::tdz() const {  //  temporary storage for averaging gradient
-        return mris->vertices[idx].tdz;
+        return repr->vertices[idx].tdz;
     }
     float Vertex::curv() const {  //  curr curvature
-        return mris->vertices[idx].curv;
+        return repr->vertices[idx].curv;
     }
     float Vertex::curvbak() const {
-        return mris->vertices[idx].curvbak;
+        return repr->vertices[idx].curvbak;
     }
     float Vertex::val() const {  //  scalar data value (file: rh.val, sig2-rh.w)
-        return mris->vertices[idx].val;
+        return repr->vertices[idx].val;
     }
     float Vertex::imag_val() const {  //  imaginary part of complex data value
-        return mris->vertices[idx].imag_val;
+        return repr->vertices[idx].imag_val;
     }
     float Vertex::cx() const {
-        return mris->vertices[idx].cx;
+        return repr->vertices[idx].cx;
     }
     float Vertex::cy() const {
-        return mris->vertices[idx].cy;
+        return repr->vertices[idx].cy;
     }
     float Vertex::cz() const {  //  coordinates in canonical coordinate system
-        return mris->vertices[idx].cz;
+        return repr->vertices[idx].cz;
     }
     float Vertex::tx() const {
-        return mris->vertices[idx].tx;
+        return repr->vertices[idx].tx;
     }
     float Vertex::ty() const {
-        return mris->vertices[idx].ty;
+        return repr->vertices[idx].ty;
     }
     float Vertex::tz() const {  //  tmp coordinate storage
-        return mris->vertices[idx].tz;
+        return repr->vertices[idx].tz;
     }
-    float Vertex::tx2() const {
-        return mris->vertices[idx].tx2;
+    float Vertex::t2x() const {
+        return repr->vertices[idx].t2x;
     }
-    float Vertex::ty2() const {
-        return mris->vertices[idx].ty2;
+    float Vertex::t2y() const {
+        return repr->vertices[idx].t2y;
     }
-    float Vertex::tz2() const {  //  tmp coordinate storage
-        return mris->vertices[idx].tz2;
+    float Vertex::t2z() const {  //  another tmp coordinate storage
+        return repr->vertices[idx].t2z;
     }
     float Vertex::targx() const {
-        return mris->vertices[idx].targx;
+        return repr->vertices[idx].targx;
     }
     float Vertex::targy() const {
-        return mris->vertices[idx].targy;
+        return repr->vertices[idx].targy;
     }
     float Vertex::targz() const {  //  target coordinates
-        return mris->vertices[idx].targz;
+        return repr->vertices[idx].targz;
     }
     float Vertex::pialx() const {
-        return mris->vertices[idx].pialx;
+        return repr->vertices[idx].pialx;
     }
     float Vertex::pialy() const {
-        return mris->vertices[idx].pialy;
+        return repr->vertices[idx].pialy;
     }
     float Vertex::pialz() const {  //  pial surface coordinates
-        return mris->vertices[idx].pialz;
+        return repr->vertices[idx].pialz;
     }
     float Vertex::whitex() const {
-        return mris->vertices[idx].whitex;
+        return repr->vertices[idx].whitex;
     }
     float Vertex::whitey() const {
-        return mris->vertices[idx].whitey;
+        return repr->vertices[idx].whitey;
     }
     float Vertex::whitez() const {  //  white surface coordinates
-        return mris->vertices[idx].whitez;
+        return repr->vertices[idx].whitez;
     }
     float Vertex::l4x() const {
-        return mris->vertices[idx].l4x;
+        return repr->vertices[idx].l4x;
     }
     float Vertex::l4y() const {
-        return mris->vertices[idx].l4y;
+        return repr->vertices[idx].l4y;
     }
     float Vertex::l4z() const {  //  layerIV surface coordinates
-        return mris->vertices[idx].l4z;
+        return repr->vertices[idx].l4z;
     }
     float Vertex::infx() const {
-        return mris->vertices[idx].infx;
+        return repr->vertices[idx].infx;
     }
     float Vertex::infy() const {
-        return mris->vertices[idx].infy;
+        return repr->vertices[idx].infy;
     }
     float Vertex::infz() const {  //  inflated coordinates
-        return mris->vertices[idx].infz;
+        return repr->vertices[idx].infz;
     }
     float Vertex::fx() const {
-        return mris->vertices[idx].fx;
+        return repr->vertices[idx].fx;
     }
     float Vertex::fy() const {
-        return mris->vertices[idx].fy;
+        return repr->vertices[idx].fy;
     }
     float Vertex::fz() const {  //  flattened coordinates
-        return mris->vertices[idx].fz;
+        return repr->vertices[idx].fz;
     }
     int Vertex::px() const {
-        return mris->vertices[idx].px;
+        return repr->vertices[idx].px;
     }
     int Vertex::qx() const {
-        return mris->vertices[idx].qx;
+        return repr->vertices[idx].qx;
     }
     int Vertex::py() const {
-        return mris->vertices[idx].py;
+        return repr->vertices[idx].py;
     }
     int Vertex::qy() const {
-        return mris->vertices[idx].qy;
+        return repr->vertices[idx].qy;
     }
     int Vertex::pz() const {
-        return mris->vertices[idx].pz;
+        return repr->vertices[idx].pz;
     }
     int Vertex::qz() const {  //  rational coordinates for exact calculations
-        return mris->vertices[idx].qz;
+        return repr->vertices[idx].qz;
     }
     float Vertex::e1x() const {
-        return mris->vertices[idx].e1x;
+        return repr->vertices[idx].e1x;
     }
     float Vertex::e1y() const {
-        return mris->vertices[idx].e1y;
+        return repr->vertices[idx].e1y;
     }
     float Vertex::e1z() const {  //  1st basis vector for the local tangent plane
-        return mris->vertices[idx].e1z;
+        return repr->vertices[idx].e1z;
     }
     float Vertex::e2x() const {
-        return mris->vertices[idx].e2x;
+        return repr->vertices[idx].e2x;
     }
     float Vertex::e2y() const {
-        return mris->vertices[idx].e2y;
+        return repr->vertices[idx].e2y;
     }
     float Vertex::e2z() const {  //  2nd basis vector for the local tangent plane
-        return mris->vertices[idx].e2z;
+        return repr->vertices[idx].e2z;
     }
     float Vertex::pe1x() const {
-        return mris->vertices[idx].pe1x;
+        return repr->vertices[idx].pe1x;
     }
     float Vertex::pe1y() const {
-        return mris->vertices[idx].pe1y;
+        return repr->vertices[idx].pe1y;
     }
     float Vertex::pe1z() const {  //  1st basis vector for the local tangent plane
-        return mris->vertices[idx].pe1z;
+        return repr->vertices[idx].pe1z;
     }
     float Vertex::pe2x() const {
-        return mris->vertices[idx].pe2x;
+        return repr->vertices[idx].pe2x;
     }
     float Vertex::pe2y() const {
-        return mris->vertices[idx].pe2y;
+        return repr->vertices[idx].pe2y;
     }
     float Vertex::pe2z() const {  //  2nd basis vector for the local tangent plane
-        return mris->vertices[idx].pe2z;
+        return repr->vertices[idx].pe2z;
     }
     float Vertex::nc() const {  //  curr length normal comp 
-        return mris->vertices[idx].nc;
+        return repr->vertices[idx].nc;
     }
     float Vertex::val2() const {  //  complex comp data value (file: sig3-rh.w) 
-        return mris->vertices[idx].val2;
+        return repr->vertices[idx].val2;
     }
     float Vertex::valbak() const {  //  scalar data stack 
-        return mris->vertices[idx].valbak;
+        return repr->vertices[idx].valbak;
     }
     float Vertex::val2bak() const {  //  complex comp data stack 
-        return mris->vertices[idx].val2bak;
+        return repr->vertices[idx].val2bak;
     }
     float Vertex::stat() const {  //  statistic 
-        return mris->vertices[idx].stat;
+        return repr->vertices[idx].stat;
     }
     int Vertex::undefval() const {  //  [previously dist=0] 
-        return mris->vertices[idx].undefval;
+        return repr->vertices[idx].undefval;
     }
     int Vertex::old_undefval() const {  //  for smooth_val_sparse 
-        return mris->vertices[idx].old_undefval;
+        return repr->vertices[idx].old_undefval;
     }
     int Vertex::fixedval() const {  //  [previously val=0] 
-        return mris->vertices[idx].fixedval;
+        return repr->vertices[idx].fixedval;
     }
     float Vertex::fieldsign() const {  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
-        return mris->vertices[idx].fieldsign;
+        return repr->vertices[idx].fieldsign;
     }
     float Vertex::fsmask() const {  //  significance mask (file: rh.fm) 
-        return mris->vertices[idx].fsmask;
+        return repr->vertices[idx].fsmask;
     }
     float Vertex::d() const {  //  for distance calculations 
-        return mris->vertices[idx].d;
+        return repr->vertices[idx].d;
     }
     int Vertex::annotation() const {  //  area label (defunct--now from label file name!) 
-        return mris->vertices[idx].annotation;
+        return repr->vertices[idx].annotation;
     }
     char Vertex::oripflag() const {
-        return mris->vertices[idx].oripflag;
+        return repr->vertices[idx].oripflag;
     }
     char Vertex::origripflag() const {  //  cuts flags 
-        return mris->vertices[idx].origripflag;
+        return repr->vertices[idx].origripflag;
     }
     p_void Vertex::vp() const {  //  to store user's information 
-        return mris->vertices[idx].vp;
+        return repr->vertices[idx].vp;
     }
     float Vertex::theta() const {
-        return mris->vertices[idx].theta;
+        return repr->vertices[idx].theta;
     }
     float Vertex::phi() const {  //  parameterization 
-        return mris->vertices[idx].phi;
+        return repr->vertices[idx].phi;
     }
     float Vertex::area() const {
-        return mris->vertices[idx].area;
+        return repr->vertices[idx].area;
     }
     float Vertex::origarea() const {
-        return mris->vertices[idx].origarea;
+        return repr->vertices[idx].origarea;
     }
     float Vertex::group_avg_area() const {
-        return mris->vertices[idx].group_avg_area;
+        return repr->vertices[idx].group_avg_area;
     }
     float Vertex::K() const {  //  Gaussian curvature 
-        return mris->vertices[idx].K;
+        return repr->vertices[idx].K;
     }
     float Vertex::H() const {  //  mean curvature 
-        return mris->vertices[idx].H;
+        return repr->vertices[idx].H;
     }
     float Vertex::k1() const {
-        return mris->vertices[idx].k1;
+        return repr->vertices[idx].k1;
     }
     float Vertex::k2() const {  //  the principal curvatures 
-        return mris->vertices[idx].k2;
+        return repr->vertices[idx].k2;
     }
     float Vertex::mean() const {
-        return mris->vertices[idx].mean;
+        return repr->vertices[idx].mean;
     }
     float Vertex::mean_imag() const {  //  imaginary part of complex statistic 
-        return mris->vertices[idx].mean_imag;
+        return repr->vertices[idx].mean_imag;
     }
     float Vertex::std_error() const {
-        return mris->vertices[idx].std_error;
+        return repr->vertices[idx].std_error;
     }
     uint Vertex::flags() const {
-        return mris->vertices[idx].flags;
+        return repr->vertices[idx].flags;
     }
     int Vertex::fno() const {  //  face that this vertex is in 
-        return mris->vertices[idx].fno;
+        return repr->vertices[idx].fno;
     }
     int Vertex::cropped() const {
-        return mris->vertices[idx].cropped;
+        return repr->vertices[idx].cropped;
     }
     short Vertex::marked() const {  //  for a variety of uses 
-        return mris->vertices[idx].marked;
+        return repr->vertices[idx].marked;
     }
     short Vertex::marked2() const {
-        return mris->vertices[idx].marked2;
+        return repr->vertices[idx].marked2;
     }
     short Vertex::marked3() const {
-        return mris->vertices[idx].marked3;
+        return repr->vertices[idx].marked3;
     }
     char Vertex::neg() const {  //  1 if the normal vector is inverted 
-        return mris->vertices[idx].neg;
+        return repr->vertices[idx].neg;
     }
     char Vertex::border() const {  //  flag 
-        return mris->vertices[idx].border;
+        return repr->vertices[idx].border;
     }
     char Vertex::ripflag() const {  //  vertex no longer exists - placed last to load the next vertex into cache
-        return mris->vertices[idx].ripflag;
+        return repr->vertices[idx].ripflag;
+    }
+    void Vertex::which_coords(int which, float *x, float *y, float *z) const {
+         MRISvertexCoord2XYZ_float(&repr->vertices[idx], which, x, y, z);
     }
     
     void Vertex::set_f(size_t i, Face to) {  // size() is num.    array[v->num] the fno's of the neighboring faces         
-        cheapAssert(mris == to.mris); mris->vertices_topology[idx].f[i] = to.idx;
+        cheapAssert(repr == to.repr); repr->vertices_topology[idx].f[i] = to.idx;
     }
     void Vertex::set_n(size_t i, size_t to) {  // size() is num.    array[v->num] the face.v[*] index for this vertex        
-        mris->vertices_topology[idx].n[i] = uchar(to);
+        repr->vertices_topology[idx].n[i] = uchar(to);
     }
     void Vertex::set_e(size_t i, int to) {  //  edge state for neighboring vertices                      
-        mris->vertices_topology[idx].e[i] = to;
+        repr->vertices_topology[idx].e[i] = to;
     }
     void Vertex::set_v(size_t i, Vertex to) {  // size() is vtotal.    array[v->vtotal or more] of vno, head sorted by hops     
-        cheapAssert(mris == to.mris); mris->vertices_topology[idx].v[i] = to.idx;
+        cheapAssert(repr == to.repr); repr->vertices_topology[idx].v[i] = to.idx;
     }
     void Vertex::set_vnum(short to) {  //  number of 1-hop neighbors    should use [p]VERTEXvnum(i, 
-        mris->vertices_topology[idx].vnum = to;
+        repr->vertices_topology[idx].vnum = to;
     }
     void Vertex::set_v2num(short to) {  //  number of 1, or 2-hop neighbors                          
-        mris->vertices_topology[idx].v2num = to;
+        repr->vertices_topology[idx].v2num = to;
     }
     void Vertex::set_v3num(short to) {  //  number of 1,2,or 3-hop neighbors                         
-        mris->vertices_topology[idx].v3num = to;
+        repr->vertices_topology[idx].v3num = to;
     }
     void Vertex::set_vtotal(short to) {  //  total # of neighbors. copy of vnum.nsizeCur              
-        mris->vertices_topology[idx].vtotal = to;
+        repr->vertices_topology[idx].vtotal = to;
     }
     void Vertex::set_nsizeMaxClock(short to) {  //  copy of mris->nsizeMaxClock when v#num                   
-        mris->vertices_topology[idx].nsizeMaxClock = to;
+        repr->vertices_topology[idx].nsizeMaxClock = to;
     }
     void Vertex::set_nsizeMax(uchar to) {  //  the max nsize that was used to fill in vnum etc          
-        mris->vertices_topology[idx].nsizeMax = to;
+        repr->vertices_topology[idx].nsizeMax = to;
     }
     void Vertex::set_nsizeCur(uchar to) {  //  index of the current v#num in vtotal                     
-        mris->vertices_topology[idx].nsizeCur = to;
+        repr->vertices_topology[idx].nsizeCur = to;
     }
     void Vertex::set_num(uchar to) {  //  number of neighboring faces                              
-        mris->vertices_topology[idx].num = to;
+        repr->vertices_topology[idx].num = to;
     }
     void Vertex::set_x(float to) {  //  current coordinates	
-        mris->vertices[idx].x = to;
+        repr->vertices[idx].x = to;
     }
     void Vertex::set_y(float to) {  //  use MRISsetXYZ() to set
-        mris->vertices[idx].y = to;
+        repr->vertices[idx].y = to;
     }
     void Vertex::set_z(float to) {
-        mris->vertices[idx].z = to;
+        repr->vertices[idx].z = to;
     }
     void Vertex::set_nx(float to) {
-        mris->vertices[idx].nx = to;
+        repr->vertices[idx].nx = to;
     }
     void Vertex::set_ny(float to) {
-        mris->vertices[idx].ny = to;
+        repr->vertices[idx].ny = to;
     }
     void Vertex::set_nz(float to) {  //  curr normal
-        mris->vertices[idx].nz = to;
+        repr->vertices[idx].nz = to;
     }
     void Vertex::set_pnx(float to) {
-        mris->vertices[idx].pnx = to;
+        repr->vertices[idx].pnx = to;
     }
     void Vertex::set_pny(float to) {
-        mris->vertices[idx].pny = to;
+        repr->vertices[idx].pny = to;
     }
     void Vertex::set_pnz(float to) {  //  pial normal
-        mris->vertices[idx].pnz = to;
+        repr->vertices[idx].pnz = to;
     }
     void Vertex::set_wnx(float to) {
-        mris->vertices[idx].wnx = to;
+        repr->vertices[idx].wnx = to;
     }
     void Vertex::set_wny(float to) {
-        mris->vertices[idx].wny = to;
+        repr->vertices[idx].wny = to;
     }
     void Vertex::set_wnz(float to) {  //  white normal
-        mris->vertices[idx].wnz = to;
+        repr->vertices[idx].wnz = to;
     }
     void Vertex::set_onx(float to) {
-        mris->vertices[idx].onx = to;
+        repr->vertices[idx].onx = to;
     }
     void Vertex::set_ony(float to) {
-        mris->vertices[idx].ony = to;
+        repr->vertices[idx].ony = to;
     }
     void Vertex::set_onz(float to) {  //  original normal
-        mris->vertices[idx].onz = to;
+        repr->vertices[idx].onz = to;
     }
     void Vertex::set_dx(float to) {
-        mris->vertices[idx].dx = to;
+        repr->vertices[idx].dx = to;
     }
     void Vertex::set_dy(float to) {
-        mris->vertices[idx].dy = to;
+        repr->vertices[idx].dy = to;
     }
     void Vertex::set_dz(float to) {  //  current change in position
-        mris->vertices[idx].dz = to;
+        repr->vertices[idx].dz = to;
     }
     void Vertex::set_odx(float to) {
-        mris->vertices[idx].odx = to;
+        repr->vertices[idx].odx = to;
     }
     void Vertex::set_ody(float to) {
-        mris->vertices[idx].ody = to;
+        repr->vertices[idx].ody = to;
     }
     void Vertex::set_odz(float to) {  //  last change of position (for momentum, 
-        mris->vertices[idx].odz = to;
+        repr->vertices[idx].odz = to;
     }
     void Vertex::set_tdx(float to) {
-        mris->vertices[idx].tdx = to;
+        repr->vertices[idx].tdx = to;
     }
     void Vertex::set_tdy(float to) {
-        mris->vertices[idx].tdy = to;
+        repr->vertices[idx].tdy = to;
     }
     void Vertex::set_tdz(float to) {  //  temporary storage for averaging gradient
-        mris->vertices[idx].tdz = to;
+        repr->vertices[idx].tdz = to;
     }
     void Vertex::set_curv(float to) {  //  curr curvature
-        mris->vertices[idx].curv = to;
+        repr->vertices[idx].curv = to;
     }
     void Vertex::set_curvbak(float to) {
-        mris->vertices[idx].curvbak = to;
+        repr->vertices[idx].curvbak = to;
     }
     void Vertex::set_val(float to) {  //  scalar data value (file: rh.val, sig2-rh.w)
-        mris->vertices[idx].val = to;
+        repr->vertices[idx].val = to;
     }
     void Vertex::set_imag_val(float to) {  //  imaginary part of complex data value
-        mris->vertices[idx].imag_val = to;
+        repr->vertices[idx].imag_val = to;
     }
     void Vertex::set_cx(float to) {
-        mris->vertices[idx].cx = to;
+        repr->vertices[idx].cx = to;
     }
     void Vertex::set_cy(float to) {
-        mris->vertices[idx].cy = to;
+        repr->vertices[idx].cy = to;
     }
     void Vertex::set_cz(float to) {  //  coordinates in canonical coordinate system
-        mris->vertices[idx].cz = to;
+        repr->vertices[idx].cz = to;
     }
     void Vertex::set_tx(float to) {
-        mris->vertices[idx].tx = to;
+        repr->vertices[idx].tx = to;
     }
     void Vertex::set_ty(float to) {
-        mris->vertices[idx].ty = to;
+        repr->vertices[idx].ty = to;
     }
     void Vertex::set_tz(float to) {  //  tmp coordinate storage
-        mris->vertices[idx].tz = to;
+        repr->vertices[idx].tz = to;
     }
-    void Vertex::set_tx2(float to) {
-        mris->vertices[idx].tx2 = to;
+    void Vertex::set_t2x(float to) {
+        repr->vertices[idx].t2x = to;
     }
-    void Vertex::set_ty2(float to) {
-        mris->vertices[idx].ty2 = to;
+    void Vertex::set_t2y(float to) {
+        repr->vertices[idx].t2y = to;
     }
-    void Vertex::set_tz2(float to) {  //  tmp coordinate storage
-        mris->vertices[idx].tz2 = to;
+    void Vertex::set_t2z(float to) {  //  another tmp coordinate storage
+        repr->vertices[idx].t2z = to;
     }
     void Vertex::set_targx(float to) {
-        mris->vertices[idx].targx = to;
+        repr->vertices[idx].targx = to;
     }
     void Vertex::set_targy(float to) {
-        mris->vertices[idx].targy = to;
+        repr->vertices[idx].targy = to;
     }
     void Vertex::set_targz(float to) {  //  target coordinates
-        mris->vertices[idx].targz = to;
+        repr->vertices[idx].targz = to;
     }
     void Vertex::set_pialx(float to) {
-        mris->vertices[idx].pialx = to;
+        repr->vertices[idx].pialx = to;
     }
     void Vertex::set_pialy(float to) {
-        mris->vertices[idx].pialy = to;
+        repr->vertices[idx].pialy = to;
     }
     void Vertex::set_pialz(float to) {  //  pial surface coordinates
-        mris->vertices[idx].pialz = to;
+        repr->vertices[idx].pialz = to;
     }
     void Vertex::set_whitex(float to) {
-        mris->vertices[idx].whitex = to;
+        repr->vertices[idx].whitex = to;
     }
     void Vertex::set_whitey(float to) {
-        mris->vertices[idx].whitey = to;
+        repr->vertices[idx].whitey = to;
     }
     void Vertex::set_whitez(float to) {  //  white surface coordinates
-        mris->vertices[idx].whitez = to;
+        repr->vertices[idx].whitez = to;
     }
     void Vertex::set_l4x(float to) {
-        mris->vertices[idx].l4x = to;
+        repr->vertices[idx].l4x = to;
     }
     void Vertex::set_l4y(float to) {
-        mris->vertices[idx].l4y = to;
+        repr->vertices[idx].l4y = to;
     }
     void Vertex::set_l4z(float to) {  //  layerIV surface coordinates
-        mris->vertices[idx].l4z = to;
+        repr->vertices[idx].l4z = to;
     }
     void Vertex::set_infx(float to) {
-        mris->vertices[idx].infx = to;
+        repr->vertices[idx].infx = to;
     }
     void Vertex::set_infy(float to) {
-        mris->vertices[idx].infy = to;
+        repr->vertices[idx].infy = to;
     }
     void Vertex::set_infz(float to) {  //  inflated coordinates
-        mris->vertices[idx].infz = to;
+        repr->vertices[idx].infz = to;
     }
     void Vertex::set_fx(float to) {
-        mris->vertices[idx].fx = to;
+        repr->vertices[idx].fx = to;
     }
     void Vertex::set_fy(float to) {
-        mris->vertices[idx].fy = to;
+        repr->vertices[idx].fy = to;
     }
     void Vertex::set_fz(float to) {  //  flattened coordinates
-        mris->vertices[idx].fz = to;
+        repr->vertices[idx].fz = to;
     }
     void Vertex::set_px(int to) {
-        mris->vertices[idx].px = to;
+        repr->vertices[idx].px = to;
     }
     void Vertex::set_qx(int to) {
-        mris->vertices[idx].qx = to;
+        repr->vertices[idx].qx = to;
     }
     void Vertex::set_py(int to) {
-        mris->vertices[idx].py = to;
+        repr->vertices[idx].py = to;
     }
     void Vertex::set_qy(int to) {
-        mris->vertices[idx].qy = to;
+        repr->vertices[idx].qy = to;
     }
     void Vertex::set_pz(int to) {
-        mris->vertices[idx].pz = to;
+        repr->vertices[idx].pz = to;
     }
     void Vertex::set_qz(int to) {  //  rational coordinates for exact calculations
-        mris->vertices[idx].qz = to;
+        repr->vertices[idx].qz = to;
     }
     void Vertex::set_e1x(float to) {
-        mris->vertices[idx].e1x = to;
+        repr->vertices[idx].e1x = to;
     }
     void Vertex::set_e1y(float to) {
-        mris->vertices[idx].e1y = to;
+        repr->vertices[idx].e1y = to;
     }
     void Vertex::set_e1z(float to) {  //  1st basis vector for the local tangent plane
-        mris->vertices[idx].e1z = to;
+        repr->vertices[idx].e1z = to;
     }
     void Vertex::set_e2x(float to) {
-        mris->vertices[idx].e2x = to;
+        repr->vertices[idx].e2x = to;
     }
     void Vertex::set_e2y(float to) {
-        mris->vertices[idx].e2y = to;
+        repr->vertices[idx].e2y = to;
     }
     void Vertex::set_e2z(float to) {  //  2nd basis vector for the local tangent plane
-        mris->vertices[idx].e2z = to;
+        repr->vertices[idx].e2z = to;
     }
     void Vertex::set_pe1x(float to) {
-        mris->vertices[idx].pe1x = to;
+        repr->vertices[idx].pe1x = to;
     }
     void Vertex::set_pe1y(float to) {
-        mris->vertices[idx].pe1y = to;
+        repr->vertices[idx].pe1y = to;
     }
     void Vertex::set_pe1z(float to) {  //  1st basis vector for the local tangent plane
-        mris->vertices[idx].pe1z = to;
+        repr->vertices[idx].pe1z = to;
     }
     void Vertex::set_pe2x(float to) {
-        mris->vertices[idx].pe2x = to;
+        repr->vertices[idx].pe2x = to;
     }
     void Vertex::set_pe2y(float to) {
-        mris->vertices[idx].pe2y = to;
+        repr->vertices[idx].pe2y = to;
     }
     void Vertex::set_pe2z(float to) {  //  2nd basis vector for the local tangent plane
-        mris->vertices[idx].pe2z = to;
+        repr->vertices[idx].pe2z = to;
     }
     void Vertex::set_nc(float to) {  //  curr length normal comp 
-        mris->vertices[idx].nc = to;
+        repr->vertices[idx].nc = to;
     }
     void Vertex::set_val2(float to) {  //  complex comp data value (file: sig3-rh.w) 
-        mris->vertices[idx].val2 = to;
+        repr->vertices[idx].val2 = to;
     }
     void Vertex::set_valbak(float to) {  //  scalar data stack 
-        mris->vertices[idx].valbak = to;
+        repr->vertices[idx].valbak = to;
     }
     void Vertex::set_val2bak(float to) {  //  complex comp data stack 
-        mris->vertices[idx].val2bak = to;
+        repr->vertices[idx].val2bak = to;
     }
     void Vertex::set_stat(float to) {  //  statistic 
-        mris->vertices[idx].stat = to;
+        repr->vertices[idx].stat = to;
     }
     void Vertex::set_undefval(int to) {  //  [previously dist=0] 
-        mris->vertices[idx].undefval = to;
+        repr->vertices[idx].undefval = to;
     }
     void Vertex::set_old_undefval(int to) {  //  for smooth_val_sparse 
-        mris->vertices[idx].old_undefval = to;
+        repr->vertices[idx].old_undefval = to;
     }
     void Vertex::set_fixedval(int to) {  //  [previously val=0] 
-        mris->vertices[idx].fixedval = to;
+        repr->vertices[idx].fixedval = to;
     }
     void Vertex::set_fieldsign(float to) {  //  fieldsign--final: -1, "0", "1" (file: rh.fs) 
-        mris->vertices[idx].fieldsign = to;
+        repr->vertices[idx].fieldsign = to;
     }
     void Vertex::set_fsmask(float to) {  //  significance mask (file: rh.fm) 
-        mris->vertices[idx].fsmask = to;
+        repr->vertices[idx].fsmask = to;
     }
     void Vertex::set_d(float to) {  //  for distance calculations 
-        mris->vertices[idx].d = to;
+        repr->vertices[idx].d = to;
     }
     void Vertex::set_annotation(int to) {  //  area label (defunct--now from label file name!) 
-        mris->vertices[idx].annotation = to;
+        repr->vertices[idx].annotation = to;
     }
     void Vertex::set_oripflag(char to) {
-        mris->vertices[idx].oripflag = to;
+        repr->vertices[idx].oripflag = to;
     }
     void Vertex::set_origripflag(char to) {  //  cuts flags 
-        mris->vertices[idx].origripflag = to;
+        repr->vertices[idx].origripflag = to;
     }
     void Vertex::set_vp(p_void to) {  //  to store user's information 
-        mris->vertices[idx].vp = to;
+        repr->vertices[idx].vp = to;
     }
     void Vertex::set_theta(float to) {
-        mris->vertices[idx].theta = to;
+        repr->vertices[idx].theta = to;
     }
     void Vertex::set_phi(float to) {  //  parameterization 
-        mris->vertices[idx].phi = to;
+        repr->vertices[idx].phi = to;
     }
     void Vertex::set_area(float to) {
-        mris->vertices[idx].area = to;
+        repr->vertices[idx].area = to;
     }
     void Vertex::set_origarea(float to) {
-        mris->vertices[idx].origarea = to;
+        repr->vertices[idx].origarea = to;
     }
     void Vertex::set_group_avg_area(float to) {
-        mris->vertices[idx].group_avg_area = to;
+        repr->vertices[idx].group_avg_area = to;
     }
     void Vertex::set_K(float to) {  //  Gaussian curvature 
-        mris->vertices[idx].K = to;
+        repr->vertices[idx].K = to;
     }
     void Vertex::set_H(float to) {  //  mean curvature 
-        mris->vertices[idx].H = to;
+        repr->vertices[idx].H = to;
     }
     void Vertex::set_k1(float to) {
-        mris->vertices[idx].k1 = to;
+        repr->vertices[idx].k1 = to;
     }
     void Vertex::set_k2(float to) {  //  the principal curvatures 
-        mris->vertices[idx].k2 = to;
+        repr->vertices[idx].k2 = to;
     }
     void Vertex::set_mean(float to) {
-        mris->vertices[idx].mean = to;
+        repr->vertices[idx].mean = to;
     }
     void Vertex::set_mean_imag(float to) {  //  imaginary part of complex statistic 
-        mris->vertices[idx].mean_imag = to;
+        repr->vertices[idx].mean_imag = to;
     }
     void Vertex::set_std_error(float to) {
-        mris->vertices[idx].std_error = to;
+        repr->vertices[idx].std_error = to;
     }
     void Vertex::set_flags(uint to) {
-        mris->vertices[idx].flags = to;
+        repr->vertices[idx].flags = to;
     }
     void Vertex::set_fno(int to) {  //  face that this vertex is in 
-        mris->vertices[idx].fno = to;
+        repr->vertices[idx].fno = to;
     }
     void Vertex::set_cropped(int to) {
-        mris->vertices[idx].cropped = to;
+        repr->vertices[idx].cropped = to;
     }
     void Vertex::set_marked(short to) {  //  for a variety of uses 
-        mris->vertices[idx].marked = to;
+        repr->vertices[idx].marked = to;
     }
     void Vertex::set_marked2(short to) {
-        mris->vertices[idx].marked2 = to;
+        repr->vertices[idx].marked2 = to;
     }
     void Vertex::set_marked3(short to) {
-        mris->vertices[idx].marked3 = to;
+        repr->vertices[idx].marked3 = to;
     }
     void Vertex::set_neg(char to) {  //  1 if the normal vector is inverted 
-        mris->vertices[idx].neg = to;
+        repr->vertices[idx].neg = to;
     }
     void Vertex::set_border(char to) {  //  flag 
-        mris->vertices[idx].border = to;
+        repr->vertices[idx].border = to;
     }
     void Vertex::set_ripflag(char to) {  //  vertex no longer exists - placed last to load the next vertex into cache
-        mris->vertices[idx].ripflag = to;
+        repr->vertices[idx].ripflag = to;
     }
 
 
-    Surface::Surface (                     ) {}                   
-    Surface::Surface ( MRIS* mris          ) : MRIS_Elt(mris,0) {}
-    Surface::Surface ( Surface const & src ) : MRIS_Elt(src) {}   
+    Surface::Surface (                                ) {}
+    Surface::Surface ( Representation* representation ) : Repr_Elt(representation,0) {}
+    Surface::Surface ( Surface const & src            ) : Repr_Elt(src) {}
 
     int Surface::nverticesFrozen() const {  //  # of vertices on surface is frozen
-        return mris->nverticesFrozen;
+        return repr->nverticesFrozen;
     }
     int Surface::nvertices() const {  //  # of vertices on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nvertices;
+        return repr->nvertices;
     }
     int Surface::nfaces() const {  //  # of faces on surface, change by calling MRISreallocVerticesAndFaces et al
-        return mris->nfaces;
+        return repr->nfaces;
     }
     bool Surface::faceAttachmentDeferred() const {  //  defer connecting faces to vertices for performance reasons
-        return mris->faceAttachmentDeferred;
+        return repr->faceAttachmentDeferred;
     }
     int Surface::nedges() const {  //  # of edges on surface
-        return mris->nedges;
+        return repr->nedges;
     }
     int Surface::nstrips() const {
-        return mris->nstrips;
+        return repr->nstrips;
     }
     Vertex Surface::vertices(size_t i) const {
-        return Vertex(mris,i);
+        return Vertex(repr,i);
     }
     p_p_void Surface::dist_storage() const {  //  the malloced/realloced vertex dist fields, so those fields can be quickly nulled and restored
-        return mris->dist_storage;
+        return repr->dist_storage;
     }
     p_p_void Surface::dist_orig_storage() const {  //  the malloced/realloced vertex dist_orig fields, so those fields can be quickly nulled and restored
-        return mris->dist_orig_storage;
+        return repr->dist_orig_storage;
     }
     int Surface::tempsAssigned() const {  //  State of various temp fields that can be borrowed if not already in use
-        return mris->tempsAssigned;
+        return repr->tempsAssigned;
     }
     Face Surface::faces(size_t i) const {
-        return Face(mris,i);
+        return Face(repr,i);
     }
     MRI_EDGE Surface::edges(size_t i) const {
-        return mris->edges[i];
+        return repr->edges[i];
     }
     FaceNormCacheEntry Surface::faceNormCacheEntries(size_t i) const {
-        return mris->faceNormCacheEntries[i];
+        return repr->faceNormCacheEntries[i];
     }
     FaceNormDeferredEntry Surface::faceNormDeferredEntries(size_t i) const {
-        return mris->faceNormDeferredEntries[i];
+        return repr->faceNormDeferredEntries[i];
     }
     STRIP Surface::strips(size_t i) const {
-        return mris->strips[i];
+        return repr->strips[i];
     }
     float Surface::xctr() const {
-        return mris->xctr;
+        return repr->xctr;
     }
     float Surface::yctr() const {
-        return mris->yctr;
+        return repr->yctr;
     }
     float Surface::zctr() const {
-        return mris->zctr;
+        return repr->zctr;
     }
     float Surface::xlo() const {
-        return mris->xlo;
+        return repr->xlo;
     }
     float Surface::ylo() const {
-        return mris->ylo;
+        return repr->ylo;
     }
     float Surface::zlo() const {
-        return mris->zlo;
+        return repr->zlo;
     }
     float Surface::xhi() const {
-        return mris->xhi;
+        return repr->xhi;
     }
     float Surface::yhi() const {
-        return mris->yhi;
+        return repr->yhi;
     }
     float Surface::zhi() const {
-        return mris->zhi;
+        return repr->zhi;
     }
     float Surface::x0() const {  //  center of spherical expansion
-        return mris->x0;
+        return repr->x0;
     }
     float Surface::y0() const {
-        return mris->y0;
+        return repr->y0;
     }
     float Surface::z0() const {
-        return mris->z0;
+        return repr->z0;
     }
     Vertex Surface::v_temporal_pole() const {
-        return Vertex(mris,mris->v_temporal_pole - mris->vertices);
+        return Vertex(repr,repr->v_temporal_pole - repr->vertices);
     }
     Vertex Surface::v_frontal_pole() const {
-        return Vertex(mris,mris->v_frontal_pole - mris->vertices);
+        return Vertex(repr,repr->v_frontal_pole - repr->vertices);
     }
     Vertex Surface::v_occipital_pole() const {
-        return Vertex(mris,mris->v_occipital_pole - mris->vertices);
+        return Vertex(repr,repr->v_occipital_pole - repr->vertices);
     }
     float Surface::max_curv() const {
-        return mris->max_curv;
+        return repr->max_curv;
     }
     float Surface::min_curv() const {
-        return mris->min_curv;
+        return repr->min_curv;
     }
     float Surface::total_area() const {
-        return mris->total_area;
+        return repr->total_area;
     }
     double Surface::avg_vertex_area() const {
-        return mris->avg_vertex_area;
+        return repr->avg_vertex_area;
     }
     double Surface::avg_vertex_dist() const {  //  set by MRIScomputeAvgInterVertexDist
-        return mris->avg_vertex_dist;
+        return repr->avg_vertex_dist;
     }
     double Surface::std_vertex_dist() const {
-        return mris->std_vertex_dist;
+        return repr->std_vertex_dist;
     }
     float Surface::orig_area() const {
-        return mris->orig_area;
+        return repr->orig_area;
     }
     float Surface::neg_area() const {
-        return mris->neg_area;
+        return repr->neg_area;
     }
     float Surface::neg_orig_area() const {  //  amount of original surface in folds
-        return mris->neg_orig_area;
+        return repr->neg_orig_area;
     }
     int Surface::zeros() const {
-        return mris->zeros;
+        return repr->zeros;
     }
     int Surface::hemisphere() const {  //  which hemisphere
-        return mris->hemisphere;
+        return repr->hemisphere;
     }
     int Surface::initialized() const {
-        return mris->initialized;
+        return repr->initialized;
     }
     PLTA Surface::lta() const {
-        return mris->lta;
+        return repr->lta;
     }
     PMATRIX Surface::SRASToTalSRAS_() const {
-        return mris->SRASToTalSRAS_;
+        return repr->SRASToTalSRAS_;
     }
     PMATRIX Surface::TalSRASToSRAS_() const {
-        return mris->TalSRASToSRAS_;
+        return repr->TalSRASToSRAS_;
     }
     int Surface::free_transform() const {
-        return mris->free_transform;
+        return repr->free_transform;
     }
     double Surface::radius() const {  //  radius (if status==MRIS_SPHERE)
-        return mris->radius;
+        return repr->radius;
     }
     float Surface::a() const {
-        return mris->a;
+        return repr->a;
     }
     float Surface::b() const {
-        return mris->b;
+        return repr->b;
     }
     float Surface::c() const {  //  ellipsoid parameters
-        return mris->c;
+        return repr->c;
     }
     MRIS_fname_t Surface::fname() const {  //  file it was originally loaded from
-        return mris->fname;
+        return repr->fname;
     }
     float Surface::Hmin() const {  //  min mean curvature
-        return mris->Hmin;
+        return repr->Hmin;
     }
     float Surface::Hmax() const {  //  max mean curvature
-        return mris->Hmax;
+        return repr->Hmax;
     }
     float Surface::Kmin() const {  //  min Gaussian curvature
-        return mris->Kmin;
+        return repr->Kmin;
     }
     float Surface::Kmax() const {  //  max Gaussian curvature
-        return mris->Kmax;
+        return repr->Kmax;
     }
     double Surface::Ktotal() const {  //  total Gaussian curvature
-        return mris->Ktotal;
+        return repr->Ktotal;
     }
     MRIS_Status Surface::status() const {  //  type of surface (e.g. sphere, plane)
-        return mris->status;
+        return repr->status;
     }
     MRIS_Status Surface::origxyz_status() const {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-        return mris->origxyz_status;
+        return repr->origxyz_status;
     }
     int Surface::patch() const {  //  if a patch of the surface
-        return mris->patch;
+        return repr->patch;
     }
     int Surface::nlabels() const {
-        return mris->nlabels;
+        return repr->nlabels;
     }
     PMRIS_AREA_LABEL Surface::labels() const {  //  nlabels of these (may be null)
-        return mris->labels;
+        return repr->labels;
     }
     p_void Surface::vp() const {  //  for misc. use
-        return mris->vp;
+        return repr->vp;
     }
     float Surface::alpha() const {  //  rotation around z-axis
-        return mris->alpha;
+        return repr->alpha;
     }
     float Surface::beta() const {  //  rotation around y-axis
-        return mris->beta;
+        return repr->beta;
     }
     float Surface::gamma() const {  //  rotation around x-axis
-        return mris->gamma;
+        return repr->gamma;
     }
     float Surface::da() const {
-        return mris->da;
+        return repr->da;
     }
     float Surface::db() const {
-        return mris->db;
+        return repr->db;
     }
     float Surface::dg() const {  //  old deltas
-        return mris->dg;
+        return repr->dg;
     }
     int Surface::type() const {  //  what type of surface was this initially
-        return mris->type;
+        return repr->type;
     }
     int Surface::max_vertices() const {  //  may be bigger than nvertices, set by calling MRISreallocVerticesAndFaces
-        return mris->max_vertices;
+        return repr->max_vertices;
     }
     int Surface::max_faces() const {  //  may be bigger than nfaces,    set by calling MRISreallocVerticesAndFaces
-        return mris->max_faces;
+        return repr->max_faces;
     }
     MRIS_subject_name_t Surface::subject_name() const {  //  name of the subject
-        return mris->subject_name;
+        return repr->subject_name;
     }
     float Surface::canon_area() const {
-        return mris->canon_area;
+        return repr->canon_area;
     }
     int Surface::noscale() const {  //  don't scale by surface area if true
-        return mris->noscale;
+        return repr->noscale;
     }
     float Surface::dx2(size_t i) const {  //  an extra set of gradient (not always alloced)
-        return mris->dx2[i];
+        return repr->dx2[i];
     }
     float Surface::dy2(size_t i) const {
-        return mris->dy2[i];
+        return repr->dy2[i];
     }
     float Surface::dz2(size_t i) const {
-        return mris->dz2[i];
+        return repr->dz2[i];
     }
     PCOLOR_TABLE Surface::ct() const {
-        return mris->ct;
+        return repr->ct;
     }
     int Surface::useRealRAS() const {  //  if 0 (default), vertex position is a conformed volume RAS with c_(r,"a","s")=0.  else is a real RAS (volume stored RAS)
-        return mris->useRealRAS;
+        return repr->useRealRAS;
     }
     VOL_GEOM Surface::vg() const {  //  volume info from which this surface is created. valid iff vg.valid = 1
-        return mris->vg;
+        return repr->vg;
     }
     MRIS_cmdlines_t Surface::cmdlines() const {
-        return mris->cmdlines;
+        return repr->cmdlines;
     }
     int Surface::ncmds() const {
-        return mris->ncmds;
+        return repr->ncmds;
     }
     float Surface::group_avg_surface_area() const {  //  average of total surface area for group
-        return mris->group_avg_surface_area;
+        return repr->group_avg_surface_area;
     }
     int Surface::group_avg_vtxarea_loaded() const {  //  average vertex area for group at each vertex
-        return mris->group_avg_vtxarea_loaded;
+        return repr->group_avg_vtxarea_loaded;
     }
     int Surface::triangle_links_removed() const {  //  for quad surfaces
-        return mris->triangle_links_removed;
+        return repr->triangle_links_removed;
     }
     p_void Surface::user_parms() const {  //  for whatever the user wants to hang here
-        return mris->user_parms;
+        return repr->user_parms;
     }
     PMATRIX Surface::m_sras2vox() const {  //  for converting surface ras to voxel
-        return mris->m_sras2vox;
+        return repr->m_sras2vox;
     }
     PMRI Surface::mri_sras2vox() const {  //  volume that the above matrix is for
-        return mris->mri_sras2vox;
+        return repr->mri_sras2vox;
     }
     p_void Surface::mht() const {
-        return mris->mht;
+        return repr->mht;
     }
     p_void Surface::temps() const {
-        return mris->temps;
+        return repr->temps;
     }
     
     void Surface::set_strips(size_t i, STRIP to) {
-        mris->strips[i] = to;
+        repr->strips[i] = to;
     }
     void Surface::set_xctr(float to) {
-        mris->xctr = to;
+        repr->xctr = to;
     }
     void Surface::set_yctr(float to) {
-        mris->yctr = to;
+        repr->yctr = to;
     }
     void Surface::set_zctr(float to) {
-        mris->zctr = to;
+        repr->zctr = to;
     }
     void Surface::set_xlo(float to) {
-        mris->xlo = to;
+        repr->xlo = to;
     }
     void Surface::set_ylo(float to) {
-        mris->ylo = to;
+        repr->ylo = to;
     }
     void Surface::set_zlo(float to) {
-        mris->zlo = to;
+        repr->zlo = to;
     }
     void Surface::set_xhi(float to) {
-        mris->xhi = to;
+        repr->xhi = to;
     }
     void Surface::set_yhi(float to) {
-        mris->yhi = to;
+        repr->yhi = to;
     }
     void Surface::set_zhi(float to) {
-        mris->zhi = to;
+        repr->zhi = to;
     }
     void Surface::set_x0(float to) {  //  center of spherical expansion
-        mris->x0 = to;
+        repr->x0 = to;
     }
     void Surface::set_y0(float to) {
-        mris->y0 = to;
+        repr->y0 = to;
     }
     void Surface::set_z0(float to) {
-        mris->z0 = to;
+        repr->z0 = to;
     }
     void Surface::set_v_temporal_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_temporal_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_temporal_pole = repr->vertices + to.idx;
     }
     void Surface::set_v_frontal_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_frontal_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_frontal_pole = repr->vertices + to.idx;
     }
     void Surface::set_v_occipital_pole(Vertex to) {
-        cheapAssert(mris == to.mris); mris->v_occipital_pole = mris->vertices + to.idx;
+        cheapAssert(repr == to.repr); repr->v_occipital_pole = repr->vertices + to.idx;
     }
     void Surface::set_max_curv(float to) {
-        mris->max_curv = to;
+        repr->max_curv = to;
     }
     void Surface::set_min_curv(float to) {
-        mris->min_curv = to;
+        repr->min_curv = to;
     }
     void Surface::set_total_area(float to) {
-        mris->total_area = to;
+        repr->total_area = to;
     }
     void Surface::set_avg_vertex_area(double to) {
-        mris->avg_vertex_area = to;
+        repr->avg_vertex_area = to;
     }
     void Surface::set_avg_vertex_dist(double to) {  //  set by MRIScomputeAvgInterVertexDist
-        mris->avg_vertex_dist = to;
+        repr->avg_vertex_dist = to;
     }
     void Surface::set_std_vertex_dist(double to) {
-        mris->std_vertex_dist = to;
+        repr->std_vertex_dist = to;
     }
     void Surface::set_orig_area(float to) {
-        mris->orig_area = to;
+        repr->orig_area = to;
     }
     void Surface::set_neg_area(float to) {
-        mris->neg_area = to;
+        repr->neg_area = to;
     }
     void Surface::set_neg_orig_area(float to) {  //  amount of original surface in folds
-        mris->neg_orig_area = to;
+        repr->neg_orig_area = to;
     }
     void Surface::set_zeros(int to) {
-        mris->zeros = to;
+        repr->zeros = to;
     }
     void Surface::set_hemisphere(int to) {  //  which hemisphere
-        mris->hemisphere = to;
+        repr->hemisphere = to;
     }
     void Surface::set_fname(MRIS_fname_t to) {  //  file it was originally loaded from
-        mris->fname = to;
+        repr->fname = to;
     }
     void Surface::set_Hmin(float to) {  //  min mean curvature
-        mris->Hmin = to;
+        repr->Hmin = to;
     }
     void Surface::set_Hmax(float to) {  //  max mean curvature
-        mris->Hmax = to;
+        repr->Hmax = to;
     }
     void Surface::set_Kmin(float to) {  //  min Gaussian curvature
-        mris->Kmin = to;
+        repr->Kmin = to;
     }
     void Surface::set_Kmax(float to) {  //  max Gaussian curvature
-        mris->Kmax = to;
+        repr->Kmax = to;
     }
     void Surface::set_Ktotal(double to) {  //  total Gaussian curvature
-        mris->Ktotal = to;
+        repr->Ktotal = to;
     }
     void Surface::set_status(MRIS_Status to) {  //  type of surface (e.g. sphere, plane)
-        mris->status = to;
+        repr->status = to;
     }
     void Surface::set_origxyz_status(MRIS_Status to) {  //  type of surface (e.g. sphere, plane) that this origxyz were obtained from
-        mris->origxyz_status = to;
+        repr->origxyz_status = to;
     }
     void Surface::set_patch(int to) {  //  if a patch of the surface
-        mris->patch = to;
+        repr->patch = to;
     }
     void Surface::set_nlabels(int to) {
-        mris->nlabels = to;
+        repr->nlabels = to;
     }
     void Surface::set_labels(PMRIS_AREA_LABEL to) {  //  nlabels of these (may be null)
-        mris->labels = to;
+        repr->labels = to;
     }
     void Surface::set_vp(p_void to) {  //  for misc. use
-        mris->vp = to;
+        repr->vp = to;
     }
     void Surface::set_alpha(float to) {  //  rotation around z-axis
-        mris->alpha = to;
+        repr->alpha = to;
     }
     void Surface::set_beta(float to) {  //  rotation around y-axis
-        mris->beta = to;
+        repr->beta = to;
     }
     void Surface::set_gamma(float to) {  //  rotation around x-axis
-        mris->gamma = to;
+        repr->gamma = to;
     }
     void Surface::set_da(float to) {
-        mris->da = to;
+        repr->da = to;
     }
     void Surface::set_db(float to) {
-        mris->db = to;
+        repr->db = to;
     }
     void Surface::set_dg(float to) {  //  old deltas
-        mris->dg = to;
+        repr->dg = to;
     }
     void Surface::set_type(int to) {  //  what type of surface was this initially
-        mris->type = to;
+        repr->type = to;
     }
 
 
     } // namespace AllM
-} // namespace SurfaceFromMRIS
+} // SurfaceFromMRIS

--- a/utils/mris_compVolFrac.cpp
+++ b/utils/mris_compVolFrac.cpp
@@ -82,7 +82,7 @@ MRI *MRIcomputeVolumeFractionFromSurface(MRI_SURFACE *mris, double acc, MRI *mri
           /* change of coordinates from image to surface domain */
           MRIvoxelToSurfaceRAS(mri_shell, x, y, z, &xs, &ys, &zs);
           /* find the closest vertex to the point */
-          MHTfindClosestVertexGeneric(mht, mris, xs, ys, zs, 10, 2, &vno, &dist);
+          MHTfindClosestVertexGeneric(mht, xs, ys, zs, 10, 2, &vno, &dist);
           /* creating the oct tree voxel structure */
           vox[0] = xs - vsize[0] / 2.0;
           vox[1] = ys - vsize[1] / 2.0;

--- a/utils/mrishash.cpp
+++ b/utils/mrishash.cpp
@@ -908,8 +908,7 @@ struct MRIS_HASH_TABLE_IMPL : public MRIS_HASH_TABLE_NoSurface {
                                       int                     const trace) const;
 
 	
-    int mhtBruteForceClosestVertex(
-        MRIS *mris, float x, float y, float z, int which, float *dmin);
+    int mhtBruteForceClosestVertex(float x, float y, float z, int which, float *dmin);
 
     void mhtfindClosestVertexGenericInBucket(
                                         //---------- inputs --------------
@@ -946,8 +945,8 @@ struct MRIS_HASH_TABLE_IMPL : public MRIS_HASH_TABLE_NoSurface {
 #define MHT_CONST_THIS              const
 #define MHT_THIS_PARAMETER_NOCOMMA
 #define MHT_THIS_PARAMETER
-#define MHT_MRIS_PARAMETER_NOCOMMA  MRIS *mris
-#define MHT_MRIS_PARAMETER          MHT_MRIS_PARAMETER_NOCOMMA ,
+#define MHT_MRIS_PARAMETER_NOCOMMA
+#define MHT_MRIS_PARAMETER
 #include "mrishash_traditional_functions.h"
 #undef MHT_ONLY_VIRTUAL
 
@@ -1060,18 +1059,16 @@ MRIS_HASH_TABLE* MRIS_HASH_TABLE::createFaceTable_Resolution(
 //  Appends or removes all faces of the vertex.
 //  Returns: NO_ERROR
 //
-int MRIS_HASH_TABLE_IMPL::addAllFaces(MRIS* mris, int vno)
+int MRIS_HASH_TABLE_IMPL::addAllFaces(int vno)
 {
-    checkConstructedWithFacesAndSurface(mris);
     Vertex v = surface.vertices(vno);
     for (int fi = 0; fi < v.num(); fi++) mhtFaceToMHT(v.f(fi), true);
     return (NO_ERROR);
 }
 
 
-int MRIS_HASH_TABLE_IMPL::removeAllFaces(MRIS *mris, int vno)
+int MRIS_HASH_TABLE_IMPL::removeAllFaces(int vno)
 {
-    checkConstructedWithFacesAndSurface(mris);
     Vertex v = surface.vertices(vno);
     for (int fi = 0; fi < v.num(); fi++) mhtFaceToMHT(v.f(fi), false);
     return (NO_ERROR);
@@ -1275,7 +1272,7 @@ int MRIS_HASH_TABLE_IMPL::MHTdoesFaceIntersect_new(int const fno, int const trac
 }
 
 
-int MRIS_HASH_TABLE_IMPL::doesFaceIntersect(MRIS *mris, int fno) {
+int MRIS_HASH_TABLE_IMPL::doesFaceIntersect(int fno) {
     return MHTdoesFaceIntersect_new(fno, false);
 }
 
@@ -1886,7 +1883,6 @@ done:
 */
 
 void MRIS_HASH_TABLE_IMPL::findClosestFaceNoGeneric(
-    MRIS *mris,
     //---------- inputs --------------
     double probex,
     double probey,
@@ -1916,7 +1912,6 @@ void MRIS_HASH_TABLE_IMPL::findClosestFaceNoGeneric(
   unsigned char central27[3][3][3];  // Indexes 0..2 stand for -1..+1
   //----------------------------------
 
-  checkConstructedWithFacesAndSurface(mris);    // seen to fail when VerticesAndSurface
   mhtres = vres;
 
   //--------------------------------------------------
@@ -2136,10 +2131,8 @@ done:
   Returns vertex in mht and mris that is closest to which-selected ###xyz.
 
   -----------------------------------------------------------------------*/
-int MRIS_HASH_TABLE_IMPL::findClosestSetVertexNo(MRIS *mris, float x, float y, float z)
+int MRIS_HASH_TABLE_IMPL::findClosestSetVertexNo(float x, float y, float z)
 {
-  checkConstructedWithVerticesAndSurface(mris);
-
   int vno;
   findClosestVertexGeneric(   x,
                               y,
@@ -2150,7 +2143,7 @@ int MRIS_HASH_TABLE_IMPL::findClosestSetVertexNo(MRIS *mris, float x, float y, f
                               NULL);
 
   if (vno < 0) {  // did not find a vertex, so use brute-force
-    vno = mhtBruteForceClosestVertex(mris, x, y, z, which_vertices, NULL);
+    vno = mhtBruteForceClosestVertex(x, y, z, which_vertices, NULL);
   }
 
   return vno;
@@ -2163,11 +2156,8 @@ int MRIS_HASH_TABLE_IMPL::findClosestSetVertexNo(MRIS *mris, float x, float y, f
   in mris & mht.
   --------------------------------------------------------------------*/
 int MRIS_HASH_TABLE_IMPL::findClosestVertexNoXYZ(
-                               MRIS *mris, 
                                float x, float y, float z, 
                                float *min_dist) {
-
-  checkConstructedWithVerticesAndSurface(mris);
 
   double min_dist_dbl;
   int vno, rslt;
@@ -2188,7 +2178,7 @@ int MRIS_HASH_TABLE_IMPL::findClosestVertexNoXYZ(
   //----------------------------------------------------------
   if (-1 == rslt) {
     // brf - should always find one that is closest
-    vno = mhtBruteForceClosestVertex(mris, x, y, z, which_vertices, min_dist);
+    vno = mhtBruteForceClosestVertex(x, y, z, which_vertices, min_dist);
   }
 
   return vno;
@@ -2199,10 +2189,8 @@ int MRIS_HASH_TABLE_IMPL::findClosestVertexNoXYZ(
   Returns vertex from mris & mht that's closest to provided coordinates.
   ---------------------------------------------------------------*/
 int MRIS_HASH_TABLE_IMPL::findVnoOfClosestVertexInTable(
-    MRIS *mris, float x, float y, float z, int do_global_search)
+    float x, float y, float z, int do_global_search)
 {
-  checkConstructedWithVerticesAndSurface(mris);
-
   int vno;
   findClosestVertexGeneric(   x,
                               y,
@@ -2226,7 +2214,7 @@ int MRIS_HASH_TABLE_IMPL::findVnoOfClosestVertexInTable(
     }
 
     if (vno < 0) { // did not find a vertex, so use brute-force (BRF)
-      vno = mhtBruteForceClosestVertex(mris, x, y, z, which_vertices, NULL);
+      vno = mhtBruteForceClosestVertex(x, y, z, which_vertices, NULL);
     }
   }
 
@@ -2234,35 +2222,13 @@ int MRIS_HASH_TABLE_IMPL::findVnoOfClosestVertexInTable(
 }
 
 #define MAX_VERTICES 50000
-/*------------------------------------------------------------
-  MHTgetAllVerticesWithinDistance
-  Returns a list of vertex numbers from mris & mht that are within
-  max_dist of vertex vno.
-
-  Allocates separate list pvnum which must be freed by caller.
-
-  As of 2007-03-20, there don't appear to be any callers of this function
-  in all the FS source code, so I'm not bothering to implement its
-  functionality in the generic Find function, however it would be easy to do.
-  ------------------------------------------------------------*/
-int * MRIS_HASH_TABLE_IMPL::getAllVerticesWithinDistance(MRIS *mris, int vno, float max_dist, int *pvnum)
-{
-  //------------------------------------------------------
-  ErrorExit(ERROR_UNSUPPORTED, "%s: not implemented.\n", __MYFUNCTION__);
-
-  return NULL;
-}
-
 int MRIS_HASH_TABLE_IMPL::mhtBruteForceClosestVertex(
-    MRIS *  mris,
     float   x,
     float   y,
     float   z,
     int     which,  // which surface within mris to search
     float * dmin)
 {
-    checkConstructedWithVerticesAndSurface(mris);
-    
     int   min_vno = -1;
     float min_dsq = 1e8;
 
@@ -2333,7 +2299,7 @@ int MRIS_HASH_TABLE::testIsMRISselfIntersecting(MRIS *mris, float res)
     MRIS_HASH_TABLE * mht = createFaceTable_Resolution(mris, CURRENT_VERTICES, res);
     int rslt = 0;
     for (int fno = 0; fno < mris->nfaces; fno++) {
-        if (mht->doesFaceIntersect(mris, fno)) {
+        if (mht->doesFaceIntersect(fno)) {
             rslt = 1;
             goto done;
         }
@@ -2343,71 +2309,6 @@ done:
     return rslt;
 }
 
-
-/*--------------------------------------------------------
-  MHTcheckFaces
-  Unchanged from mrishash.c 1.27
-  -------------------------------------------------------*/
-int MRIS_HASH_TABLE_IMPL::checkFaces(MRIS *mris)
-//--------------------------------------------------------
-{
-  static int ncalls = 0;
-
-  if (ncalls++ >= 0) {
-#if 0
-    checkFace(mris, 144) ;
-    checkFace(mris, 185) ;
-    checkFace(mris, 16960) ;
-    checkFace(mris, 18168) ;
-    checkFace(mris, 39705) ;
-    checkFace(mris, 32319) ;
-    checkAllVertexFaces(mris, 15300) ;
-    checkAllVertexFaces(mris, 4303) ;
-    checkAllVertexFaces(mris, 35701) ;
-    checkAllVertexFaces(mris, 4632) ;
-    checkAllVertexFaces(mris, 1573) ;
-#endif
-  }
-  return (NO_ERROR);
-}
-
-/*-----------------------------------------------------
-  MHTcheckSurface
-  Unchanged from mrishash.c 1.27
-  However, subsidiary checkFace is disabled
-  ------------------------------------------------------*/
-int MRIS_HASH_TABLE_IMPL::checkSurface( MRIS *mris)
-//--------------------------------------------------------
-{
-    auto mht = createFaceTable(mris);
-
-    for (int fno = 0; fno < mris->nfaces; fno++) {
-        if (!(fno % (mris->nfaces / 10))) DiagHeartbeat((float)fno / (float)mris->nfaces);
-        mht->checkFace(mris, fno);
-    }
-  
-    MHTfree(&mht);
-  
-    return (NO_ERROR);
-}
-
-
-/*-----------------------------------------------------
-  checkFace
-  Conducts a brute-force test of self-intersection relative to
-  the one provided face.
-  I think the intent here was to conduct brute-force intersections test,
-  and if diag flags set, compare that to MHT results.
-  However, the only output produced is printed or to file, this
-  func doesn't return result of intersection test.
-  I have disabled this whole routine because it doesn't look useful,
-  and it calls
-  local functions that I've refactored away.
-  ------------------------------------------------------*/
-int MRIS_HASH_TABLE_IMPL::checkFace(MRIS *mris, int fno1)
-{
-  return (NO_ERROR);
-}
 
 
 static void mhtComputeFaceCentroid(
@@ -2463,7 +2364,7 @@ int MHTfindClosestVertexNo2(
     Surface surface(mris_for_v);
     float x,y,z;
     mhtVertex2xyz(surface.vertices(vno), mht->which_vertices, &x, &y, &z);
-    return mht->findClosestVertexNoXYZ(mris, x,y,z, pmin_dist);
+    return mht->findClosestVertexNoXYZ(x,y,z, pmin_dist);
 }
 
 VERTEX * MHTfindClosestVertex2(
@@ -2489,7 +2390,7 @@ VERTEX* MHTfindClosestVertexSet2(
     Surface surface(mris_for_v);
     float x,y,z;
     mhtVertex2xyz(surface.vertices(vno), mht->which_vertices, &x, &y, &z);
-    int closest_vno =  mht->findClosestSetVertexNo(mris, x,y,z);
+    int closest_vno =  mht->findClosestSetVertexNo(x,y,z);
     return (closest_vno < 0) ? nullptr : &mris->vertices[closest_vno];
 }
 
@@ -2499,7 +2400,7 @@ VERTEX* MHTfindClosestVertexInTable(
     MRIS *mris,
     float x, float y, float z, int do_global_search)
 {
-    int closest_vno =  mht->findVnoOfClosestVertexInTable(mris, x, y, z, do_global_search);
+    int closest_vno =  mht->findVnoOfClosestVertexInTable(x, y, z, do_global_search);
     return (closest_vno < 0) ? nullptr : &mris->vertices[closest_vno];
 }
 
@@ -2519,6 +2420,7 @@ void MHTfindClosestFaceGeneric(
     int *pfno, 
     double *pface_distance)
 {
-    mht->findClosestFaceNoGeneric(mris, probex,probey,probez, in_max_distance_mm,in_max_mhts,project_into_face,pfno,pface_distance);
+    //checkConstructedWithFacesAndSurface(mris);    // seen to fail when VerticesAndSurface
+    mht->findClosestFaceNoGeneric(probex,probey,probez, in_max_distance_mm,in_max_mhts,project_into_face,pfno,pface_distance);
     *pface = (*pfno < 0) ? nullptr : &mris->faces[*pfno];
 }

--- a/utils/mrishash.cpp
+++ b/utils/mrishash.cpp
@@ -1916,7 +1916,7 @@ void MRIS_HASH_TABLE_IMPL::findClosestFaceNoGeneric(
   unsigned char central27[3][3][3];  // Indexes 0..2 stand for -1..+1
   //----------------------------------
 
-  checkConstructedWithVerticesAndSurface(mris);
+  checkConstructedWithFacesAndSurface(mris);    // seen to fail when VerticesAndSurface
   mhtres = vres;
 
   //--------------------------------------------------

--- a/utils/mrishash.cpp
+++ b/utils/mrishash.cpp
@@ -50,8 +50,9 @@
 
 #include "mrishash_internals.h"
 
-using namespace SurfaceFromMRIS::Analysis;
-
+//using namespace SurfaceFromMRIS::Analysis;
+using namespace SurfaceFromMRIS::XYZPositionConsequences;
+//using namespace SurfaceFromMRISPV::XYZPositionConsequences;
 
 //==================================================================
 // Local macros
@@ -168,10 +169,9 @@ static void checkThread0()
 // Utilities that do not require a MRIS_HASH_TABLE
 //
 static void mhtComputeFaceCentroid      (Surface const surface, int which, int fno, float *x, float *y, float *z);
-static void mhtVertex2xyz_float         (Vertex  const vtx,     int which, float  *x, float  *y, float  *z);
-static void mhtVertex2xyz_double        (Vertex  const vtx,     int which, double *x, double *y, double *z);
-static void mhtVertex2Ptxyz_double      (Vertex  const vtx,     int which, Ptdbl_t *pt);
-static void mhtVertex2array3_double     (Vertex  const vtx,     int which, double  *array3);
+static void mhtVertex2xyz               (Vertex  const vtx,     int which, float  *x, float  *y, float  *z);
+static void mhtVertex2xyz               (Vertex  const vtx,     int which, Ptdbl_t *pt);
+static void mhtVertex2xyz               (Vertex  const vtx,     int which, double  *array3);
 
 static void mhtVoxelList_Init           (VOXEL_LISTgw *voxlist);
 static void mhtVoxelList_SampleTriangle (float mhtres, Ptdbl_t const *vpt0, Ptdbl_t const *vpt1, Ptdbl_t const *vpt2, VOXEL_LISTgw *voxlist);
@@ -181,167 +181,29 @@ static void mhtVoxelList_AddPath        (VOXEL_LISTgw *voxlist, VOXEL_COORD oldv
 
 
 //---------------------------------------------
-static void mhtVertex2xyz_float(Vertex  const vtx, int which, float *x, float *y, float *z)
+static void mhtVertex2xyz(Vertex  const vtx, int which, float *x, float *y, float *z)
 {
-  //---------------------------------------------
-  switch (which) {
-    case ORIGINAL_VERTICES:
-      *x = vtx.origx();
-      *y = vtx.origy();
-      *z = vtx.origz();
-      break;
-    case CANONICAL_VERTICES:
-      *x = vtx.cx();
-      *y = vtx.cy();
-      *z = vtx.cz();
-      break;
-    case CURRENT_VERTICES:
-      *x = vtx.x();
-      *y = vtx.y();
-      *z = vtx.z();
-      break;
-    case FLATTENED_VERTICES:
-      *x = vtx.fx();
-      *y = vtx.fy();
-      *z = 0;
-      break;
-    case PIAL_VERTICES:
-      *x = vtx.pialx();
-      *y = vtx.pialy();
-      *z = vtx.pialz();
-      break;
-    case WHITE_VERTICES:
-      *x = vtx.whitex();
-      *y = vtx.whitey();
-      *z = vtx.whitez();
-      break;
-    default:
-      cheapAssert(false);
-      *x = *y = *z = 0.0f;
-  }
-  return;
-}
-//---------------------------------------------
-static void mhtVertex2xyz_double(Vertex  const vtx, int which, double *x, double *y, double *z)
-{
-  switch (which) {
-    case ORIGINAL_VERTICES:
-      *x = vtx.origx();
-      *y = vtx.origy();
-      *z = vtx.origz();
-      break;
-    case CANONICAL_VERTICES:
-      *x = vtx.cx();
-      *y = vtx.cy();
-      *z = vtx.cz();
-      break;
-    case CURRENT_VERTICES:
-      *x = vtx.x();
-      *y = vtx.y();
-      *z = vtx.z();
-      break;
-    case FLATTENED_VERTICES:
-      *x = vtx.fx();
-      *y = vtx.fy();
-      *z = 0;
-      break;
-    case PIAL_VERTICES:
-      *x = vtx.pialx();
-      *y = vtx.pialy();
-      *z = vtx.pialz();
-      break;
-    case WHITE_VERTICES:
-      *x = vtx.whitex();
-      *y = vtx.whitey();
-      *z = vtx.whitez();
-      break;
-    default:
-      cheapAssert(false);
-      *x = *y = *z = 0.0f;
-  }
-  return;
+  vtx.which_coords(which, x, y, z);
 }
 
-static void mhtVertex2Ptxyz_double(Vertex  const vtx, int which, Ptdbl_t *pt)
+static void mhtVertex2xyz(Vertex  const vtx, int which, Ptdbl_t *pt)
 {
-  switch (which) {
-    case ORIGINAL_VERTICES:
-      pt->x = vtx.origx();
-      pt->y = vtx.origy();
-      pt->z = vtx.origz();
-      break;
-    case CANONICAL_VERTICES:
-      pt->x = vtx.cx();
-      pt->y = vtx.cy();
-      pt->z = vtx.cz();
-      break;
-    case CURRENT_VERTICES:
-      pt->x = vtx.x();
-      pt->y = vtx.y();
-      pt->z = vtx.z();
-      break;
-    case FLATTENED_VERTICES:
-      pt->x = vtx.fx();
-      pt->y = vtx.fy();
-      pt->z = 0;
-      break;
-    case PIAL_VERTICES:
-      pt->x = vtx.pialx();
-      pt->y = vtx.pialy();
-      pt->z = vtx.pialz();
-      break;
-    case WHITE_VERTICES:
-      pt->x = vtx.whitex();
-      pt->y = vtx.whitey();
-      pt->z = vtx.whitez();
-      break;
-    default:
-      cheapAssert(false);
-      pt->x = pt->y = pt->z = 0.0f;
-  }
-  return;
+  float x,y,z;
+  vtx.which_coords(which, &x, &y, &z);
+  pt->x = x;
+  pt->y = y;
+  pt->z = z;
 }
 
-
-static void mhtVertex2array3_double(Vertex  const vtx, int which, double *array3)
+static void mhtVertex2xyz(Vertex  const vtx, int which, double *array3)
 {
-  switch (which) {
-    case ORIGINAL_VERTICES:
-      array3[0] = vtx.origx();
-      array3[1] = vtx.origy();
-      array3[2] = vtx.origz();
-      break;
-    case CANONICAL_VERTICES:
-      array3[0] = vtx.cx();
-      array3[1] = vtx.cy();
-      array3[2] = vtx.cz();
-      break;
-    case CURRENT_VERTICES:
-      array3[0] = vtx.x();
-      array3[1] = vtx.y();
-      array3[2] = vtx.z();
-      break;
-    case FLATTENED_VERTICES:
-      array3[0] = vtx.fx();
-      array3[1] = vtx.fy();
-      array3[2] = 0;
-      break;
-    case PIAL_VERTICES:
-      array3[0] = vtx.pialx();
-      array3[1] = vtx.pialy();
-      array3[2] = vtx.pialz();
-      break;
-    case WHITE_VERTICES:
-      array3[0] = vtx.whitex();
-      array3[1] = vtx.whitey();
-      array3[2] = vtx.whitez();
-      break;
-    default:
-      cheapAssert(false);
-      array3[0] = array3[1] = array3[2] = 0.0f;
-  }
-  return;
+  float x,y,z;
+  vtx.which_coords(which, &x, &y, &z);
+  array3[0] = x;
+  array3[1] = y;
+  array3[2] = z;
 }
+
 
 static void mhtVoxelList_Init(VOXEL_LISTgw *voxlist)
 {
@@ -617,8 +479,8 @@ struct MRIS_HASH_TABLE_IMPL : public MRIS_HASH_TABLE {
     virtual MRIS_HASH_TABLE_IMPL*       toMRIS_HASH_TABLE_IMPL_Wkr()       { return this; }
     virtual MRIS_HASH_TABLE_IMPL const* toMRIS_HASH_TABLE_IMPL_Wkr() const { return this; }
 
-    MRIS_HASH_TABLE_IMPL(MHTFNO_t fno_usage, float vres, MRIS * mris, int which_vertices) 
-      : MRIS_HASH_TABLE(fno_usage, vres, which_vertices), surface(mris) 
+    MRIS_HASH_TABLE_IMPL(MHTFNO_t fno_usage, float vres, Surface surface, int which_vertices) 
+      : MRIS_HASH_TABLE(fno_usage, vres, which_vertices), surface(surface) 
     {
         nfaces = surface.nfaces();
         f      = (MHT_FACE*)calloc(nfaces, sizeof(MHT_FACE));
@@ -644,8 +506,8 @@ struct MRIS_HASH_TABLE_IMPL : public MRIS_HASH_TABLE {
     
     void checkConstructedWithFaces   () const;
     void checkConstructedWithVertices() const;
-    void checkConstructedWithFaces   (MRIS *mris) const;
-    void checkConstructedWithVertices(MRIS *mris) const;
+    void checkConstructedWithFaces   (Surface surface) const;
+    void checkConstructedWithVertices(Surface surface) const;
 
     void mhtFaceCentroid2xyz_float   (int fno, float *x, float *y, float *z);
         // Centroids are computed once and stored in the MHT_FACE
@@ -766,11 +628,11 @@ static void freeBins(MHBT* bucket) {
 
 
 
-// Primitives that have to be correct...
+// Primitives that manage storage and threading
 //
-static MRIS_HASH_TABLE_IMPL* newMHT(MHTFNO_t fno_usage, float vres, int which_vertices, MRIS *mris)
+static MRIS_HASH_TABLE_IMPL* newMHT(MHTFNO_t fno_usage, float vres, int which_vertices, Surface surface)
 {
-    auto mht = new MRIS_HASH_TABLE_IMPL(fno_usage, vres, mris, which_vertices);
+    auto mht = new MRIS_HASH_TABLE_IMPL(fno_usage, vres, surface, which_vertices);
     if (!mht) ErrorExit(ERROR_NO_MEMORY, "%s: could not allocate hash table.\n", __MYFUNCTION__);
 
     return mht;
@@ -794,6 +656,10 @@ MRIS_HASH_TABLE_IMPL::~MRIS_HASH_TABLE_IMPL()
             ::free(buckets_mustUseAcqRel[xv][yv]);
         }
     }
+
+#ifdef HAVE_OPENMP
+    omp_destroy_lock(&buckets_lock);
+#endif
 }
 
 
@@ -973,15 +839,15 @@ void MRIS_HASH_TABLE_IMPL::checkConstructedWithFaces() const
     }
 }
 
-void MRIS_HASH_TABLE_IMPL::checkConstructedWithVertices(MRIS *mris) const
+void MRIS_HASH_TABLE_IMPL::checkConstructedWithVertices(Surface surface) const
 {
-    if (!(surface == Surface(mris))) ErrorExit(ERROR_BADPARM, "%s: mris is bad\n", __MYFUNCTION__);
+    if (this->surface != surface) ErrorExit(ERROR_BADPARM, "%s: mris is bad\n", __MYFUNCTION__);
     checkConstructedWithVertices();
 }
 
-void MRIS_HASH_TABLE_IMPL::checkConstructedWithFaces(MRIS *mris) const
+void MRIS_HASH_TABLE_IMPL::checkConstructedWithFaces(Surface surface) const
 {
-    if (surface != Surface(mris)) ErrorExit(ERROR_BADPARM, "%s: mris is bad\n", __MYFUNCTION__);
+    if (this->surface != surface) ErrorExit(ERROR_BADPARM, "%s: mris is bad\n", __MYFUNCTION__);
     checkConstructedWithFaces();
 }
 
@@ -1001,7 +867,7 @@ MRIS_HASH_TABLE* MRIS_HASH_TABLE::createFaceTable_Resolution(
     ncalls++;
 
     Surface surface(mris);
-    auto mht = newMHT(MHTFNO_FACE, res, which, mris);
+    auto mht = newMHT(MHTFNO_FACE, res, which, surface);
   
     // Capture data from caller and surface
     //    
@@ -1095,9 +961,9 @@ int MRIS_HASH_TABLE_IMPL::mhtFaceToMHT(Face const face, bool const on)
     Vertex const v2 = face.v(2);
 
     Ptdbl_t vpt0, vpt1, vpt2;
-    mhtVertex2Ptxyz_double(v0, which_vertices, &vpt0);
-    mhtVertex2Ptxyz_double(v1, which_vertices, &vpt1);
-    mhtVertex2Ptxyz_double(v2, which_vertices, &vpt2);
+    mhtVertex2xyz(v0, which_vertices, &vpt0);
+    mhtVertex2xyz(v1, which_vertices, &vpt1);
+    mhtVertex2xyz(v2, which_vertices, &vpt2);
 
     if (Gx >= 0) {
         double dist0 = sqrt(SQR(vpt0.x - Gx) + SQR(vpt0.y - Gy) + SQR(vpt0.z - Gz));
@@ -1145,7 +1011,7 @@ MRIS_HASH_TABLE* MRIS_HASH_TABLE::createVertexTable_Resolution(MRIS *mris, int w
         auto v = surface.vertices(vno);
         if (v.ripflag()) continue;
         float x, y, z;
-        mhtVertex2xyz_float(v, mht->which_vertices, &x, &y, &z);
+        mhtVertex2xyz(v, mht->which_vertices, &x, &y, &z);
         mht->mhtAddFaceOrVertexAtCoords(x, y, z, vno);
     }
 
@@ -1319,7 +1185,7 @@ int MRIS_HASH_TABLE_IMPL::isVectorFilled(
             if (corner.vno() == vtxno) {
                 point->x = moved_x; point->y = moved_y; point->z = moved_z;
             } else {
-                mhtVertex2Ptxyz_double(corner, which_vertices, point);
+                mhtVertex2xyz(corner, which_vertices, point);
                 if (trace) {
                     fprintf(stderr, "corner:%d vertex:%d stays at (%g,%g,%g)\n",
                         corneri, corner.vno(), point->x, point->y, point->z);
@@ -1354,7 +1220,7 @@ int MRIS_HASH_TABLE_IMPL::MHTdoesFaceIntersect_new(int const fno, int const trac
 
     MHT_TRIANGLE triangle;
     for (int corneri = 0; corneri < 3; corneri++) {
-        mhtVertex2Ptxyz_double(face.v(corneri), which_vertices, &triangle.corners[corneri]);
+        mhtVertex2xyz(face.v(corneri), which_vertices, &triangle.corners[corneri]);
     }
 
     int touchingFnos[MHT_MAX_TOUCHING_FACES];
@@ -1526,9 +1392,9 @@ int MRIS_HASH_TABLE_IMPL::mhtDoesTriangleVoxelListIntersect(
     Face const face = surface.faces(facelist[fli]);
     
     double u0[3], u1[3], u2[3];   
-    mhtVertex2array3_double(face.v(0), which_vertices, u0);
-    mhtVertex2array3_double(face.v(1), which_vertices, u1);
-    mhtVertex2array3_double(face.v(2), which_vertices, u2);
+    mhtVertex2xyz(face.v(0), which_vertices, u0);
+    mhtVertex2xyz(face.v(1), which_vertices, u1);
+    mhtVertex2xyz(face.v(2), which_vertices, u2);
 
     int const intersect = tri_tri_intersect(v0, v1, v2, u0, u1, u2);
     
@@ -1589,7 +1455,7 @@ void MRIS_HASH_TABLE_IMPL::mhtfindClosestVertexGenericInBucket(
         if (AVtx.ripflag()) continue ;
 
         float tryx, tryy, tryz;
-        mhtVertex2xyz_float(AVtx, which_vertices, &tryx, &tryy, &tryz);
+        mhtVertex2xyz(AVtx, which_vertices, &tryx, &tryy, &tryz);
 
         double ADistSq = SQR(tryx - probex) + SQR(tryy - probey) + SQR(tryz - probez);
 
@@ -2379,7 +2245,7 @@ int MRIS_HASH_TABLE_IMPL::mhtBruteForceClosestVertex(
         if (vtx.ripflag()) continue;
             
         float tryx, tryy, tryz;
-        mhtVertex2xyz_float(vtx, which, &tryx, &tryy, &tryz);
+        mhtVertex2xyz(vtx, which, &tryx, &tryy, &tryz);
 
         float dx  = tryx - x, dy = tryy - y, dz = tryz - z;
         float dsq = dx * dx + dy * dy + dz * dz;  // squared distance is fine for detecting min
@@ -2538,7 +2404,7 @@ static void mhtComputeFaceCentroid(
     
     for (int n = 0; n < VERTICES_PER_FACE; n++) {
         float x = 0, y = 0, z = 0;
-        mhtVertex2xyz_float(face.v(n), which, &x, &y, &z);
+        mhtVertex2xyz(face.v(n), which, &x, &y, &z);
         xt += x;
         yt += y;
         zt += z;
@@ -2580,7 +2446,7 @@ int MHTfindClosestVertexNo2(
     cheapAssert(0 <= vno && vno < mris_for_v->nvertices);
     Surface surface(mris_for_v);
     float x,y,z;
-    mhtVertex2xyz_float(surface.vertices(vno), mht->which_vertices, &x, &y, &z);
+    mhtVertex2xyz(surface.vertices(vno), mht->which_vertices, &x, &y, &z);
     return mht->findClosestVertexNoXYZ(mris, x,y,z, pmin_dist);
 }
 
@@ -2606,7 +2472,7 @@ VERTEX* MHTfindClosestVertexSet2(
     cheapAssert(0 <= vno && vno < mris_for_v->nvertices);
     Surface surface(mris_for_v);
     float x,y,z;
-    mhtVertex2xyz_float(surface.vertices(vno), mht->which_vertices, &x, &y, &z);
+    mhtVertex2xyz(surface.vertices(vno), mht->which_vertices, &x, &y, &z);
     int closest_vno =  mht->findClosestSetVertexNo(mris, x,y,z);
     return (closest_vno < 0) ? nullptr : &mris->vertices[closest_vno];
 }

--- a/utils/mrisurf_defect.cpp
+++ b/utils/mrisurf_defect.cpp
@@ -9413,7 +9413,6 @@ MRI_SURFACE *MRIScorrectTopology(
     MRISsaveVertexPositions(mris_corrected, TMP_VERTICES);
     MRISrestoreVertexPositions(mris_corrected, ORIG_VERTICES);
     mht = MHTcreateFaceTable(mris_corrected);
-    mht->checkSurface(mris_corrected);
     MHTfree(&mht);
     MRISrestoreVertexPositions(mris_corrected, TMP_VERTICES);
   }

--- a/utils/mrisurf_defect.cpp
+++ b/utils/mrisurf_defect.cpp
@@ -9141,16 +9141,16 @@ MRI_SURFACE *MRIScorrectTopology(
         /* save border positions */
         for (n = 0; n < defect->nborder; n++) {
           VERTEX * const vdst = &mris_corrected->vertices[vertex_trans[defect->border[n]]];
-          vdst->tx2 = vdst->cx;
-          vdst->ty2 = vdst->cy;
-          vdst->tz2 = vdst->cz;
+          vdst->t2x = vdst->cx;
+          vdst->t2y = vdst->cy;
+          vdst->t2z = vdst->cz;
         }
         /* save inside positions */
         for (n = 0; n < defect->nvertices; n++) {
           VERTEX * const vdst = &mris_corrected->vertices[vertex_trans[defect->vertices[n]]];
-          vdst->tx2 = vdst->cx;
-          vdst->ty2 = vdst->cy;
-          vdst->tz2 = vdst->cz;
+          vdst->t2x = vdst->cx;
+          vdst->t2y = vdst->cy;
+          vdst->t2z = vdst->cz;
         }
 
         /* generate different mappings (max 10) */
@@ -9273,16 +9273,16 @@ MRI_SURFACE *MRIScorrectTopology(
           /* restore border positions */
           for (n = 0; n < defect->nborder; n++) {
             VERTEX * const vdst = &mris_corrected->vertices[vertex_trans[defect->border[n]]];
-            vdst->cx = vdst->tx2;
-            vdst->cy = vdst->ty2;
-            vdst->cz = vdst->tz2;
+            vdst->cx = vdst->t2x;
+            vdst->cy = vdst->t2y;
+            vdst->cz = vdst->t2z;
           }
           /* save inside positions */
           for (n = 0; n < defect->nvertices; n++) {
             VERTEX * const vdst = &mris_corrected->vertices[vertex_trans[defect->vertices[n]]];
-            vdst->cx = vdst->tx2;
-            vdst->cy = vdst->ty2;
-            vdst->cz = vdst->tz2;
+            vdst->cx = vdst->t2x;
+            vdst->cy = vdst->t2y;
+            vdst->cz = vdst->t2z;
           }
           break;
 

--- a/utils/mrisurf_deform.cpp
+++ b/utils/mrisurf_deform.cpp
@@ -1224,7 +1224,7 @@ int mrisComputeSurfaceNormalIntersectionTerm(MRI_SURFACE *mris, MHT *mht, double
     return (NO_ERROR);
   }
 
-  step = mht->vres / 2;
+  step = mht->vres() / 2;
   ROMP_PF_begin
 #ifdef HAVE_OPENMP
   #pragma omp parallel for if_ROMP(experimental)

--- a/utils/mrisurf_deform.cpp
+++ b/utils/mrisurf_deform.cpp
@@ -6758,7 +6758,7 @@ double mrisComputeNegativeLogPosterior2D(MRI_SURFACE *mris, INTEGRATION_PARMS *p
 
           // update distance with continuum measure
           MRIvoxelToSurfaceRAS(mri, x, y, z, &xs, &ys, &zs);
-          MHTfindClosestVertexGeneric(mht, mris, xs, ys, zs, 10, 4, &vno, &vdist);
+          MHTfindClosestVertexGeneric(mht, xs, ys, zs, 10, 4, &vno, &vdist);
           v = (vno < 0) ? nullptr : &mris->vertices[vno];
           if (v != NULL)  // compute distance from surface in normal direction
           {
@@ -7045,7 +7045,7 @@ int mrisComputePosterior2DTerm(MRI_SURFACE *mris, INTEGRATION_PARMS *parms)
 
         // add this voxel to the list of voxels of the vertex it is closest to
         MRIvoxelToSurfaceRAS(mri, x, y, z, &xs, &ys, &zs);
-        MHTfindClosestVertexGeneric(mht, mris, xs, ys, zs, 10, 4, &vno, &dist);
+        MHTfindClosestVertexGeneric(mht, xs, ys, zs, 10, 4, &vno, &dist);
         if (vno < 0) continue;
         if (FZERO(val) && dist > 1) continue;
         if (vno == Gdiag_no) DiagBreak();
@@ -8482,7 +8482,7 @@ int mrisComputePosteriorTerm(MRI_SURFACE *mris, INTEGRATION_PARMS *parms)
 
         // add this voxel to the list of voxels of the vertex it is closest to
         MRIvoxelToSurfaceRAS(mri, x, y, z, &xs, &ys, &zs);
-        MHTfindClosestVertexGeneric(mht, mris, xs, ys, zs, 10, 4, &vno, &dist);
+        MHTfindClosestVertexGeneric(mht, xs, ys, zs, 10, 4, &vno, &dist);
         if (vno < 0) continue;
         VERTEX * v = &mris->vertices[vno];
         if (vno == Gdiag_no) DiagBreak();

--- a/utils/mrisurf_deform.cpp
+++ b/utils/mrisurf_deform.cpp
@@ -556,16 +556,16 @@ int mrisComputeLaplacianTerm(MRI_SURFACE *mris, double l_lap)
     z = v->z;
 
     n = 0;
-    vx = v->x - v->tx2;
-    vy = v->y - v->ty2;
-    vz = v->z - v->tz2;
+    vx = v->x - v->t2x;
+    vy = v->y - v->t2y;
+    vz = v->z - v->t2z;
     dx = dy = dz = 0.0f;
     for (m = 0; m < vt->vnum; m++) {
       VERTEX const * const vn = &mris->vertices[vt->v[m]];
       if (!vn->ripflag) {
-        vnx = vn->x - vn->tx2;
-        vny = vn->y - vn->ty2;
-        vnz = vn->z - vn->tz2;
+        vnx = vn->x - vn->t2x;
+        vny = vn->y - vn->t2y;
+        vnz = vn->z - vn->t2z;
         dx += (vnx - vx);
         dy += (vny - vy);
         dz += (vnz - vz);
@@ -4944,14 +4944,14 @@ double mrisComputeLaplacianEnergy(MRI_SURFACE *mris)
       continue;
     }
 
-    vx = v->x - v->tx2;
-    vy = v->y - v->ty2;
-    vz = v->z - v->tz2;
+    vx = v->x - v->t2x;
+    vy = v->y - v->t2y;
+    vz = v->z - v->t2z;
     for (v_sse = 0.0, n = 0; n < vt->vnum; n++) {
       VERTEX const * const vn = &mris->vertices[vt->v[n]];
-      vnx = vn->x - vn->tx2;
-      vny = vn->y - vn->ty2;
-      vnz = vn->z - vn->tz2;
+      vnx = vn->x - vn->t2x;
+      vny = vn->y - vn->t2y;
+      vnz = vn->z - vn->t2z;
       dx = vnx - vx;
       dy = vny - vy;
       dz = vnz - vz;

--- a/utils/mrisurf_metricProperties.cpp
+++ b/utils/mrisurf_metricProperties.cpp
@@ -282,9 +282,9 @@ int MRISimportVertexCoords(MRIS * const mris, float * locations[3], int const wh
         v->cz = locations[2][vno];
         break;
       case TMP2_VERTICES:
-        v->tx2 = locations[0][vno];
-        v->ty2 = locations[1][vno];
-        v->tz2 = locations[2][vno];
+        v->t2x = locations[0][vno];
+        v->t2y = locations[1][vno];
+        v->t2z = locations[2][vno];
         break;
       case TMP_VERTICES:
         v->tx = locations[0][vno];
@@ -1973,9 +1973,9 @@ int MRISextractVertexCoords(MRIS *mris, float *locations[3], int which)
         locations[2][vno] = v->origz;
         break;
       case TMP2_VERTICES:
-        locations[0][vno] = v->tx2;
-        locations[1][vno] = v->ty2;
-        locations[2][vno] = v->tz2;
+        locations[0][vno] = v->t2x;
+        locations[1][vno] = v->t2y;
+        locations[2][vno] = v->t2z;
         break;
       case TMP_VERTICES:
         locations[0][vno] = v->tx;
@@ -3187,9 +3187,9 @@ int MRISsaveVertexPositions(MRIS *mris, int which)
           v->cz = v->z;
           break;
         case TMP2_VERTICES:
-          v->tx2 = v->x;
-          v->ty2 = v->y;
-          v->tz2 = v->z;
+          v->t2x = v->x;
+          v->t2y = v->y;
+          v->t2z = v->z;
           break;
         case TMP_VERTICES:
           v->tx = v->x;
@@ -3275,9 +3275,9 @@ int MRISrestoreVertexPositions(MRIS *mris, int which)
         v->z = v->origz;
         break;
       case TMP2_VERTICES:
-        v->x = v->tx2;
-        v->y = v->ty2;
-        v->z = v->tz2;
+        v->x = v->t2x;
+        v->y = v->t2y;
+        v->z = v->t2z;
         break;
       default:
       case TMP_VERTICES:
@@ -3325,9 +3325,9 @@ int MRISrestoreVertexPositions(MRIS *mris, int which)
           v->cz = v->origz;
           break;
         case TMP2_VERTICES:
-          v->cx = v->tx2;
-          v->cy = v->ty2;
-          v->cz = v->tz2;
+          v->cx = v->t2x;
+          v->cy = v->t2y;
+          v->cz = v->t2z;
           break;
         default:
         case TMP_VERTICES:
@@ -3358,9 +3358,9 @@ int MRISsaveNormals(MRIS *mris, int which)
         v->tz = v->nz;
         break;
       case TMP2_VERTICES:
-        v->tx2 = v->nx;
-        v->ty2 = v->ny;
-        v->tz2 = v->nz;
+        v->t2x = v->nx;
+        v->t2y = v->ny;
+        v->t2z = v->nz;
         break;
       case PIAL_VERTICES:
         v->pnx = v->nx;
@@ -3400,9 +3400,9 @@ int MRISrestoreNormals(MRIS *mris, int which)
         v->nz = v->tz;
         break;
       case TMP2_VERTICES:
-        v->nx = v->tx2;
-        v->ny = v->ty2;
-        v->nz = v->tz2;
+        v->nx = v->t2x;
+        v->ny = v->t2y;
+        v->nz = v->t2z;
         break;
       case PIAL_VERTICES:
         v->nx = v->pnx;
@@ -3693,129 +3693,41 @@ int MRIScomputeCanonicalCoordinates(MRIS *mris)
 
 int MRISvertexCoord2XYZ_float(VERTEX const * const v, int const which, float * const x, float * const y, float * const z)
 {
+#define CASE(WHICH, FIELD) \
+  case WHICH: \
+    cheapAssert(sizeof(*x) == sizeof(v->FIELD##x)); \
+    *x = v->FIELD##x;  *y = v->FIELD##y;  *z = v->FIELD##z; \
+    break;
+        
   switch (which) {
-    case ORIGINAL_VERTICES:
-      *x = v->origx;
-      *y = v->origy;
-      *z = v->origz;
-      break;
-    case TMP_VERTICES:
-      *x = v->tx;
-      *y = v->ty;
-      *z = v->tz;
-      break;
-    case CANONICAL_VERTICES:
-      *x = v->cx;
-      *y = v->cy;
-      *z = v->cz;
-      break;
-    case CURRENT_VERTICES:
-      *x = v->x;
-      *y = v->y;
-      *z = v->z;
-      break;
-    case INFLATED_VERTICES:
-      *x = v->infx;
-      *y = v->infy;
-      *z = v->infz;
-      break;
-    case PIAL_VERTICES:
-      *x = v->pialx;
-      *y = v->pialy;
-      *z = v->pialz;
-      break;
-    case TMP2_VERTICES:
-      *x = v->tx2;
-      *y = v->ty2;
-      *z = v->tz2;
-      break;
-    case FLATTENED_VERTICES:
-      *x = v->fx;
-      *y = v->fy;
-      *z = v->fz;
-      break;
-    case WHITE_VERTICES:
-      *x = v->whitex;
-      *y = v->whitey;
-      *z = v->whitez;
-      break;
-    case VERTEX_NORMALS:
-      *x = v->nx;
-      *y = v->ny;
-      *z = v->nz;
-      break;
-    case PIAL_NORMALS:
-      *x = v->pnx;
-      *y = v->pny;
-      *z = v->pnz;
-      break;
-    case WHITE_NORMALS:
-      *x = v->wnx;
-      *y = v->wny;
-      *z = v->wnz;
-      break;
+    CASE(ORIGINAL_VERTICES,orig)
+    CASE(TMP_VERTICES,t)
+    CASE(CANONICAL_VERTICES,c)
+    CASE(CURRENT_VERTICES,)
+    CASE(INFLATED_VERTICES,inf)
+    CASE(PIAL_VERTICES,pial)
+    CASE(TMP2_VERTICES,t2)   
+    CASE(FLATTENED_VERTICES,f)
+    CASE(WHITE_VERTICES,white)
+    CASE(VERTEX_NORMALS,n)
+    CASE(PIAL_NORMALS,pn)
+    CASE(WHITE_NORMALS,wn)
     default:
-    case GOOD_VERTICES:
       ErrorExit(ERROR_UNSUPPORTED, "MRISvertexCoord2XYZ_float: unsupported which %d", which);
       break;
   }
+
+#undef CASE
+  
   return (NO_ERROR);
 }
 
 int MRISvertexCoord2XYZ_double(VERTEX const * const v, int const which, double * const x, double * const y, double * const z)
 {
-  switch (which) {
-    default:
-    case GOOD_VERTICES:
-      ErrorExit(ERROR_UNSUPPORTED, "MRISvertexCoord2XYZ_double: unsupported which %d", which);
-      break;
-    case ORIGINAL_VERTICES:
-      *x = (double)v->origx;
-      *y = (double)v->origy;
-      *z = (double)v->origz;
-      break;
-    case TMP_VERTICES:
-      *x = (double)v->tx;
-      *y = (double)v->ty;
-      *z = (double)v->tz;
-      break;
-    case CANONICAL_VERTICES:
-      *x = (double)v->cx;
-      *y = (double)v->cy;
-      *z = (double)v->cz;
-      break;
-    case CURRENT_VERTICES:
-      *x = (double)v->x;
-      *y = (double)v->y;
-      *z = (double)v->z;
-      break;
-    case INFLATED_VERTICES:
-      *x = (double)v->infx;
-      *y = (double)v->infy;
-      *z = (double)v->infz;
-      break;
-    case PIAL_VERTICES:
-      *x = (double)v->pialx;
-      *y = (double)v->pialy;
-      *z = (double)v->pialz;
-      break;
-    case TMP2_VERTICES:
-      *x = (double)v->tx2;
-      *y = (double)v->ty2;
-      *z = (double)v->tz2;
-      break;
-    case FLATTENED_VERTICES:
-      *x = (double)v->fx;
-      *y = (double)v->fy;
-      *z = (double)v->fz;
-      break;
-    case WHITE_VERTICES:
-      *x = (double)v->whitex;
-      *y = (double)v->whitey;
-      *z = (double)v->whitez;
-      break;
-  }
-  return (NO_ERROR);
+    float fx,fy,fz;
+    auto result = MRISvertexCoord2XYZ_float(v, which, &fx, &fy, &fz);
+    *x = fx; *y = fy; *z = fz;
+    return result;
 }
 
 #define VERTEX_DIF(leg, v0, v1) leg[0] = v1->x - v0->x, leg[1] = v1->y - v0->y, leg[2] = v1->z - v0->z;

--- a/utils/mrisurf_mri.cpp
+++ b/utils/mrisurf_mri.cpp
@@ -665,9 +665,6 @@ int MRISpositionSurface(MRI_SURFACE *mris, MRI *mri_brain, MRI *mri_smooth, INTE
       if (gMRISexternalTimestep) {
         (*gMRISexternalTimestep)(mris, parms);
       }
-      if (!(parms->flags & IPFLAG_NO_SELF_INT_TEST)) {
-        mht->checkFaces(mris);
-      }
 
       MRIScomputeMetricProperties(mris);
 
@@ -943,9 +940,6 @@ int MRISpositionSurface_mef(
     do {
       MRISsaveVertexPositions(mris, WHITE_VERTICES);
       delta_t = mrisAsynchronousTimeStep(mris, parms->momentum, dt, mht, max_mm);
-      if (!(parms->flags & IPFLAG_NO_SELF_INT_TEST)) {
-        mht->checkFaces(mris);
-      }
       MRIScomputeMetricProperties(mris);
       rms = mrisRmsValError_mef(mris, mri_30, mri_5, weight30, weight5);
       sse = mrisComputeSSE_MEF(mris, parms, mri_30, mri_5, weight30, weight5, mht_v_orig);

--- a/utils_generator/Generator.cpp
+++ b/utils_generator/Generator.cpp
@@ -20,6 +20,8 @@ static std::ostream& indent(std::ostream & os, size_t depth) {
 	return os;
 }
 
+void bpt() {}
+
 namespace ColumnedOutput {
 
 	using namespace std;
@@ -426,8 +428,8 @@ namespace Generator {
 				// in			for the metric properties calculations
 				"status",
 				"origxyz_status",
-				"nvertices",
-				"nfaces",
+				"nvertices",    "vertices",
+				"nfaces",       "faces",
 				"nsize",
 				"radius",
 				// in out		for the metric properties calculations
@@ -450,6 +452,8 @@ namespace Generator {
 				"neg_area",
 				// in			for the metric properties calculations
 				"v_ripflag",
+                "v_num",
+                "v_f",
 				// in out		for the metric properties calculations
 				"v_dist_capacity",
 				"v_border",
@@ -466,6 +470,7 @@ namespace Generator {
 				"v_dist",
 				// in			for the metric properties calculations 
 				"f_ripflag",
+                "f_v",
 				"f_norm_orig_area",
 				// in out		for the metric properties calculations
 				// out			for the metric properties calculations
@@ -679,6 +684,8 @@ namespace Generator {
 							}
 							continue;
 						}
+
+                        if (c.id == "Surface" && d.id == "vertices") bpt();
 
 						if (!d.type) continue;
 
@@ -1075,6 +1082,7 @@ namespace Generator {
 				}
 			}
 			else if (c.id == "Surface" && d.id == "vertices") {
+                bpt();
 				if (!write) {
 					cols << "return Vertex(repr,i)";
 				}
@@ -1168,10 +1176,10 @@ namespace Generator {
 
 			if (c.id == "Face" && d.id == "v") {
 				if (!write) {
-					cols << "return Vertex(repr,repr->faces[idx].v[i])";
+					cols << "return Vertex(repr," << raw << "[i]" << ")";
 				}
 				else {
-					cols << "cheapAssert(repr == to.repr); repr->faces[idx].v[i] = to.idx";
+					cols << "cheapAssert(repr == to.repr); " << raw << "[i]" << " = to.idx";
 				}
 			}
 			else if (c.id == "Vertex" && d.id == "f") {
@@ -1199,6 +1207,7 @@ namespace Generator {
 				}
 			}
 			else if (c.id == "Surface" && d.id == "vertices") {
+                bpt();
 				if (!write) {
 					cols << "return Vertex(repr,i)";
 				}
@@ -1284,7 +1293,8 @@ cols << "#undef CASE" << endR;
 		if (true) {
 			string const root_fnm = "mrisurf_SurfaceFromMRIS_generated";
 			ofstream os(createFilesWithin + root_fnm + ".h");
-
+            os << "#pragma once" << endl;
+            
 			auto fnm_inco = root_fnm + "_prefix";
 			os << "#include \"./" << fnm_inco << ".h\"" << endl;
 			{
@@ -1307,6 +1317,7 @@ cols << "#undef CASE" << endR;
 		if (true) {
 			string const root_fnm = "mrisurf_SurfaceFromMRISPV_generated";
 			ofstream os(createFilesWithin + root_fnm + ".h");
+            os << "#pragma once" << endl;
 
 			auto fnm_inco = root_fnm + "_prefix";
 			os << "#include \"./" << fnm_inco << ".h\"" << endl;

--- a/utils_generator/Generator.cpp
+++ b/utils_generator/Generator.cpp
@@ -1,6 +1,6 @@
 // Compile with     g++ -std=c++11 Generator.cpp
 // Run with         rm -rf tmp ; mkdir tmp ; ./a.out ./tmp/
-// Merge with       bcompare ./tmp ../include
+// Merge with       bcompare ./tmp ../include &
 //
 #include <iostream>
 #include <iomanip>
@@ -1262,6 +1262,7 @@ cols << ("    CASE("+d.which+","+d.id.substr(0,d.id.size()-1)+")") << endR;
             }
             
 cols << "    default:" << endR;
+cols << "      *x = *y = *z = 0.0;" << endR;
 cols << "      ErrorExit(ERROR_UNSUPPORTED, \"which_coords: unsupported which %d\", which);" << endR;
 cols << "      break;" << endR;
 cols << "  }" << endR;


### PR DESCRIPTION
Next step in supporting changed representations of the Surface Face and Vertex concepts

Same testing and recon-all results

Switch mrishash over to using a template that is instantiated with both the traditional MRIS and properties-in-vectors MRISPV representation, both via their respective implementations of Surface Face and Vertex as C++ classes rather than as pointers.

The next step is start using this ability to allow sse terms to be evaluated using the faster representation