### PR TITLE
Another batch of gcc8 fixes

### DIFF
--- a/include/mrisurf.h
+++ b/include/mrisurf.h
@@ -451,8 +451,56 @@ class INTEGRATION_PARMS {
   double       stressthresh ;
   int          explode_flag ;
   
-  INTEGRATION_PARMS() : fp(NULL) {}
-  INTEGRATION_PARMS(FILE* file) : fp(file) {}
+  /*
+    Introduce all initializers in an effort to avoid some memset() calls
+    which gcc8 finds unsettling.
+
+    I do find myself contemplating whether this class may benefit from
+    some splitting up - whether by composition, inheritance, or both.
+   */
+  INTEGRATION_PARMS(FILE* file = nullptr)
+    : tol(0), l_angle(0), l_pangle(0), l_area(0), l_parea(0),
+      l_nlarea(0), l_nldist(0), l_thick_normal(0), l_thick_spring(0),
+      l_ashburner_triangle(0), l_ashburner_lambda(0), l_corr(0),
+      l_ocorr(0), l_pcorr(0), l_curv(0), l_norm(0), l_scurv(0), l_lap(0),
+      l_link(0), l_spring(0), l_nlspring(0), l_max_spring(0),
+      l_spring_norm(0), l_tspring(0), l_nltspring(0), l_nspring(0),
+      l_spring_nzr(0), l_spring_nzr_len(0), l_hinge(0), l_repulse(0),
+      l_repulse_ratio(0), l_boundary(0), l_dist(0), l_location(0),
+      l_neg(0), l_intensity(0), l_sphere(0), l_expand(0), l_grad(0),
+      l_convex(0), l_tsmooth(0), l_surf_repulse(0), l_osurf_repulse(0),
+      l_external(0), l_thick_parallel(0), l_thick_min(0), l_shrinkwrap(0),
+      l_expandwrap(0), l_unfold(0), l_dura(0), l_histo(0), l_map(0),
+      l_map2d(0), dura_thresh(0), mri_dura(nullptr), n_averages(0),
+      min_averages(0), first_pass_averages(0), nbhd_size(0), max_nbrs(0),
+      write_iterations(0),
+      base_name(), /* Should default initialize array to zero */
+      projection(0), niterations(0), a(0), b(0), c(0), start_t(0), t(0),
+      fp(file), // Highlighted as the sole configurable value
+      Hdesired(0), integration_type(0), momentum(0), dt(0), base_dt(0),
+      flags(0), dt_increase(0), dt_decrease(0), error_ratio(0), epsilon(0),
+      desired_rms_height(0), starting_sse(0), ending_sse(0), scale(0),
+      mrisp(nullptr), frame_no(0), mrisp_template(nullptr),
+      mrisp_blurred_template(nullptr), area_coef_scale(0), sigma(0),
+      nfields(0),
+      fields(), /* Array should initialize to zero */
+      mri_brain(nullptr), mri_smooth(nullptr), user_parms(nullptr),
+      mri_dist(nullptr), target_radius(0), ignore_energy(0), check_tol(0),
+      overlay_dir(nullptr), nsurfaces(0), mri_ll(nullptr), rmin(0), rmax(0),
+      var_smoothness(0), vsmoothness(nullptr), dist_error(nullptr),
+      area_error(nullptr), geometry_error(nullptr), which_norm(0),
+      abs_norm(0), grad_dir(0), fill_interior(0), rms(0), complete_dist_mat(0),
+      nsubjects(0), nlabels(0), mht_array(nullptr), mris_array(nullptr),
+      mris_ico(nullptr), mht(nullptr), smooth_averages(0), ico_order(0),
+      remove_neg(0), mri_hires(nullptr), mri_hires_smooth(nullptr),
+      mri_vno(nullptr), mri_template(nullptr), which_surface(0),
+      trinarize_thresh(0), nonmax(0), smooth_intersections(0), uncompress(0),
+      min_dist(0), h_wm(nullptr), h_gm(nullptr), h_nonbrain(nullptr),
+      mri_labels(nullptr), mri_white(nullptr), mri_aseg(nullptr), hwm(nullptr),
+      hgm(nullptr), hout(nullptr), h2d_wm(nullptr), h2d_gm(nullptr), 
+      h2d_out(nullptr), h2d(nullptr), mri_volume_fractions(nullptr), 
+      mri_dtrans(nullptr), resolution(0), target_intensity(0), stressthresh(0),
+      explode_flag(0) {}
   
 };
 

--- a/include/mrisurf.h
+++ b/include/mrisurf.h
@@ -261,8 +261,8 @@ MRI_SURFACE_PARAMETERIZATION, MRI_SP ;
 /* VECTORIAL_REGISTRATION */
 #include "field_code.h"
 
-typedef struct INTEGRATION_PARMS
-{
+class INTEGRATION_PARMS {
+ public:
   double  tol ;               /* tolerance for terminating a step */
   float   l_angle ;           /* coefficient of angle term */
   float   l_pangle ;          /* coefficient of "positive" angle term - only penalize narrower angles */
@@ -454,8 +454,7 @@ typedef struct INTEGRATION_PARMS
   INTEGRATION_PARMS() : fp(NULL) {}
   INTEGRATION_PARMS(FILE* file) : fp(file) {}
   
-}
-INTEGRATION_PARMS ;
+};
 
 void INTEGRATION_PARMS_copy   (INTEGRATION_PARMS* dst, INTEGRATION_PARMS const * src);
 

--- a/utils/mrimorph.cpp
+++ b/utils/mrimorph.cpp
@@ -1309,7 +1309,10 @@ static int mriLinearAlignPyramidLevel(MRI *mri_in, MRI *mri_ref, MORPH_PARMS *pa
   for (k = 0; k < parms->lta->num_xforms; k++) MatrixClear(parms->lta->xforms[k].m_last_dL);
 
   strcpy(base_name, parms->base_name);
-  sprintf(parms->base_name, "level%d_%s", ncalls, base_name);
+  int req = snprintf(parms->base_name, 100, "level%d_%s", ncalls, base_name);
+  if( req >= 100 ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
 
   ncalls++; /* for diagnostics */
 #if 0
@@ -1353,7 +1356,10 @@ static int mriLinearAlignPyramidLevel(MRI *mri_in, MRI *mri_ref, MORPH_PARMS *pa
       MRIwrite(parms->mri_ref, fname) ;
 #endif
 #if USE_INVERSE == 0
-      sprintf(fname, "%sref", base_name);
+      int req = snprintf(fname, STRLEN, "%sref", base_name);  
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       fprintf(stdout, "writing reference views to %s...\n", fname);
       MRIwriteImageViews(parms->mri_ref, fname, IMAGE_SIZE);
 #endif
@@ -2581,8 +2587,11 @@ MORPH_3D *MRI3Dmorph(MRI *mri_in, MRI *mri_ref, MORPH_PARMS *parms)
     parms->dt = dt / (mri_in_pyramid[i]->thick);
 #endif
     /*    parms->l_intensity = l_intensity * (sigma*sigma+1.0f) ;*/
-    sprintf(parms->base_name, "%s_level%d_", base_name, i);
-    sprintf(parms->base_name, "%s_", base_name);
+
+    int req = snprintf(parms->base_name, 100, "%s_", base_name);
+    if( req >= 100 ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     parms->tol = mri_in_pyramid[MIN_LEVEL]->thick * base_tol / mri_in_pyramid[i]->thick;
     for (sigma = base_sigma; sigma >= 0; sigma /= 4) {
       if (sigma < 1) sigma = 0;
@@ -5410,7 +5419,6 @@ MRI_SURFACE *MRISshrinkWrapSkull(MRI *mri, MORPH_PARMS *parms)
   mri_kernel = MRIgaussian1d(0.5, 13);
   mri_smooth = MRIconvolveGaussian(mri, NULL, mri_kernel);
   diag = Gdiag;
-  memset(&lparms, 0, sizeof(lparms));
   lparms.momentum = .75;
   lparms.dt = .75;
   lparms.l_spring_norm = 1.0f;

--- a/utils/mripolv.cpp
+++ b/utils/mripolv.cpp
@@ -928,7 +928,11 @@ MRI *MRIcentralPlaneOfLeastVarianceNormal(MRI *mri_src, MRI *mri_dst, int wsize)
     MRI *mri_tmp;
 
     /* try and read previously computed CPOLV file from disk */
-    sprintf(fname, "%s/cpolv.mnc", mri_src->fname);
+    int req = snprintf(fname, 100, "%s/cpolv.mnc", mri_src->fname);
+    if( req >= 100 ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+
     mri_tmp = MRIread(fname);
     if (mri_tmp) {
       if (Gdiag & DIAG_SHOW) fprintf(stderr, "reading previously calculated cpolv %s\n", fname);

--- a/utils/mrishash.cpp
+++ b/utils/mrishash.cpp
@@ -745,9 +745,12 @@ void MRIS_HASH_TABLE_NoSurface::mhtFaceCentroid2xyz_float(
   -------------------------------------------------------------*/
 int MRIS_HASH_TABLE_NoSurface::mhtAddFaceOrVertexAtVoxIx(int xv, int yv, int zv, int forvnum)
 {
-  if (xv < 0) xv = 0; if (xv >= TABLE_SIZE) xv = TABLE_SIZE - 1;
-  if (yv < 0) yv = 0; if (yv >= TABLE_SIZE) yv = TABLE_SIZE - 1;
-  if (zv < 0) zv = 0; if (zv >= TABLE_SIZE) zv = TABLE_SIZE - 1;
+  if (xv < 0) xv = 0;
+  if (xv >= TABLE_SIZE) xv = TABLE_SIZE - 1;
+  if (yv < 0) yv = 0;
+  if (yv >= TABLE_SIZE) yv = TABLE_SIZE - 1;
+  if (zv < 0) zv = 0;
+  if (zv >= TABLE_SIZE) zv = TABLE_SIZE - 1;
 
   {
     MHBT *bucket = makeAndAcqBucket(xv, yv, zv);

--- a/utils/mrisurf_base.cpp
+++ b/utils/mrisurf_base.cpp
@@ -1614,20 +1614,18 @@ int slprints(char *apch_txt)
   size_t len_hostname;
   char *pch_timeMon = NULL;
   char *pch_time = NULL;
-  char pch_output[65536];
+  std::string pch_output;
 
   t = time(NULL);
   len_hostname = 255;
   gethostname(pch_hostname, len_hostname);
   strcpy(pch_hostname, strtok(pch_hostname, "."));
-  strcpy(pch_output, "");
   ptm_local = localtime(&t);
   pch_timeMon = strtok(asctime(ptm_local), "\n");
   pch_time = strdup(pch_timeMon + 4);
-  sprintf(pch_output, "%s %s", pch_time, pch_hostname);
-  sprintf(pch_output, "%s %s", pch_output, apch_txt);
-  printf("%s", pch_output);
-  return strlen(pch_output);
+  pch_output = std::string(pch_time) + std::string(pch_hostname) + apch_txt;
+  printf("%s", pch_output.c_str());
+  return pch_output.size();
 }
 
 void cprints(const char *apch_left, const char *apch_right)


### PR DESCRIPTION
Most are fairly unremarkable string fixes. However, in order to deal with one rather unpleasant `memset()` call, make all initializers explicit for `INTEGRATION_PARMS` in `mrisurf.h`. It is within the bounds of possibility that this class could be refactored, by composition, inheritance, or possibly both.