### PR TITLE
nf: mris_annot_diff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,6 +374,7 @@ add_subdirectories(
   mri_voldiff
   mri_watershed
   mris_anatomical_stats
+  mris_annot_diff
   mris_ca_label
   mris_calc
   mris_convert

--- a/include/annotation.h
+++ b/include/annotation.h
@@ -30,6 +30,8 @@
 #include <vector>
 #include <string>
 
+#include <mrisurf.h>
+
 #ifdef ANNOTATION_SRC
 char *annotation_table_file = NULL;
 #else
@@ -48,6 +50,7 @@ LABEL*	annotation2label(int annotid, MRIS *Surf);
 int 	set_atable_from_ctable(COLOR_TABLE *pct);
 int  	MRISdivideAnnotation(MRI_SURFACE *mris, int *nunits) ;
 int  	MRISdivideAnnotationUnit(MRI_SURFACE *mris, int annot, int nunits) ;
+std::vector<int> readAnnotationIntoVector(const std::string& filename);
 int  	MRISmergeAnnotations(MRIS *mris, int nparcs, std::vector<std::string> parcnames, const char *newparcname);
 MRI*	MRISannot2seg(MRIS *surf, int base);
 MRI*	MRISannot2border(MRIS *surf);

--- a/mris_annot_diff/CMakeLists.txt
+++ b/mris_annot_diff/CMakeLists.txt
@@ -1,0 +1,8 @@
+project(mris_annot_diff)
+
+include_directories(${FS_INCLUDE_DIRS})
+
+add_executable(mris_annot_diff mris_annot_diff.cpp)
+add_help(mris_annot_diff mris_annot_diff.help.xml)
+target_link_libraries(mris_annot_diff utils)
+install(TARGETS mris_annot_diff DESTINATION bin) 

--- a/mris_annot_diff/mris_annot_diff.cpp
+++ b/mris_annot_diff/mris_annot_diff.cpp
@@ -1,0 +1,32 @@
+#include "argparse.h"
+#include "log.h"
+#include "annotation.h"
+
+#include "mris_annot_diff.help.xml.h"
+ 
+
+int main(int argc, const char *argv[])
+{
+  ArgumentParser parser;
+  parser.addHelp(mris_annot_diff_help_xml, mris_annot_diff_help_xml_len);
+  parser.addArgument("annot1");
+  parser.addArgument("annot2");
+  parser.parse(argc, argv);
+
+  // load input
+  std::vector<int> annot1 = readAnnotationIntoVector(parser.retrieve<std::string>("annot1"));
+  std::vector<int> annot2 = readAnnotationIntoVector(parser.retrieve<std::string>("annot2"));
+
+  // compare lengths
+  int length = annot1.size();
+  if (length != annot2.size()) logFatal(1) << "annotation sizes (" << length << " and " << annot2.size() << ") do not match";
+
+  // diff labels
+  int ndiffs = 0;
+  for (int i = 0; i < length; i++) {
+    if (annot1[i] != annot2[i]) ndiffs++;
+  }
+
+  if (ndiffs > 0) logFatal(1) << "found " << ndiffs << " differences between annotations";
+  exit(0);
+}

--- a/mris_annot_diff/mris_annot_diff.help.xml
+++ b/mris_annot_diff/mris_annot_diff.help.xml
@@ -1,0 +1,5 @@
+<help>
+  <name>mris_annot_diff</name>
+  <usage>mris_annot_diff [options] &lt;annot1&gt; &lt;annot2&gt;</usage>
+  <description>Compare two surface annotation files.</description>
+</help>

--- a/utils/annotation.cpp
+++ b/utils/annotation.cpp
@@ -28,12 +28,17 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <map>
+#include <vector>
+
 #include "colortab.h"
 #include "const.h"
 #include "diag.h"
 #include "error.h"
 #include "label.h"
 #include "mri2.h"
+#include "log.h"
+#include "fio.h"
 #include "mrisurf.h"
 #include "utils.h"
 
@@ -79,6 +84,30 @@ int print_annotation_colortable(FILE *fp)
         fp, "%3d   %-40s  %3d %3d %3d  0\n", atable[n].index, atable[n].name, atable[n].r, atable[n].g, atable[n].b);
   return (0);
 }
+
+
+std::vector<int> readAnnotationIntoVector(const std::string& filename)
+{
+  FILE *file = fopen(filename.c_str(), "r");
+  if (!file) logFatal(1) << "could not open " << filename;
+
+  std::map<int,int> annotmap;
+  int num = freadInt(file);
+
+  for (int i = 0; i < num; i++) {
+    int vno = freadInt(file);
+    int v = freadInt(file);
+    annotmap[vno] = v;
+  }
+
+  fclose(file);
+
+  int maxv = annotmap.rbegin()->first;
+  std::vector<int> annotlist(maxv, 0);
+  for (auto const& elt : annotmap) annotlist[elt.first] = elt.second;
+  return annotlist;
+}
+
 
 int read_named_annotation_table(char *name)
 {


### PR DESCRIPTION
New binary to compare two annotations without a reference surface

```bash
mris_annot_diff <annot1> <annot2>
```