### PR TITLE
nf: cache brainvol.stats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,7 @@ add_subdirectories(
   mri_aparc2aseg
   mri_aparc2wmseg
   mri_binarize
+  mri_brainvol_stats
   mri_ca_label
   mri_ca_normalize
   mri_ca_register

--- a/include/cma.h
+++ b/include/cma.h
@@ -551,8 +551,11 @@ int IsSubCorticalGray(int SegId);
 #include "mri.h"
 double SupraTentorialVolCorrection(MRI *aseg, MRI *ribbon);
 double CorticalGMVolCorrection(MRI *aseg, MRI *ribbon, int hemi);
-double *ComputeBrainVolumeStats(char *subject, char *suffix, char *sdir);
 MRI *MRIfixAsegWithRibbon(MRI *aseg, MRI *ribbon, MRI *asegfixed);
+
+std::vector<double> ComputeBrainVolumeStats(const std::string& subject, const std::string& subjdir);
+void CacheBrainVolumeStats(const std::vector<double>& stats, const std::string& subject, const std::string& subjdir);
+std::vector<double> ReadCachedBrainVolumeStats(const std::string& subject, const std::string& subjdir);
 
 #define IS_FIMBRIA(l) ((l) == left_fimbria || (l) == right_fimbria || (l) == fimbria)
 #define CSF_CLASS        0

--- a/mri_brainvol_stats/CMakeLists.txt
+++ b/mri_brainvol_stats/CMakeLists.txt
@@ -1,0 +1,7 @@
+project(mri_brainvol_stats)
+
+include_directories(${FS_INCLUDE_DIRS})
+
+add_executable(mri_brainvol_stats mri_brainvol_stats.cpp)
+target_link_libraries(mri_brainvol_stats utils)
+install(TARGETS mri_brainvol_stats DESTINATION bin) 

--- a/mri_brainvol_stats/mri_brainvol_stats.cpp
+++ b/mri_brainvol_stats/mri_brainvol_stats.cpp
@@ -1,0 +1,36 @@
+// A very simple tool that computes a variety of brain volume statistics for a given subject.
+// The calculated values are cached in a stats file so they can be easily referenced by
+// mri_segstats and mris_anatomical_stats later on.
+
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include "argparse.h"
+#include "cma.h"
+
+
+int main(int argc, const char **argv) 
+{
+  // parse arguments
+  ArgumentParser parser;
+  parser.addArgument("subject");
+  parser.addArgument("--sd", 1);
+  parser.parse(argc, argv);
+
+  std::string subject = parser.retrieve<std::string>("subject");
+  std::string subjdir = parser.retrieve<std::string>("sd");
+
+  // get subjects directory from flag or env var
+  if (subjdir.empty()) {
+    const char* sd = std::getenv("SUBJECTS_DIR");
+    if (!sd) fs::fatal() << "must set SUBJECTS_DIR or specify path with the --sd flag";
+    subjdir = std::string(sd);
+  }
+
+  // compute and write the vol stats to a cache file at subjects/stats/brainvol.stats
+  std::vector<double> stats = ComputeBrainVolumeStats(subject, subjdir);
+  CacheBrainVolumeStats(stats, subject, subjdir);
+
+  return 0;
+}

--- a/mris_anatomical_stats/mris_anatomical_stats.cpp
+++ b/mris_anatomical_stats/mris_anatomical_stats.cpp
@@ -1088,6 +1088,11 @@ get_option(int argc, char *argv[])
   {
     print_version() ;
   }
+  else if (!stricmp(option, "suffix"))
+  {
+    fs::warning() << "the --suffix flag has been removed. Brain volume stats will be computed normally";
+    nargs = 1 ;
+  }
   else if (!stricmp(option, "log"))
   {
     log_file_name = argv[2] ;

--- a/scripts/recon-all
+++ b/scripts/recon-all
@@ -4764,6 +4764,10 @@ if($DoSegStats) then
     |& tee -a $SF |& tee -a $LF |& tee -a $CF
   cd $subjdir > /dev/null
   $PWD |& tee -a $LF
+  
+  # cache volume stats
+  if($RunIt) $fs_time mri_brainvol_stats $subjid |& tee -a $LF
+
   set xopts = `fsr-getxopts mri_segstats $XOptsFile $GlobXOptsFile`;
   set cmd = (mri_segstats)
   if ($NoRandomness) set cmd = ($cmd --seed $RngSeed)


### PR DESCRIPTION
Caches the results of `ComputeBrainVolumeStats()` in a subject stats file so that these values can be easily referenced by `mri_segstats` and `mris_anatomical_stats` later on