### PR TITLE
Stop build errors on Ubuntu 18 caused by log2 being already defined

### DIFF
--- a/include/macros.h
+++ b/include/macros.h
@@ -32,10 +32,13 @@
 #include "proto.h"
 #include "math.h"
 
+#define DEFINE_LOG2 static double log2(double x) { return log(x) / log(2.0); }
+	// defining log2 as a macro has problems with other header files that also define it as a function taking an integer arg 
+	
 #ifdef _MSDOS
 #include <math.h>
 #define exp2(f)     pow(2.0,(f))
-#define log2(f)     (log(f) / log(2.0))
+DEFINE_LOG2
 #ifndef M_E
 #define M_E 2.718282 /* exp(1) */
 #endif
@@ -110,17 +113,16 @@
 
 #ifdef Linux
 #define exp2(f)     pow(2.0,(f))
-#define log2(f)     (log(f) / log(2.0))
 #endif
 
 #ifdef IRIX
 #define exp2(f)     pow(2.0,(f))
-#define log2(f)     (log(f) / log(2.0))
+DEFINE_LOG2
 #endif
 
 #ifdef SunOS
 #define exp2(f)     pow(2.0,(f))
-#define log2(f)     (log(f) / log(2.0))
+DEFINE_LOG2
 #define ceilf(f)    (int)ceil((double)f)
 #define floorf(f)   (int)floor((double)f)
 #endif


### PR DESCRIPTION
log2 should have been defined as a static function on platforms that don't have it - it is already defined on linux with gcc 5