### PR TITLE
Detect dimensions and order of mosaics with incomplete header.

### DIFF
--- a/mri_convert/mri_convert.cpp
+++ b/mri_convert/mri_convert.cpp
@@ -1389,6 +1389,9 @@ int main(int argc, char *argv[])
       sprintf(tmpstr,"%d",NRowsOverride);
       setenv("NROWS_OVERRIDE",tmpstr,1);
     }
+    else if (strcmp(argv[i], "--mosaic-fix-noascii") == 0) {
+        setenv("FS_MOSAIC_FIX_NOASCII","1",1);
+    }
     /*-------------------------------------------------------------*/
     else if ( (strcmp(argv[i], "--nspmzeropad") == 0) ||
               (strcmp(argv[i], "--out_nspmzeropad") == 0))

--- a/mri_convert/mri_convert.help.xml
+++ b/mri_convert/mri_convert.help.xml
@@ -164,6 +164,8 @@ The main and aux volumes should overlap very closely. If they do not, use tkregi
       <explanation>reverse order of slices, update vox2ras</explanation> 
       <argument>--nslices-override nslices </argument>
       <explanation>Use this number of slices when converting DICOM mosaics</explanation> 
+      <argument>--mosaic-fix-noascii</argument>
+      <explanation>fix the center of DICOM mosaics without using the ASCII header</explanation>
       <argument>--slice-bias alpha </argument>
       <explanation>apply half-cosine bias field</explanation> 
       <argument>--fwhm fwhm </argument>

--- a/mri_convert/test.sh
+++ b/mri_convert/test.sh
@@ -25,3 +25,15 @@ compare_vol nuuc.mgz nuuc.ref.mgz
 # (i.e. gcam->depth * gcam->spacing = gcam->atlas.depth - 1)
 test_command mri_convert -at odd.m3z orig.mgz morphed.mgz
 compare_vol morphed.mgz odd.ref.mgz
+
+# standard mosaic'd DICOM
+test_command mri_convert ep2d.mosaic.dcm ep2d.mosaic.mgz
+compare_vol ep2d.mosaic.mgz ep2d.mosaic.ref.mgz
+
+# non-mosaic DICOM with incomplete ASCII header
+test_command mri_convert vnav.non-mosaic.dcm vnav.non-mosaic.mgz
+compare_vol vnav.non-mosaic.mgz vnav.non-mosaic.ref.mgz
+
+# DICOM with identical geometry - but mosaic'd
+test_command mri_convert --mosaic-fix-noascii vnav.mosaic.dcm vnav.mosaic.mgz
+compare_vol vnav.mosaic.mgz vnav.mosaic.ref.mgz

--- a/utils/DICOMRead.cpp
+++ b/utils/DICOMRead.cpp
@@ -3339,14 +3339,19 @@ int sdfiAssignRunNo2(SDCMFILEINFO **sdfi_list, int nlist)
     sdfi0 = sdfi_list[RunList[0]];
 
     if (sdfi0->IsMosaic) {
-      /* It is a mosaic */
+      /* 2019-10-05, mu40: do not set the error flag if the number of files in
+       * the run exceeds the number of repetitions, as the run is most likely
+       * not truncated. The lRepetition field may not have been set, e.g. in
+       * vNavs. */
       sdfi0->NFrames = nfilesperrun;
       if (nfilesperrun != (sdfi0->lRepetitions + 1)) {
         fprintf(stderr, "WARNING: Run %d appears to be truncated\n", nthrun + 1);
         fprintf(stderr, "  Files Found: %d, Files Expected (lRep+1): %d\n", nfilesperrun, (sdfi0->lRepetitions + 1));
         DumpSDCMFileInfo(stderr, sdfi0);
         fflush(stderr);
-        sdfi0->ErrorFlag = 1;
+        if (nfilesperrun < (sdfi0->lRepetitions + 1)) {
+            sdfi0->ErrorFlag = 1;
+        }
       }
     }
 


### PR DESCRIPTION
Improve conversion from mosaic'd DICOMs. Until now, the dimensions of vNavs were not being detected correctly. Although it was possible to override the dimensions using --n*-override flags, frames were never sorted, resulting in vNav time series with volumes in arbitrary order. The code was tested on mosaic'd rs-fMRI data from HCP.