### PR TITLE
String updates for fio.cpp and related updates

### DIFF
--- a/include/fio.h
+++ b/include/fio.h
@@ -12,6 +12,7 @@
  *
  */
 
+#include <string>
 
 #ifndef FIO_H
 #define FIO_H
@@ -85,7 +86,7 @@ int fio_NLines(const char *fname);
 
 int fio_pushd(const char *dir);
 int fio_popd(void);
-char *fio_fullpath(const char *fname);
+std::string fio_fullpath(const char *fname);
 int fio_mkdirp(const char *path, mode_t mode);
 int fio_FileHasCarriageReturn(char *fname);
 

--- a/mri_glmfit/mri_glmfit.cpp
+++ b/mri_glmfit/mri_glmfit.cpp
@@ -566,12 +566,11 @@ const char *Progname = "mri_glmfit";
 
 int SynthSeed = -1;
 
-char *yFile = NULL, *XFile=NULL, *betaFile=NULL, *rvarFile=NULL;
+char *XFile=NULL, *betaFile=NULL, *rvarFile=NULL;
 char *yhatFile=NULL, *eresFile=NULL, *maskFile=NULL;
 char *wgFile=NULL,*wFile=NULL;
 char *eresSCMFile=NULL;
 char *condFile=NULL;
-char *yffxvarFile = NULL;
 char *GLMDir=NULL;
 char *pvrFiles[50];
 int yhatSave=0;
@@ -579,6 +578,7 @@ int eresSave=0;
 int SaveFWHMMap=0;
 int eresSCMSave=0;
 int condSave=0;
+std::string yFile, yOutFile, yffxvarFile;
 
 char *labelFile=NULL;
 LABEL *clabel=NULL;
@@ -715,7 +715,6 @@ int DoSkew = 0;
 char *Gamma0File[GLMMAT_NCONTRASTS_MAX];
 MATRIX *Xtmp=NULL, *Xnorm=NULL;
 char *XOnlyFile = NULL;
-char *yOutFile = NULL;
 
 char *frameMaskFile = NULL;
 
@@ -851,12 +850,14 @@ int main(int argc, char **argv) {
   mriglm->condsave = condSave;
 
   // Load input--------------------------------------
-  printf("Loading y from %s\n",yFile);fflush(stdout);
+  printf("Loading y from %s\n",yFile.c_str());
+  fflush(stdout);
   if(! UseStatTable){
-    mriglm->y = MRIread(yFile);
-    printf("   ... done reading.\n"); fflush(stdout);
+    mriglm->y = MRIread(yFile.c_str());
+    printf("   ... done reading.\n");
+    fflush(stdout);
     if (mriglm->y == NULL) {
-      printf("ERROR: loading y %s\n",yFile);
+      printf("ERROR: loading y %s\n",yFile.c_str());
       exit(1);
     }
     nvoxels = mriglm->y->width * mriglm->y->height * mriglm->y->depth;
@@ -879,9 +880,9 @@ int main(int argc, char **argv) {
     }
   }
   else {
-    StatTable = LoadStatTable(yFile);
+    StatTable = LoadStatTable(yFile.c_str());
     if(StatTable == NULL) {
-      printf("ERROR: loading y %s as a stat table\n",yFile);
+      printf("ERROR: loading y %s as a stat table\n",yFile.c_str());
       exit(1);
     }
     mriglm->y = StatTable->mri;
@@ -899,10 +900,10 @@ int main(int argc, char **argv) {
 
   if(DoFFx){
     // Load yffx var--------------------------------------
-    printf("Loading yffxvar from %s\n",yffxvarFile);
-    mriglm->yffxvar = MRIread(yffxvarFile);
+    printf("Loading yffxvar from %s\n",yffxvarFile.c_str());
+    mriglm->yffxvar = MRIread(yffxvarFile.c_str());
     if(mriglm->yffxvar == NULL) {
-      printf("ERROR: loading yffxvar %s\n",yffxvarFile);
+      printf("ERROR: loading yffxvar %s\n",yffxvarFile.c_str());
       exit(1);
     }
   }
@@ -1977,9 +1978,11 @@ int main(int argc, char **argv) {
     MRIwrite(mritmp,eresSCMFile);
     MRIfree(&mritmp);
   }
-  if(yOutFile){
-    err = MRIwrite(mriglm->y,yOutFile);
-    if(err) exit(1);
+  if(yOutFile.size() != 0){
+    err = MRIwrite(mriglm->y,yOutFile.c_str());
+    if(err) {
+      exit(1);
+    }
   }
 
   sprintf(tmpstr,"%s/Xg.dat",GLMDir);
@@ -2262,10 +2265,23 @@ int main(int argc, char **argv) {
     if (strlen(fsgd->measname) == 0) {
       strcpy(fsgd->measname,"external");
     }
-    if(yOutFile != NULL) sprintf(fsgd->datafile,"%s",yOutFile);
-    else                 sprintf(fsgd->datafile,"%s",yFile);
-    if (surf) strcpy(fsgd->tessellation,"surface");
-    else      strcpy(fsgd->tessellation,"volume");
+
+    const size_t FSGD_datafile_size = 1000;
+    if(yOutFile.size() != 0) {
+      std::string truncName(yOutFile);
+      truncName.erase(FSGD_datafile_size);
+      snprintf(fsgd->datafile,FSGD_datafile_size,"%s",truncName.c_str());
+    }  else {
+       std::string truncName(yFile);
+      truncName.erase(FSGD_datafile_size);
+      snprintf(fsgd->datafile,FSGD_datafile_size,"%s",truncName.c_str());
+    }
+
+    if (surf) {
+      strcpy(fsgd->tessellation,"surface");
+    } else {
+      strcpy(fsgd->tessellation,"volume");
+    }
 
     sprintf(fsgd->DesignMatFile,"X.mat");
     sprintf(tmpstr,"%s/y.fsgd",GLMDir);
@@ -3420,7 +3436,7 @@ static void check_options(void) {
     exit(0);
   }
 
-  if(yFile == NULL) {
+  if(yFile.size() == 0) {
     printf("ERROR: must specify input y file\n");
     exit(1);
   }
@@ -3498,7 +3514,7 @@ static void check_options(void) {
       printf("ERROR: you need to specify the dof with FFx\n");
       exit(1);
     }
-    if(yffxvarFile == NULL){
+    if(yffxvarFile.size() == 0){
       printf("ERROR: you need to specify the yffxvar file with FFx\n");
       exit(1);
     }
@@ -3575,7 +3591,7 @@ static void dump_options(FILE *fp) {
   if (synth) fprintf(fp,"SynthSeed = %d\n",SynthSeed);
   fprintf(fp,"OneSampleGroupMean %d\n",OneSampleGroupMean);
 
-  fprintf(fp,"y    %s\n",yFile);
+  fprintf(fp,"y    %s\n",yFile.c_str());
   fprintf(fp,"logyflag %d\n",logflag);
   if (XFile)     fprintf(fp,"X    %s\n",XFile);
   fprintf(fp,"usedti  %d\n",usedti);
@@ -3600,7 +3616,7 @@ static void dump_options(FILE *fp) {
   fprintf(fp,"DoFFx %d\n",DoFFx);
   if(DoFFx){
     fprintf(fp,"FFxDOF %d\n",mriglm->ffxdof);
-    fprintf(fp,"yFFxVar %s\n",yffxvarFile);
+    fprintf(fp,"yFFxVar %s\n",yffxvarFile.c_str());
   }
   if(wgFile) fprintf(fp,"wgFile %s\n",wgFile);
   if(wFile){

--- a/mri_glmfit/mri_glmfit.cpp
+++ b/mri_glmfit/mri_glmfit.cpp
@@ -2267,13 +2267,17 @@ int main(int argc, char **argv) {
     }
 
     const size_t FSGD_datafile_size = 1000;
-    if(yOutFile.size() != 0) {
+    if(!yOutFile.empty()) {
       std::string truncName(yOutFile);
-      truncName.erase(FSGD_datafile_size);
+      if( yOutFile.size() > (FSGD_datafile_size-1) ) {
+	truncName.erase(FSGD_datafile_size);
+      }
       snprintf(fsgd->datafile,FSGD_datafile_size,"%s",truncName.c_str());
     }  else {
-       std::string truncName(yFile);
-      truncName.erase(FSGD_datafile_size);
+      std::string truncName(yFile);
+      if( yFile.size() > (FSGD_datafile_size-1) ) {
+	truncName.erase(FSGD_datafile_size);
+      }
       snprintf(fsgd->datafile,FSGD_datafile_size,"%s",truncName.c_str());
     }
 

--- a/mri_voldiff/mri_voldiff.cpp
+++ b/mri_voldiff/mri_voldiff.cpp
@@ -60,7 +60,7 @@ static void dump_options(FILE *fp);
 int main(int argc, char *argv[]) ;
 const char *Progname = NULL;
 
-char *vol1File = NULL, *vol2File=NULL;
+std::string vol1File, vol2File;
 MRI *vol1=NULL, *vol2=NULL;
 MATRIX *vox2ras1,*vox2ras2;
 
@@ -109,9 +109,9 @@ int main(int argc, char **argv) {
 
   dump_options(stdout);
 
-  vol1 = MRIread(vol1File);
+  vol1 = MRIread(vol1File.c_str());
   if (vol1 == NULL) exit(1);
-  vol2 = MRIread(vol2File);
+  vol2 = MRIread(vol2File.c_str());
   if (vol2 == NULL) exit(1);
 
   vox2ras1 = MRIxfmCRS2XYZ(vol1,0);
@@ -284,11 +284,11 @@ static void print_version(void) {
 }
 /* --------------------------------------------- */
 static void check_options(void) {
-  if (vol1File == NULL) {
+  if (vol1File.size() == 0) {
     printf("ERROR: must specify a vol1 file\n");
     exit(1);
   }
-  if (vol2File == NULL) {
+  if (vol2File.size() == 0) {
     printf("ERROR: must specify a vol2 file\n");
     exit(1);
   }
@@ -297,8 +297,8 @@ static void check_options(void) {
 
 /* --------------------------------------------- */
 static void dump_options(FILE *fp) {
-  fprintf(fp,"vol1    %s\n",vol1File);
-  fprintf(fp,"vol2    %s\n",vol2File);
+  fprintf(fp,"vol1    %s\n",vol1File.c_str());
+  fprintf(fp,"vol2    %s\n",vol2File.c_str());
   fprintf(fp,"pix thresh  %g\n",pixdiff_thresh);
   fprintf(fp,"vox2ras thresh %g\n",vox2ras_thresh);
   return;

--- a/mris_fwhm/mris_fwhm.cpp
+++ b/mris_fwhm/mris_fwhm.cpp
@@ -165,7 +165,7 @@ char tmpstr[2000];
 MRI *InVals=NULL;
 
 char *maskpath=NULL;
-char *labelpath=NULL;
+std::string labelpath;
 MRI *mask=NULL;
 LABEL *label=NULL;
 int maskinv = 0;
@@ -301,10 +301,10 @@ int main(int argc, char *argv[]) {
     MRIsquare(InVals,NULL,InVals);
   }
 
-  if(labelpath) {
-    label = LabelRead(subject, labelpath);
+  if(labelpath.size() != 0 ) {
+    label = LabelRead(subject, labelpath.c_str());
     if (label == NULL) {
-      printf("ERROR reading %s\n",labelpath);
+      printf("ERROR reading %s\n",labelpath.c_str());
       exit(1);
     }
     mask = MRISlabel2Mask(surf, label, NULL);
@@ -560,9 +560,11 @@ static int parse_commandline(int argc, char **argv) {
     } 
     else if (!strcasecmp(option, "--label")) {
       if (nargc < 1) CMDargNErr(option,1);
-      if(fio_FileExistsReadable(pargv[0]))
+      if(fio_FileExistsReadable(pargv[0])) {
 	labelpath = fio_fullpath(pargv[0]); // defeat LabelRead()
-      else labelpath = pargv[0];
+      } else {
+	labelpath = pargv[0];
+      }
       nargsused = 1;
     } 
     else if (!strcasecmp(option, "--cortex")) {
@@ -849,7 +851,7 @@ static void check_options(void) {
     printf("ERROR: need to specify --in or --synth\n");
     exit(1);
   }
-  if (maskpath && labelpath) {
+  if (maskpath && (labelpath.size() != 0 )) {
     printf("ERROR: cannot specify both --label and --mask\n");
     exit(1);
   }
@@ -872,12 +874,11 @@ static void check_options(void) {
     exit(1);
   }
   if(UseCortexLabel){
-    if(labelpath != NULL){
+    if(labelpath.size() != 0){
       printf("ERROR: cannot spec --label and --cortex\n");
       exit(1);
     }
-    sprintf(tmpstr,"%s/%s/label/%s.cortex.label",SUBJECTS_DIR,subject,hemi);
-    labelpath = strcpyalloc(tmpstr);
+    labelpath = std::string(SUBJECTS_DIR) + '/' + std::string(subject) + '/' + std::string(hemi) + ".cortex.label";
   }
   return;
 }

--- a/trc/blood.h
+++ b/trc/blood.h
@@ -40,29 +40,29 @@
 
 class Blood {
   public:
-    Blood(const char *TrainListFile, const char *TrainTrkFile,
-          const char *TrainRoi1File, const char *TrainRoi2File,
-          const char *TrainAsegFile, const char *TrainMaskFile,
-          float TrainMaskLabel, const char *ExcludeFile,
-          const std::vector<char *> &TestMaskList,
-          const std::vector<char *> &TestFaList,
-          const char *TestAffineXfmFile,
-          const char *TestNonlinXfmFile,
-          const char *TestNonlinRefFile,
-          const std::vector<char *> &TestBaseXfmList,
-          const char *TestBaseMaskFile,
-          bool UseTruncated, std::vector<int> &NumControls,
-          bool Debug=false);
-    Blood(const char *TrainTrkFile,
-          const char *TrainRoi1File, const char *TrainRoi2File,
-          bool Debug=false);
-    ~Blood();
-    void SetNumControls(std::vector<int> &NumControls);
-    void ReadStreamlines(const char *TrainListFile, const char *TrainTrkFile,
-                         const char *TrainRoi1File, const char *TrainRoi2File,
-                         float TrainMaskLabel, const char *ExcludeFile);
-    void ReadAnatomy(const char *TrainListFile, const char *TrainAsegFile,
-                                                const char *TrainMaskFile);
+  Blood(const std::string TrainListFile, const std::string TrainTrkFile,
+	const std::string TrainRoi1File, const std::string TrainRoi2File,
+	const std::string TrainAsegFile, const std::string TrainMaskFile,
+	float TrainMaskLabel, const std::string ExcludeFile,
+	const std::vector<std::string> &TestMaskList,
+	const std::vector<std::string> &TestFaList,
+	const std::string TestAffineXfmFile,
+	const std::string TestNonlinXfmFile,
+	const std::string TestNonlinRefFile,
+	const std::vector<std::string> &TestBaseXfmList,
+	const std::string TestBaseMaskFile,
+	bool UseTruncated, std::vector<int> &NumControls,
+	bool Debug=false);
+  Blood(const std::string TrainTrkFile,
+	const std::string TrainRoi1File, const std::string TrainRoi2File,
+	bool Debug=false);
+  ~Blood();
+  void SetNumControls(std::vector<int> &NumControls);
+  void ReadStreamlines(const std::string TrainListFile, const std::string TrainTrkFile,
+		       const std::string TrainRoi1File, const std::string TrainRoi2File,
+		       float TrainMaskLabel, const std::string ExcludeFile);
+  void ReadAnatomy(const std::string TrainListFile, const std::string TrainAsegFile,
+		   const std::string TrainMaskFile);
     void RemoveLengthOutliers();
     void MatchStreamlineEnds();
     void ComputeHistogram();
@@ -70,15 +70,15 @@ class Blood {
     void FindCenterStreamline(bool CheckOverlap=true, bool CheckDeviation=true,
                                                       bool CheckFa=true);
     void WriteOutputs(const char *OutTrainBase, const char *OutTestBase=NULL);
-    void WriteCenterStreamline(const char *CenterTrkFile,
-                               const char *RefTrkFile);
-    void WriteEndPoints(const char *OutBase, MRI *RefVol);
+    void WriteCenterStreamline(const std::string CenterTrkFile,
+                               const std::string RefTrkFile);
+    void WriteEndPoints(const std::string OutBase, MRI *RefVol);
     void PrintStreamline(int SubjIndex, int LineIndex);
     std::vector<float> ComputeAvgPath(std::vector<MRI *> &ValueVolumes);
     std::vector<float> ComputeWeightAvgPath(std::vector<MRI *> &ValueVolumes);
     std::vector<float> ComputeAvgCenter(std::vector<MRI *> &ValueVolumes);
     void WriteValuesPointwise(std::vector<MRI *> &ValueVolumes,
-                              const char *TextFile);
+                              const std::string TextFile);
     int GetVolume();
     int GetNumStr();
     int GetLengthMin();
@@ -136,7 +136,7 @@ class Blood {
     std::vector<AffineReg> mTestBaseReg;
     MRI *mHistoStr, *mHistoSubj, *mTestBaseMask;
 
-    void ReadExcludedStreamlines(const char *ExcludeFile);
+    void ReadExcludedStreamlines(const std::string ExcludeFile);
     void ComputeStats();
     void ComputeStatsEnds();
     void ComputeEndPointCoM();
@@ -175,4 +175,3 @@ class Blood {
 };
 
 #endif
-

--- a/trc/coffin.cxx
+++ b/trc/coffin.cxx
@@ -18,6 +18,9 @@
  *
  */
 
+#include <sstream>
+#include <iomanip>
+
 #include <coffin.h>
 
 using namespace std;
@@ -76,18 +79,19 @@ void Aeon::SetPathMap(unsigned int PathIndex) {
 //
 // Read data specific to a single time point
 //
-void Aeon::ReadData(const char *RootDir, const char *DwiFile,
-                    const char *GradientFile, const char *BvalueFile,
-                    const char *MaskFile, const char *BedpostDir,
+void Aeon::ReadData(const std::string RootDir, const std::string DwiFile,
+                    const std::string GradientFile, const std::string BvalueFile,
+                    const std::string MaskFile, const std::string BedpostDir,
                     const int NumTract, const float FminPath,
-                    const char *BaseXfmFile) {
+                    const std::string BaseXfmFile) {
   string dwifile, gradfile, bvalfile, maskfile, bpdir;
-  char fname[PATH_MAX];
+  std::string fname;
   MRI *dwi, *phi[NumTract], *theta[NumTract], *f[NumTract],
       *v0[NumTract], *f0[NumTract], *d0;
 
-  if (RootDir)
-    mRootDir = string(RootDir) + "/";
+  if (!RootDir.empty()) {
+    mRootDir = RootDir + "/";
+  }
 
   dwifile    = mRootDir + DwiFile;
   gradfile   = mRootDir + GradientFile;
@@ -120,40 +124,40 @@ void Aeon::ReadData(const char *RootDir, const char *DwiFile,
   // Read parameter samples from BEDPOST directory
   cout << "Loading BEDPOST parameter samples from " << bpdir << endl;
   for (int itract = 0; itract < NumTract; itract++) {
-    sprintf(fname, "%s/merged_ph%usamples.nii.gz", bpdir.c_str(), itract+1);
-    phi[itract] = MRIread(fname);
+    fname = bpdir + "/merged_ph" + std::to_string(itract+1) + "samples.nii.gz";
+    phi[itract] = MRIread(fname.c_str());
     if (!phi[itract]) {
       cout << "ERROR: Could not read " << fname << endl;
       exit(1);
     }
-    sprintf(fname, "%s/merged_th%usamples.nii.gz", bpdir.c_str(), itract+1);
-    theta[itract] = MRIread(fname);
+    fname = bpdir + "/merged_th" + std::to_string(itract+1) + "samples.nii.gz";
+    theta[itract] = MRIread(fname.c_str());
     if (!theta[itract]) {
       cout << "ERROR: Could not read " << fname << endl;
       exit(1);
     }
-    sprintf(fname, "%s/merged_f%usamples.nii.gz", bpdir.c_str(), itract+1);
-    f[itract] = MRIread(fname);
+    fname = bpdir + "/merged_f" + std::to_string(itract+1) + "samples.nii.gz";
+    f[itract] = MRIread(fname.c_str());
     if (!f[itract]) {
       cout << "ERROR: Could not read " << fname << endl;
       exit(1);
     }
-    sprintf(fname, "%s/dyads%u.nii.gz", bpdir.c_str(), itract+1);
-    v0[itract] = MRIread(fname);
+    fname = bpdir + "/dyads" + std::to_string(itract+1) + ".nii.gz";
+    v0[itract] = MRIread(fname.c_str());
     if (!v0[itract]) {
       cout << "ERROR: Could not read " << fname << endl;
       exit(1);
     }
-    sprintf(fname, "%s/mean_f%usamples.nii.gz", bpdir.c_str(), itract+1);
-    f0[itract] = MRIread(fname);
+    fname = bpdir + "/mean_f" + std::to_string(itract+1) + "samples.nii.gz";
+    f0[itract] = MRIread(fname.c_str());
     if (!f0[itract]) {
       cout << "ERROR: Could not read " << fname << endl;
       exit(1);
     }
   }
 
-  sprintf(fname, "%s/mean_dsamples.nii.gz", bpdir.c_str());
-  d0 = MRIread(fname);
+  fname = bpdir + "/mean_dsamples.nii.gz";
+  d0 = MRIread(fname.c_str());
   if (!d0) {
     cout << "ERROR: Could not read " << fname << endl;
     exit(1);
@@ -212,7 +216,7 @@ void Aeon::ReadData(const char *RootDir, const char *DwiFile,
 
   // Read transform from base template space to native DWI space
   // (only used for longitudinal data)
-  if (BaseXfmFile) {
+  if (!BaseXfmFile.empty()) {
     string regfile = mRootDir + BaseXfmFile;
     if (!mBaseMask) {
       cout << "ERROR: Cannot load base-to-DWI transform without base mask"
@@ -256,7 +260,7 @@ void Aeon::FreeMask() {
 //
 // Set this time point's output directory for the current pathway
 //
-void Aeon::SetOutputDir(const char *OutDir) {
+void Aeon::SetOutputDir(const std::string OutDir) {
   string cmdline("mkdir -p ");
 
   mOutDir = mRootDir + OutDir;
@@ -1055,33 +1059,33 @@ double Aeon::GetDataFit() const {
 //
 // The main container
 //
-Coffin::Coffin(const char *OutDir, vector<char *> InDirList,
-               const char *DwiFile,
-               const char *GradientFile, const char *BvalueFile,
-               const char *MaskFile, const char *BedpostDir,
+Coffin::Coffin(const std::string OutDir, vector<std::string> InDirList,
+               const std::string DwiFile,
+               const std::string GradientFile, const std::string BvalueFile,
+               const std::string MaskFile, const std::string BedpostDir,
                const int NumTract, const float FminPath,
-               const char *BaseXfmFile, const char *BaseMaskFile,
-               const char *InitFile,
-               const char *RoiFile1, const char *RoiFile2,
-               const char *RoiMeshFile1, const char *RoiMeshFile2,
-               const char *RoiRefFile1, const char *RoiRefFile2,
-               const char *XyzPriorFile0, const char *XyzPriorFile1,
-               const char *TangPriorFile, const char *CurvPriorFile,
-               const char *NeighPriorFile, const char *NeighIdFile,
+               const std::string BaseXfmFile, const std::string BaseMaskFile,
+               const std::string InitFile,
+               const std::string RoiFile1, const std::string RoiFile2,
+               const std::string RoiMeshFile1, const std::string RoiMeshFile2,
+               const std::string RoiRefFile1, const std::string RoiRefFile2,
+               const std::string XyzPriorFile0, const std::string XyzPriorFile1,
+               const std::string TangPriorFile, const std::string CurvPriorFile,
+               const std::string NeighPriorFile, const std::string NeighIdFile,
                const int NeighPriorSet, 
-               const char *LocalPriorFile, const char *LocalIdFile,
+               const std::string LocalPriorFile, const std::string LocalIdFile,
                const int LocalPriorSet, 
-               const vector<char *>AsegList,
-               const char *AffineXfmFile, const char *NonlinXfmFile,
+               const vector<std::string> AsegList,
+               const std::string AffineXfmFile, const std::string NonlinXfmFile,
                const int NumBurnIn, const int NumSample,
                const int KeepSampleNth, const int UpdatePropNth,
-               const char *PropStdFile,
+               const std::string PropStdFile,
                const bool Debug) :
                mDebug(Debug),
                mPriorSetLocal(LocalPriorSet), mPriorSetNear(NeighPriorSet),
                mMask(0), mRoi1(0), mRoi2(0),
                mXyzPrior0(0), mXyzPrior1(0) {
-  vector<char *>::const_iterator idir;
+  vector<std::string >::const_iterator idir;
   MRI *atlasref;
   ostringstream infostr;
 
@@ -1099,29 +1103,29 @@ Coffin::Coffin(const char *OutDir, vector<char *> InDirList,
            << "BEDPOST directory: " << BedpostDir << endl
            << "Max number of tracts per voxel: " << NumTract << endl
            << "Tract volume fraction threshold: " << FminPath << endl;
-  if (BaseXfmFile)
+  if (!BaseXfmFile.empty())
     infostr << "Base-to-DWI affine registration: " << BaseXfmFile << endl;
-  if (BaseMaskFile)
+  if (!BaseMaskFile.empty())
     infostr << "Base mask: " << BaseMaskFile << endl;
-  if (AffineXfmFile)
-    infostr << (BaseMaskFile?"Base":"DWI")
+  if (!AffineXfmFile.empty())
+    infostr << (!BaseMaskFile.empty()?"Base":"DWI")
             << "-to-atlas affine registration: " << AffineXfmFile << endl;
-  if (NonlinXfmFile)
-    infostr << (BaseMaskFile?"Base":"DWI")
+  if (!NonlinXfmFile.empty())
+    infostr << (!BaseMaskFile.empty()?"Base":"DWI")
             << "-to-atlas nonlinear registration: " << NonlinXfmFile << endl;
   if (!AsegList.empty()) {
     infostr << "Segmentation map: ";
-    for (vector<char *>::const_iterator ifile = AsegList.begin();
-                                        ifile < AsegList.end(); ifile++)
+    for (auto ifile = AsegList.begin(); ifile < AsegList.end(); ifile++) {
       infostr << " " << *ifile;
+    }
     infostr << endl;
   }
   mInfoGeneral = infostr.str();
 
   // Read base template mask for longitudinal data
-  if (BaseMaskFile) {
+  if (!BaseMaskFile.empty()) {
     cout << "Loading base mask from " << BaseMaskFile << endl;
-    mMask = MRIread(BaseMaskFile);
+    mMask = MRIread(BaseMaskFile.c_str());
     if (!mMask) {
       cout << "ERROR: Could not read " << BaseMaskFile << endl;
       exit(1);
@@ -1189,9 +1193,9 @@ Coffin::Coffin(const char *OutDir, vector<char *> InDirList,
 
   // Read start ROI as atlas-space reference volume
   // TODO: Use more general reference volume if ROI isn't specified
-  if (RoiFile1) {
+  if (!RoiFile1.empty()) {
     cout << "Loading atlas reference volume from " << RoiFile1 << endl;
-    atlasref = MRIread(RoiFile1);
+    atlasref = MRIread(RoiFile1.c_str());
     if (!atlasref) {
       cout << "ERROR: Could not read " << RoiFile1 << endl;
       exit(1);
@@ -1200,15 +1204,18 @@ Coffin::Coffin(const char *OutDir, vector<char *> InDirList,
 
   // Read DWI-to-atlas registration
 #ifndef NO_CVS_UP_IN_HERE
-  if (NonlinXfmFile) {
-    mAffineReg.ReadXfm(AffineXfmFile, mMask, 0);
-    mNonlinReg.ReadXfm(NonlinXfmFile, atlasref);
-  }
-  else
+  if (!NonlinXfmFile.empty()) {
+    mAffineReg.ReadXfm(AffineXfmFile.c_str(), mMask, 0);
+    mNonlinReg.ReadXfm(NonlinXfmFile.c_str(), atlasref);
+  } else {
 #endif
-  if (AffineXfmFile)
-    mAffineReg.ReadXfm(AffineXfmFile, mMask, atlasref);
-
+    if (!AffineXfmFile.empty()) {
+      mAffineReg.ReadXfm(AffineXfmFile.c_str(), mMask, atlasref);
+    }
+#ifndef NO_CVS_UP_IN_HERE
+  }
+#endif
+    
 	/*
 vector<float> pt(3);
 pt[0] = 75; pt[1] = 55; pt[2] = 51;
@@ -1223,12 +1230,11 @@ exit(1);
   MRIfree(&atlasref);
 
   // Read segmentation map
-  for (vector<char *>::const_iterator ifile = AsegList.begin();
-                                      ifile < AsegList.end(); ifile++) {
+  for (auto ifile = AsegList.begin(); ifile < AsegList.end(); ifile++) {
     MRI *aseg = 0;
 
     cout << "Loading segmentation map from " << *ifile << endl;
-    aseg = MRIread(*ifile);
+    aseg = MRIread((*ifile).c_str());
     if (!aseg) {
       cout << "ERROR: Could not read " << *ifile << endl;
       exit(1);
@@ -1276,7 +1282,7 @@ Coffin::~Coffin() {
 //
 // Set output directory for each time point
 //
-void Coffin::SetOutputDir(const char *OutDir) {
+void Coffin::SetOutputDir(const std::string OutDir) {
   for (vector<Aeon>::iterator idwi = mDwi.begin(); idwi < mDwi.end(); idwi++)
     idwi->SetOutputDir(OutDir);
 
@@ -1286,14 +1292,14 @@ void Coffin::SetOutputDir(const char *OutDir) {
 //
 // Set atlas-derived information specific to a given pathway
 //
-void Coffin::SetPathway(const char *InitFile,
-                        const char *RoiFile1, const char *RoiFile2,
-                        const char *RoiMeshFile1, const char *RoiMeshFile2,
-                        const char *RoiRefFile1, const char *RoiRefFile2,
-                        const char *XyzPriorFile0, const char *XyzPriorFile1,
-                        const char *TangPriorFile, const char *CurvPriorFile,
-                        const char *NeighPriorFile, const char *NeighIdFile,
-                        const char *LocalPriorFile, const char *LocalIdFile) {
+void Coffin::SetPathway(const std::string InitFile,
+                        const std::string RoiFile1, const std::string RoiFile2,
+                        const std::string RoiMeshFile1, const std::string RoiMeshFile2,
+                        const std::string RoiRefFile1, const std::string RoiRefFile2,
+                        const std::string XyzPriorFile0, const std::string XyzPriorFile1,
+                        const std::string TangPriorFile, const std::string CurvPriorFile,
+                        const std::string NeighPriorFile, const std::string NeighIdFile,
+                        const std::string LocalPriorFile, const std::string LocalIdFile) {
   int dirs[45] = { 0,  0,  0,
                    1,  0,  0,
                   -1,  0,  0,
@@ -1316,59 +1322,60 @@ void Coffin::SetPathway(const char *InitFile,
   // Save input info for logging
   infostr << "Initial control point file: " << InitFile << endl
           << "End ROI 1: " << RoiFile1 << endl;
-  if (RoiMeshFile1)
+  if (!RoiMeshFile1.empty())
     infostr << "End ROI 1 mesh: " << RoiMeshFile1 << endl
             << "End ROI 1 reference volume: " << RoiRefFile1 << endl;
   infostr << "End ROI 2: " << RoiFile2 << endl;
-  if (RoiMeshFile2)
+  if (!RoiMeshFile2.empty())
     infostr << "End ROI 2 mesh: " << RoiMeshFile2 << endl
             << "End ROI 2 reference volume: " << RoiRefFile2 << endl;
-  if (XyzPriorFile0)
+  if (!XyzPriorFile0.empty())
     infostr << "Spatial prior (off path): " << XyzPriorFile0 << endl
             << "Spatial prior (on path): " << XyzPriorFile1 << endl;
-  if (TangPriorFile)
+  if (!TangPriorFile.empty())
     infostr << "Tangent prior: " << TangPriorFile << endl;
-  if (CurvPriorFile)
+  if (!CurvPriorFile.empty())
     infostr << "Curvature prior: " << CurvPriorFile << endl;
-  if (NeighPriorFile)
+  if (!NeighPriorFile.empty())
     infostr << "Neighbor aseg prior: " << NeighPriorFile << endl
             << "Neighbor aseg label ID list: " << NeighIdFile << endl;
-  if (LocalPriorFile)
+  if (!LocalPriorFile.empty())
     infostr << "Local aseg prior: " << LocalPriorFile << endl
             << "Local aseg label ID list: " << LocalIdFile << endl;
   mInfoPathway = infostr.str();
 
   // Read start ROI
-  if (RoiFile1) {
+  if (!RoiFile1.empty()) {
     if (mRoi1)
       MRIfree(&mRoi1);
 
     cout << "Loading end ROI from " << RoiFile1 << endl;
-    mRoi1 = MRIread(RoiFile1);
+    mRoi1 = MRIread(RoiFile1.c_str());
     if (!mRoi1) {
       cout << "ERROR: Could not read " << RoiFile1 << endl;
       exit(1);
     }
 
-    if (RoiMeshFile1) {
+    if (!RoiMeshFile1.empty()) {
       cout << "ERROR: .label ROIs not supported" << endl;
       exit(1);
     }
   }
 
   // Read end ROI
-  if (RoiFile2) {
-    if (mRoi2)
+  if (!RoiFile2.empty()) {
+    if (mRoi2) {
       MRIfree(&mRoi2);
+    }
 
     cout << "Loading end ROI from " << RoiFile2 << endl;
-    mRoi2 = MRIread(RoiFile2);
+    mRoi2 = MRIread(RoiFile2.c_str());
     if (!mRoi2) {
       cout << "ERROR: Could not read " << RoiFile2 << endl;
       exit(1);
     }
 
-    if (RoiMeshFile2) {
+    if (!RoiMeshFile2.empty()) {
       cout << "ERROR: .label ROIs not supported" << endl;
       exit(1);
     }
@@ -1389,22 +1396,24 @@ void Coffin::SetPathway(const char *InitFile,
   }
 
   // Read spatial path priors
-  if (XyzPriorFile0 && XyzPriorFile1) {
-    if (mXyzPrior0)
+  if ((!XyzPriorFile0.empty()) && (!XyzPriorFile1.empty())) {
+    if (mXyzPrior0) {
       MRIfree(&mXyzPrior0);
+    }
 
     cout << "Loading spatial path prior from " << XyzPriorFile0 << endl;
-    mXyzPrior0 = MRIread(XyzPriorFile0);
+    mXyzPrior0 = MRIread(XyzPriorFile0.c_str());
     if (!mXyzPrior0) {
       cout << "ERROR: Could not read " << XyzPriorFile0 << endl;
       exit(1);
     }
 
-    if (mXyzPrior1)
+    if (mXyzPrior1) {
       MRIfree(&mXyzPrior1);
+    }
 
     cout << "Loading spatial path prior from " << XyzPriorFile1 << endl;
-    mXyzPrior1 = MRIread(XyzPriorFile1);
+    mXyzPrior1 = MRIread(XyzPriorFile1.c_str());
     if (!mXyzPrior1) {
       cout << "ERROR: Could not read " << XyzPriorFile1 << endl;
       exit(1);
@@ -1418,7 +1427,7 @@ void Coffin::SetPathway(const char *InitFile,
   mNumArc = 0;
 
   // Read path tangent prior
-  if (TangPriorFile) {
+  if (!TangPriorFile.empty()) {
     const int nbin = (int) ceil(2 / mTangentBinSize),
               nbin2 = nbin*nbin;
     string prline;
@@ -1457,7 +1466,7 @@ void Coffin::SetPathway(const char *InitFile,
   }
 
   // Read path curvature prior
-  if (CurvPriorFile) {
+  if (!CurvPriorFile.empty()) {
     string prline;
     ifstream prfile;
 
@@ -1497,7 +1506,7 @@ void Coffin::SetPathway(const char *InitFile,
   }
 
   // Read neighbor aseg priors
-  if (NeighPriorFile && NeighIdFile) {
+  if ((!NeighPriorFile.empty()) && (!NeighIdFile.empty())) {
     mPriorNear.clear();
     mIdsNear.clear();
     mDirNear.clear();
@@ -1511,23 +1520,29 @@ void Coffin::SetPathway(const char *InitFile,
     for (vector<int>::const_iterator idir = mDirNear.begin();
                                      idir < mDirNear.end(); idir += 3) {
       const int idx = idir[0], idy = idir[1], idz = idir[2];
-      char prname[PATH_MAX], idname[PATH_MAX];
+      std::stringstream prname, idname;
       string prline, idline;
       ifstream prfile, idfile;
 
-      sprintf(prname, "%s_%d_%d_%d.txt", NeighPriorFile, idx, idy, idz);
-      sprintf(idname, "%s_%d_%d_%d.txt", NeighIdFile, idx, idy, idz);
+      prname << NeighPriorFile << '_'
+	     << idx << '_'
+	     << idy << '_'
+	     << idz << ".txt";
+      idname << NeighIdFile << '_'
+	     << idx << '_'
+	     << idy << '_'
+	     << idz << ".txt";
 
-      cout << "Loading nearest neighbor prior from " << prname
-           << " with label IDs from " << idname << endl;
+      cout << "Loading nearest neighbor prior from " << prname.str()
+           << " with label IDs from " << idname.str() << endl;
 
-      prfile.open(prname, ios::in);
+      prfile.open(prname.str(), ios::in);
       if (!prfile) {
         cout << "ERROR: Could not open " << prname << endl;
         exit(1);
       }
 
-      idfile.open(idname, ios::in);
+      idfile.open(idname.str(), ios::in);
       if (!idfile) {
         cout << "ERROR: Could not open " << idname << endl;
         exit(1);
@@ -1565,10 +1580,10 @@ void Coffin::SetPathway(const char *InitFile,
       mNumArc = (int) (mPriorNear.size() / mPriorSetNear);
     else if (mNumArc != (int) (mPriorNear.size() / mPriorSetNear)) {
       cout << "ERROR: Mismatch between the numbers of arc segments in ";
-      if (TangPriorFile)
+      if (!TangPriorFile.empty())
         cout << TangPriorFile
              << " (" << mPriorTangent.size() << "), ";
-      if (CurvPriorFile)
+      if (!CurvPriorFile.empty())
         cout << CurvPriorFile
              << " (" << mPriorCurvature.size() << "), ";
       cout << NeighPriorFile
@@ -1577,7 +1592,7 @@ void Coffin::SetPathway(const char *InitFile,
   }
 
   // Read local aseg priors
-  if (LocalPriorFile && LocalIdFile) {
+  if ((!LocalPriorFile.empty()) && (!LocalIdFile.empty())) {
     mPriorLocal.clear();
     mIdsLocal.clear();
     mDirLocal.clear();
@@ -1593,23 +1608,23 @@ void Coffin::SetPathway(const char *InitFile,
     for (vector<int>::const_iterator idir = mDirLocal.begin();
                                      idir < mDirLocal.end(); idir += 3) {
       const int idx = idir[0], idy = idir[1], idz = idir[2];
-      char prname[PATH_MAX], idname[PATH_MAX];
+      std::stringstream prname, idname;
       string prline, idline;
       ifstream prfile, idfile;
 
-      sprintf(prname, "%s_%d_%d_%d.txt", LocalPriorFile, idx, idy, idz);
-      sprintf(idname, "%s_%d_%d_%d.txt", LocalIdFile, idx, idy, idz);
+      prname << LocalPriorFile << "_" << idx << "_" << idy << '_' << idz << ".txt";
+      idname << LocalIdFile << '_' << idx << "_" << idy << '_' << idz << ".txt";
 
-      cout << "Loading local prior from " << prname
-           << " with label IDs from " << idname << endl;
+      cout << "Loading local prior from " << prname.str()
+           << " with label IDs from " << idname.str() << endl;
 
-      prfile.open(prname, ios::in);
+      prfile.open(prname.str(), ios::in);
       if (!prfile) {
         cout << "ERROR: Could not open " << prname << endl;
         exit(1);
       }
 
-      idfile.open(idname, ios::in);
+      idfile.open(idname.str(), ios::in);
       if (!idfile) {
         cout << "ERROR: Could not open " << idname << endl;
         exit(1);
@@ -1643,17 +1658,17 @@ void Coffin::SetPathway(const char *InitFile,
       idfile.close();
     }
 
-    if (mNumArc == 0)
+    if (mNumArc == 0) {
       mNumArc = (int) (mPriorLocal.size() / mPriorSetLocal);
-    else if (mNumArc != (int) (mPriorLocal.size() / mPriorSetLocal)) {
+    } else if (mNumArc != (int) (mPriorLocal.size() / mPriorSetLocal)) {
       cout << "ERROR: Mismatch between the numbers of arc segments in ";
-      if (TangPriorFile)
+      if (!TangPriorFile.empty())
         cout << TangPriorFile
              << " (" << mPriorTangent.size() << "), ";
-      if (CurvPriorFile)
+      if (!CurvPriorFile.empty())
         cout << CurvPriorFile
              << " (" << mPriorCurvature.size() << "), ";
-      if (NeighPriorFile)
+      if (!NeighPriorFile.empty())
         cout << NeighPriorFile
              << " (" << mPriorNear.size() / mPriorSetNear << "), ";
       cout << LocalPriorFile
@@ -1668,7 +1683,7 @@ void Coffin::SetPathway(const char *InitFile,
 //
 void Coffin::SetMcmcParameters(const int NumBurnIn, const int NumSample,
                                const int KeepSampleNth, const int UpdatePropNth,
-                               const char *PropStdFile) {
+                               const std::string PropStdFile) {
   ostringstream infostr;
 
   // Save input info for logging
@@ -1676,8 +1691,9 @@ void Coffin::SetMcmcParameters(const int NumBurnIn, const int NumSample,
           << "Number of post-burn-in samples: " << NumSample << endl
           << "Keep every: " << KeepSampleNth << "-th sample" << endl
           << "Update proposal every: " << UpdatePropNth << "-th sample" << endl;
-  if (PropStdFile)
+  if (!PropStdFile.empty()) {
     infostr << "Initial proposal SD file: " << PropStdFile << endl;
+  }
   mInfoMcmc = infostr.str();
 
   // Set sampling parameters
@@ -1698,7 +1714,7 @@ void Coffin::SetMcmcParameters(const int NumBurnIn, const int NumSample,
 //
 // Read initial control points
 //
-void Coffin::ReadControlPoints(const char *ControlPointFile) {
+void Coffin::ReadControlPoints(const std::string ControlPointFile) {
   float coord;
   ifstream infile(ControlPointFile, ios::in);
 
@@ -1912,10 +1928,10 @@ void Coffin::ReadControlPoints(const char *ControlPointFile) {
 //
 // Read initial proposal standard deviations for control point perturbations
 //
-void Coffin::ReadProposalStds(const char *PropStdFile) {
+void Coffin::ReadProposalStds(const std::string PropStdFile) {
   mProposalStdInit.clear();
 
-  if (PropStdFile) {
+  if (!PropStdFile.empty()) {
     float val;
     ifstream infile(PropStdFile, ios::in);
 
@@ -1935,8 +1951,9 @@ void Coffin::ReadProposalStds(const char *PropStdFile) {
     istd = mProposalStdInit.begin();
 
     copy(mResolution.begin(), mResolution.end(), istd);			//x5.0
-    for (istd += 3; istd < mProposalStdInit.end() - 3; istd +=3)
+    for (istd += 3; istd < mProposalStdInit.end() - 3; istd +=3) {
       copy(mResolution.begin(), mResolution.end(), istd);		//x1.0
+    }
     copy(mResolution.begin(), mResolution.end(), istd);			//x5.0
   }
 }
@@ -1946,11 +1963,11 @@ void Coffin::ReadProposalStds(const char *PropStdFile) {
 //
 bool Coffin::RunMcmcFull() {
   int iprop, ikeep;
-  char fname[PATH_MAX];
+  std::string fname;
   string cmdline;
 
   // Open log file in first time point's output directory
-  sprintf(fname, "%s/log.txt", mOutDir.c_str());
+  fname = mOutDir + "/log.txt";
   mLog.open(fname, ios::out | ios::app);
   if (!mLog) {
     cout << "ERROR: Could not open " << fname << " for writing" << endl;
@@ -1969,8 +1986,8 @@ bool Coffin::RunMcmcFull() {
   }
 
   if (mDebug) {
-    sprintf(fname, "%s/Finit.nii.gz", mOutDir.c_str());
-    mSpline.WriteVolume(fname, true);
+    fname = mOutDir + "/Finit.nii.gz";
+    mSpline.WriteVolume(fname.c_str(), true);
   }
 
   cout << "Running MCMC burn-in jumps" << endl;
@@ -1982,18 +1999,26 @@ bool Coffin::RunMcmcFull() {
       UpdateAcceptanceRateFull();
 
       if (mDebug) {
-        sprintf(fname, "%s/Faccept_b%05d.nii.gz",
-                mOutDir.c_str(), mNumBurnIn-ijump+1);
-        mSpline.WriteVolume(fname, true);
+	std::stringstream tmp;
+	tmp << mOutDir << '/'
+	    << "Faccept_b"
+	    << std::setw(5) << std::setfill('0') << mNumBurnIn-ijump+1
+	    << ".nii.gz";
+	fname = tmp.str();
+        mSpline.WriteVolume(fname.c_str(), true);
       }
     }
     else {						// Reject new path
       UpdateRejectionRateFull();
 
       if (mDebug) {
-        sprintf(fname, "%s/Freject_b%05d.nii.gz",
-                mOutDir.c_str(), mNumBurnIn-ijump+1);
-        mSpline.WriteVolume(fname, true);
+	std::stringstream tmp;
+	tmp << mOutDir << '/'
+	    << "Freject_b"
+	    << std::setw(5) << std::setfill('0') << mNumBurnIn-ijump+1
+	    << ".nii.gz";
+	fname = tmp.str();
+        mSpline.WriteVolume(fname.c_str(), true);
       }
     }
 
@@ -2018,9 +2043,13 @@ bool Coffin::RunMcmcFull() {
       UpdateAcceptanceRateFull();
 
       if (mDebug) {
-        sprintf(fname, "%s/Faccept_%05d.nii.gz",
-                mOutDir.c_str(), mNumSample-ijump+1);
-        mSpline.WriteVolume(fname, true);
+	std::stringstream tmp;
+	tmp << mOutDir << '/'
+	    << "Faccept_"
+	    << std::setw(5) << std::setfill('0') << mNumSample-ijump+1
+	    << ".nii.gz";
+	fname = tmp.str();
+        mSpline.WriteVolume(fname.c_str(), true);
       }
     }
     else {						// Reject new path
@@ -2028,9 +2057,13 @@ bool Coffin::RunMcmcFull() {
       UpdateRejectionRateFull();
 
       if (mDebug) {
-        sprintf(fname, "%s/Freject_%05d.nii.gz",
-                mOutDir.c_str(), mNumSample-ijump+1);
-        mSpline.WriteVolume(fname, true);
+	std::stringstream tmp;
+	tmp << mOutDir << '/'
+	    << "Freject_"
+	    << std::setw(5) << std::setfill('0') << mNumSample-ijump+1
+	    << ".nii.gz";
+	fname = tmp.str();
+        mSpline.WriteVolume(fname.c_str(), true);
       }
     }
 
@@ -2073,13 +2106,13 @@ bool Coffin::RunMcmcFull() {
 //
 bool Coffin::RunMcmcSingle() {
   int iprop, ikeep;
-  char fname[PATH_MAX];
+  std::string fname;
   string cmdline;
   vector<int> cptorder(mNumControl);
   vector<int>::const_iterator icpt;
 
   // Open log file in first time point's output directory
-  sprintf(fname, "%s/log.txt", mOutDir.c_str());
+  fname = mOutDir + "/log.txt";
   mLog.open(fname, ios::out | ios::app);
   if (!mLog) {
     cout << "ERROR: Could not open " << fname << " for writing" << endl;
@@ -2098,8 +2131,8 @@ bool Coffin::RunMcmcSingle() {
   }
 
   if (mDebug) {
-    sprintf(fname, "%s/Finit.nii.gz", mOutDir.c_str());
-    mSpline.WriteVolume(fname, true);
+    fname = mOutDir + "/Finit.nii.gz";
+    mSpline.WriteVolume(fname.c_str(), true);
   }
 
   cout << "Running MCMC burn-in jumps" << endl;
@@ -2107,8 +2140,9 @@ bool Coffin::RunMcmcSingle() {
   iprop = 1;
   for (int ijump = mNumBurnIn; ijump > 0; ijump--) {
     // Perturb control points in random order
-    for (int k = 0; k < mNumControl; k++)
+    for (int k = 0; k < mNumControl; k++) {
       cptorder[k] = k;
+    }
     random_shuffle(cptorder.begin(), cptorder.end());
 
     fill(mRejectControl.begin(), mRejectControl.end(), false);
@@ -2125,18 +2159,30 @@ bool Coffin::RunMcmcSingle() {
         UpdatePath();
 
         if (mDebug) {
-          sprintf(fname, "%s/Faccept_b%05d_%d.nii.gz",
-                  mOutDir.c_str(), mNumBurnIn-ijump+1, *icpt);
-          mSpline.WriteVolume(fname, true);
+	  std::stringstream tmp;
+	  tmp << mOutDir << '/'
+	      << "Faccept_b"
+	      << std::setw(5) << std::setfill('0') << mNumBurnIn-ijump+1
+	      << '_'
+	      << *icpt
+	      << ".nii.gz";
+	  fname = tmp.str();
+          mSpline.WriteVolume(fname.c_str(), true);
         }
       }
       else {							// Reject point
         mRejectControl[*icpt] = true;
 
         if (mDebug) {
-          sprintf(fname, "%s/Freject_b%05d_%d.nii.gz",
-                  mOutDir.c_str(), mNumBurnIn-ijump+1, *icpt);
-          mSpline.WriteVolume(fname, true);
+	  std::stringstream tmp;
+	  tmp << mOutDir << '/'
+	      << "Freject_b"
+	      << std::setw(5) << std::setfill('0') << mNumBurnIn-ijump+1
+	      << '_'
+	      << *icpt
+	      << ".nii.gz";
+	  fname = tmp.str();
+          mSpline.WriteVolume(fname.c_str(), true);
         }
       }
     }
@@ -2178,9 +2224,14 @@ bool Coffin::RunMcmcSingle() {
         UpdatePath();
 
         if (mDebug) {
-          sprintf(fname, "%s/Faccept_%05d_%d.nii.gz",
-                  mOutDir.c_str(), mNumSample-ijump+1, *icpt);
-          mSpline.WriteVolume(fname, true);
+	  std::stringstream tmp;
+	  tmp << mOutDir << '/'
+	      << "Faccept_"
+	      << std::setw(5) << std::setfill('0') << mNumSample-ijump+1
+	      << '_'
+	      << *icpt;
+	  fname = tmp.str();
+          mSpline.WriteVolume(fname.c_str(), true);
         }
       }
       else {							// Reject point
@@ -2188,9 +2239,14 @@ bool Coffin::RunMcmcSingle() {
         mRejectControl[*icpt] = true;
 
         if (mDebug) {
-          sprintf(fname, "%s/Freject_%05d_%d.nii.gz",
-                  mOutDir.c_str(), mNumSample-ijump+1, *icpt);
-          mSpline.WriteVolume(fname, true);
+	  std::stringstream tmp;
+	  tmp << mOutDir << '/'
+	      << "Freject_"
+	      << std::setw(5) << std::setfill('0') << mNumSample-ijump+1
+	      << '_'
+	      << *icpt;
+	  fname = tmp.str();
+          mSpline.WriteVolume(fname.c_str(), true);
         }
       }
     }
@@ -2466,16 +2522,20 @@ bool Coffin::InitializeFixOffWhite(int FailSegment) {
   int failseg = FailSegment,
       perturbfirst = failseg,
       perturblast  = (failseg == mNumControl-1) ? failseg : failseg+1;
-  char fname[PATH_MAX];
+  std::string fname;
   vector<int> controlorig(mControlPoints);
 
   // Set proposal standard deviations to a conservative value for this
-  if (mMaxTryWhite > 0)
+  if (mMaxTryWhite > 0) {
     for (vector<float>::iterator istd = mProposalStd.begin();
-                                 istd < mProposalStd.end(); istd += 3)
-      for (int k = 0; k < 3; k++)
-        if (istd[k] > mResolution[k])
+	 istd < mProposalStd.end(); istd += 3) {
+      for (int k = 0; k < 3; k++) {
+        if (istd[k] > mResolution[k]) {
           istd[k] = mResolution[k];
+	}
+      }
+    }
+  }
 
   // Perturb control points to find a valid initial path
   for (unsigned int itry = 0; itry < mMaxTryWhite; itry++) {
@@ -2515,16 +2575,23 @@ bool Coffin::InitializeFixOffWhite(int FailSegment) {
         improved = ( (noffnew / (float) ntotnew) < (noff / (float) ntot)
                      && AcceptPath(true) );
       }
-      else
+      else {
         improved = success;
+      }
 
       if (success || improved) {				// Accept point
         UpdatePath();
 
         if (mDebug) {
-          sprintf(fname, "%s/Faccept_f%05d_%d.nii.gz",
-                  mOutDir.c_str(), itry+1, icpt);
-          mSpline.WriteVolume(fname, true);
+	  std::stringstream tmp;
+	  tmp << mOutDir << '/'
+	      << "Faccept_f"
+	      << std::setw(5) << std::setfill('0') << itry+1
+	      << '_'
+	      << icpt
+	      << ".nii.gz";
+	  fname = tmp.str();
+          mSpline.WriteVolume(fname.c_str(), true);
         }
 
         if (success)
@@ -2546,9 +2613,15 @@ bool Coffin::InitializeFixOffWhite(int FailSegment) {
         mRejectControl[icpt] = true;
 
         if (mDebug) {
-          sprintf(fname, "%s/Freject_f%05d_%d.nii.gz",
-                  mOutDir.c_str(), itry+1, icpt);
-          mSpline.WriteVolume(fname, true);
+	  std::stringstream tmp;
+	  tmp << mOutDir << '/'
+	      << "Freject_f"
+	      << std::setw(5) << std::setfill('0') << itry+1
+	      << '_'
+	      << icpt
+	      << ".nii.gz";
+	  fname = tmp.str();
+          mSpline.WriteVolume(fname.c_str(), true);
         }
       }
     }

--- a/trc/coffin.h
+++ b/trc/coffin.h
@@ -48,11 +48,11 @@ class Aeon {		// One point in time
     static void SavePathPriors(std::vector<float> &Priors);
     static void SaveBasePath(std::vector<int> &PathPoints);
     static void SetPathMap(unsigned int PathIndex);
-    void ReadData(const char *RootDir, const char *DwiFile,
-                  const char *GradientFile, const char *BvalueFile,
-                  const char *MaskFile, const char *BedpostDir,
+    void ReadData(const std::string RootDir, const std::string DwiFile,
+                  const std::string GradientFile, const std::string BvalueFile,
+                  const std::string MaskFile, const std::string BedpostDir,
                   const int NumTract, const float FminPath,
-                  const char *BaseXfmFile);
+                  const std::string BaseXfmFile);
     MRI *GetMask() const;
     MRI *GetBaseMask() const;
     float GetDx() const;
@@ -60,7 +60,7 @@ class Aeon {		// One point in time
     float GetDz() const;
     unsigned int GetNumSample() const;
     void FreeMask();
-    void SetOutputDir(const char *OutDir);
+    void SetOutputDir(const std::string OutDir);
     const string &GetOutputDir() const;
     void ClearPath();
     bool MapPathFromBase(Spline &BaseSpline);
@@ -133,42 +133,42 @@ class Aeon {		// One point in time
 };
 
 class Coffin {		// The main container
-  public:
-    Coffin(const char *OutDir, std::vector<char *> InDirList,
-           const char *DwiFile,
-           const char *GradientFile, const char *BvalueFile,
-           const char *MaskFile, const char *BedpostDir,
-           const int NumTract, const float FminPath,
-           const char *BaseXfmFile, const char *BaseMaskFile,
-           const char *InitFile,
-           const char *RoiFile1, const char *RoiFile2,
-           const char *RoiMeshFile1, const char *RoiMeshFile2,
-           const char *RoiRefFile1, const char *RoiRefFile2,
-           const char *XyzPriorFile0, const char *XyzPriorFile1,
-           const char *TangPriorFile, const char *CurvPriorFile,
-           const char *NeighPriorFile, const char *NeighIdFile,
-           const int NeighPriorSet,
-           const char *LocalPriorFile, const char *LocalIdFile,
-           const int LocalPriorSet,
-           const std::vector<char *>AsegList,
-           const char *AffineXfmFile, const char *NonlinXfmFile,
-           const int NumBurnIn, const int NumSample,
-           const int KeepSampleNth, const int UpdatePropNth,
-           const char *PropStdFile,
-           const bool Debug=false);
+ public:
+  Coffin(const std::string OutDir, std::vector<std::string> InDirList,
+	 const std::string DwiFile,
+	 const std::string GradientFile, const std::string BvalueFile,
+	 const std::string MaskFile, const std::string BedpostDir,
+	 const int NumTract, const float FminPath,
+	 const std::string BaseXfmFile, const std::string BaseMaskFile,
+	 const std::string InitFile,
+	 const std::string RoiFile1, const std::string RoiFile2,
+	 const std::string RoiMeshFile1, const std::string RoiMeshFile2,
+	 const std::string RoiRefFile1, const std::string RoiRefFile2,
+	 const std::string XyzPriorFile0, const std::string XyzPriorFile1,
+	 const std::string angPriorFile, const std::string CurvPriorFile,
+	 const std::string NeighPriorFile, const std::string NeighIdFile,
+	 const int NeighPriorSet,
+	 const std::string LocalPriorFile, const std::string LocalIdFile,
+	 const int LocalPriorSet,
+	 const std::vector<std::string> AsegList,
+	 const std::string AffineXfmFile, const std::string NonlinXfmFile,
+	 const int NumBurnIn, const int NumSample,
+	 const int KeepSampleNth, const int UpdatePropNth,
+	 const std::string PropStdFile,
+	 const bool Debug=false);
     ~Coffin();
-    void SetOutputDir(const char *OutDir);
-    void SetPathway(const char *InitFile,
-                    const char *RoiFile1, const char *RoiFile2,
-                    const char *RoiMeshFile1, const char *RoiMeshFile2,
-                    const char *RoiRefFile1, const char *RoiRefFile2,
-                    const char *XyzPriorFile0, const char *XyzPriorFile1,
-                    const char *TangPriorFile, const char *CurvPriorFile,
-                    const char *NeighPriorFile, const char *NeighIdFile,
-                    const char *LocalPriorFile, const char *LocalIdFile);
+    void SetOutputDir(const std::string OutDir);
+    void SetPathway(const std::string InitFile,
+                    const std::string RoiFile1, const std::string RoiFile2,
+                    const std::string RoiMeshFile1, const std::string RoiMeshFile2,
+                    const std::string RoiRefFile1, const std::string RoiRefFile2,
+                    const std::string XyzPriorFile0, const std::string XyzPriorFile1,
+                    const std::string TangPriorFile, const std::string CurvPriorFile,
+                    const std::string NeighPriorFile, const std::string NeighIdFile,
+                    const std::string LocalPriorFile, const std::string LocalIdFile);
     void SetMcmcParameters(const int NumBurnIn, const int NumSample,
                            const int KeepSampleNth, const int UpdatePropNth,
-                           const char *PropStdFile);
+                           const std::string PropStdFile);
     bool RunMcmcFull();
     bool RunMcmcSingle();
     void WriteOutputs();
@@ -217,8 +217,8 @@ class Coffin {		// The main container
     std::vector<MRI *> mAseg;
     std::vector<Aeon> mDwi;
 
-    void ReadControlPoints(const char *ControlPointFile);
-    void ReadProposalStds(const char *PropStdFile);
+    void ReadControlPoints(const std::string ControlPointFile);
+    void ReadProposalStds(const std::string PropStdFile);
     bool InitializeMcmc();
     bool InitializeFixOffMask(int FailSegment);
     bool InitializeFixOffWhite(int FailSegment);

--- a/trc/dmri_forrest.cxx
+++ b/trc/dmri_forrest.cxx
@@ -63,8 +63,7 @@ int main(int argc, char *argv[]);
 
 const char *Progname = "dmri_forrest";
 
-char *testDir = NULL, *trainListFile = NULL,
-     *maskFile = NULL, *asegFile = NULL, *orientFile = NULL;
+std::string testDir, trainListFile, maskFile, asegFile, orientFile;
 vector<char *> tractFileList;
 
 struct utsname uts;
@@ -102,7 +101,7 @@ int main(int argc, char **argv) {
   cputimer.reset();
 
   cout << "Reading test subject data..." << endl;
-  myforrest.ReadTestSubject(testDir, maskFile, asegFile, orientFile);
+  myforrest.ReadTestSubject(testDir.c_str(), maskFile.c_str(), asegFile.c_str(), orientFile.c_str());
 
   // Get volume dimensions from test subject
   nx = myforrest.GetNx();
@@ -110,7 +109,7 @@ int main(int argc, char **argv) {
   nz = myforrest.GetNz();
 
   cout << "Reading training subject data..." << endl;
-  myforrest.ReadTrainingSubjects(trainListFile, maskFile, asegFile, orientFile,
+  myforrest.ReadTrainingSubjects(trainListFile.c_str(), maskFile.c_str(), asegFile.c_str(), orientFile.c_str(),
                                  tractFileList);
 
   // Get total number of training samples
@@ -310,15 +309,15 @@ static void print_version(void) {
 
 /* --------------------------------------------- */
 static void check_options(void) {
-  if (!testDir) {
+  if (testDir.empty()) {
     cout << "ERROR: Must specify test subject directory" << endl;
     exit(1);
   }
-  if (!trainListFile) {
+  if (trainListFile.empty()) {
     cout << "ERROR: Must specify training subject list file" << endl;
     exit(1);
   }
-  if (!maskFile) {
+  if (maskFile.empty()) {
     cout << "ERROR: Must specify brain mask volume" << endl;
     exit(1);
   }
@@ -354,13 +353,15 @@ static void dump_options() {
     cout << " " << *istr;
   cout << endl;
 
-  if (asegFile)
+  if (!asegFile.empty()) {
     cout << "Location of aparc+aseg's relative to subject directory: "
          << asegFile << endl;
+  }
 
-  if (orientFile)
+  if (!orientFile.empty()) {
     cout << "Location of diffusion orientations relative to subject directory: "
          << orientFile << endl;
+  }
 
   return;
 }

--- a/trc/dmri_group.cxx
+++ b/trc/dmri_group.cxx
@@ -68,7 +68,7 @@ const char *Progname = "dmri_group";
 
 int nSection = 0;
 
-char *inListFile = NULL, *outRefFile = NULL, *outBase = NULL;
+std::string inListFile, outRefFile, outBase;
 
 struct utsname uts;
 char *cmdline, cwd[2000];
@@ -123,9 +123,9 @@ int main(int argc, char **argv) {
   cputimer.reset();
 
   // Read output reference volume
-  if (outRefFile) {
+  if (!outRefFile.empty()) {
     cout << "Loading output reference volume from " << outRefFile << endl;
-    outref = MRIread(outRefFile);
+    outref = MRIread(outRefFile.c_str());
     if (!outref) {
       cout << "ERROR: Could not read " << outRefFile << endl;
       exit(1);
@@ -864,11 +864,11 @@ static void print_version(void) {
 
 /* --------------------------------------------- */
 static void check_options(void) {
-  if (!outBase) {
+  if (outBase.empty()) {
     cout << "ERROR: must specify base name for output files" << endl;
     exit(1);
   }
-  if (!inListFile) {
+  if (inListFile.empty()) {
     cout << "ERROR: must specify input list file" << endl;
     exit(1);
   }

--- a/trc/dmri_mergepaths.cxx
+++ b/trc/dmri_mergepaths.cxx
@@ -65,7 +65,8 @@ const char *Progname = "dmri_mergepaths";
 
 int nframe = 0;
 float dispThresh = 0;
-char *inDir = NULL, *inFile[100], *outFile = NULL, *ctabFile = NULL;
+std::string inDir, outFile, ctabFile;
+std::vector<std::string> inFile;
 
 struct utsname uts;
 char *cmdline, cwd[2000];
@@ -75,7 +76,7 @@ Timer cputimer;
 /*--------------------------------------------------*/
 int main(int argc, char **argv) {
   int nargs, cputime;
-  char fname[PATH_MAX];
+  std::string fname;
   MRI *invol = 0, *outvol = 0;
 
   nargs = handleVersionOption(argc, argv, "dmri_mergepaths");
@@ -107,12 +108,13 @@ int main(int argc, char **argv) {
     cout << "Merging volume " << iframe+1 << " of " << nframe << "... " << endl;
 
     // Read input volume
-    if (inDir)
-      sprintf(fname, "%s/%s", inDir, inFile[iframe]);
-    else
-      strcpy(fname, inFile[iframe]);
+    if (!inDir.empty()) {
+      fname = inDir + "/" + inFile.at(iframe);
+    } else {
+      fname = inFile.at(iframe);
+    }
 
-    invol = MRIread(fname);
+    invol = MRIread(fname.c_str());
 
     if (invol) {
       if (!outvol) {
@@ -120,13 +122,14 @@ int main(int argc, char **argv) {
         outvol = MRIcloneBySpace(invol, invol->type, nframe);
 
         // Read color table
-        outvol->ct = CTABreadASCII(ctabFile);
+        outvol->ct = CTABreadASCII(ctabFile.c_str());
       }
 
       MRIcopyFrame(invol, outvol, 0, iframe);
 
-      if (dispThresh > 0)
+      if (dispThresh > 0) {
         inmax = (float) MRIfindPercentile(invol, .99, 0);	// Robust max
+      }
     }
 
     outvol->frames[iframe].thresh = dispThresh * inmax;
@@ -136,7 +139,7 @@ int main(int argc, char **argv) {
     for (int ict = outvol->ct->nentries; ict > 0; ict--) {
       CTE *cte = outvol->ct->entries[ict];
 
-      if (cte != NULL && strstr(inFile[iframe], cte->name)) {
+      if (cte != NULL && strstr(inFile.at(iframe).c_str(), cte->name)) {
         outvol->frames[iframe].label = ict;
         strcpy(outvol->frames[iframe].name, cma_label_to_name(ict));
 
@@ -149,9 +152,9 @@ int main(int argc, char **argv) {
   }
 
   // Write output file
-  if (outvol)
-    MRIwrite(outvol, outFile);
-  else {
+  if (outvol) {
+    MRIwrite(outvol, outFile.c_str());
+  } else {
     cout << "ERROR: could not open any of the input files" << endl;
     exit(1);
   }
@@ -195,7 +198,7 @@ static int parse_commandline(int argc, char **argv) {
       if (nargc < 1) CMDargNErr(option,1);
       nargsused = 0;
       while (nargsused < nargc && strncmp(pargv[nargsused], "--", 2)) {
-        inFile[nframe] = pargv[nargsused];
+        inFile.push_back( std::string(pargv[nargsused]) );
         nargsused++;
         nframe++;
       }
@@ -281,11 +284,11 @@ static void check_options(void) {
     printf("ERROR: must specify input volume(s)\n");
     exit(1);
   }
-  if(!outFile) {
+  if(outFile.empty()) {
     printf("ERROR: must specify output volume\n");
     exit(1);
   }
-  if(!ctabFile) {
+  if(ctabFile.empty()) {
     printf("ERROR: must specify color table file\n");
     exit(1);
   }
@@ -307,14 +310,16 @@ static void dump_options(FILE *fp) {
   fprintf(fp,"machine  %s\n",uts.machine);
   fprintf(fp,"user     %s\n",VERuser());
 
-  if (inDir)
-    fprintf(fp, "Input directory: %s\n", inDir);
+  if (!inDir.empty()) {
+    fprintf(fp, "Input directory: %s\n", inDir.c_str());
+  }
   fprintf(fp, "Input files:");
-  for (int k = 0; k < nframe; k++)
-    fprintf(fp, " %s", inFile[k]);
+  for (int k = 0; k < nframe; k++) {
+    fprintf(fp, " %s", inFile[k].c_str());
+  }
   fprintf(fp, "\n");
-  fprintf(fp, "Output file: %s\n", outFile);
-  fprintf(fp, "Color table file: %s\n", ctabFile);
+  fprintf(fp, "Output file: %s\n", outFile.c_str());
+  fprintf(fp, "Color table file: %s\n", ctabFile.c_str());
   fprintf(fp, "Lower threshold for display: %f\n", dispThresh);
 
   return;

--- a/trc/dmri_motion.cxx
+++ b/trc/dmri_motion.cxx
@@ -68,8 +68,8 @@ const char *Progname = "dmri_motion";
 
 float T = 100, D = .001;
 
-vector<char *> inDwiList, inBvalList;
-char *inMatFile = NULL, *outFile = NULL, *outFrameFile = NULL;
+vector<std::string> inDwiList, inBvalList;
+std::string inMatFile, outFile, outFrameFile;
 
 MRI *dwi;
 
@@ -125,7 +125,7 @@ int main(int argc, char **argv) {
  
       // Read DWI volume series
       cout << "Loading DWI volume series from " << inDwiList[irun] << endl;
-      dwi = MRIread(inDwiList[irun]);
+      dwi = MRIread(inDwiList[irun].c_str());
       if (!dwi) {
         cout << "ERROR: Could not read " << inDwiList[irun] << endl;
         exit(1);
@@ -245,7 +245,7 @@ int main(int argc, char **argv) {
       score = 1;
   }
 
-  if (inMatFile) {		// Estimate between-volume motion
+  if (!inMatFile.empty()) {		// Estimate between-volume motion
     bool isMat;
     int nframe = 0;
     vector<float> xform, tr(3,0), ro(3,0), tr0(3,0), ro0(3,0),
@@ -377,7 +377,7 @@ int main(int argc, char **argv) {
   outfile.close();
 
   // Write frame-by-frame measures to file
-  if (outFrameFile) {
+  if (!outFrameFile.empty()) {
     vector<float>::const_iterator itr, iro, iscore;
 
     if (trframe.empty()) 
@@ -584,7 +584,7 @@ static void print_version(void) {
 
 /* --------------------------------------------- */
 static void check_options(void) {
-  if (!outFile) {
+  if (outFile.empty()) {
     cout << "ERROR: must specify output file" << endl;
     exit(1);
   }
@@ -592,7 +592,7 @@ static void check_options(void) {
     cout << "ERROR: must specify equal numbers of DWI and b-value files" << endl;
     exit(1);
   }
-  if (inBvalList.empty() && !inMatFile) {
+  if (inBvalList.empty() && inMatFile.empty()) {
     cout << "ERROR: must specify inputs for between-volume and/or "
          << "within-volume motion measures" << endl;
     exit(1);
@@ -616,24 +616,26 @@ static void dump_options() {
 
   cout << "Output motion measure file: " << outFile << endl;
 
-  if (outFrameFile)
+  if (!outFrameFile.empty()) {
     cout << "Output frame-by-frame motion measure file: " << outFrameFile
          << endl;
+  }
 
-  if (inMatFile)
+  if (!inMatFile.empty()) {
     cout << "Input transform file: " << inMatFile << endl;
+  }
 
   if (!inDwiList.empty()) {
     cout << "Input DWI file(s):";
-    for (vector<char *>::const_iterator ifile = inDwiList.begin();
-                                        ifile < inDwiList.end(); ifile++)
+    for (auto ifile = inDwiList.begin(); ifile < inDwiList.end(); ifile++) {
       cout << " " << *ifile;
+    }
     cout << endl;
 
     cout << "Input b-value table(s):";
-    for (vector<char *>::const_iterator ifile = inBvalList.begin();
-                                        ifile < inBvalList.end(); ifile++)
+    for (auto ifile = inBvalList.begin(); ifile < inBvalList.end(); ifile++) {
       cout << " " << *ifile;
+    }
     cout << endl;
 
     cout << "Low-b image intensity threshold: " << T << endl;

--- a/trc/dmri_paths.cxx
+++ b/trc/dmri_paths.cxx
@@ -68,11 +68,9 @@ unsigned int nTract = 1,
              nBurnIn = 5000, nSample = 5000, nKeepSample = 10, nUpdateProp = 40,
              localPriorSet = 15, neighPriorSet = 14;
 float fminPath = 0;
-char *dwiFile = NULL, *gradFile = NULL, *bvalFile = NULL,
-     *maskFile = NULL, *bedpostDir = NULL,
-     *baseXfmFile = NULL, *baseMaskFile = NULL,
-     *affineXfmFile = NULL, *nonlinXfmFile = NULL;
-vector<char *> outDir, inDirList, initFile, roiFile1, roiFile2,
+std::string dwiFile, gradFile, bvalFile, maskFile, bedpostDir,
+  baseXfmFile, baseMaskFile, affineXfmFile, nonlinXfmFile;
+vector<std::string> outDir, inDirList, initFile, roiFile1, roiFile2,
                roiMeshFile1, roiMeshFile2, roiRefFile1, roiRefFile2,
                xyzPriorFile0, xyzPriorFile1, tangPriorFile, curvPriorFile,
                neighPriorFile, neighIdFile, localPriorFile, localIdFile,
@@ -131,51 +129,51 @@ int main(int argc, char **argv) {
                   baseXfmFile, baseMaskFile,
                   initFile[0],
                   roiFile1[0], roiFile2[0],
-                  strstr(roiFile1[0], ".label") ? roiMeshFile1[ilab1] : 0,
-                  strstr(roiFile2[0], ".label") ? roiMeshFile2[ilab2] : 0,
-                  strstr(roiFile1[0], ".label") ? roiRefFile1[ilab1] : 0,
-                  strstr(roiFile2[0], ".label") ? roiRefFile2[ilab2] : 0,
-                  doxyzprior ? xyzPriorFile0[0] : 0,
-                  doxyzprior ? xyzPriorFile1[0] : 0,
-                  dotangprior ? tangPriorFile[0] : 0,
-                  docurvprior ? curvPriorFile[0] : 0,
-                  doneighprior ? neighPriorFile[0] : 0,
-                  doneighprior ? neighIdFile[0] : 0,
+                  strstr(roiFile1[0].c_str(), ".label") ? roiMeshFile1[ilab1] : std::string(),
+                  strstr(roiFile2[0].c_str(), ".label") ? roiMeshFile2[ilab2] : std::string(),
+                  strstr(roiFile1[0].c_str(), ".label") ? roiRefFile1[ilab1] : std::string(),
+                  strstr(roiFile2[0].c_str(), ".label") ? roiRefFile2[ilab2] : std::string(),
+                  doxyzprior ? xyzPriorFile0[0] : std::string(),
+                  doxyzprior ? xyzPriorFile1[0] : std::string(),
+                  dotangprior ? tangPriorFile[0] : std::string(),
+                  docurvprior ? curvPriorFile[0] : std::string(),
+                  doneighprior ? neighPriorFile[0] : std::string(),
+                  doneighprior ? neighIdFile[0] : std::string(),
                   doneighprior ? neighPriorSet : 0,
-                  dolocalprior ? localPriorFile[0] : 0,
-                  dolocalprior ? localIdFile[0] : 0,
+                  dolocalprior ? localPriorFile[0] : std::string(),
+                  dolocalprior ? localIdFile[0] : std::string(),
                   dolocalprior ? localPriorSet : 0,
                   asegList,
                   affineXfmFile, nonlinXfmFile,
                   nBurnIn, nSample, nKeepSample, nUpdateProp,
-                  dopropinit ? stdPropFile[0] : 0,
+                  dopropinit ? stdPropFile[0] : std::string(),
                   debug);
 
-  if (strstr(roiFile1[0], ".label")) ilab1++;
-  if (strstr(roiFile2[0], ".label")) ilab2++;
+  if (strstr(roiFile1[0].c_str(), ".label")) ilab1++;
+  if (strstr(roiFile2[0].c_str(), ".label")) ilab2++;
 
   for (unsigned int iout = 0; iout < outDir.size(); iout++) {
     if (iout > 0) {
       mycoffin.SetOutputDir(outDir[iout]);
       mycoffin.SetPathway(initFile[iout],
-                  roiFile1[iout], roiFile2[iout],
-                  strstr(roiFile1[iout], ".label") ? roiMeshFile1[ilab1] : 0,
-                  strstr(roiFile2[iout], ".label") ? roiMeshFile2[ilab2] : 0,
-                  strstr(roiFile1[iout], ".label") ? roiRefFile1[ilab1] : 0,
-                  strstr(roiFile2[iout], ".label") ? roiRefFile2[ilab2] : 0,
-                  doxyzprior ? xyzPriorFile0[iout] : 0,
-                  doxyzprior ? xyzPriorFile1[iout] : 0,
-                  dotangprior ? tangPriorFile[iout] : 0,
-                  docurvprior ? curvPriorFile[iout] : 0,
-                  doneighprior ? neighPriorFile[iout] : 0,
-                  doneighprior ? neighIdFile[iout] : 0,
-                  dolocalprior ? localPriorFile[iout] : 0,
-                  dolocalprior ? localIdFile[iout] : 0);
+			  roiFile1[iout], roiFile2[iout],
+			  strstr(roiFile1[iout].c_str(), ".label") ? roiMeshFile1[ilab1] : std::string(),
+			  strstr(roiFile2[iout].c_str(), ".label") ? roiMeshFile2[ilab2] : std::string(),
+			  strstr(roiFile1[iout].c_str(), ".label") ? roiRefFile1[ilab1] : std::string(),
+			  strstr(roiFile2[iout].c_str(), ".label") ? roiRefFile2[ilab2] : std::string(),
+			  doxyzprior ? xyzPriorFile0[iout] : std::string(),
+			  doxyzprior ? xyzPriorFile1[iout] : std::string(),
+			  dotangprior ? tangPriorFile[iout] : std::string(),
+			  docurvprior ? curvPriorFile[iout] : std::string(),
+			  doneighprior ? neighPriorFile[iout] : std::string(),
+			  doneighprior ? neighIdFile[iout] : std::string(),
+			  dolocalprior ? localPriorFile[iout] : std::string(),
+			  dolocalprior ? localIdFile[iout] : std::string());
       mycoffin.SetMcmcParameters(nBurnIn, nSample, nKeepSample, nUpdateProp,
-                  dopropinit ? stdPropFile[iout] : 0);
+				 dopropinit ? stdPropFile[iout] : std::string());
 
-      if (strstr(roiFile1[iout], ".label")) ilab1++;
-      if (strstr(roiFile2[iout], ".label")) ilab2++;
+      if (strstr(roiFile1.at(iout).c_str(), ".label")) ilab1++;
+      if (strstr(roiFile2.at(iout).c_str(), ".label")) ilab2++;
     }
 
     cout << "Processing pathway " << iout+1 << " of " << outDir.size() << "..."
@@ -183,10 +181,11 @@ int main(int argc, char **argv) {
     cputimer.reset();
 
     //if (mycoffin.RunMcmcFull())
-    if (mycoffin.RunMcmcSingle())
+    if (mycoffin.RunMcmcSingle()) {
       mycoffin.WriteOutputs();
-    else
+    } else {
       cout << "ERROR: Pathway reconstruction failed" << endl;
+    }
 
     cputime = cputimer.milliseconds();
     printf("Done in %g sec.\n", cputime/1000.0);
@@ -285,7 +284,7 @@ static int parse_commandline(int argc, char **argv) {
       nargsused = 0;
       while (nargsused < nargc && strncmp(pargv[nargsused], "--", 2)) {
         roiFile1.push_back(fio_fullpath(pargv[nargsused]));
-        if(strstr(*(roiFile1.end()-1), ".label"))
+        if(strstr(roiFile1.back().c_str(), ".label"))
           nlab1++;
         nargsused++;
       }
@@ -295,7 +294,7 @@ static int parse_commandline(int argc, char **argv) {
       nargsused = 0;
       while (nargsused < nargc && strncmp(pargv[nargsused], "--", 2)) {
         roiFile2.push_back(fio_fullpath(pargv[nargsused]));
-        if(strstr(*(roiFile2.end()-1), ".label"))
+        if(strstr(roiFile2.back().c_str(), ".label"))
           nlab2++;
         nargsused++;
       }
@@ -578,23 +577,23 @@ static void check_options(void) {
     cout << "ERROR: Must specify output directory" << endl;
     exit(1);
   }
-  if (!dwiFile) {
+  if (dwiFile.empty()) {
     cout << "ERROR: Must specify DWI volume series" << endl;
     exit(1);
   }
-  if (!gradFile) {
+  if (gradFile.empty()) {
     cout << "ERROR: Must specify gradient text file" << endl;
     exit(1);
   }
-  if (!bvalFile) {
+  if (bvalFile.empty()) {
     cout << "ERROR: Must specify b-value text file" << endl;
     exit(1);
   }
-  if (!maskFile) {
+  if (maskFile.empty()) {
     cout << "ERROR: Must specify mask volume" << endl;
     exit(1);
   }
-  if (!bedpostDir) {
+  if (bedpostDir.empty()) {
     cout << "ERROR: Must specify BEDPOST directory" << endl;
     exit(1);
   }
@@ -666,7 +665,7 @@ static void check_options(void) {
 
 /* --------------------------------------------- */
 static void dump_options() {
-  vector<char *>::const_iterator istr;
+  vector<std::string>::const_iterator istr;
 
   cout << endl
        << getVersion() << endl
@@ -684,8 +683,9 @@ static void dump_options() {
 
   if (!inDirList.empty()) {
     cout << "Input directory:";
-    for (istr = inDirList.begin(); istr < inDirList.end(); istr++)
+    for (istr = inDirList.begin(); istr < inDirList.end(); istr++) {
       cout << " " << *istr;
+    }
     cout << endl;
   }
 
@@ -698,65 +698,76 @@ static void dump_options() {
        << "Tract volume fraction threshold: " << fminPath << endl;
 
   cout << "Initial control point file:";
-  for (istr = initFile.begin(); istr < initFile.end(); istr++)
+  for (istr = initFile.begin(); istr < initFile.end(); istr++) {
     cout << " " << *istr;
+  }
   cout << endl;
 
   cout << "End ROI 1:";
-  for (istr = roiFile1.begin(); istr < roiFile1.end(); istr++)
+  for (istr = roiFile1.begin(); istr < roiFile1.end(); istr++) {
     cout << " " << *istr;
+  }
   cout << endl;
 
   if (nlab1 > 0) {
     cout << "End ROI 1 mesh:";
-    for (istr = roiMeshFile1.begin(); istr < roiMeshFile1.end(); istr++)
+    for (istr = roiMeshFile1.begin(); istr < roiMeshFile1.end(); istr++) {
       cout << " " << *istr;
+    }
     cout << endl;
 
     cout << "End ROI 1 reference volume:";
-    for (istr = roiRefFile1.begin(); istr < roiRefFile1.end(); istr++)
+    for (istr = roiRefFile1.begin(); istr < roiRefFile1.end(); istr++) {
       cout << " " << *istr;
+    }
     cout << endl;
   }
 
   cout << "End ROI 2:";
-  for (istr = roiFile2.begin(); istr < roiFile2.end(); istr++)
+  for (istr = roiFile2.begin(); istr < roiFile2.end(); istr++) {
     cout << " " << *istr;
+  }
   cout << endl;
 
   if (nlab2 > 0) {
     cout << "End ROI 2 mesh:";
-    for (istr = roiMeshFile2.begin(); istr < roiMeshFile2.end(); istr++)
+    for (istr = roiMeshFile2.begin(); istr < roiMeshFile2.end(); istr++) {
       cout << " " << *istr;
+    }
     cout << endl;
 
     cout << "End ROI 2 reference volume:";
-    for (istr = roiRefFile2.begin(); istr < roiRefFile2.end(); istr++)
+    for (istr = roiRefFile2.begin(); istr < roiRefFile2.end(); istr++) {
       cout << " " << *istr;
+    }
     cout << endl;
   }
 
   if (!xyzPriorFile0.empty()) {
     cout << "Spatial prior (off path):";
-    for (istr = xyzPriorFile0.begin(); istr < xyzPriorFile0.end(); istr++)
+    for (istr = xyzPriorFile0.begin(); istr < xyzPriorFile0.end(); istr++) {
       cout << " " << *istr;
+    }
     cout << endl;
 
     cout << "Spatial prior (on path):";
-    for (istr = xyzPriorFile1.begin(); istr < xyzPriorFile1.end(); istr++)
+    for (istr = xyzPriorFile1.begin(); istr < xyzPriorFile1.end(); istr++) {
       cout << " " << *istr;
+    }
     cout << endl;
   }
 
   if (!neighPriorFile.empty()) {
     cout << "Neighbor aseg prior:";
-    for (istr = neighPriorFile.begin(); istr < neighPriorFile.end(); istr++)
+    for (istr = neighPriorFile.begin(); istr < neighPriorFile.end(); istr++) {
       cout << " " << *istr;
+    }
     cout << endl;
 
     cout << "Neighbor aseg label ID list:";
-    for (istr = neighIdFile.begin(); istr < neighIdFile.end(); istr++)
+    for (istr = neighIdFile.begin(); istr < neighIdFile.end(); istr++) {
       cout << " " << *istr;
+    }
     cout <<  endl;
 
     cout << "Neighbor aseg prior set: " << neighPriorSet << endl;
@@ -764,13 +775,15 @@ static void dump_options() {
 
   if (!localPriorFile.empty()) {
     cout << "Local aseg prior:";
-    for (istr = localPriorFile.begin(); istr < localPriorFile.end(); istr++)
+    for (istr = localPriorFile.begin(); istr < localPriorFile.end(); istr++) {
       cout << " " << *istr;
+    }
     cout  << endl;
 
     cout << "Local aseg label ID list:";
-    for (istr = localIdFile.begin(); istr < localIdFile.end(); istr++)
+    for (istr = localIdFile.begin(); istr < localIdFile.end(); istr++) {
       cout << " " << *istr;
+    }
     cout  << endl;
 
     cout << "Local aseg prior set: " << localPriorSet << endl;
@@ -778,16 +791,19 @@ static void dump_options() {
 
   if (!asegList.empty()) {
     cout << "Segmentation map: ";
-    for (istr = asegList.begin(); istr < asegList.end(); istr++)
+    for (istr = asegList.begin(); istr < asegList.end(); istr++) {
       cout << " " << *istr;
+    }
     cout  << endl;
   }
 
-  if (affineXfmFile)
+  if (!affineXfmFile.empty()) {
     cout << "DWI-to-atlas affine registration: " << affineXfmFile << endl;
+  }
 
-  if (nonlinXfmFile)
+  if (!nonlinXfmFile.empty()) {
     cout << "DWI-to-atlas nonlinear registration: " << nonlinXfmFile << endl;
+  }
 
   cout << "Number of burn-in samples: " << nBurnIn << endl
        << "Number of post-burn-in samples: " << nSample << endl
@@ -796,8 +812,9 @@ static void dump_options() {
 
   if (!stdPropFile.empty()) {
     cout << "Initial proposal SD file:";
-    for (istr = stdPropFile.begin(); istr < stdPropFile.end(); istr++)
+    for (istr = stdPropFile.begin(); istr < stdPropFile.end(); istr++) {
       cout << " " << *istr;
+    }
     cout << endl;
   }
 

--- a/trc/dmri_spline.cxx
+++ b/trc/dmri_spline.cxx
@@ -65,8 +65,7 @@ int main(int argc, char *argv[]);
 const char *Progname = "dmri_spline";
 
 bool showControls = false;
-char *inFile = NULL, *maskFile = NULL,
-     *outVolFile = NULL, *outTextFile = NULL, *outVecBase = NULL;
+std::string inFile, outVolFile, outVecBase, maskFile, outTextFile;
 
 struct utsname uts;
 char *cmdline, cwd[2000];
@@ -98,7 +97,7 @@ int main(int argc, char **argv) {
 
   dump_options();
 
-  Spline myspline(inFile, maskFile);
+  Spline myspline(inFile.c_str(), maskFile.c_str());
 
   printf("Computing spline...\n");
   cputimer.reset();
@@ -108,14 +107,16 @@ int main(int argc, char **argv) {
   cputime = cputimer.milliseconds();
   printf("Done in %g sec.\n", cputime/1000.0);
 
-  if (outVolFile)
-    myspline.WriteVolume(outVolFile, showControls);
+  if (!outVolFile.empty() ) {
+    myspline.WriteVolume(outVolFile.c_str(), showControls);
+  }
 
-  if (outTextFile)
-    myspline.WriteAllPoints(outTextFile);
+  if (!outTextFile.empty()) {
+    myspline.WriteAllPoints(outTextFile.c_str());
+  }
 
-  if (outVecBase) {
-    char fname[PATH_MAX];
+  if (!outVecBase.empty()) {
+    std::string fname;
 
     printf("Computing analytical tangent, normal, and curvature...\n");
     cputimer.reset();
@@ -128,12 +129,12 @@ int main(int argc, char **argv) {
     printf("Done in %g sec.\n", cputime/1000.0);
 
     // Write tangent, normal, and curvature (analytical) to text files
-    sprintf(fname, "%s_tang.txt", outVecBase);
-    myspline.WriteTangent(fname);
-    sprintf(fname, "%s_norm.txt", outVecBase);
-    myspline.WriteNormal(fname);
-    sprintf(fname, "%s_curv.txt", outVecBase);
-    myspline.WriteCurvature(fname);
+    fname = outVecBase + "_tang.txt";
+    myspline.WriteTangent(fname.c_str());
+    fname = outVecBase + "_norm.txt";
+    myspline.WriteNormal(fname.c_str());
+    fname = outVecBase + "_curv.txt";
+    myspline.WriteCurvature(fname.c_str());
 
     printf("Computing discrete tangent, normal, and curvature...\n");
     cputimer.reset();
@@ -146,12 +147,12 @@ int main(int argc, char **argv) {
     printf("Done in %g sec.\n", cputime/1000.0);
 
     // Write tangent, normal, and curvature (discrete) to text files
-    sprintf(fname, "%s_tang_diff.txt", outVecBase);
-    myspline.WriteTangent(fname);
-    sprintf(fname, "%s_norm_diff.txt", outVecBase);
-    myspline.WriteNormal(fname);
-    sprintf(fname, "%s_curv_diff.txt", outVecBase);
-    myspline.WriteCurvature(fname);
+    fname = outVecBase + "_tang_diff.txt";
+    myspline.WriteTangent(fname.c_str());
+    fname = outVecBase + "_norm_diff.txt";
+    myspline.WriteNormal(fname.c_str());
+    fname = outVecBase + "_curv_diff.txt";
+    myspline.WriteCurvature(fname.c_str());
   }
 
   printf("dmri_spline done\n");
@@ -275,15 +276,15 @@ static void print_version(void) {
 
 /* --------------------------------------------- */
 static void check_options(void) {
-  if(!inFile) {
+  if(inFile.size() == 0) {
     cout << "ERROR: Must specify input text file" << endl;
     exit(1);
   }
-  if(!maskFile) {
+  if(maskFile.size() == 0) {
     cout << "ERROR: Must specify mask volume" << endl;
     exit(1);
   }
-  if(!outVolFile && !outTextFile && !outVecBase) {
+  if((outVolFile.size() + outTextFile.size() + outVecBase.size()) == 0) {
     cout << "ERROR: Must specify at least one type of output file" << endl;
     exit(1);
   }
@@ -303,14 +304,16 @@ static void dump_options() {
 
   cout << "Control points: " << inFile << endl;
   cout << "Mask volume: " << maskFile << endl;
-  if (outVolFile) {
+  if (outVolFile.size() != 0) {
     cout << "Output volume: " << outVolFile << endl
          << "Show controls: " << showControls << endl;
   }
-  if (outTextFile)
+  if (outTextFile.size() != 0) {
     cout << "Output text file: " << outTextFile << endl;
-  if (outVecBase)
+  }
+  if (outVecBase.size() != 0 ) {
     cout << "Output tangent vector file base name: " << outVecBase << endl;
+  }
 
   return;
 }

--- a/trc/dmri_train.cxx
+++ b/trc/dmri_train.cxx
@@ -65,13 +65,12 @@ const char *Progname = "dmri_train";
 
 bool useTrunc = false, excludeStr = false;
 vector<float> trainMaskLabel;
-vector< vector<int> > nControl;
-vector<char *> outBase, trainTrkList, trainRoi1List, trainRoi2List,
+vector<vector<int>> nControl;
+vector<std::string> outBase, trainTrkList, trainRoi1List, trainRoi2List,
                testMaskList, testFaList, testBaseXfmList;
-char *outDir = NULL, *outTestDir = NULL,
-     *trainListFile = NULL, *trainAsegFile = NULL, *trainMaskFile = NULL,
-     *testAffineXfmFile = NULL, *testNonlinXfmFile = NULL,
-     *testNonlinRefFile = NULL, *testBaseMaskFile = NULL;
+std::string outDir, outTestDir, trainListFile,
+  trainAsegFile, trainMaskFile, testAffineXfmFile,
+  testNonlinXfmFile, testNonlinRefFile, testBaseMaskFile;
 
 struct utsname uts;
 char *cmdline, cwd[2000];
@@ -81,7 +80,7 @@ Timer cputimer;
 /*--------------------------------------------------*/
 int main(int argc, char **argv) {
   int nargs, cputime;
-  char excfile[PATH_MAX], fbase[PATH_MAX];
+  std::string excfile, fbase;
 
   nargs = handleVersionOption(argc, argv, "dmri_train");
   if (nargs && argc - nargs == 1) exit (0);
@@ -105,18 +104,19 @@ int main(int argc, char **argv) {
   dump_options();
 
   if (excludeStr) {
-      if (outDir)
-	sprintf(excfile, "%s/%s_cpts_all.bad.txt", outDir, outBase[0]);
-      else
-	sprintf(excfile, "%s_cpts_all.bad.txt", outBase[0]);
+    if (!outDir.empty()) {
+      excfile = outDir + '/' + outBase.at(0) + "_cpts_all.bad.txt";
+    } else {
+      excfile = outBase.at(0) + "_cpts_all.bad.txt";
+    }
   }
   
   Blood myblood(trainListFile, trainTrkList[0],
-                trainRoi1List.size() ? trainRoi1List[0] : 0,
-                trainRoi2List.size() ? trainRoi2List[0] : 0,
+                trainRoi1List.size() ? trainRoi1List[0] : std::string(),
+                trainRoi2List.size() ? trainRoi2List[0] : std::string(),
                 trainAsegFile, trainMaskFile,
-                trainMaskLabel.size() ? trainMaskLabel[0] : 0,
-                excludeStr ? excfile : 0,
+                trainMaskLabel.size() ? trainMaskLabel[0] : 0.0f,
+                excludeStr ? excfile : std::string(),
                 testMaskList, testFaList,
                 testAffineXfmFile, testNonlinXfmFile, testNonlinRefFile,
                 testBaseXfmList, testBaseMaskFile,
@@ -126,10 +126,11 @@ int main(int argc, char **argv) {
   for (unsigned int itrk = 0; itrk < trainTrkList.size(); itrk++) {
     if (itrk > 0) {
       if (excludeStr) {
-        if (outDir)
-          sprintf(excfile, "%s/%s_cpts_all.bad.txt", outDir, outBase[itrk]);
-        else
-          sprintf(excfile, "%s_cpts_all.bad.txt", outBase[itrk]);
+        if (!outDir.empty()) {
+	  excfile = outDir + '/' + outBase.at(itrk) + "_cpts_all.bad.txt";
+        } else {
+	  excfile = outBase.at(itrk) + "_cpts_all.bad.txt";
+	}
       }
 
       if (nControl.size() > 1)		// Variable number of controls
@@ -148,20 +149,21 @@ int main(int argc, char **argv) {
 
     myblood.ComputePriors();
 
-    if (outDir)
-      sprintf(fbase, "%s/%s", outDir, outBase[itrk]);
-    else
-      strcpy(fbase, outBase[itrk]);
-
-    if (outTestDir) {
-      char ftbase[PATH_MAX];
-
-      sprintf(ftbase, "%s/%s", outTestDir, outBase[itrk]);
-
-      myblood.WriteOutputs(fbase, ftbase);
+    if (!outDir.empty()) {
+      fbase = outDir + '/' + outBase.at(itrk);
+    } else {
+      fbase = outBase.at(itrk);
     }
-    else
-      myblood.WriteOutputs(fbase);
+
+    if (!outTestDir.empty()) {
+      std::string ftbase;
+
+      ftbase = outTestDir + outBase.at(itrk);
+      myblood.WriteOutputs(fbase.c_str(), ftbase.c_str());
+    }
+    else {
+      myblood.WriteOutputs(fbase.c_str());
+    }
 
     cputime = cputimer.milliseconds();
     cout << "Done in " << cputime/1000.0 << " sec." << endl;
@@ -409,7 +411,7 @@ static void check_options(void) {
     cout << "ERROR: Must specify at least one output name" << endl;
     exit(1);
   }
-  if (!trainListFile) {
+  if (trainListFile.empty()) {
     cout << "ERROR: Must specify training subject list file" << endl;
     exit(1);
   }
@@ -423,11 +425,11 @@ static void check_options(void) {
          << endl;
     exit(1);
   }
-  if (!trainAsegFile) {
+  if (trainAsegFile.empty()) {
     cout << "ERROR: Must specify location of aparc+aseg volume" << endl;
     exit(1);
   }
-  if (!trainMaskFile) {
+  if (trainMaskFile.empty()) {
     cout << "ERROR: Must specify location of cortex mask volume" << endl;
     exit(1);
   }
@@ -465,12 +467,12 @@ static void check_options(void) {
          << endl;
     exit(1);
   }
-  if (testNonlinXfmFile && !testNonlinRefFile) {
+  if ((!testNonlinXfmFile.empty()) && testNonlinRefFile.empty()) {
     cout << "ERROR: Must specify source reference volume for nonlinear warp"
          << endl;
     exit(1);
   }
-  if (!testBaseXfmList.empty() && !testBaseMaskFile) {
+  if (!testBaseXfmList.empty() && testBaseMaskFile.empty()) {
     cout << "ERROR: Must specify reference volume for base space" << endl;
     exit(1);
   }
@@ -485,7 +487,7 @@ static void check_options(void) {
 
 /* --------------------------------------------- */
 static void dump_options() {
-  vector<char *>::const_iterator istr;
+  vector<std::string>::const_iterator istr;
 
   cout << endl
        << getVersion() << endl
@@ -496,33 +498,39 @@ static void dump_options() {
        << "machine  " << uts.machine << endl
        << "user     " << VERuser() << endl;
 
-  if (outDir)
+  if (!outDir.empty()) {
     cout << "Output directory: " << outDir << endl;
+  }
 
-  if (outTestDir)
+  if (!outTestDir.empty()) {
     cout << "Output directory in test subject's space: " << outTestDir << endl;
+  }
 
   cout << "Output base:";
-  for (istr = outBase.begin(); istr < outBase.end(); istr++)
+  for (istr = outBase.begin(); istr < outBase.end(); istr++) {
     cout << " " << *istr;
+  }
   cout << endl;
 
   cout << "Training subject directory list: " << trainListFile << endl;
 
   cout << "Location of streamline files relative to base:";
-  for (istr = trainTrkList.begin(); istr < trainTrkList.end(); istr++)
+  for (istr = trainTrkList.begin(); istr < trainTrkList.end(); istr++) {
     cout << " " << *istr;
+  }
   cout << endl;
 
   if (!trainRoi1List.empty()) {
     cout << "Location of start ROI files relative to base:";
-    for (istr = trainRoi1List.begin(); istr < trainRoi1List.end(); istr++)
+    for (istr = trainRoi1List.begin(); istr < trainRoi1List.end(); istr++) {
       cout << " " << *istr;
+    }
     cout << endl;
 
     cout << "Location of end ROI files relative to base:";
-    for (istr = trainRoi2List.begin(); istr < trainRoi2List.end(); istr++)
+    for (istr = trainRoi2List.begin(); istr < trainRoi2List.end(); istr++) {
       cout << " " << *istr;
+    }
     cout << endl;
   }
 
@@ -532,8 +540,9 @@ static void dump_options() {
   if (!trainMaskLabel.empty()) {
     cout << "Label ID's from aparc+aseg to add to cortex mask:";
     for (vector<float>::const_iterator ilab = trainMaskLabel.begin();
-                                       ilab < trainMaskLabel.end(); ilab++)
+	 ilab < trainMaskLabel.end(); ilab++) {
       cout << " " << (int) *ilab;
+    }
     cout << endl;
   }
 
@@ -541,48 +550,57 @@ static void dump_options() {
        << endl;
 
   cout << "Brain mask for output subject:";
-  for (vector<char *>::const_iterator ifile = testMaskList.begin();
-                                      ifile < testMaskList.end(); ifile++)
+  for (auto ifile = testMaskList.begin();
+       ifile < testMaskList.end(); ifile++) {
     cout << " " << *ifile;
+  }
   cout << endl;
 
   if (!testFaList.empty()) {
     cout << "FA map for output subject:";
-    for (vector<char *>::const_iterator ifile = testFaList.begin();
-                                        ifile < testFaList.end(); ifile++)
+    for (auto ifile = testFaList.begin();
+	 ifile < testFaList.end(); ifile++) {
       cout << " " << *ifile;
+    }
     cout << endl;
   }
 
-  if (testAffineXfmFile)
+  if (!testAffineXfmFile.empty()) {
     cout << "Affine registration from atlas to base for output subject: "
          << testAffineXfmFile << endl;
+  }
 
-  if (testNonlinXfmFile)
+  if (!testNonlinXfmFile.empty()) {
     cout << "Nonlinear registration from atlas to base for output subject: "
          << testNonlinXfmFile << endl;
+  }
 
-  if (testNonlinRefFile)
+  if (!testNonlinRefFile.empty()) {
     cout << "Nonlinear registration source reference for output subject: "
          << testNonlinRefFile << endl;
+  }
 
   if (!testBaseXfmList.empty()) {
     cout << "Affine registration from base to FA map for output subject:";
-    for (vector<char *>::const_iterator ifile = testBaseXfmList.begin();
-                                        ifile < testBaseXfmList.end(); ifile++)
+    for (auto ifile = testBaseXfmList.begin();
+	 ifile < testBaseXfmList.end(); ifile++) {
       cout << " " << *ifile;
+    }
     cout << endl;
   }
 
-  if (testBaseMaskFile)
+  if (!testBaseMaskFile.c_str()) {
     cout << "Base mask for output subject: " << testBaseMaskFile << endl;
+  }
 
   cout << "Number of control points for initial spline:";
   for (vector< vector<int> >::const_iterator inlist = nControl.begin();
-                                             inlist < nControl.end(); inlist++)
+       inlist < nControl.end(); inlist++) {
     for (vector<int>::const_iterator inum = inlist->begin();
-                                     inum < inlist->end(); inum++)
+	 inum < inlist->end(); inum++) {
       cout << " " << *inum;
+    }
+  }
   cout << endl;
 
   cout << "Exclude previously chosen center streamlines: " << excludeStr << endl

--- a/trc/dmri_vox2vox.cxx
+++ b/trc/dmri_vox2vox.cxx
@@ -64,10 +64,8 @@ int main(int argc, char *argv[]) ;
 const char *Progname = "dmri_vox2vox";
 
 int doInvNonlin = 0, nin = 0, nout = 0;
-char *inDir = NULL, *inFile[100],
-     *outDir = NULL, *outFile[100],
-     *inRefFile = NULL, *outRefFile = NULL,
-     *affineXfmFile = NULL, *nonlinXfmFile = NULL;
+std::string inDir, outDir, inRefFile, outRefFile, affineXfmFile, nonlinXfmFile;
+std::vector<std::string> inFile, outFile;
 
 struct utsname uts;
 char *cmdline, cwd[2000];
@@ -77,7 +75,7 @@ Timer cputimer;
 /*--------------------------------------------------*/
 int main(int argc, char **argv) {
   int nargs, cputime;
-  char fname[PATH_MAX];
+  std::string fname;
   vector<float> point(3);
   MRI *inref = 0, *outref = 0;
   AffineReg affinereg;
@@ -107,20 +105,24 @@ int main(int argc, char **argv) {
   dump_options(stdout);
 
   // Read reference volumes
-  inref = MRIread(inRefFile);
-  outref = MRIread(outRefFile);
+  inref = MRIread(inRefFile.c_str());
+  outref = MRIread(outRefFile.c_str());
 
   // Read transform files
 #ifndef NO_CVS_UP_IN_HERE
-  if (nonlinXfmFile) {
-    if (affineXfmFile)
-      affinereg.ReadXfm(affineXfmFile, inref, 0);
-    nonlinreg.ReadXfm(nonlinXfmFile, outref);
-  }
-  else
+  if (!nonlinXfmFile.empty()) {
+    if (!affineXfmFile.empty()) {
+      affinereg.ReadXfm(affineXfmFile.c_str(), inref, 0);
+    }
+    nonlinreg.ReadXfm(nonlinXfmFile.c_str(), outref);
+  } else {
 #endif
-  if (affineXfmFile)
-    affinereg.ReadXfm(affineXfmFile, inref, outref);
+    if (!affineXfmFile.empty()) {
+      affinereg.ReadXfm(affineXfmFile.c_str(), inref, outref);
+    }
+#ifndef NO_CVS_UP_IN_HERE
+  }
+#endif
 
   for (int k = 0; k < nout; k++) {
     float coord;
@@ -132,10 +134,11 @@ int main(int argc, char **argv) {
     cputimer.reset();
 
     // Read input text file
-    if (inDir)
-      sprintf(fname, "%s/%s", inDir, inFile[k]);
-    else
-      strcpy(fname, inFile[k]);
+    if (!inDir.empty()) {
+      fname = inDir + '/' + inFile.at(k);
+    } else {
+      fname = inFile.at(k);
+    }
 
     infile.open(fname, ios::in);
     if (!infile) {
@@ -177,10 +180,11 @@ int main(int argc, char **argv) {
     }
 
     // Write output text file
-    if (outDir)
-      sprintf(fname, "%s/%s", outDir, outFile[k]);
-    else
-      strcpy(fname, outFile[k]);
+    if (!outDir.empty()) {
+      fname = outDir + '/' + outFile.at(k);
+    } else {
+      fname = outFile.at(k);
+    }
 
     outfile.open(fname, ios::out);
     if (!outfile) {
@@ -237,7 +241,7 @@ static int parse_commandline(int argc, char **argv) {
       if (nargc < 1) CMDargNErr(option,1);
       nargsused = 0;
       while (nargsused < nargc && strncmp(pargv[nargsused], "--", 2)) {
-        inFile[nin] = pargv[nargsused];
+        inFile.push_back(pargv[nargsused]);
         nargsused++;
         nin++;
       }
@@ -251,7 +255,7 @@ static int parse_commandline(int argc, char **argv) {
       if (nargc < 1) CMDargNErr(option,1);
       nargsused = 0;
       while (nargsused < nargc && strncmp(pargv[nargsused], "--", 2)) {
-        outFile[nout] = pargv[nargsused];
+        outFile.push_back(pargv[nargsused]);
         nargsused++;
         nout++;
       }
@@ -361,11 +365,11 @@ static void check_options(void) {
     printf("ERROR: must specify as many output text files as input files\n");
     exit(1);
   }
-  if(!inRefFile) {
+  if(inRefFile.empty()) {
     printf("ERROR: must specify input reference volume\n");
     exit(1);
   }
-  if(!outRefFile) {
+  if(outRefFile.empty()) {
     printf("ERROR: must specify output reference volume\n");
     exit(1);
   }
@@ -383,26 +387,31 @@ static void dump_options(FILE *fp) {
   fprintf(fp,"machine  %s\n",uts.machine);
   fprintf(fp,"user     %s\n",VERuser());
 
-  if (inDir)
-    fprintf(fp, "Input directory: %s\n", inDir);
+  if (!inDir.empty()) {
+    fprintf(fp, "Input directory: %s\n", inDir.c_str());
+  }
   fprintf(fp, "Input files:");
-  for (int k = 0; k < nin; k++)
-    fprintf(fp, " %s", inFile[k]);
+  for (int k = 0; k < nin; k++) {
+    fprintf(fp, " %s", inFile.at(k).c_str());
+  }
   fprintf(fp, "\n");
-  if (outDir)
-    fprintf(fp, "Output directory: %s\n", outDir);
+  if (!outDir.empty()) {
+    fprintf(fp, "Output directory: %s\n", outDir.c_str());
+  }
   if (nout > 0) {
     fprintf(fp, "Output files:");
-    for (int k = 0; k < nout; k++)
-      fprintf(fp, " %s", outFile[k]);
+    for (int k = 0; k < nout; k++) {
+      fprintf(fp, " %s", outFile.at(k).c_str());
+    }
     fprintf(fp, "\n");
   }
-  fprintf(fp, "Input reference: %s\n", inRefFile);
-  fprintf(fp, "Output reference: %s\n", outRefFile);
-  if (affineXfmFile)
-    fprintf(fp, "Affine registration: %s\n", affineXfmFile);
-  if (nonlinXfmFile) {
-    fprintf(fp, "Nonlinear registration: %s\n", nonlinXfmFile);
+  fprintf(fp, "Input reference: %s\n", inRefFile.c_str());
+  fprintf(fp, "Output reference: %s\n", outRefFile.c_str());
+  if (!affineXfmFile.empty()) {
+    fprintf(fp, "Affine registration: %s\n", affineXfmFile.c_str());
+  }
+  if (!nonlinXfmFile.empty()) {
+    fprintf(fp, "Nonlinear registration: %s\n", nonlinXfmFile.c_str());
     fprintf(fp, "Invert nonlinear morph: %d\n", doInvNonlin);
   }
 

--- a/utils/fio.cpp
+++ b/utils/fio.cpp
@@ -876,11 +876,11 @@ int fio_popd(void)
   by pushing into the file dir, getting the cwd, appending the file
   basename to the cwd to get the full path, then popping the stack.
   -------------------------------------------------------------------*/
-char *fio_fullpath(const char *fname)
+std::string fio_fullpath(const char *fname)
 {
   static char cwd[1000];
   char *dirname, *basename;
-  char *fullpath;
+  std::string fullpath;
   int err;
 
   basename = fio_basename(fname, NULL);
@@ -897,13 +897,12 @@ char *fio_fullpath(const char *fname)
   }
   fio_popd();
 
-  sprintf(cwd, "%s/%s", cwd, basename);
-  fullpath = strcpyalloc(cwd);
+  fullpath = std::string(cwd) + std::string(basename);
 
   free(dirname);
   free(basename);
 
-  return (fullpath);
+  return fullpath;
 }
 
 // Replicates mkdir -p

--- a/utils/fio.cpp
+++ b/utils/fio.cpp
@@ -908,33 +908,34 @@ std::string fio_fullpath(const char *fname)
 // Replicates mkdir -p
 int fio_mkdirp(const char *path, mode_t mode)
 {
-  int l, n, m, nthseg, err;
-  char seg[2000], path2[2000];
-  memset(path2, '\0', 2000);
-
-  l = strlen(path);
+  int nthseg, err;
+  std::string seg, path2;
+  size_t n;
+  
+  const size_t l = strlen(path);
 
   n = 0;
   nthseg = 0;
   while (n < l) {
-    m = 0;
+    std::string seg;
     while (n < l && path[n] != '/') {
-      seg[m] = path[n];
-      m++;
+      seg.push_back(path[n]);
       n++;
     }
-    seg[m] = '\0';
-    if (nthseg == 0 && path[0] != '/')
-      sprintf(path2, "%s", seg);
-    else
-      sprintf(path2, "%s/%s", path2, seg);
-    err = mkdir(path2, mode);
+    if (nthseg == 0 && path[0] != '/') {
+      path2 = seg;
+    } else {
+      path2 = path2 + '/' + seg;
+    }
+    err = mkdir(path2.c_str(), mode);
     if (err != 0 && errno != EEXIST) {
-      printf("ERROR: creating directory %s\n", path2);
+      printf("ERROR: creating directory %s\n", path2.c_str());
       perror(NULL);
       return (err);
     }
-    while (n < l && path[n] == '/') n++;
+    while (n < l && path[n] == '/') {
+      n++;
+    }
     nthseg++;
   }
 

--- a/utils/fio.cpp
+++ b/utils/fio.cpp
@@ -897,7 +897,7 @@ std::string fio_fullpath(const char *fname)
   }
   fio_popd();
 
-  fullpath = std::string(cwd) + std::string(basename);
+  fullpath = std::string(cwd) + '/' + std::string(basename);
 
   free(dirname);
   free(basename);


### PR DESCRIPTION
Update `fio.cpp` to use `std::string` wherever gcc8 complains. There are ripple changes from one of the routines being changed to return a string. Substantial changes were made to `trc` as a consequence of this.