### PR TITLE
Explicitly use the std:: versions

### DIFF
--- a/mri_glmfit/mri_glmfit.cpp
+++ b/mri_glmfit/mri_glmfit.cpp
@@ -2590,7 +2590,7 @@ static int parse_commandline(int argc, char **argv) {
       sscanf(pargv[0],"%lf",&FWHM);
       csd->nullfwhm = FWHM;
       printf("FWHM = %f\n",FWHM);
-      if(isnan(FWHM)){
+      if(std::isnan(FWHM)){
 	printf("ERROR: input FWHM is NaN (not a number).\n");
 	printf("  Check the mask in the glm directory.\n");
 	exit(1);

--- a/mri_ms_fitparms/mri_ms_fitparms.cpp
+++ b/mri_ms_fitparms/mri_ms_fitparms.cpp
@@ -3006,7 +3006,7 @@ estimate_T2star(MRI **mri_flash, int nvolumes, MRI *mri_PD,
           {
             DiagBreak() ;
           }
-          if (isnan(PD))
+          if (std::isnan(PD))
           {
             DiagBreak() ;
           }

--- a/utils/mrisurf_defect.cpp
+++ b/utils/mrisurf_defect.cpp
@@ -11532,7 +11532,7 @@ void MRIScomputeDistanceVolume(TOPOFIX_PARMS *parms, float distance_to_surface)
         computeVertexPseudoNormal(mris, vn, n_v2, 0);
       }
     }
-    if (isnan(n_v0[0]) || isnan(n_v1[0]) || isnan(n_v2[0])) {
+    if (std::isnan(n_v0[0]) || std::isnan(n_v1[0]) || std::isnan(n_v2[0])) {
       fprintf(stderr,
               ".%d & %d[%d(%d) %d(%d) %d(%d)][%f %f %f]\n",
               wsurf,

--- a/utils/randomfields.cpp
+++ b/utils/randomfields.cpp
@@ -432,7 +432,7 @@ double RFstat2PVal(RFS *rfs, double stat)
     printf("ERROR: RFstat2PVal(): field type %s unknown\n", rfs->name);
     return (10000000000.0);
   }
-  if (isinf(p) || p < FLT_MIN) p = FLT_MIN;
+  if (std::isinf(p) || p < FLT_MIN) p = FLT_MIN;
   return (p);
 }
 


### PR DESCRIPTION
I am getting error messages with gcc 5.5 and ubuntu 18 without these std:: prefixes