### PR TITLE
Raise the threshold for reporting

### DIFF
--- a/utils/mrisurf_topology.cpp
+++ b/utils/mrisurf_topology.cpp
@@ -361,7 +361,7 @@ short modVnum(MRIS const *mris, int vno, short add, bool clear)
   short * p = const_cast<short*>(&vt->vnum);
   if (clear) *p = 0;
   *p += add;
-  static short maxVnumSeen = 10;
+  static short maxVnumSeen = 30;
   if (*p > maxVnumSeen) {
     maxVnumSeen =*p;
     fprintf(stdout, "modVnum: vno:%d has %d immediate neighbours mrisurf_topology.cpp:%d\n",vno,*p,__LINE__); 


### PR DESCRIPTION
Fixes the fails of mris_divide_parcellation and mris_surface_stats caused by their exact text compares being messed up by some logging output

no other effects