### PR TITLE
Added defect_labels to CommandLoadSubject

### DIFF
--- a/freeview/MainWindow.cpp
+++ b/freeview/MainWindow.cpp
@@ -2036,8 +2036,8 @@ void MainWindow::CommandLoadSubject(const QStringList &sa)
                          //                         "%1/surf/rh.orig:edgecolor=green:visible=0 "
                          "%1/surf/lh.inflated:annot=aparc:visible=0 "
                          "%1/surf/rh.inflated:annot=aparc:visible=0 "
-                         "%1/surf/lh.orig.nofix:overlay=%1surf/lh.defect_labels:edgecolor=overlay:overlay_threshold=0.01,100,percentile:visible=0"
-                         "%1/surf/rh.orig.nofix:overlay=%1surf/rh.defect_labels:edgecolor=overlay:overlay_threshold=0.01,100,percentile:visible=0"
+                         "%1/surf/lh.orig.nofix:overlay=%1/surf/lh.defect_labels:edgecolor=overlay:overlay_threshold=0.01,100,percentile:visible=0 "
+                         "%1/surf/rh.orig.nofix:overlay=%1/surf/rh.defect_labels:edgecolor=overlay:overlay_threshold=0.01,100,percentile:visible=0 "
                          "-viewport coronal ").arg(subject_path);
   QString control_pt_file = QString("%1/tmp/control.dat").arg(subject_path);
   if (QFile::exists(control_pt_file))

--- a/freeview/MainWindow.cpp
+++ b/freeview/MainWindow.cpp
@@ -2036,6 +2036,8 @@ void MainWindow::CommandLoadSubject(const QStringList &sa)
                          //                         "%1/surf/rh.orig:edgecolor=green:visible=0 "
                          "%1/surf/lh.inflated:annot=aparc:visible=0 "
                          "%1/surf/rh.inflated:annot=aparc:visible=0 "
+                         "%1/surf/lh.orig.nofix:overlay=%1surf/lh.defect_labels:edgecolor=overlay:overlay_threshold=0.01,100,percentile:visible=0"
+                         "%1/surf/rh.orig.nofix:overlay=%1surf/rh.defect_labels:edgecolor=overlay:overlay_threshold=0.01,100,percentile:visible=0"
                          "-viewport coronal ").arg(subject_path);
   QString control_pt_file = QString("%1/tmp/control.dat").arg(subject_path);
   if (QFile::exists(control_pt_file))


### PR DESCRIPTION
CommandLoadSubject now automatically loads the ?h.defect_labels onto orig.nofix surfaces to QA. The labels are visible in the 2D displays thanks to the edgecolor=overlay option. I've included a threshold of 0.01% -- 100% to include all defect labels and set the visibility to 0 in case the user wants the surface out of sight.