### PR TITLE
Further fixes fo GCC 8

### DIFF
--- a/include/gw_utils.h
+++ b/include/gw_utils.h
@@ -63,7 +63,7 @@ extern int gw_log_init(char * AProgname,
                        char * AProgversion, 
                        char * ALogfilepath, 
                        int newfile);
-extern void gw_log_message(char * msg);
+extern void gw_log_message(const char * msg);
 extern void gw_log_timestamp(const char * label);
 extern void gw_log_begin(void);
 extern void gw_log_end(void);

--- a/include/mri.h
+++ b/include/mri.h
@@ -1338,7 +1338,6 @@ int MRIstats(MRI *mri, float *min, float *max, int *n_voxels,
 float MRIvolumeDeterminant(MRI *mri);
 
 int mriio_command_line(int argc, char *argv[]);
-int mriio_set_subject_name(const char *name);
 void mriio_set_gdf_crop_flag(int new_gdf_crop_flag);
 int MRIgetVolumeName(const char *string, char *name_only);
 MRI *MRIread(const char *fname);

--- a/utils/gtm.cpp
+++ b/utils/gtm.cpp
@@ -572,7 +572,11 @@ COLOR_TABLE *GTMSEGctab(GTMSEG *gtmseg, COLOR_TABLE *ctSubCort)
     ct->entries[segid] = (CTE *)calloc(1, sizeof(COLOR_TABLE_ENTRY));
     cte = ct->entries[segid];
     memcpy(cte, cte0, sizeof(CTE));
-    sprintf(cte->name, "ctx-lh-%s", cte0->name);  // new name reflects cortex and hemi
+    // The memcpy on the previous line makes converting to std::string rather tricky
+    int err = snprintf(cte->name, STRLEN-1, "ctx-lh-%s", cte0->name);  // new name reflects cortex and hemi
+    if( err >= STRLEN-1 ) {
+      std::cerr << __FUNCTION__ << ": Truncation prepending ctx-lh-" << std::endl;
+    }
     cte->TissueType = 1;
   }
 
@@ -597,7 +601,11 @@ COLOR_TABLE *GTMSEGctab(GTMSEG *gtmseg, COLOR_TABLE *ctSubCort)
     ct->entries[segid] = (CTE *)calloc(1, sizeof(COLOR_TABLE_ENTRY));
     cte = ct->entries[segid];
     memcpy(cte, cte0, sizeof(CTE));
-    sprintf(cte->name, "ctx-rh-%s", cte0->name);
+    // The preceding memcpy is an issue with trying to change to std::string
+    int err = snprintf(cte->name, STRLEN-1, "ctx-rh-%s", cte0->name);
+    if( err >= STRLEN-1 ) {
+      std::cerr << __FUNCTION__ << ": Truncation prepending ctx-rh-" << std::endl;
+    }
     cte->TissueType = 1;
   }
 
@@ -623,7 +631,11 @@ COLOR_TABLE *GTMSEGctab(GTMSEG *gtmseg, COLOR_TABLE *ctSubCort)
       ct->entries[segid] = (CTE *)calloc(1, sizeof(COLOR_TABLE_ENTRY));
       cte = ct->entries[segid];
       memcpy(cte, cte0, sizeof(CTE));
-      sprintf(cte->name, "wm-lh-%s", cte0->name);
+      // The preceding memcpy is an issue with trying to change to std::string
+      int err = snprintf(cte->name, STRLEN-1, "wm-lh-%s", cte0->name);
+      if( err >= STRLEN-1 ) {
+	std::cerr << __FUNCTION__ << ": Truncation prepending wm-lh-" << std::endl;
+      }
       cte->TissueType = 3;
     }
     ct0 = gtmseg->rhw->ct;
@@ -646,7 +658,11 @@ COLOR_TABLE *GTMSEGctab(GTMSEG *gtmseg, COLOR_TABLE *ctSubCort)
       ct->entries[segid] = (CTE *)calloc(1, sizeof(COLOR_TABLE_ENTRY));
       cte = ct->entries[segid];
       memcpy(cte, cte0, sizeof(CTE));
-      sprintf(cte->name, "wm-rh-%s", cte0->name);
+      // The preceding memcpy is an issue with trying to change to std::string
+      int err = snprintf(cte->name, STRLEN-1, "wm-rh-%s", cte0->name);
+      if( err >= STRLEN-1 ) {
+	std::cerr << __FUNCTION__ << ": Truncation prepending wm-rh-" << std::endl;
+      }
       cte->TissueType = 3;
     }
   }
@@ -2902,7 +2918,7 @@ int GTMwriteText(GTM *gtm, char *OutDir, int DeMean)
 {
   int nthseg, f, segid;
   FILE *fp;
-  char fname[1000];
+  std::string fname;
   double mean;
 
   for(nthseg=0; nthseg < gtm->nsegs; nthseg++){
@@ -2912,10 +2928,11 @@ int GTMwriteText(GTM *gtm, char *OutDir, int DeMean)
       for(f=0; f < gtm->beta->cols; f++) mean += gtm->beta->rptr[nthseg+1][f+1];
       mean /= gtm->beta->cols;
     }
-    sprintf(fname,"%s/%s.dat",OutDir,gtm->ctGTMSeg->entries[segid]->name);
-    fp = fopen(fname,"w");
+    fname = std::string(OutDir) + '/' +
+      std::string(gtm->ctGTMSeg->entries[segid]->name) + ".dat";
+    fp = fopen(fname.c_str(),"w");
     if(fp==NULL){
-      printf("ERROR: GTMwriteText(): could not open %s\n",fname);
+      printf("ERROR: GTMwriteText(): could not open %s\n",fname.c_str());
       return(1);
     }
     for(f=0; f < gtm->beta->cols; f++) 

--- a/utils/gw_utils.cpp
+++ b/utils/gw_utils.cpp
@@ -263,7 +263,7 @@ int gw_log_init(char *AProgname, char *AProgversion, char *ALogfilepath, int new
 }
 
 //------------------------------
-void gw_log_message(char *msg)
+void gw_log_message(const char *msg)
 {
   //------------------------------
   FILE *afile;
@@ -291,11 +291,13 @@ void gw_log_timestamp(const char *label)
 {
   //------------------------------
   char datestr[100];
-  char msg[200];
+  std::stringstream msg;
 
   nowstr(datestr);
-  sprintf(msg, "---[%s]--- %s version %s at %s", label, local_Progname, local_Progversion, datestr);
-  gw_log_message(msg);
+  msg << "---[" << label << "]--- "
+      << local_Progname << " version " << local_Progversion
+      << " at " << datestr;
+  gw_log_message(msg.str().c_str());
 }
 
 //------------------------------

--- a/utils/imageio.cpp
+++ b/utils/imageio.cpp
@@ -863,9 +863,10 @@ static IMAGE *TiffReadImage(const char *fname, int frame0)
       }
       break;
     case 4:
+      // The lack of break is deliberate and the 'fall through' comment is recognised by GCC
       // extra_samples = 1;
       nsamples = 3;
-    // no break
+      // fall through
     case 3:
       switch (bits_per_sample) {
         default:

--- a/utils/label.cpp
+++ b/utils/label.cpp
@@ -579,9 +579,10 @@ int LabelWriteInto(LABEL *area, FILE *fp)
 ------------------------------------------------------*/
 int LabelWrite(LABEL *area, const char *label_name)
 {
-  char fname[STRLEN], *cp, subjects_dir[STRLEN], lname[STRLEN];
+  char *cp, subjects_dir[STRLEN], lname[STRLEN];
   FILE *fp;
   int ret;
+  std::string fname;
 
   strcpy(lname, label_name);
   cp = strrchr(lname, '.');
@@ -598,20 +599,21 @@ int LabelWrite(LABEL *area, const char *label_name)
                 "(SUBJECTS_DIR)",
                 Progname);
     strcpy(subjects_dir, cp);
-    sprintf(fname, "%s/%s/label/%s.label", subjects_dir, area->subject_name, label_name);
+    fname = std::string(subjects_dir) + '/' + std::string(area->subject_name) +
+      "/label/" + std::string(label_name) + ".label";
   }
   else {
     cp = strrchr(lname, '.');
     if (cp && stricmp(cp, ".label") == 0) {
-      strcpy(fname, label_name);
+      fname = label_name;
     }
     else {
-      sprintf(fname, "%s.label", label_name);
+      fname = std::string(label_name) + ".label";
     }
   }
 
-  fp = fopen(fname, "w");
-  if (!fp) ErrorReturn(ERROR_NOFILE, (ERROR_NO_FILE, "%s: could not open label file %s", Progname, fname));
+  fp = fopen(fname.c_str(), "w");
+  if (!fp) ErrorReturn(ERROR_NOFILE, (ERROR_NO_FILE, "%s: could not open label file %s", Progname, fname.c_str()));
 
   ret = LabelWriteInto(area, fp);
   fclose(fp);

--- a/utils/label.cpp
+++ b/utils/label.cpp
@@ -1082,12 +1082,13 @@ int LabelFillAll(LABEL *area, int *vertex_list, int nvertices, int max_vertices,
 ------------------------------------------------------*/
 static Transform *labelLoadTransform(const char *subject_name, const char *sdir, General_transform *transform)
 {
-  char xform_fname[STRLEN];
+  std::string xform_fname;
 
-  sprintf(xform_fname, "%s/%s/mri/transforms/talairach.xfm", sdir, subject_name);
-  if (FileExists(xform_fname) == 0) return (NULL);
-  if (input_transform_file(xform_fname, transform) != OK)
-    ErrorReturn(NULL, (ERROR_NOFILE, "%s: could not load transform file '%s'", Progname, xform_fname));
+  xform_fname = std::string(sdir) + '/' + std::string(subject_name) + "/mri/transforms/talairach.xfm";
+  if (FileExists(xform_fname.c_str()) == 0) return (NULL);
+  if (input_transform_file(xform_fname.c_str(), transform) != OK) {
+    ErrorReturn(NULL, (ERROR_NOFILE, "%s: could not load transform file '%s'", Progname, xform_fname.c_str()));
+  }
 
   return (get_linear_transform_ptr(transform));
 }

--- a/utils/mri.cpp
+++ b/utils/mri.cpp
@@ -14574,7 +14574,7 @@ char *MRIcheckOrientationString(const char *ostr)
 {
   int c, nsag = 0, ncor = 0, nax = 0, err;
   char errstr[1000], *errstrret = NULL;
-  char tmpstr[1000];
+  std::string tmpstr;
 
   errstr[0] = '\0';
   tmpstr[0] = '\0';
@@ -14601,8 +14601,10 @@ char *MRIcheckOrientationString(const char *ostr)
       nax++;
       break;
     default:
-      sprintf(tmpstr, "%s  Character %c in position %d is invalid.\n", errstr, ostr[c], c + 1);
-      strcpy(errstr, tmpstr);
+      tmpstr = std::string(errstr) + std::string("Character ") + ostr[c]
+	+ std::string(" in position ") + std::to_string(c+1) 
+	+ std::string(" is invalid.\n");
+      strncpy(errstr, tmpstr.c_str(), 999);
       err = 1;
       break;
     }
@@ -15842,6 +15844,7 @@ int MRIfindSliceWithMostStructure(MRI *mri_aseg, int slice_direction, int label)
     switch (slice_direction) {
     default:
       ErrorExit(ERROR_UNSUPPORTED, "MRIfindSliceWithMostStructure: unknown slice direction %d", slice_direction);
+      break; // Kill off a 'fall through' warning
     case MRI_CORONAL:
       vox = cor_vox[i];
       break;

--- a/utils/mri2.cpp
+++ b/utils/mri2.cpp
@@ -2050,13 +2050,19 @@ int MRImakeVox2VoxReg(MRI *targ, MRI *mov, int regtype, char *regname, mriTransf
       /* If we're reading a file, copy the file from the input or
       generate one from our data file location. */
       if (VOX2VOXREGTYPE_FILE == regtype) {
-        strncpy(fullregname, regname, sizeof(fullregname));
+	int written = snprintf(fullregname, 1000-1, "%s", regname);
+	if( written == (1000-1)) {
+	  std::cerr << __FUNCTION__ << ": Truncation writing fullregname" << std::endl;
+	}
       }
       else if (VOX2VOXREGTYPE_FIND == regtype) {
         /* Copy the movable volume name and find the last / in the
            file name. From there, copy in "register.dat" for our file
            name. */
-        strncpy(regpath, mov->fname, sizeof(regpath));
+	int written = snprintf(regpath, 1000-1, "%s", mov->fname);
+	if( written == (1000-1)) {
+	  std::cerr << __FUNCTION__ << ": Truncation writing regpath" << std::endl;
+	}
         cur_char = regpath;
         base_end = regpath;
         while (NULL != cur_char && '\0' != *cur_char) {
@@ -2064,7 +2070,10 @@ int MRImakeVox2VoxReg(MRI *targ, MRI *mov, int regtype, char *regname, mriTransf
           cur_char++;
         }
         *base_end = '\0';
-        snprintf(fullregname, sizeof(fullregname), "%s/%s", regpath, "register.dat");
+        written = snprintf(fullregname, sizeof(fullregname), "%s/%s", regpath, "register.dat");
+	if( written == sizeof(fullregname) ) {
+	  std::cerr << __FUNCTION__ << ": Truncation writing fullregname (with regpath)" << std::endl;
+	}
       }
 
       /* Check that the file exists. */

--- a/utils/mri_identify.cpp
+++ b/utils/mri_identify.cpp
@@ -1036,7 +1036,7 @@ int is_ximg(const char *fname) { return (FALSE); } /* end is_ximg() */
 int is_nifti1(const char *fname)
 {
   char fname_stem[STRLEN];
-  char hdr_fname[STRLEN];
+  std::string hdr_fname;
   char *dot;
   FILE *fp;
   char magic[4];
@@ -1045,11 +1045,12 @@ int is_nifti1(const char *fname)
 
   strcpy(fname_stem, fname);
   dot = strrchr(fname_stem, '.');
-  if (dot != NULL)
+  if (dot != NULL) {
     if (strcmp(dot, ".img") == 0 || strcmp(dot, ".hdr") == 0) *dot = '\0';
-  sprintf(hdr_fname, "%s.hdr", fname_stem);
+  }
+  hdr_fname = std::string(fname_stem) + ".hdr";
 
-  fp = fopen(hdr_fname, "r");
+  fp = fopen(hdr_fname.c_str(), "r");
   if (fp == NULL) {
     errno = 0;
     return (FALSE);

--- a/utils/mri_tess.cpp
+++ b/utils/mri_tess.cpp
@@ -950,9 +950,12 @@ static void make_surface_with_connectivity(tesselation_parms *parms)
                 nlabels = computeconnectedcomponents(&tab);
 
                 for (m = 0; m < nlabels; m++) {
-                  if (tab[0][0][0] * tab[0][0][1] * tab[0][1][0] * tab[0][1][1] * tab[1][0][0] * tab[1][0][1] *
-                      tab[1][1][0] * tab[1][1][1])
+                  if ((  tab[0][0][0] * tab[0][0][1] * tab[0][1][0]
+		       * tab[0][1][1] * tab[1][0][0] * tab[1][0][1]
+		       * tab[1][1][0] * tab[1][1][1])
+		      != 0) {
                     continue;
+		  }
                   comp = m + 2;
 
                   /*if(!(((tab[1][0][0]==comp)&&(!tab[0][0][0]))  ||

--- a/utils/mriio.cpp
+++ b/utils/mriio.cpp
@@ -8014,8 +8014,14 @@ static int nifti1Write(MRI *mri0, const char *fname)
   if (dot != NULL)
     if (strcmp(dot, ".img") == 0 || strcmp(dot, ".hdr") == 0) *dot = '\0';
 
-  sprintf(hdr_fname, "%s.hdr", fname_stem);
-  sprintf(img_fname, "%s.img", fname_stem);
+  int needed = snprintf(hdr_fname, STRLEN, "%s.hdr", fname_stem);
+  if( needed >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation of hdr_fname" << std::endl;
+  }
+  needed = snprintf(img_fname, STRLEN, "%s.img", fname_stem);
+  if( needed >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation of img_fname" << std::endl;
+  }
 
   fp = fopen(hdr_fname, "w");
   if (fp == NULL) {

--- a/utils/mriio.cpp
+++ b/utils/mriio.cpp
@@ -455,9 +455,12 @@ int mriio_set_subject_name(const char *name)
                  STRLEN));
   }
 
-  if (name == NULL)
-    strcpy(subject_name, name);
-  else {
+  if (name != NULL) {
+    int req = snprintf(subject_name, STRLEN, "%s", name);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+  } else {
     free(subject_name);
     subject_name = NULL;
   }

--- a/utils/mriio.cpp
+++ b/utils/mriio.cpp
@@ -3494,7 +3494,7 @@ static MRI *bvolumeRead(const char *fname_passed, int read_volume, int type)
                       (ERROR_BADFILE,
                        "bvolumeRead(): "
                        "error reading from file %s",
-                       fname));
+                       fname.c_str()));
         }
 
         if (swap_bytes_flag) {
@@ -6247,7 +6247,7 @@ static int gdfWrite(MRI *mri, const char *fname)
     if (fp == NULL) {
       free(buf);
       errno = 0;
-      ErrorReturn(ERROR_BADFILE, (ERROR_BADFILE, "gdfWrite(): error opening file %s", im_fname));
+      ErrorReturn(ERROR_BADFILE, (ERROR_BADFILE, "gdfWrite(): error opening file %s", im_fname.c_str()));
     }
 
     for (j = 0; j < mri->height; j++) {
@@ -9545,7 +9545,7 @@ MRI *MRIreadGeRoi(const char *fname, int n_slices)
           fclose(fp);
           MRIfree(&mri);
           errno = 0;
-          ErrorReturn(NULL, (ERROR_BADFILE, "MRIreadGeRoi(): error reading from file file %s", fname_use));
+          ErrorReturn(NULL, (ERROR_BADFILE, "MRIreadGeRoi(): error reading from file file %s", fname_use.c_str()));
         }
 #if (BYTE_ORDER == LITTLE_ENDIAN)
         swab(mri->slices[i][y], mri->slices[i][y], (size_t)(2 * mri->width));

--- a/utils/mriio.cpp
+++ b/utils/mriio.cpp
@@ -6170,7 +6170,7 @@ static int gdfWrite(MRI *mri, const char *fname)
 {
   FILE *fp;
   int i, j;
-  char im_fname[STRLEN];
+  std::string im_fname;
   unsigned char *buf;
   int buf_size = 0;
 
@@ -6214,8 +6214,8 @@ static int gdfWrite(MRI *mri, const char *fname)
   }
 
   for (i = 0; i < mri->depth; i++) {
-    sprintf(im_fname, "%s_%d.img", mri->gdf_image_stem, i + 1);
-    fp = fopen(im_fname, "w");
+    im_fname = std::string(mri->gdf_image_stem) + '_' + std::to_string(i+1) + ".img";
+    fp = fopen(im_fname.c_str(), "w");
     if (fp == NULL) {
       free(buf);
       errno = 0;

--- a/utils/mriio.cpp
+++ b/utils/mriio.cpp
@@ -2216,6 +2216,10 @@ static MRI *siemensRead(const char *fname, int read_volume_flag)
 #else
 	{
 	  std::vector<short> temp(cols);
+	  // Note:
+	  // void swab(const void *from, void *to, ssize_t n);
+	  // void *memcpy(void *dest, const void *src, size_t n);
+	  // Because consistency is the hobgoblin of small minds...
 	  swab(&MRISvox(mri_raw, 0, i, file_n - n_low), temp.data(), sizeof(short)*cols );
 	  memcpy(&MRISvox(mri_raw, 0, i, file_n - n_low), temp.data(), sizeof(short)*cols );
 	}
@@ -3525,6 +3529,10 @@ static MRI *bvolumeRead(const char *fname_passed, int read_volume, int type)
         if (swap_bytes_flag) {
           if (type == MRI_SHORT) {
 	    std::vector<short> temp(mri->width);
+	    // Note:
+	    // void swab(const void *from, void *to, ssize_t n);
+	    // void *memcpy(void *dest, const void *src, size_t n);
+	    // Because consistency is the hobgoblin of small minds...
 	    swab(mri->slices[k][row], temp.data(), (size_t)(mri->width * size));
 	    memcpy(mri->slices[k][row], temp.data(), (size_t)(mri->width * size));
           } else {
@@ -4289,6 +4297,10 @@ static MRI *genesisRead(const char *fname, int read_volume)
 #else
         {
 	  std::vector<short> temp(mri->width);
+	  // Note:
+	  // void swab(const void *from, void *to, ssize_t n);
+	  // void *memcpy(void *dest, const void *src, size_t n);
+	  // Because consistency is the hobgoblin of small minds...
 	  swab(&MRISseq_vox(mri, 0, y, slice, frame), temp.data(), sizeof(short) * mri->width);
 	  memcpy(&MRISseq_vox(mri, 0, y, slice, frame), temp.data(), sizeof(short) * mri->width);
 	}
@@ -4583,6 +4595,10 @@ static MRI *gelxRead(const char *fname, int read_volume)
 #if (BYTE_ORDER == LITTLE_ENDIAN)
 	{
 	  std::vector<short> temp(2*mri->width);
+	  // Note:
+	  // void swab(const void *from, void *to, ssize_t n);
+	  // void *memcpy(void *dest, const void *src, size_t n);
+	  // Because consistency is the hobgoblin of small minds...
 	  swab(mri->slices[i - im_low][y], temp.data(), (size_t)(2 * mri->width));
 	  memcpy(mri->slices[i - im_low][y], temp.data(), (size_t)(2 * mri->width));
 	}
@@ -6654,6 +6670,10 @@ static int read_otl_file(
 #else
       {
 	std::vector<short> tmp(2*n_rows);
+	// Note:
+	// void swab(const void *from, void *to, ssize_t n);
+	// void *memcpy(void *dest, const void *src, size_t n);
+	// Because consistency is the hobgoblin of small minds...
 	swab(points, tmp.data(), 2 * n_rows * sizeof(short));
 	memcpy(points, tmp.data(), 2 * n_rows * sizeof(short));
       }
@@ -6959,6 +6979,10 @@ int list_labels_in_otl_file(FILE *fp)
 #else
       {
 	std::vector<short> tmp(2*n_rows);
+	// Note:
+	// void swab(const void *from, void *to, ssize_t n);
+	// void *memcpy(void *dest, const void *src, size_t n);
+	// Because consistency is the hobgoblin of small minds...
 	swab(points, tmp.data(), 2 * n_rows * sizeof(short));
 	memcpy(points, tmp.data(), 2 * n_rows * sizeof(short));
       }

--- a/utils/mriio.cpp
+++ b/utils/mriio.cpp
@@ -3293,10 +3293,16 @@ static MRI *get_b_info(const char *fname_passed, int read_volume, char *director
   mri = MRIallocHeader(1, 1, 1, type, 1);
 
   /* ----- try to read the stem.bhdr ----- */
-  sprintf(bhdr_name, "%s/%s.bhdr", directory, stem);
+  int required = snprintf(bhdr_name, STRLEN, "%s/%s.bhdr", directory, stem);
+  if( required >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": bhdr_name truncated" << std::endl;
+  }
   if ((fp = fopen(bhdr_name, "r")) != NULL) {
     read_bhdr(mri, fp);
-    sprintf(fname, "%s/%s_000.hdr", directory, stem);
+    int required = snprintf(fname, STRLEN, "%s/%s_000.hdr", directory, stem);
+    if( required >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": fname truncated" << std::endl;
+    }
     if ((fp = fopen(fname, "r")) == NULL) {
       MRIfree(&mri);
       errno = 0;
@@ -3327,7 +3333,10 @@ static MRI *get_b_info(const char *fname_passed, int read_volume, char *director
               "If not suitable, please provide the information in %s file\n"
               "-----------------------------------------------------------------\n",
               bhdr_name);
-    sprintf(fname, "%s/%s_000.hdr", directory, stem);
+    int required = snprintf(fname, STRLEN, "%s/%s_000.hdr", directory, stem);
+    if( required >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if ((fp = fopen(fname, "r")) == NULL) {
       MRIfree(&mri);
       errno = 0;
@@ -3343,7 +3352,10 @@ static MRI *get_b_info(const char *fname_passed, int read_volume, char *director
     fclose(fp);
 
     /* --- get the number of slices --- */
-    sprintf(fname, "%s/%s_000.%s", directory, stem, extension);
+    int req = snprintf(fname, STRLEN, "%s/%s_000.%s", directory, stem, extension);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (!FileExists(fname)) {
       MRIfree(&mri);
       errno = 0;
@@ -3353,8 +3365,12 @@ static MRI *get_b_info(const char *fname_passed, int read_volume, char *director
                    "bailing out on read",
                    fname));
     }
-    for (nslices = 0; FileExists(fname); nslices++)
-      sprintf(fname, "%s/%s_%03d.%s", directory, stem, nslices, extension);
+    for (nslices = 0; FileExists(fname); nslices++) {
+      int req = snprintf(fname, STRLEN, "%s/%s_%03d.%s", directory, stem, nslices, extension);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
     nslices--;
 
     mri->width = nx;
@@ -5970,7 +5986,10 @@ static MRI *gdfRead(const char *fname, int read_volume)
   n_files = 0;
   do {
     n_files++;
-    sprintf(fname_use, "%s%d%s", file_path_1, n_files, file_path_2);
+    int req = snprintf(fname_use, STRLEN, "%s%d%s", file_path_1, n_files, file_path_2);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
   } while (FileExists(fname_use));
 
   /* ----- try padding the zeros if no files are found ----- */
@@ -5980,7 +5999,10 @@ static MRI *gdfRead(const char *fname, int read_volume)
     n_files = 0;
     do {
       n_files++;
-      sprintf(fname_use, "%s%03d%s", file_path_1, n_files, file_path_2);
+      int req = snprintf(fname_use, STRLEN, "%s%03d%s", file_path_1, n_files, file_path_2);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     } while (FileExists(fname_use));
 
     /* ----- still a problem? ----- */
@@ -6087,10 +6109,17 @@ static MRI *gdfRead(const char *fname, int read_volume)
   }
 
   for (i = 1; i <= n_files; i++) {
-    if (pad_zeros_flag)
-      sprintf(fname_use, "%s%03d%s", file_path_1, i, file_path_2);
-    else
-      sprintf(fname_use, "%s%d%s", file_path_1, i, file_path_2);
+    if (pad_zeros_flag) {
+      int req = snprintf(fname_use, STRLEN, "%s%03d%s", file_path_1, i, file_path_2);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    } else {
+      int req = snprintf(fname_use, STRLEN, "%s%d%s", file_path_1, i, file_path_2);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
 
     fp = fopen(fname_use, "r");
     if (fp == NULL) {

--- a/utils/mriio.cpp
+++ b/utils/mriio.cpp
@@ -2832,7 +2832,10 @@ static int bvolumeWrite(MRI *vol, const char *fname_passed, int type)
       if (dealloc) MRIfree(&mri);
     }
     else {
-      sprintf(subject_dir, "%s/%s", subjects_dir, sn);
+      int req = snprintf(subject_dir, STRLEN, "%s/%s", subjects_dir, sn);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (stat(subject_dir, &stat_buf) < 0) {
         fprintf(stderr, "can't stat %s; writing to bhdr instead\n", subject_dir);
       }

--- a/utils/mriio.cpp
+++ b/utils/mriio.cpp
@@ -7473,8 +7473,14 @@ static MRI *nifti1Read(const char *fname, int read_volume)
   if (dot != NULL)
     if (strcmp(dot, ".img") == 0 || strcmp(dot, ".hdr") == 0) *dot = '\0';
 
-  sprintf(hdr_fname, "%s.hdr", fname_stem);
-  sprintf(img_fname, "%s.img", fname_stem);
+  int req = snprintf(hdr_fname, STRLEN, "%s.hdr", fname_stem);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+  req = snprintf(img_fname, STRLEN, "%s.img", fname_stem);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
 
   fp = fopen(hdr_fname, "r");
   if (fp == NULL) {

--- a/utils/mriio.cpp
+++ b/utils/mriio.cpp
@@ -1572,10 +1572,14 @@ static MRI *corRead(const char *fname, int read_volume)
 
   if (strlen(xform) > 0) {
     char xform_use[STRLEN];
-    if (xform[0] == '/')
+    if (xform[0] == '/') {
       strcpy(mri->transform_fname, xform);
-    else
-      sprintf(mri->transform_fname, "%s/%s", fname, xform);
+    } else {
+      int req = snprintf(mri->transform_fname, STRLEN, "%s/%s", fname, xform);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
 
     strcpy(xform_use, mri->transform_fname);
 
@@ -3945,8 +3949,14 @@ static MRI *genesisRead(const char *fname, int read_volume)
       *c = '\0';
       // this is too quick to assume of this type
       // another type %s%%03d.MR" must be examined
-      sprintf(fname_format, "%s%%d.MR", fname_base);
-      sprintf(fname_format2, "%s%%03d.MR", fname_base);
+      int req = snprintf(fname_format, STRLEN, "%s%%d.MR", fname_base);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+      req = snprintf(fname_format2, STRLEN, "%s%%03d.MR", fname_base);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
     else {
       errno = 0;
@@ -3960,12 +3970,18 @@ static MRI *genesisRead(const char *fname, int read_volume)
 
   if (strlen(fname_format) != 0) {
     strcpy(temp_string, fname_format);
-    sprintf(fname_format, "%s%s", fname_dir, temp_string);
+    int req = snprintf(fname_format, STRLEN, "%s%s", fname_dir, temp_string);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("fname_format  : %s\n", fname_format);
   }
   if (strlen(fname_format2) != 0) {
     strcpy(temp_string, fname_format2);
-    sprintf(fname_format2, "%s%s", fname_dir, temp_string);
+    int req = snprintf(fname_format2, STRLEN, "%s%s", fname_dir, temp_string);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("fname_format2 : %s\n", fname_format2);
   }
   /* ----- find the low and high files ----- */
@@ -7140,7 +7156,10 @@ static MRI *ximgRead(const char *fname, int read_volume)
       c++;
       im_init = atoi(c);
       *c = '\0';
-      sprintf(fname_format, "%s%%d.MR", fname_base);
+      int req = snprintf(fname_format, STRLEN, "%s%%d.MR", fname_base);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
     else {
       errno = 0;
@@ -7152,8 +7171,14 @@ static MRI *ximgRead(const char *fname, int read_volume)
     ErrorReturn(NULL, (ERROR_BADPARM, "genesisRead(): can't determine file name format for %s", fname));
   }
 
-  strcpy(temp_string, fname_format);
-  sprintf(fname_format, "%s%s", fname_dir, temp_string);
+  int req = snprintf(temp_string, STRLEN, "%s", fname_format);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+  req = snprintf(fname_format, STRLEN, "%s%s", fname_dir, temp_string);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
 
   /* ----- find the low and high files ----- */
   im_low = im_init;

--- a/utils/mriio.cpp
+++ b/utils/mriio.cpp
@@ -442,33 +442,6 @@ int mriio_command_line(int argc, char *argv[])
 
 } /* end mriio_command_line() */
 
-int mriio_set_subject_name(const char *name)
-{
-  if (subject_name == NULL) subject_name = (char *)malloc(STRLEN);
-
-  if (subject_name == NULL) {
-    errno = 0;
-    ErrorReturn(ERROR_NO_MEMORY,
-                (ERROR_NO_MEMORY,
-                 "mriio_set_subject_name(): "
-                 "could't allocate %d bytes...!",
-                 STRLEN));
-  }
-
-  if (name != NULL) {
-    int req = snprintf(subject_name, STRLEN, "%s", name);
-    if( req >= STRLEN ) {
-      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
-    }
-  } else {
-    free(subject_name);
-    subject_name = NULL;
-  }
-
-  return (NO_ERROR);
-
-} /* end mriio_set_subject_name() */
-
 void mriio_set_gdf_crop_flag(int new_gdf_crop_flag)
 {
   gdf_crop_flag = new_gdf_crop_flag;

--- a/utils/mriio.cpp
+++ b/utils/mriio.cpp
@@ -3409,7 +3409,7 @@ static MRI *bvolumeRead(const char *fname_passed, int read_volume, int type)
 {
   MRI *mri;
   FILE *fp;
-  char fname[STRLEN];
+  std::string fname;
   char directory[STRLEN];
   char stem[STRLEN];
   int swap_bytes_flag;
@@ -3445,9 +3445,13 @@ static MRI *bvolumeRead(const char *fname_passed, int read_volume, int type)
   if (!read_volume) return (mri);
 
   /* Read in the header of the first slice to get the endianness */
-  sprintf(fname, "%s/%s_%03d.hdr", directory, stem, 0);
-  if ((fp = fopen(fname, "r")) == NULL) {
-    fprintf(stderr, "ERROR: can't open file %s; assuming big-endian bvolume\n", fname);
+  std::stringstream tmp;
+  tmp << directory << '/' << stem << '_'
+      << std::setw(3) << std::setfill('0') << 0
+      << ".hdr";
+  fname = tmp.str();
+  if ((fp = fopen(fname.c_str(), "r")) == NULL) {
+    fprintf(stderr, "ERROR: can't open file %s; assuming big-endian bvolume\n", fname.c_str());
     swap_bytes_flag = 0;
   }
   else {
@@ -3462,12 +3466,16 @@ static MRI *bvolumeRead(const char *fname_passed, int read_volume, int type)
 
   /* Go through each slice */
   for (slice = 0; slice < mri->depth; slice++) {
-    /* Open the file for this slice */
-    sprintf(fname, "%s/%s_%03d.%s", directory, stem, slice, ext);
-    if ((fp = fopen(fname, "r")) == NULL) {
+    /* Open the file for this slice */ 
+    std::stringstream tmp;
+    tmp << directory << '/' << stem << '_'
+	<< std::setw(3) << std::setfill('0') << slice
+	<< '.' << ext;
+    fname = tmp.str();
+    if ((fp = fopen(fname.c_str(), "r")) == NULL) {
       MRIfree(&mri);
       errno = 0;
-      ErrorReturn(NULL, (ERROR_BADFILE, "bvolumeRead(): error opening file %s", fname));
+      ErrorReturn(NULL, (ERROR_BADFILE, "bvolumeRead(): error opening file %s", fname.c_str()));
     }
     // fprintf(stderr, "Reading %s ... \n", fname);
     /* Loop through the frames */
@@ -9460,7 +9468,7 @@ MRI *MRIreadGeRoi(const char *fname, int n_slices)
   int n_digits;
   FILE *fp;
   int width, height;
-  char fname_use[STRLEN];
+  std::string fname_use;
   int read_one_flag;
   int pixel_data_offset;
   int y;
@@ -9521,8 +9529,10 @@ MRI *MRIreadGeRoi(const char *fname, int n_slices)
   read_one_flag = FALSE;
 
   for (i = 0; i < n_slices; i++) {
-    sprintf(fname_use, "%s%03d%s", prefix, i, postfix);
-    if ((fp = fopen(fname_use, "r")) != NULL) {
+    std::stringstream tmp;
+    tmp << prefix << std::setw(3) << std::setfill('0') << i << postfix;
+    fname_use = tmp.str();
+    if ((fp = fopen(fname_use.c_str(), "r")) != NULL) {
       fseek(fp, 4, SEEK_SET);
       if (fread(&pixel_data_offset, 4, 1, fp) != 1) {
          ErrorPrintf(ERROR_BADFILE, "MRIreadGeRoi(): could not read file");

--- a/utils/mriio.cpp
+++ b/utils/mriio.cpp
@@ -4339,15 +4339,24 @@ static MRI *gelxRead(const char *fname, int read_volume)
     c = strrchr(fname_base, 'i');
     im_init = atoi(c + 1);
     *c = '\0';
-    sprintf(fname_format, "%si%%d", fname_base);
+    int req = snprintf(fname_format, STRLEN, "%si%%d", fname_base);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
   }
   else {
     errno = 0;
     ErrorReturn(NULL, (ERROR_BADPARM, "genesisRead(): can't determine file name format for %s", fname));
   }
 
-  strcpy(temp_string, fname_format);
-  sprintf(fname_format, "%s%s", fname_dir, temp_string);
+  int req = snprintf(temp_string, STRLEN, "%s", fname_format);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+  req = snprintf(fname_format, STRLEN, "%s%s", fname_dir, temp_string);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
 
   /* ----- find the low and high files ----- */
   im_low = im_init;


### PR DESCRIPTION
More changes to ensure compatibility with GCC8:

- Introduce `std::string` where possible
- Switch more complex cases to using `snprintf` in place of `strcpy`, `strncpy` and `sprint`
- Provide temporary workspace for `swab()` calls
- Add `// fall through` comments to reassure compiler in some `switch` statements
- Remove `mriio_set_subject_name()` since the logic looked off and nothing appears to call it