### PR TITLE
Finish fixing utils for GCC 8

### DIFF
--- a/utils/mrisComputeVertexDistancesWkr_extracted.h
+++ b/utils/mrisComputeVertexDistancesWkr_extracted.h
@@ -1,3 +1,8 @@
+#if GCC_VERSION > 80000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+
 static bool FUNCTION_NAME(
 #ifdef COMPILING_MRIS_MP
     MRIS_MP* mris, 
@@ -237,3 +242,7 @@ static bool FUNCTION_NAME(
 #undef INPUT_Z
 #undef OUTPUT_DIST
 #undef OUTPUT_MAKER
+
+#if GCC_VERSION > 80000
+#pragma GCC diagnostic pop
+#endif

--- a/utils/mrisurf_compute_dxyz.cpp
+++ b/utils/mrisurf_compute_dxyz.cpp
@@ -5048,11 +5048,15 @@ int mrisComputePosterior2DTerm(MRI_SURFACE *mris, INTEGRATION_PARMS *parms)
     char fname[STRLEN], path[STRLEN];
 
     FileNamePath(mris->fname, path);
-    sprintf(fname,
-            "%s/%s.%d.dist.mgz",
-            path,
-            mris->hemisphere == LEFT_HEMISPHERE ? "lh" : mris->hemisphere == BOTH_HEMISPHERES ? "both" : "rh",
-            parms->t);
+    int req = snprintf(fname,
+		       STRLEN,
+		       "%s/%s.%d.dist.mgz",
+		       path,
+		       mris->hemisphere == LEFT_HEMISPHERE ? "lh" : mris->hemisphere == BOTH_HEMISPHERES ? "both" : "rh",
+		       parms->t);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     MRISwriteD(mris, fname);
     DiagBreak();
   }

--- a/utils/mrisurf_defect.cpp
+++ b/utils/mrisurf_defect.cpp
@@ -8640,7 +8640,12 @@ MRI_SURFACE *MRIScorrectTopology(
       FILE *fp;
       char fname[STRLEN];
 
-      sprintf(fname, "%s.%s.defect%d.log", mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", mris->subject_name.data(), i);
+      int req = snprintf(fname, STRLEN, "%s.%s.defect%d.log",
+			 mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", mris->subject_name.data(), i);
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+
       fp = fopen(fname, "wb");
       fprintf(fp, "%d %2.3f\n", dl->defects[i].nvertices, dl->defects[i].area);
       for (n = 0; n < dl->defects[i].nvertices; n++) {
@@ -8667,7 +8672,12 @@ MRI_SURFACE *MRIScorrectTopology(
       }
       fclose(fp);
 
-      sprintf(fname, "%s.%s.defects.log", mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", mris->subject_name.data());
+      req = snprintf(fname, STRLEN, "%s.%s.defects.log",
+		     mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", mris->subject_name.data());
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+
       fp = fopen(fname, "wb");
       for (total_defective_area = 0.0f, total_defective_vertices = i = 0; i < dl->ndefects; i++) {
         total_defective_vertices += dl->defects[i].nvertices;
@@ -8921,7 +8931,12 @@ MRI_SURFACE *MRIScorrectTopology(
   if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON) {
     FILE *fp;
     char fname[STRLEN];
-    sprintf(fname, "%s.%s.vtrans.log", mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", mris->subject_name.data());
+    int req = snprintf(fname, STRLEN, "%s.%s.vtrans.log",
+		       mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", mris->subject_name.data()); 
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+
     fp = fopen(fname, "wb");
     if (!fp) {
       DiagBreak();
@@ -8931,7 +8946,11 @@ MRI_SURFACE *MRIScorrectTopology(
       fprintf(fp, "%6d --> %6d\n", vno, vertex_trans[vno]);
     }
     fclose(fp);
-    sprintf(fname, "%s.%s.ftrans.log", mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", mris->subject_name.data());
+    req = snprintf(fname, STRLEN, "%s.%s.ftrans.log",
+		   mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", mris->subject_name.data());
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fp = fopen(fname, "wb");
 
     for (vno = 0; vno < mris->nfaces; vno++) {
@@ -9389,7 +9408,12 @@ MRI_SURFACE *MRIScorrectTopology(
       }
     }
     FileNamePath(mris->fname, path);
-    sprintf(fname, "%s/%s.fixed.defect_labels.mgz", path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh");
+    int req = snprintf(fname, STRLEN, "%s/%s.fixed.defect_labels.mgz",
+		       path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh");
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+
     printf("writing corrected defect labels to %s\n", fname);
     MRISwriteCurvature(mris_corrected, fname);
   }
@@ -9660,7 +9684,11 @@ FACE_DEFECT_LIST *MRISmarkAmbiguousVertices(MRI_SURFACE *mris, int mark)
   if (!fdl->faces) ErrorExit(ERROR_NO_MEMORY, "MRISmarkAmbiguousFaces: could allocate face defect list");
   if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON) {
     char fname[STRLEN];
-    sprintf(fname, "%s.%s.topology.log", mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", mris->subject_name.data());
+    int req = snprintf(fname, STRLEN, "%s.%s.topology.log",
+		       mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", mris->subject_name.data());
+    if( req >= STRLEN ) {
+       std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fp = fopen(fname, "w");
   }
 
@@ -9823,7 +9851,11 @@ DEFECT_LIST *MRISsegmentDefects(MRI_SURFACE *mris, int mark_ambiguous, int mark_
 
   if (Gdiag & DIAG_WRITE) {
     char fname[STRLEN];
-    sprintf(fname, "%s.%s.topology.log", mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", mris->subject_name.data());
+    int req = snprintf(fname, STRLEN, "%s.%s.topology.log",
+		       mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", mris->subject_name.data());
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fp = fopen(fname, "a");
   }
 
@@ -14035,7 +14067,10 @@ static NOINLINE int mrisComputeOptimalRetessellation_wkr(MRI_SURFACE *mris,
       if (i == 0 && Gdiag & 0x1000000) {
         int i;
         char fname[STRLEN];
-        sprintf(fname, "%s_defect%d_%03d", mris->fname.data(), dno - 1, sno++);
+        int req = snprintf(fname, STRLEN, "%s_defect%d_%03d", mris->fname.data(), dno - 1, sno++); 
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         dp = &dps[best_i];
         mrisRetessellateDefect(
             mris, mris_corrected, dp->defect, vertex_trans, dp->etable->edges, dp->nedges, dp->ordering, dp->etable);

--- a/utils/mrisurf_deform.cpp
+++ b/utils/mrisurf_deform.cpp
@@ -1828,11 +1828,16 @@ int mrisComputePosteriorTerm(MRI_SURFACE *mris, INTEGRATION_PARMS *parms)
     char fname[STRLEN], path[STRLEN];
 
     FileNamePath(mris->fname, path);
-    sprintf(fname,
-            "%s/%s.%d.dist.mgz",
-            path,
-            mris->hemisphere == LEFT_HEMISPHERE ? "lh" : mris->hemisphere == BOTH_HEMISPHERES ? "both" : "rh",
-            parms->t);
+    int req = snprintf(fname,
+		       STRLEN,
+		       "%s/%s.%d.dist.mgz",
+		       path,
+		       mris->hemisphere == LEFT_HEMISPHERE ? "lh" : mris->hemisphere == BOTH_HEMISPHERES ? "both" : "rh",
+		       parms->t);
+    if( req >= STRLEN ) {   
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+
     MRISwriteD(mris, fname);
     DiagBreak();
   }
@@ -2004,7 +2009,11 @@ int mrisRemoveNegativeArea(
   if (Gdiag & DIAG_WRITE && parms->fp == NULL) {
     char fname[STRLEN];
 
-    sprintf(fname, "%s.%s.out", mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);
+    int req = snprintf(fname, STRLEN, "%s.%s.out", 
+		       mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name); 
+    if( req >= STRLEN ) {   
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (!parms->start_t) {
       INTEGRATION_PARMS_openFp(parms, fname, "w");
     }

--- a/utils/mrisurf_deform.cpp
+++ b/utils/mrisurf_deform.cpp
@@ -4241,7 +4241,6 @@ int MRISrepositionSurface(
 
   printf("flags = %x, size = %ld\n", flags, (long)sizeof(flags));
 
-  memset(&parms, 0, sizeof(parms));
   parms.fill_interior = 0;
   parms.projection = NO_PROJECTION;
   parms.tol = 1e-4;
@@ -4313,9 +4312,8 @@ int MRISrepositionSurfaceToCoordinate(
 
 #define SCALE .01
 
-  printf(
-      "MRISrepositionSurfaceToCoordinate(%d, %f, %f, %f, %d, %f, %x)\n", target_vno, tx, ty, tz, nsize, sigma, flags);
-  memset(&parms, 0, sizeof(parms));
+  printf("MRISrepositionSurfaceToCoordinate(%d, %f, %f, %f, %d, %f, %x)\n",
+	 target_vno, tx, ty, tz, nsize, sigma, flags);
   parms.fill_interior = 0;
   parms.projection = NO_PROJECTION;
   parms.tol = 1e-4;
@@ -4671,7 +4669,6 @@ int MRISrigidBodyAlignLocal(MRI_SURFACE *mris, INTEGRATION_PARMS *old_parms)
   /* dx,dy,dz interpreted as rotations in applyGradient when status is rigid */
   auto const old_status = mris->status; /* okay, okay, this is a hack too... */
   mris->status = MRIS_RIGID_BODY;
-  memset(&parms, 0, sizeof(parms));
   parms.integration_type = INTEGRATE_LM_SEARCH;
   parms.integration_type = INTEGRATE_LINE_MINIMIZE;
 
@@ -4713,7 +4710,6 @@ int MRISrigidBodyAlignVectorLocal(MRI_SURFACE *mris, INTEGRATION_PARMS *old_parm
   /* dx,dy,dz interpreted as rotations in applyGradient when status is rigid */
   auto const old_status = mris->status; /* okay, okay, this is a hack too... */
   mris->status = MRIS_RIGID_BODY;
-  memset(&parms, 0, sizeof(parms));
   parms.integration_type = INTEGRATE_LM_SEARCH;
   parms.integration_type = INTEGRATE_LINE_MINIMIZE;
 

--- a/utils/mrisurf_integrate.cpp
+++ b/utils/mrisurf_integrate.cpp
@@ -282,7 +282,12 @@ static int mrisIntegrationEpoch(MRI_SURFACE *mris, INTEGRATION_PARMS *parms, int
     if (Gdiag & DIAG_WRITE) {
       char fname[STRLEN];
       if (!parms->fp) {
-        sprintf(fname, "%s.%s.out", mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);
+        int req = snprintf(fname, STRLEN, "%s.%s.out", 
+			   mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);   
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+
         if (!parms->start_t) {
           INTEGRATION_PARMS_openFp(parms, fname, "w");
         }
@@ -407,7 +412,12 @@ int MRISintegrate(MRI_SURFACE *mris, INTEGRATION_PARMS *parms, int n_averages)
   if (Gdiag & DIAG_WRITE && parms->fp == NULL) {
     char fname[STRLEN];
 
-    sprintf(fname, "%s.%s.out", mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);
+    int req = snprintf(fname, STRLEN, "%s.%s.out", 
+		       mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name); 
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+
     if (!parms->start_t) {
       INTEGRATION_PARMS_openFp(parms, fname, "w");
     }
@@ -524,7 +534,12 @@ int MRISintegrate(MRI_SURFACE *mris, INTEGRATION_PARMS *parms, int n_averages)
       MRIsetVoxVal(mri_vector, vno, 0, 0, 2, zp - zw);
     }
 
-    sprintf(fname, "%s.%s.%3.3d.mgz", mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", parms->base_name, parms->t);
+    int req = snprintf(fname, STRLEN, "%s.%s.%3.3d.mgz",
+		       mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", parms->base_name, parms->t);  
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+    
     printf("writing vectors to %s\n", fname);
     MRIwrite(mri_vector, fname);
     MRIfree(&mri_vector);
@@ -652,11 +667,16 @@ int MRISintegrate(MRI_SURFACE *mris, INTEGRATION_PARMS *parms, int n_averages)
           MRIsetVoxVal(mri_vector, vno, 0, 0, 2, zp - zw);
         }
 
-        sprintf(fname,
-                "%s.%s.%3.3d.vec.mgz",
-                mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh",
-                parms->base_name,
-                parms->t + 1);
+        int req = snprintf(fname,
+			   STRLEN,
+			   "%s.%s.%3.3d.vec.mgz",
+			   mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh",
+			   parms->base_name,
+			   parms->t + 1);   
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+
         printf("writing vectors to %s\n", fname);
         MRIwrite(mri_vector, fname);
         MRIfree(&mri_vector);
@@ -677,7 +697,6 @@ int MRISintegrate(MRI_SURFACE *mris, INTEGRATION_PARMS *parms, int n_averages)
     if (parms->remove_neg && mris->neg_area > 0) {
       INTEGRATION_PARMS p;
       //      printf("removing overlap with smoothing\n") ;
-      memset(&p, 0, sizeof(p));
       p.niterations = 150;
       MRISremoveOverlapWithSmoothing(mris, &p);
     }
@@ -792,7 +811,12 @@ int MRISregister(MRI_SURFACE *mris,
   }
   Timer start;
   FileNamePath(mris->fname, path);
-  sprintf(base_name, "%s/%s.%s", path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", parms->base_name);
+  int req = snprintf(base_name, STRLEN, "%s/%s.%s",
+		     path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", parms->base_name);  
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+  
 
   mrisComputeOriginalVertexDistances(mris);
   
@@ -813,7 +837,12 @@ int MRISregister(MRI_SURFACE *mris,
   
   base_dt = parms->dt;
   if (Gdiag & DIAG_WRITE) {
-    sprintf(fname, "%s.%s.out", mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);
+    int req = snprintf(fname, STRLEN, "%s.%s.out",
+		       mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+
     if (!parms->start_t) {
       INTEGRATION_PARMS_openFp(parms, fname, "w");
     }
@@ -855,7 +884,12 @@ int MRISregister(MRI_SURFACE *mris,
     ino = parms->frame_no = sno * IMAGES_PER_SURFACE;
     if (curvature_names[sno]) /* read in precomputed curvature file */
     {
-      sprintf(fname, "%s.%s", mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", curvature_names[sno]);
+      int req = snprintf(fname, STRLEN, "%s.%s", 
+			 mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", curvature_names[sno]); 
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+
       printf("%d Reading %s\n", sno, fname);
       if (MRISreadCurvatureFile(mris, fname) != NO_ERROR)
         ErrorExit(Gerror, "%s: could not read curvature file '%s'\n", "MRISregister", fname);
@@ -868,7 +902,11 @@ int MRISregister(MRI_SURFACE *mris,
     }
     else /* compute curvature of surface */
     {
-      sprintf(fname, "%s", mrisurf_surface_names[sno]);
+      int req = snprintf(fname, STRLEN, "%s", mrisurf_surface_names[sno]);
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+
       MRISsaveVertexPositions(mris, TMP_VERTICES);
       printf("%d Reading %s\n", sno, fname);
       if (MRISreadVertexPositions(mris, fname) != NO_ERROR)
@@ -879,8 +917,9 @@ int MRISregister(MRI_SURFACE *mris,
       MRIScomputeSecondFundamentalForm(mris);
       MRISuseMeanCurvature(mris);
       MRISnormalizeCurvature(mris, parms->which_norm);
-      if (parms->nonmax)
+      if (parms->nonmax) {
 	MRISnonmaxSuppress(mris) ;
+      }
       MRISresetNeighborhoodSize(mris, 1); /*only use nearest neighbor distances*/
 
       MRISrestoreVertexPositions(mris, TMP_VERTICES);
@@ -964,12 +1003,17 @@ int MRISregister(MRI_SURFACE *mris,
         MRIScomputeMetricProperties(mris);
         MRISfromParameterization(mrisp_template, mris, ino);
         MRISnormalizeCurvature(mris, parms->which_norm);
-        sprintf(fname,
-                "%s/%s.%s.target%d",
-                path,
-                mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh",
-                parms->base_name,
-                sno);
+        int req = snprintf(fname,
+			   STRLEN,
+			   "%s/%s.%s.target%d",
+			   path,
+			   mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh",
+			   parms->base_name,
+			   sno);    
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+	
         MRISwriteCurvature(mris, fname);
         MRISrestoreVertexPositions(mris, TMP_VERTICES);
         MRIScomputeMetricProperties(mris);
@@ -1014,13 +1058,18 @@ int MRISregister(MRI_SURFACE *mris,
         MRIScomputeMetricProperties(mris);
 #endif
         MRISfromParameterization(mrisp_template, mris, ino);
-        sprintf(fname,
-                "%s/%s.%s.sno%d_target_blur%2.2f",
-                path,
-                mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh",
-                parms->base_name,
-                sno,
-                sigma);
+        int req = snprintf(fname,
+			   STRLEN,
+			   "%s/%s.%s.sno%d_target_blur%2.2f",
+			   path,
+			   mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh",
+			   parms->base_name,
+			   sno,
+			   sigma);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+	
         MRISwriteCurvature(mris, fname);
 #if 1
         MRISrestoreVertexPositions(mris, TMP_VERTICES);
@@ -1041,23 +1090,32 @@ int MRISregister(MRI_SURFACE *mris,
                                 to projectSurface */
 
       if (Gdiag & DIAG_WRITE) {
-        sprintf(fname,
-                "%s/%s.%s.sno%d_blur%2.2f",
-                path,
-                mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh",
-                parms->base_name,
-                sno,
-                sigma);
+        int req = snprintf(fname,
+			   STRLEN,
+			   "%s/%s.%s.sno%d_blur%2.2f",
+			   path,
+			   mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh",
+			   parms->base_name,
+			   sno,
+			   sigma);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+
         MRISwriteCurvature(mris, fname);
       }
       if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON) {
-        sprintf(fname,
-                "%s/%s.%s.%4.4dblur%2.2f",
-                path,
-                mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh",
-                parms->base_name,
-                parms->start_t,
-                sigma);
+        int req = snprintf(fname,
+			   STRLEN,
+			   "%s/%s.%s.%4.4dblur%2.2f",
+			   path,
+			   mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh",
+			   parms->base_name,
+			   parms->start_t,
+			   sigma);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         if (Gdiag & DIAG_SHOW) {
           fprintf(stdout, "writing curvature file %s...", fname);
         }
@@ -1065,7 +1123,12 @@ int MRISregister(MRI_SURFACE *mris,
         if (Gdiag & DIAG_SHOW) {
           fprintf(stdout, "done.\n");
         }
-        sprintf(fname, "target.%s.%4.4d.hipl", parms->base_name, parms->start_t);
+        req = snprintf(fname, STRLEN, "target.%s.%4.4d.hipl",
+		       parms->base_name, parms->start_t);   
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+       
         if (Gdiag & DIAG_SHOW) {
           fprintf(stdout, "writing parameterization file %s...", fname);
         }
@@ -1092,12 +1155,17 @@ int MRISregister(MRI_SURFACE *mris,
           if (Gdiag & DIAG_WRITE && parms->write_iterations != 0) {
             char fname[STRLEN], path[STRLEN];
             FileNamePath(mris->fname, path);
-            sprintf(fname,
-                    "%s/%s.%s.sno%d.rotated",
-                    path,
-                    mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh",
-                    parms->base_name,
-                    sno);
+            int req = snprintf(fname,
+			       STRLEN,
+			       "%s/%s.%s.sno%d.rotated",
+			       path,
+			       mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh",
+			       parms->base_name,
+			       sno);
+	    if( req >= STRLEN ) {
+	      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	    }
+	    
             printf("writing rigid aligned surface to %s\n", fname);
             MRISwrite(mris, fname);
           }
@@ -1207,11 +1275,21 @@ int MRISvectorRegister(MRI_SURFACE *mris,
   Timer start;
   MRISsaveVertexPositions(mris, ORIGINAL_VERTICES);
   FileNamePath(mris->fname, path);
-  sprintf(base_name, "%s/%s.%s", path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", parms->base_name);
+  int req = snprintf(base_name, STRLEN, "%s/%s.%s",
+		     path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", parms->base_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
 
   base_dt = parms->dt;
   if (Gdiag & DIAG_WRITE) {
-    sprintf(fname, "%s.%s.out", mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);
+    int req = snprintf(fname, STRLEN, "%s.%s.out",
+		       mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);  
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+
     if (!parms->start_t) {
       INTEGRATION_PARMS_openFp(parms, fname, "w");
       if (!parms->fp) ErrorExit(ERROR_NOFILE, "%s: could not open log file %s", Progname, fname);
@@ -1285,19 +1363,29 @@ int MRISvectorRegister(MRI_SURFACE *mris,
       char path[STRLEN];
       FileNamePath(mris->fname, path);
       if (parms->overlay_dir == NULL) {
-        sprintf(fname,
-                "%s/../label/%s.%s",
-                path,
-                mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh",
-                parms->fields[n].name);
+        int req = snprintf(fname,
+			   STRLEN,
+			   "%s/../label/%s.%s",
+			   path,
+			   mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh",
+			   parms->fields[n].name);  
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+
       }
       else {
-        sprintf(fname,
-                "%s/../%s/%s.%s",
-                path,
-                parms->overlay_dir,
-                mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh",
-                parms->fields[n].name);
+        int req = snprintf(fname,
+			   STRLEN,
+			   "%s/../%s/%s.%s",
+			   path,
+			   parms->overlay_dir,
+			   mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh",
+			   parms->fields[n].name);    
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+	
       }
       printf("reading overlay file %s...\n", fname);
       if (MRISreadValues(mris, fname) != NO_ERROR)
@@ -1309,8 +1397,12 @@ int MRISvectorRegister(MRI_SURFACE *mris,
     }
     else if (ReturnFieldName(parms->fields[n].field)) {
       /* read in precomputed curvature file */
-      sprintf(
-          fname, "%s.%s", mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", ReturnFieldName(parms->fields[n].field));
+      int req = snprintf(fname, STRLEN, "%s.%s", 
+			 mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", ReturnFieldName(parms->fields[n].field));
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+
       if (MRISreadCurvatureFile(mris, fname) != NO_ERROR) {
         fprintf(stderr, "%s: could not read curvature file '%s'\n", "MRISvectorRegister", fname);
         fprintf(stderr, "setting up correlation coefficient to zero\n");
@@ -1320,7 +1412,11 @@ int MRISvectorRegister(MRI_SURFACE *mris,
     }
     else {
       /* compute curvature of surface */
-      sprintf(fname, "%s", mrisurf_surface_names[parms->fields[n].field]);
+      int req = snprintf(fname, STRLEN, "%s", mrisurf_surface_names[parms->fields[n].field]);   
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+
       /*                        if(parms->fields[n].field==0) */
       /*                                sprintf(fname, "inflated") ; */
       /*                        else */
@@ -1361,7 +1457,12 @@ int MRISvectorRegister(MRI_SURFACE *mris,
     if (Gdiag & DIAG_WRITE && !i && !parms->start_t) {
       MRISfromParameterizations(parms->mrisp_template, mris, frames, indices, nframes);
       //      MRISnormalizeCurvature(mris, parms->fields[0].which_norm) ;
-      sprintf(fname, "%s/%s.%s.target", path, mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);
+      int req = snprintf(fname, STRLEN, "%s/%s.%s.target",
+			 path, mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name); 
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+      
       if (Gdiag & DIAG_SHOW) {
         fprintf(stdout, "writing curvature file %s...\n", fname);
       }
@@ -1383,13 +1484,17 @@ int MRISvectorRegister(MRI_SURFACE *mris,
     if (Gdiag & DIAG_WRITE) fprintf(parms->fp, "\ncorrelating surfaces with with sigma=%2.2f\n", sigma);
 
     if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON) {
-      sprintf(fname,
-              "%s/%s.%s.%4.4dtarget%2.2f",
-              path,
-              mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh",
-              parms->base_name,
-              parms->start_t,
-              sigma);
+      int req = snprintf(fname,
+			 STRLEN,
+			 "%s/%s.%s.%4.4dtarget%2.2f",
+			 path,
+			 mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh",
+			 parms->base_name,
+			 parms->start_t,
+			 sigma);
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (Gdiag & DIAG_SHOW) {
         fprintf(stdout, "writing curvature file %s...", fname);
       }
@@ -2056,7 +2161,11 @@ int MRISminimizeThicknessFunctional(MRI_SURFACE *mris, INTEGRATION_PARMS *parms,
       MRISwriteWhiteNormals(mris, fname) ;
     }
 #endif
-    sprintf(fname, "%s.wnormals.a%3.3d.%s.mgz", base_name, navgs, parms->base_name);
+    int req = snprintf(fname, STRLEN, "%s.wnormals.a%3.3d.%s.mgz",
+		       base_name, navgs, parms->base_name);   
+    if( req >= STRLEN ) {   
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing smoothed white matter surface normals to %s\n", fname);
     MRISwriteWhiteNormals(mris, fname);
   }
@@ -2070,7 +2179,11 @@ int MRISminimizeThicknessFunctional(MRI_SURFACE *mris, INTEGRATION_PARMS *parms,
   if (Gdiag & DIAG_WRITE) {
     char fname[STRLEN];
 
-    sprintf(fname, "%s.%s.out", mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);
+    int req = snprintf(fname, STRLEN, "%s.%s.out",
+		       mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);  
+    if( req >= STRLEN ) {   
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (!parms->fp) {
       if (!parms->start_t) {
         INTEGRATION_PARMS_openFp(parms, fname, "w");
@@ -2199,7 +2312,11 @@ MRI_SURFACE *MRISunfold(MRI_SURFACE *mris, INTEGRATION_PARMS *parms, int max_pas
   if (Gdiag & DIAG_WRITE) {
     char fname[STRLEN];
 
-    sprintf(fname, "%s.%s.out", mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);
+    int req = snprintf(fname, STRLEN, "%s.%s.out",
+		       mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name); 
+    if( req >= STRLEN ) {   
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (!parms->fp) {
       if (!parms->start_t) {
         INTEGRATION_PARMS_openFp(parms, fname, "w");
@@ -2496,7 +2613,11 @@ MRI_SURFACE *MRISquickSphere(MRI_SURFACE *mris, INTEGRATION_PARMS *parms, int ma
   if (Gdiag & DIAG_WRITE) {
     char fname[STRLEN];
 
-    sprintf(fname, "%s.%s.out", mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);
+    int req = snprintf(fname, STRLEN, "%s.%s.out",
+		       mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);
+    if( req >= STRLEN ) {   
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (!parms->fp) {
       if (!parms->start_t) {
         INTEGRATION_PARMS_openFp(parms, fname, "w");
@@ -2648,7 +2769,10 @@ int MRISinflateBrain(MRI_SURFACE *mris, INTEGRATION_PARMS *parms)
   if (Gdiag & DIAG_WRITE) {
     char fname[STRLEN];
 
-    sprintf(fname, "%s.out", parms->base_name);
+    int req = snprintf(fname, STRLEN, "%s.out", parms->base_name);
+    if( req >= STRLEN ) {   
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (!parms->start_t) {
       INTEGRATION_PARMS_openFp(parms, fname, "w");
     }
@@ -2847,7 +2971,11 @@ int MRISinflateToSphere(MRI_SURFACE *mris, INTEGRATION_PARMS *parms)
 
   if (Gdiag & DIAG_WRITE) {
     char fname[STRLEN];
-    sprintf(fname, "%s.%s.out", mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);
+    int req = snprintf(fname, STRLEN, "%s.%s.out",
+		       mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);  
+    if( req >= STRLEN ) {   
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (!parms->fp) {
       if (!parms->start_t) 
         INTEGRATION_PARMS_openFp(parms, fname, "w");

--- a/utils/mrisurf_io.cpp
+++ b/utils/mrisurf_io.cpp
@@ -96,7 +96,11 @@ int MRISreadTriangleProperties(MRI_SURFACE *mris, const char *mris_fname)
   hemi[2] = 0;
   FileNamePath(mris_fname, fpref);
 
-  sprintf(fname, "%s/%s.triangle_area", fpref, hemi);
+  int req = snprintf(fname, STRLEN, "%s/%s.triangle_area", fpref, hemi);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
 
   fp = fopen(fname, "r");
   if (fp == NULL) {
@@ -140,7 +144,11 @@ int MRISreadTriangleProperties(MRI_SURFACE *mris, const char *mris_fname)
   }
 
   /* now open and read the angle file */
-  sprintf(fname, "%s/%s.triangle_angle", fpref, hemi);
+  req = snprintf(fname, STRLEN, "%s/%s.triangle_angle", fpref, hemi);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   fp = fopen(fname, "r");
   if (fp == NULL) {
     return (1); /* doesn't exist */
@@ -166,30 +174,6 @@ int MRISreadTriangleProperties(MRI_SURFACE *mris, const char *mris_fname)
       face->orig_angle[ano] = f;
     }
   }
-
-#if 0
-  /* read in the distances to all neighboring vertices */
-  sprintf(fname, "%s/%s.dist", fpref, hemi) ;
-  fp = fopen(fname,"rb");
-  if (!fp)
-    ErrorReturn(ERROR_NO_FILE,
-                (ERROR_NO_FILE,
-                 "MRISreadTriangleProperties: could not open %s",
-                 fname)) ;
-
-  fread4((float *)&vnum,fp);
-  fread4((float *)&fnum,fp);
-  for (vno = 0; vno < mris->nvertices ; vno++)
-  {
-    v = &mris->vertices[vno] ;
-    for (n = 0 ; n < v->vtotal ; n++)
-    {
-      v->dist_orig[n] = freadFloat(fp) ;
-    }
-  }
-
-  fclose(fp);
-#endif
 
   return (NO_ERROR);
 }
@@ -222,7 +206,11 @@ int MRISwriteTriangleProperties(MRI_SURFACE *mris, const char *mris_fname)
   hemi[2] = 0;
   FileNamePath(mris_fname, fpref);
 
-  sprintf(fname, "%s/%s.triangle_area", fpref, hemi);
+  int req = snprintf(fname, STRLEN, "%s/%s.triangle_area", fpref, hemi); 
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   fp = fopen(fname, "wb");
   if (!fp) ErrorReturn(ERROR_NO_FILE, (ERROR_NO_FILE, "MRISwriteTriangleProperties: could not open %s", fname));
 
@@ -236,7 +224,11 @@ int MRISwriteTriangleProperties(MRI_SURFACE *mris, const char *mris_fname)
 
   fclose(fp);
 
-  sprintf(fname, "%s/%s.triangle_angle", fpref, hemi);
+  req = snprintf(fname, STRLEN, "%s/%s.triangle_angle", fpref, hemi);    
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   fp = fopen(fname, "wb");
   if (!fp) ErrorReturn(ERROR_NO_FILE, (ERROR_NO_FILE, "MRISwriteTriangleProperties: could not open %s", fname));
 
@@ -251,30 +243,6 @@ int MRISwriteTriangleProperties(MRI_SURFACE *mris, const char *mris_fname)
   }
 
   fclose(fp);
-
-#if 0
-  /* write out the distances to all neighboring vertices */
-  sprintf(fname, "%s/%s.dist", fpref, hemi) ;
-  fp = fopen(fname,"wb");
-  if (!fp)
-    ErrorReturn(ERROR_NO_FILE,
-                (ERROR_NO_FILE,
-                 "MRISwriteTriangleProperties: could not open %s",
-                 fname)) ;
-
-  fwrite4(mris->nvertices,fp);
-  fwrite4(mris->nfaces,fp);
-  for (vno = 0; vno < mris->nvertices ; vno++)
-  {
-    v = &mris->vertices[vno] ;
-    for (n = 0 ; n < v->v2num ; n++)
-    {
-      fwriteFloat(v->dist[n], fp) ;
-    }
-  }
-
-  fclose(fp);
-#endif
 
   return (NO_ERROR);
 }
@@ -316,19 +284,31 @@ int MRISwriteCurvature(MRI_SURFACE *mris, const char *sname)
     if (!cp || ((cp - sname) != 2) || *(cp - 1) != 'h' || ((*(cp - 2) != 'l' && *(cp - 2) != 'r'))) {
       if (getenv("FS_POSIX")) {
         // PW 2017/05/15: If FS_POSIX is set, write to cwd (as per POSIX:4.11)
-        sprintf(fname, "./%s.%s", hemi, sname);
+        int req = snprintf(fname, STRLEN, "./%s.%s", hemi, sname);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
       else {
-        sprintf(fname, "%s/%s.%s", path, hemi, sname);
+        int req = snprintf(fname, STRLEN, "%s/%s.%s", path, hemi, sname);  
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
     }
     else {
       if (getenv("FS_POSIX")) {
         // PW 2017/05/15: If FS_POSIX is set, write to cwd (as per POSIX:4.11)
-        sprintf(fname, "./%s", sname);
+        int req = snprintf(fname, STRLEN, "./%s", sname); 
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
       else {
-        sprintf(fname, "%s/%s", path, sname);
+        int req = snprintf(fname, STRLEN, "%s/%s", path, sname);   
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
     }
   }
@@ -337,10 +317,16 @@ int MRISwriteCurvature(MRI_SURFACE *mris, const char *sname)
     FileNameOnly(sname, name);
     cp = strchr(name, '.');
     if (!cp || ((cp - name) != 2) || *(cp - 1) != 'h' || ((*(cp - 2) != 'l' && *(cp - 2) != 'r'))) {
-      sprintf(fname, "%s/%s.%s", path, hemi, name);
+      int req = snprintf(fname, STRLEN, "%s/%s.%s", path, hemi, name); 
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
     else {
-      sprintf(fname, "%s/%s", path, name);
+      int req = snprintf(fname, STRLEN, "%s/%s", path, name); 
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
   }
   if (Gdiag & DIAG_SHOW) {
@@ -414,20 +400,33 @@ int MRISwriteDists(MRI_SURFACE *mris, const char *sname)
     if (!cp)
       if (getenv("FS_POSIX")) {
         // PW 2017/05/15: If FS_POSIX is set, write to cwd (as per POSIX:4.11)
-        sprintf(fname, "./%s.%s", mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", sname);
+        int req = snprintf(fname, STRLEN, "./%s.%s", mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", sname);  
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
       else {
         // PW 2017/05/15: Legacy behaviour
-        sprintf(fname, "%s/%s.%s", path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", sname);
+        int req = snprintf(fname, STRLEN, "%s/%s.%s",
+			   path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", sname);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
     else {
       if (getenv("FS_POSIX")) {
         // PW 2017/05/15: If FS_POSIX is set, write to cwd (as per POSIX:4.11)
-        sprintf(fname, "./%s", sname);
+        int req = snprintf(fname, STRLEN, "./%s", sname); 
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
       else {
         // PW 2017/05/15: Legacy behaviour
-        sprintf(fname, "%s/%s", path, sname);
+        int req = snprintf(fname, STRLEN, "%s/%s", path, sname);  
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
     }
   }
@@ -1348,12 +1347,6 @@ static int mrisLabelVertices(MRI_SURFACE *mris, float cx, float cy, float cz, in
     yd = cy - v->y;
     zd = cz - v->z;
     d = sqrt(xd * xd + yd * yd + zd * zd);
-#if 0                                               // weird - see comment below
-    if (d <= radius)
-    {
-      v->label = label ;
-    }
-#endif
   }
 
   return (NO_ERROR);
@@ -1418,11 +1411,6 @@ int MRISreadAnnotation(MRI_SURFACE *mris, const char *sname)
   char fname[STRLEN], path[STRLEN], fname_no_path[STRLEN];
   const char *cp;
   int *array;
-#if 0
-  int   numannothist;
-  float f;
-  char  histfname[STRLEN], freqfname[STRLEN];
-#endif
 
   // first attempt to read as gifti file
   int mritype = mri_identify(sname);
@@ -1438,22 +1426,31 @@ int MRISreadAnnotation(MRI_SURFACE *mris, const char *sname)
   // else fall-thru with default .annot processing...
 
   cp = strchr(sname, '/');
-  if (!cp) /* no path - use same one as mris was read from */
-  {
+  if (!cp) {
+    /* no path - use same one as mris was read from */
     FileNameOnly(sname, fname_no_path);
     cp = strstr(fname_no_path, ".annot");
     if (!cp) {
       strcat(fname_no_path, ".annot");
     }
-
+      
     need_hemi = stricmp(fname_no_path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh");
-
+      
     FileNamePath(mris->fname, path);
     if (!need_hemi) {
-      sprintf(fname, "%s/../label/%s", path, fname_no_path);
+      int req = snprintf(fname, STRLEN, "%s/../label/%s", path, fname_no_path); 
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
-    else /* no hemisphere specified */
-      sprintf(fname, "%s/../label/%s.%s", path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", fname_no_path);
+    else {
+      /* no hemisphere specified */
+      int req = snprintf(fname, STRLEN, "%s/../label/%s.%s", 
+			 path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", fname_no_path); 
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
   }
   else {
     strcpy(fname, sname); /* full path specified */
@@ -1462,10 +1459,13 @@ int MRISreadAnnotation(MRI_SURFACE *mris, const char *sname)
       strcat(fname, ".annot");
     }
   }
-
+  
   // As a last resort, just assume the sname is the path
   if (!fio_FileExistsReadable(fname) && fio_FileExistsReadable(sname)) {
-    sprintf(fname, "%s", sname);
+    int req = snprintf(fname, STRLEN, "%s", sname);  
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
   }
 
   /* Try to read it into an array. */
@@ -1489,77 +1489,6 @@ int MRISreadAnnotation(MRI_SURFACE *mris, const char *sname)
   if (NO_ERROR != return_code) {
     return return_code;
   }
-
-#if 0
-  for (vno=0; vno<vertex_index; vno++)
-  {
-    vertex[vno].annotfreq=1;
-  }
-
-  sprintf(freqfname,"%s.freq",fname);
-  fp = fopen(freqfname,"r");
-  if (fp!=NULL)
-  {
-    printf("file %s read\n",freqfname);
-    for (vno=0; vno<vertex_index; vno++)
-    {
-      vertex[vno].annotfreq=0;
-    }
-    fread(&num,1,sizeof(int),fp);
-    printf("surfer: num=%d\n",num);
-    for (j=0; j<num; j++)
-    {
-      fread(&vno,1,sizeof(int),fp);
-      fread(&f,1,sizeof(float),fp);
-      if (vno>=vertex_index||vno<0)
-      {
-        printf("surfer: vertex index out of range: %d f=%f\n",vno,f);
-      }
-      else
-      {
-        vertex[vno].annotfreq = f;
-      }
-    }
-    fclose(fp);
-  }
-
-  sprintf(histfname,"%s.hist",fname);
-  fp = fopen(histfname,"r");
-  if (fp!=NULL)
-  {
-    printf("file %s read\n",histfname);
-    for (vno=0; vno<vertex_index; vno++)
-    {
-      vertex[vno].numannothist=0;
-    }
-    fread(&num,1,sizeof(int),fp);
-    printf("surfer: num=%d\n",num);
-    for (j=0; j<num; j++)
-    {
-      fread(&vno,1,sizeof(int),fp);
-      fread(&numannothist,1,sizeof(int),fp);
-      if (vno>=vertex_index||vno<0)
-      {
-        printf("surfer: vertex index out of range: %d f=%f\n",vno,f);
-      }
-      else
-      {
-        vertex[vno].numannothist = numannothist;
-        vertex[vno].annothistlabel = calloc(numannothist,sizeof(int));
-        vertex[vno].annothistcount = calloc(numannothist,sizeof(int));
-        for (i=0; i<numannothist; i++)
-        {
-          fread(&vertex[vno].annothistlabel[i],1,sizeof(int),fp);
-        }
-        for (i=0; i<numannothist; i++)
-        {
-          fread(&vertex[vno].annothistcount[i],1,sizeof(int),fp);
-        }
-      }
-    }
-    fclose(fp);
-  }
-#endif
 
   return (NO_ERROR);
 }
@@ -1803,21 +1732,35 @@ int MRISwriteAnnotation(MRI_SURFACE *mris, const char *sname)
     if (!need_hemi) {
       if (getenv("FS_POSIX")) {
         // PW 2017/05/15: If FS_POSIX is set, write to cwd (as per POSIX:4.11)
-        sprintf(fname, "./%s", fname_no_path);
+        int req = snprintf(fname, STRLEN, "./%s", fname_no_path);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
       else {
         // PW 2017/05/15: Legacy behaviour
-        sprintf(fname, "%s/../label/%s", path, fname_no_path);
+        int req = snprintf(fname, STRLEN, "%s/../label/%s", path, fname_no_path); 
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
     }
     else { /* no hemisphere specified */
       if (getenv("FS_POSIX")) {
         // PW 2017/05/15: If FS_POSIX is set, write to cwd (as per POSIX:4.11)
-        sprintf(fname, "./%s.%s", mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", fname_no_path);
+        int req = snprintf(fname, STRLEN, "./%s.%s",
+			   mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", fname_no_path);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
       else {
         // PW 2017/05/15: Legacy behaviour
-        sprintf(fname, "%s/../label/%s.%s", path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", fname_no_path);
+        int req = snprintf(fname, STRLEN, "%s/../label/%s.%s",
+			   path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", fname_no_path); 
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
     }
   }
@@ -1905,7 +1848,7 @@ int MRISreadValuesIntoArray(const char *sname, int in_array_size, float **out_ar
   if (in_array_size < 0) ErrorReturn(ERROR_BADPARM, (ERROR_BADPARM, "in_array_size was negative."));
 
   /* First try to load it as a volume */
-  strncpy(fname, sname, sizeof(fname));
+  strncpy(fname, sname, sizeof(fname)-1);
   type = mri_identify(fname);
   if (type != MRI_VOLUME_TYPE_UNKNOWN) {
     frame = MRISgetReadFrame();
@@ -2209,11 +2152,19 @@ int mrisWriteSnapshots(MRI_SURFACE *mris, INTEGRATION_PARMS *parms, int t)
   strcpy(base_name, parms->base_name);
 
   MRISrestoreVertexPositions(mris, PIAL_VERTICES);
-  sprintf(parms->base_name, "%s_pial", base_name);
+  int req = snprintf(parms->base_name, STRLEN, "%s_pial", base_name); 
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   mrisWriteSnapshot(mris, parms, t);
 
   MRISrestoreVertexPositions(mris, ORIGINAL_VERTICES);
-  sprintf(parms->base_name, "%s_white", base_name);
+  req = snprintf(parms->base_name, STRLEN, "%s_white", base_name); 
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   mrisWriteSnapshot(mris, parms, t);
 
   MRISrestoreVertexPositions(mris, TMP_VERTICES);
@@ -2250,14 +2201,24 @@ int mrisWriteSnapshot(MRI_SURFACE *mris, INTEGRATION_PARMS *parms, int t)
       break;
   }
   FileNamePath(mris->fname, path);
-  sprintf(base_name, "%s/%s.%s", path, hemi, parms->base_name);
+  int req = snprintf(base_name, STRLEN, "%s/%s.%s", path, hemi, parms->base_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   if ((cp = strstr(base_name, ".geo")) != NULL) {
     *cp = 0;
-    sprintf(fname, "%s%4.4d.geo", base_name, t);
+    int req = snprintf(fname, STRLEN, "%s%4.4d.geo", base_name, t); 
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     *cp = '.';
   }
   else {
-    sprintf(fname, "%s%4.4d", base_name, t);
+    int req = snprintf(fname, STRLEN, "%s%4.4d", base_name, t);   
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
   }
 #if 1
   if (Gdiag & DIAG_SHOW) {
@@ -2302,7 +2263,10 @@ int mrisWriteSnapshot(MRI_SURFACE *mris, INTEGRATION_PARMS *parms, int t)
         MRIsetVoxVal(mri_vector, vno, 0, 0, 1, dy);
         MRIsetVoxVal(mri_vector, vno, 0, 0, 2, dz);
       }
-      sprintf(fname, "%s%4.4d.mgz", base_name, t);
+      int req = snprintf(fname, STRLEN, "%s%4.4d.mgz", base_name, t);
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("writing vector field to %s\n", fname);
       MRIwrite(mri_vector, fname);
       MRIfree(&mri_vector);
@@ -2320,7 +2284,11 @@ int mrisWriteSnapshot(MRI_SURFACE *mris, INTEGRATION_PARMS *parms, int t)
   if (mris->status == MRIS_PARAMETERIZED_SPHERE && DIAG_VERBOSE_ON) {
     MRI_SP *mrisp = (MRI_SP *)mris->vp;
 
-    sprintf(fname, "%s%4.4d.hipl", parms->base_name, t);
+    int req = snprintf(fname, STRLEN, "%s%4.4d.hipl", parms->base_name, t);  
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+
     if (Gdiag & DIAG_SHOW) {
       fprintf(stdout, "writing %s\n", fname);
     }
@@ -2328,7 +2296,11 @@ int mrisWriteSnapshot(MRI_SURFACE *mris, INTEGRATION_PARMS *parms, int t)
     MRISPwrite(mrisp, fname);
   }
   if (!FZERO(parms->l_area) && DIAG_VERBOSE_ON) {
-    sprintf(fname, "%s%4.4d.area_error", base_name, t);
+    int req = snprintf(fname, STRLEN, "%s%4.4d.area_error", base_name, t); 
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+
     if (Gdiag & DIAG_SHOW) {
       fprintf(stdout, " %s...", fname);
     }
@@ -2336,7 +2308,11 @@ int mrisWriteSnapshot(MRI_SURFACE *mris, INTEGRATION_PARMS *parms, int t)
   }
 
   if (!FZERO(parms->l_corr) && DIAG_VERBOSE_ON) {
-    sprintf(fname, "%s%4.4d.angle_error", base_name, t);
+    int req = snprintf(fname, STRLEN, "%s%4.4d.angle_error", base_name, t); 
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+
     if (Gdiag & DIAG_SHOW) {
       fprintf(stdout, " %s...", fname);
     }
@@ -3220,12 +3196,6 @@ int MRISwritePatchAscii(MRI_SURFACE *mris, const char *fname)
   int i;
 
   type = MRISfileNameType(fname);
-#if 0
-  if (type == MRIS_ASCII_TRIANGLE_FILE)
-  {
-    return(MRISwriteAscii(mris, fname)) ;
-  }
-#endif
 
   fp = fopen(fname, "w");
   if (!fp) ErrorReturn(ERROR_NOFILE, (ERROR_NOFILE, "MRISwritePatchAscii: could not open file %s", fname));
@@ -3298,11 +3268,7 @@ static MRI_SURFACE *mrisReadAsciiFile(const char *fname)
   cp = fgetl(line, STRLEN, fp);
   sscanf(cp, "%d %d\n", &nvertices, &nfaces);
   mris = MRISalloc(nvertices, nfaces);
-#if 0
-  mris->type = MRIS_ASCII_TRIANGLE_FILE ;
-#else
   mris->type = MRIS_TRIANGULAR_SURFACE;
-#endif
   for (vno = 0; vno < mris->nvertices; vno++) {
     VERTEX * v = &mris->vertices[vno];
     float x,y,z;
@@ -3461,54 +3427,6 @@ static int mrisReadGeoFilePositions(MRI_SURFACE *mris, const char *fname)
   fclose(fp);
   return (NO_ERROR);
 }
-
-#if 0
-/*-----------------------------------------------------
-  Parameters:
-
-  Returns value:
-
-  Description
-  ------------------------------------------------------*/
-static MRI_SURFACE *
-mrisReadAsciiPatchFile(char *fname)
-{
-  MRI_SURFACE   *mris ;
-  char    line[STRLEN], *cp ;
-  int     vno, fno, n, nvertices, nfaces ;
-  VERTEX  *v ;
-  FACE    *face ;
-  FILE    *fp ;
-
-  fp = fopen(fname, "r") ;
-  if (!fp)
-    ErrorReturn(NULL,
-                (ERROR_NOFILE,
-                 "MRISreadAsciiFile: could not open file %s",fname));
-
-  cp = fgetl(line, 100, fp) ;
-  sscanf(cp, "%d %d\n", &nvertices, &nfaces) ;
-  mris = MRISalloc(nvertices, nfaces) ;
-  for (vno = 0 ; vno < mris->nvertices ; vno++)
-  {
-    v = &mris->vertices[vno] ;
-    fscanf(fp, "%f  %f  %f\n", &v->x, &v->y, &v->z) ;
-  }
-  for (fno = 0 ; fno < mris->nfaces ; fno++)
-  {
-    face = &mris->faces[fno] ;
-    for (n = 0 ; n < VERTICES_PER_FACE ; n++)
-    {
-      fscanf(fp, "%d ", &face->v[n]) ;
-      mris->vertices[face->v[n]].num++;
-    }
-    fscanf(fp, "\n") ;
-  }
-
-  fclose(fp) ;
-  return(mris) ;
-}
-#endif
 
 
 /*-----------------------------------------------------
@@ -3692,9 +3610,6 @@ static MRIS* MRISreadOverAlloc_new(const char *fname, double nVFMultiplier)
           float z = freadFloat(fp);
           MRISsetXYZ(mris,vno, x,y,z);
         }
-  #if 0
-        vertex->label = NO_LABEL ;
-  #endif
         if (version == 0) /* old surface format */
         {
           int num;
@@ -4105,9 +4020,6 @@ static MRIS* MRISreadOverAlloc_old(const char *fname, double nVFMultiplier)
         float z = freadFloat(fp);
         MRISsetXYZ(mris,vno, x,y,z);
       }
-#if 0
-      vertex->label = NO_LABEL ;
-#endif
       /* brain-dead code and never used again either */
       imnr = (int)((vertex->y - START_Y) / SLICE_THICKNESS + 0.5);
       if (imnr > imnr1) {
@@ -4928,23 +4840,6 @@ int mrisReadTransform(MRIS *mris, const char *mris_fname)
   // mark to make sure it is freed
   mris->free_transform = 1;
 
-#if 0
-  if (input_transform_file(transform_fname, &mris->transform) != OK)
-  {
-    ErrorReturn(ERROR_NO_FILE,
-                (ERROR_NOFILE,
-                 "mrisReadTransform: could not read xform file '%s'",
-                 transform_fname)) ;
-  }
-  else
-  {
-    mris->linear_transform = get_linear_transform_ptr(&mris->transform) ;
-    mris->inverse_linear_transform =
-      get_inverse_linear_transform_ptr(&mris->transform) ;
-    mris->free_transform = 1 ;
-  }
-#endif
-
   mrisCheckVertexFaceTopology(mris);
   
   return (NO_ERROR);
@@ -4968,7 +4863,10 @@ int MRISreadBinaryCurvature(MRI_SURFACE *mris, const char *mris_fname)
 
   FileNamePath(mris_fname, fpref);
   strcpy(hemi, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh");
-  sprintf(fname, "%s/%s.curv", fpref, hemi);
+  int req = snprintf(fname, STRLEN, "%s/%s.curv", fpref, hemi); 
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   return (MRISreadCurvatureFile(mris, fname));
 }
 
@@ -5030,17 +4928,28 @@ int MRISreadCurvatureFile(MRI_SURFACE *mris, const char *sname)
   {
     if (getenv("FS_POSIX")) {
       // PW 2017/05/15: If FS_POSIX is set, write to cwd (as per POSIX:4.11)
-      sprintf(fname, "./%s", sname);
+      int req = snprintf(fname, STRLEN, "./%s", sname);    
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
     else {
       cp = strchr(sname, '.');
       FileNamePath(mris->fname, path);
       if (cp && ((strncmp(cp - 2, "lh", 2) == 0) || (strncmp(cp - 2, "rh", 2) == 0))) {
-        sprintf(fname, "%s/%s", path, sname);
+        int req = snprintf(fname, STRLEN, "%s/%s", path, sname); 
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
       else /* no hemisphere specified */
       {
-        sprintf(fname, "%s/%s.%s", path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", sname);
+        int req = snprintf(fname, STRLEN, "%s/%s.%s", 
+			   path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", sname); 
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+
       }
     }
   }
@@ -5191,10 +5100,19 @@ float *MRISreadCurvatureVector(MRI_SURFACE *mris, const char *sname)
     cp = strchr(sname, '.');
     FileNamePath(mris->fname, path);
     if (cp) {
-      sprintf(fname, "%s/%s", path, sname);
+      int req = snprintf(fname, STRLEN, "%s/%s", path, sname); 
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
-    else /* no hemisphere specified */
-      sprintf(fname, "%s/%s.%s", path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", sname);
+    else {
+      /* no hemisphere specified */
+      int req = snprintf(fname, STRLEN, "%s/%s.%s",
+			 path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", sname); 
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
   }
   else {
     strcpy(fname, sname); /* path specified explcitly */
@@ -5281,10 +5199,18 @@ int MRISreadFloatFile(MRI_SURFACE *mris, const char *sname)
     cp = strchr(sname, '.');
     FileNamePath(mris->fname, path);
     if (cp) {
-      sprintf(fname, "%s/%s", path, sname);
+      int req = snprintf(fname, STRLEN, "%s/%s", path, sname);  
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
-    else /* no hemisphere specified */
-      sprintf(fname, "%s/%s.%s", path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", sname);
+    else { /* no hemisphere specified */
+      int req = snprintf(fname, STRLEN, "%s/%s.%s",
+			 path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", sname);
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
   }
   else {
     strcpy(fname, sname); /* path specified explcitly */
@@ -5343,7 +5269,10 @@ int MRISreadBinaryAreas(MRI_SURFACE *mris, const char *mris_fname)
 
   FileNamePath(mris_fname, fpref);
   strcpy(hemi, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh");
-  sprintf(fname, "%s/%s.area", fpref, hemi);
+  int req = snprintf(fname, STRLEN, "%s/%s.area", fpref, hemi);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
 
   /*  mris->orig_area = 0.0f ;*/
   fp = fopen(fname, "r");
@@ -5366,14 +5295,6 @@ int MRISreadBinaryAreas(MRI_SURFACE *mris, const char *mris_fname)
   }
   fclose(fp);
 
-/* hack to correct for overestimation of area in compute_normals */
-#if 0
-  mris->orig_area /= 2;
-  if (Gdiag & DIAG_SHOW)
-  {
-    fprintf(stdout, "total area = %2.0f.\n", mris->orig_area) ;
-  }
-#endif
   return (NO_ERROR);
 }
 
@@ -5567,9 +5488,6 @@ static SMALL_SURFACE *mrisReadTriangleFileVertexPositionsOnly(const char *fname)
     v->x = freadFloat(fp);
     v->y = freadFloat(fp);
     v->z = freadFloat(fp);
-#if 0
-    v->label = NO_LABEL ;
-#endif
     if (fabs(v->x) > 10000 || !std::isfinite(v->x))
       ErrorExit(ERROR_BADFILE, "%s: vertex %d x coordinate %f!", Progname, vno, v->x);
     if (fabs(v->y) > 10000 || !std::isfinite(v->y))
@@ -5592,10 +5510,6 @@ static int mrisReadTriangleFilePositions(MRI_SURFACE *mris, const char *fname)
   int nvertices, nfaces, magic, vno;
   char line[STRLEN];
   FILE *fp;
-#if 0
-  FACE        *f ;
-  int         fno, n ;
-#endif
 
   fp = fopen(fname, "rb");
   if (!fp) ErrorReturn(ERROR_NOFILE, (ERROR_NOFILE, "mrisReadTriangleFile(%s): could not open file", fname));
@@ -5632,20 +5546,6 @@ static int mrisReadTriangleFilePositions(MRI_SURFACE *mris, const char *fname)
     float z = freadFloat(fp);
     MRISsetXYZ(mris, vno, x,y,z);
   }
-
-#if 0
-  for (fno = 0 ; fno < mris->nfaces ; fno++)
-  {
-    f = &mris->faces[fno] ;
-    for (n = 0 ; n < VERTICES_PER_FACE ; n++)
-    {
-      f->v[n] = freadInt(fp);
-      if (f->v[n] >= mris->nvertices || f->v[n] < 0)
-        ErrorExit(ERROR_BADFILE, "f[%d]->v[%d] = %d - out of range!\n",
-                  fno, n, f->v[n]) ;
-    }
-  }
-#endif
 
   fclose(fp);
   return (NO_ERROR);
@@ -5735,11 +5635,6 @@ static MRI_SURFACE *mrisReadTriangleFile(const char *fname, double nVFMultiplier
       switch (tag) {
         case TAG_GROUP_AVG_SURFACE_AREA:
           mris->group_avg_surface_area = freadFloat(fp);
-#if 0
-        fprintf(stdout,
-                "reading group avg surface area %2.0f cm^2 from file\n",
-                mris->group_avg_surface_area/100.0) ;
-#endif
           break;
         case TAG_OLD_SURF_GEOM:
           readVolGeom(fp, &mris->vg);
@@ -5793,22 +5688,31 @@ int MRISbuildFileName(MRI_SURFACE *mris, const char *sname, char *fname)
     if (dot && (*(dot - 1) == 'h') && (*(dot - 2) == 'l' || *(dot - 2) == 'r')) {
       if (getenv("FS_POSIX")) {
         // PW 2017/05/15: If FS_POSIX is set, write to cwd (as per POSIX:4.11)
-        sprintf(fname, "./%s", sname);
+        int req = snprintf(fname, STRLEN, "./%s", sname); 
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
       else {
         // PW 2017/05/15: Legacy behaviour
-        sprintf(fname, "%s/%s", path, sname);
+        int req = snprintf(fname, STRLEN, "%s/%s", path, sname); 
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
     }
     else /* no hemisphere specified */
         if (getenv("FS_POSIX")) {
       // PW 2017/05/15: If FS_POSIX is set, write to cwd (as per POSIX:4.11)
-      sprintf(fname,
-              "./%s.%s",
-              mris->hemisphere == LEFT_HEMISPHERE ? "lh" : mris->hemisphere == BOTH_HEMISPHERES ? "both" : "rh",
-              sname);
-    }
-    else {
+	  int req = snprintf(fname, STRLEN,
+			     "./%s.%s",
+			     mris->hemisphere == LEFT_HEMISPHERE ? "lh" : mris->hemisphere == BOTH_HEMISPHERES ? "both" : "rh",
+			     sname);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
+	}
+	else {
       // PW 2017/05/15: Legacy behaviour
       sprintf(fname,
               "%s/%s.%s",
@@ -5904,10 +5808,19 @@ int MRISreadNewCurvatureFile(MRI_SURFACE *mris, const char *sname)
     cp = strchr(sname, '.');
     FileNamePath(mris->fname, path);
     if (cp) {
-      sprintf(fname, "%s/%s", path, sname);
+      int req = snprintf(fname, STRLEN, "%s/%s", path, sname); 
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
-    else /* no hemisphere specified */
-      sprintf(fname, "%s/%s.%s", path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", sname);
+    else {
+      /* no hemisphere specified */
+      int req = snprintf(fname, STRLEN, "%s/%s.%s",
+			 path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", sname); 
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
   }
   else {
     strcpy(fname, sname); /* path specified explcitly */
@@ -5980,10 +5893,18 @@ float *MRISreadNewCurvatureVector(MRI_SURFACE *mris, const char *sname)
     cp = strchr(sname, '.');
     FileNamePath(mris->fname, path);
     if (cp) {
-      sprintf(fname, "%s/%s", path, sname);
+      int req = snprintf(fname, STRLEN, "%s/%s", path, sname);  
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
-    else /* no hemisphere specified */
-      sprintf(fname, "%s/%s.%s", path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", sname);
+    else { /* no hemisphere specified */
+      int req = snprintf(fname, STRLEN, "%s/%s.%s",
+			 path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", sname);  
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
   }
   else {
     strcpy(fname, sname); /* path specified explcitly */

--- a/utils/mrisurf_metricProperties.cpp
+++ b/utils/mrisurf_metricProperties.cpp
@@ -9019,7 +9019,14 @@ static int get_face_axes(
 // Deformity support
 //
 void INTEGRATION_PARMS_copy   (INTEGRATION_PARMS* dst, INTEGRATION_PARMS const * src) {
+#if GCC_VERSION > 80000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
     memcpy(dst, src, sizeof(*src)); // note: copies the const fp et. al.!
+#if GCC_VERSION > 80000
+#pragma GCC diagnostic pop
+#endif
 }
 
 void INTEGRATION_PARMS_setFp  (INTEGRATION_PARMS* parms, FILE* file) {

--- a/utils/mrisurf_mri.cpp
+++ b/utils/mrisurf_mri.cpp
@@ -120,7 +120,11 @@ int MRISpositionSurfaces(MRI_SURFACE *mris, MRI **mri_flash, int nvolumes, INTEG
     char fname[STRLEN];
 
     if (!parms->fp) {
-      sprintf(fname, "%s.%s.out", mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);
+      int req = snprintf(fname, STRLEN, "%s.%s.out",
+			 mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name); 
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (!parms->start_t) {
         INTEGRATION_PARMS_openFp(parms, fname, "w");
       }
@@ -478,10 +482,14 @@ int MRISpositionSurface(MRI_SURFACE *mris, MRI *mri_brain, MRI *mri_smooth, INTE
     char fname[STRLEN];
 
     if (!parms->fp) {
-      sprintf(fname,
-              "%s.%s.out",
-              mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : mris->hemisphere == BOTH_HEMISPHERES ? "both" : "lh",
-              parms->base_name);
+      int req = snprintf(fname,
+			 STRLEN,
+			 "%s.%s.out",
+			 mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : mris->hemisphere == BOTH_HEMISPHERES ? "both" : "lh",
+			 parms->base_name); 
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (!parms->start_t) {
         INTEGRATION_PARMS_openFp(parms, fname, "w");
       }
@@ -895,7 +903,11 @@ int MRISpositionSurface_mef(
     char fname[STRLEN];
 
     if (!parms->fp) {
-      sprintf(fname, "%s.%s.out", mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);
+      int req = snprintf(fname, STRLEN, "%s.%s.out",
+			 mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name); 
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (!parms->start_t) {
         INTEGRATION_PARMS_openFp(parms, fname, "w");
       }
@@ -1075,7 +1087,11 @@ int MRISmoveSurface(MRI_SURFACE *mris, MRI *mri_brain, MRI *mri_smooth, INTEGRAT
     char fname[STRLEN];
 
     if (!parms->fp) {
-      sprintf(fname, "%s.%s.out", mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);
+      int req = snprintf(fname, STRLEN, "%s.%s.out",
+			 mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name); 
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (!parms->start_t) {
         INTEGRATION_PARMS_openFp(parms, fname, "w");
       }

--- a/utils/mrisurf_sseTerms.cpp
+++ b/utils/mrisurf_sseTerms.cpp
@@ -1183,7 +1183,10 @@ double SseTerms_MRIS::NegativeLogPosterior( INTEGRATION_PARMS *parms, int *pnvox
   if (Gdiag & DIAG_WRITE) {
     char fname[STRLEN];
     mri_ll = MRIcloneDifferentType(mri, MRI_FLOAT);
-    sprintf(fname, "%s.vfrac.%4.4d.mgz", parms->base_name, parms->t);
+    int req = snprintf(fname, STRLEN, "%s.vfrac.%4.4d.mgz", parms->base_name, parms->t); 
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     MRIwrite(parms->mri_volume_fractions, fname);
   }
 
@@ -1223,9 +1226,16 @@ double SseTerms_MRIS::NegativeLogPosterior( INTEGRATION_PARMS *parms, int *pnvox
     HISTOmakePDF(hout, hout);
     if (Gdiag & DIAG_WRITE) {
       char fname[STRLEN];
-      sprintf(fname, "hin.%s.%3.3d.plt", parms->base_name, parms->t);
+      int req = snprintf(fname, STRLEN, "hin.%s.%3.3d.plt", 
+			 parms->base_name, parms->t);  
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       HISTOplot(hin, fname);
-      sprintf(fname, "hout.%s.%3.3d.plt", parms->base_name, parms->t);
+      req = snprintf(fname, STRLEN, "hout.%s.%3.3d.plt", parms->base_name, parms->t);  
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       HISTOplot(hout, fname);
     }
   }
@@ -1281,7 +1291,10 @@ double SseTerms_MRIS::NegativeLogPosterior( INTEGRATION_PARMS *parms, int *pnvox
   if (!FZERO(last_sse) && sse > last_sse) DiagBreak();
   if (mri_ll) {
     char fname[STRLEN];
-    sprintf(fname, "%s.ll.%4.4d.mgz", parms->base_name, parms->t);
+    int req = snprintf(fname, STRLEN, "%s.ll.%4.4d.mgz", parms->base_name, parms->t); 
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing log likelihood volume to %s\n", fname);
     MRIwrite(mri_ll, fname);
     MRIfree(&mri_ll);
@@ -1334,7 +1347,10 @@ double SseTerms_MRIS::NegativeLogPosterior2D( INTEGRATION_PARMS *parms, int *pnv
   if (Gdiag & DIAG_WRITE) {
     char fname[STRLEN];
     mri_ll = MRIcloneDifferentType(mri, MRI_FLOAT);
-    sprintf(fname, "%s.vfrac.%4.4d.mgz", parms->base_name, parms->t);
+    int req = snprintf(fname, STRLEN, "%s.vfrac.%4.4d.mgz", parms->base_name, parms->t);  
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     MRIwrite(parms->mri_volume_fractions, fname);
   }
 
@@ -1397,7 +1413,10 @@ double SseTerms_MRIS::NegativeLogPosterior2D( INTEGRATION_PARMS *parms, int *pnv
     if (Gdiag & DIAG_WRITE) {
       char fname[STRLEN];
 
-      sprintf(fname, "h.%s.%3.3d.plt", parms->base_name, parms->t);
+      int req = snprintf(fname, STRLEN, "h.%s.%3.3d.plt", parms->base_name, parms->t);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("writing histogram %s\n", fname);
       HISTO2Dwrite(parms->h2d, fname);
     }
@@ -1406,7 +1425,10 @@ double SseTerms_MRIS::NegativeLogPosterior2D( INTEGRATION_PARMS *parms, int *pnv
     hs = HISTO2DmakePDF(parms->h2d, NULL);
     if (Gdiag & DIAG_WRITE) {
       char fname[STRLEN];
-      sprintf(fname, "h.%s.%3.3d.pdf.plt", parms->base_name, parms->t);
+      int req = snprintf(fname, STRLEN, "h.%s.%3.3d.pdf.plt", parms->base_name, parms->t); 
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("writing histogram %s\n", fname);
       HISTO2Dwrite(hs, fname);
     }
@@ -1417,7 +1439,10 @@ double SseTerms_MRIS::NegativeLogPosterior2D( INTEGRATION_PARMS *parms, int *pnv
     HISTO2DmakePDF(parms->h2d_out, hs);
     if (Gdiag & DIAG_WRITE) {
       char fname[STRLEN];
-      sprintf(fname, "h.%s.%3.3d.pdf.smooth.plt", parms->base_name, parms->t);
+      int req = snprintf(fname, STRLEN, "h.%s.%3.3d.pdf.smooth.plt", parms->base_name, parms->t); 
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("writing histogram %s\n", fname);
       HISTO2Dwrite(hs, fname);
     }
@@ -1503,7 +1528,10 @@ double SseTerms_MRIS::NegativeLogPosterior2D( INTEGRATION_PARMS *parms, int *pnv
   if (!FZERO(last_sse) && sse > last_sse) DiagBreak();
   if (mri_ll) {
     char fname[STRLEN];
-    sprintf(fname, "%s.ll.%4.4d.mgz", parms->base_name, parms->t);
+    int req = snprintf(fname, STRLEN, "%s.ll.%4.4d.mgz", parms->base_name, parms->t);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing log likelihood volume to %s\n", fname);
     MRIwrite(mri_ll, fname);
     MRIfree(&mri_ll);
@@ -1728,7 +1756,6 @@ double MRIScomputeCorrelationError(MRI_SURFACE *mris, MRI_SP *mrisp_template, in
     return (0.0);
   }
 
-  memset(&parms, 0, sizeof(parms));
   parms.mrisp_template = mrisp_template;
   parms.l_corr = 1.0f;
   parms.frame_no = fno;
@@ -1930,7 +1957,6 @@ double SseTerms_MRIS::RmsDistanceError()
   INTEGRATION_PARMS parms;
   double rms;
 
-  memset(&parms, 0, sizeof(parms));
   parms.l_location = 1;
   rms = mrisComputeTargetLocationError(mris, &parms);
   return (sqrt(rms / MRISvalidVertices(mris)));

--- a/utils/mrisurf_timeStep.cpp
+++ b/utils/mrisurf_timeStep.cpp
@@ -2094,7 +2094,10 @@ int MRISexpandSurface(MRI_SURFACE *mris, float distance, INTEGRATION_PARMS *parm
       MRISsaveVertexPositions(mris, ORIGINAL_VERTICES);
       MRISsaveVertexPositions(mris, WHITE_VERTICES);
     }
-    sprintf(fname, "%s.%s%3.3d", hemi, parms->base_name, 0);
+    int req = snprintf(fname, STRLEN, "%s.%s%3.3d", hemi, parms->base_name, 0);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing expanded surface to %s...\n", fname);
     MRISwrite(mris, fname);
   }
@@ -2124,7 +2127,6 @@ int MRISexpandSurface(MRI_SURFACE *mris, float distance, INTEGRATION_PARMS *parm
   else {
     MRISsaveVertexPositions(mris, ORIGINAL_VERTICES);
     if (use_thick) {
-      memset(&thick_parms, 0, sizeof(thick_parms));
       thick_parms.dt = 0.2;
       thick_parms.momentum = .5;
       thick_parms.l_nlarea = 1;
@@ -2136,7 +2138,10 @@ int MRISexpandSurface(MRI_SURFACE *mris, float distance, INTEGRATION_PARMS *parm
       if (cp == NULL) {
         ErrorExit(ERROR_BADPARM, "%s: FREESURFER_HOME not defined in environment", cp);
       }
-      sprintf(fname, "%s/lib/bem/ic7.tri", cp);
+      int req = snprintf(fname, STRLEN, "%s/lib/bem/ic7.tri", cp);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       mris_ico = MRISread(fname);
       if (!mris_ico) {
         ErrorExit(ERROR_NOFILE, "%s: could not open surface file %s", Progname, fname);
@@ -2279,10 +2284,16 @@ int MRISexpandSurface(MRI_SURFACE *mris, float distance, INTEGRATION_PARMS *parm
           }
         }
 
-        sprintf(fname, "%s.target_dist.%d.mgz", parms->base_name, surf_no);
+        int req = snprintf(fname, STRLEN, "%s.target_dist.%d.mgz", parms->base_name, surf_no);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         printf("writing target surface distances to %s\n", fname);
         MRISwriteD(mris, fname);
-        sprintf(fname, "%s.targets.%d", parms->base_name, surf_no);
+        req = snprintf(fname, STRLEN, "%s.targets.%d", parms->base_name, surf_no);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         printf("writing target surface to %s\n", fname);
         MRISsaveVertexPositions(mris, TMP_VERTICES);
         MRISrestoreVertexPositions(mris, TARGET_VERTICES);
@@ -2370,7 +2381,10 @@ int MRISexpandSurface(MRI_SURFACE *mris, float distance, INTEGRATION_PARMS *parm
       else {
         printf("\n");
       }
-      sprintf(fname, "%s.%s%3.3d", hemi, parms->base_name, surf_no + 1);
+      int req = snprintf(fname, STRLEN, "%s.%s%3.3d", hemi, parms->base_name, surf_no + 1);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (nsurfaces > 1) {
         printf("writing expanded surface to %s...\n", fname);
         MRISwrite(mris, fname);
@@ -2404,7 +2418,11 @@ int MRISremoveOverlapWithSmoothing(MRI_SURFACE *mris, INTEGRATION_PARMS *parms)
   if (Gdiag & DIAG_WRITE) {
     char fname[STRLEN];
     if (!parms->fp) {
-      sprintf(fname, "%s.%s.out", mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);
+      int req = snprintf(fname, STRLEN, "%s.%s.out",
+			 mris->hemisphere == RIGHT_HEMISPHERE ? "rh" : "lh", parms->base_name);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       INTEGRATION_PARMS_openFp(parms, fname, "a");
       if (!parms->fp) ErrorExit(ERROR_NOFILE, "%s: could not open log file %s", Progname, fname);
     }
@@ -2629,9 +2647,6 @@ int MRISremoveCompressedRegions(MRI_SURFACE *mris, double min_dist)
       setFaceOrigArea(mris,fno,0.5f);
     }
   }
-
-  memset(&parms, 0, sizeof(parms));
-
   parms.l_parea = .002;
   l_spring = .01;
   l_convex = 0;

--- a/utils/mrisurf_topology.cpp
+++ b/utils/mrisurf_topology.cpp
@@ -1046,6 +1046,10 @@ void MRIS_VertexNeighbourInfo_check(
 void MRIS_VertexNeighbourInfo_load_from_VERTEX (MRIS_VertexNeighbourInfo* info, MRIS* mris, int vno) {
   VERTEX_TOPOLOGY const * const vt = &mris->vertices_topology[vno];
   info->hops = vt->nsizeMax;
+#if GCC_VERSION > 80000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
   switch (info->hops) {
   default: cheapAssert(false);
   case 3: info->vnum[3] = vt->v3num;
@@ -1053,6 +1057,9 @@ void MRIS_VertexNeighbourInfo_load_from_VERTEX (MRIS_VertexNeighbourInfo* info, 
   case 1: info->vnum[1] = vt->vnum;
   case 0: info->vnum[0] = 1;
   }
+#if GCC_VERSION > 80000
+#pragma GCC diagnostic pop
+#endif
   int i;
   for (i = 0; i < info->vnum[info->hops]; i++) info->v[i] = vt->v[i];
 }

--- a/utils/mrisurf_vals.cpp
+++ b/utils/mrisurf_vals.cpp
@@ -3251,6 +3251,10 @@ HISTOGRAM *MRISgetHistogram(MRI_SURFACE *mris, int nbins, int field)
     if (v->ripflag) {
       continue;
     }
+#if GCC_VERSION > 80000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
     switch (field) {
       default:
         ErrorExit(ERROR_BADPARM, "MRISgetHistogram: unknown field %d", field);
@@ -3282,6 +3286,9 @@ HISTOGRAM *MRISgetHistogram(MRI_SURFACE *mris, int nbins, int field)
         val = v->std_error;
         break;
     }
+#if GCC_VERSION > 80000
+#pragma GCC diagnostic pop
+#endif
     if (val < fmin) {
       fmin = val;
     }
@@ -3310,6 +3317,10 @@ HISTOGRAM *MRISgetHistogram(MRI_SURFACE *mris, int nbins, int field)
     if (v->ripflag) {
       continue;
     }
+#if GCC_VERSION > 80000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
     switch (field) {
       default:
         ErrorExit(ERROR_BADPARM, "MRISgetHistogram: unknown field %d", field);
@@ -3341,6 +3352,9 @@ HISTOGRAM *MRISgetHistogram(MRI_SURFACE *mris, int nbins, int field)
         val = v->std_error;
         break;
     }
+#if GCC_VERSION > 80000
+#pragma GCC diagnostic pop
+#endif
     bin = HISTOvalToBinDirect(h, val);
     h->counts[bin]++;
   }

--- a/utils/mrisutils.cpp
+++ b/utils/mrisutils.cpp
@@ -2182,7 +2182,6 @@ MRI_SP *MRISmakeTemplate(int nsubjects, char **subjlist, int nhemis, char **hemi
   MRIS *mris;
 
   /* default template fields*/
-  memset(&parms, 0, sizeof(parms));
   parms.nfields = 3;
   SetFieldLabel(&parms.fields[0], INFLATED_CURV_CORR_FRAME, 0, 0.0, 0.0, 0, which_norm);
   /* only use sulc for rigid registration */

--- a/utils/mrivoxel.cpp
+++ b/utils/mrivoxel.cpp
@@ -501,7 +501,14 @@ float MRIvoxelMedian(MRI *mri, int x0, int y0, int z0, int wsize)
   }
   wcubed = (wsize * wsize * wsize);
   median_index = wcubed / 2;
+#if GCC_VERSION > 80000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull"
+#endif
   qsort(sort_array, wcubed, sizeof(float), compare_sort_array);
+#if GCC_VERSION > 80000
+#pragma GCC diagnostic pop
+#endif
   median = sort_array[median_index];
   return (median);
 }

--- a/utils/path.cpp
+++ b/utils/path.cpp
@@ -310,10 +310,11 @@ PATH *PathAlloc(int n_points, const char *name)
   path->n_points = n_points;
 
   /* Copy in a name. */
-  if (NULL != name)
-    strncpy(path->name, name, 100);
-  else
+  if (NULL != name) {
+    strncpy(path->name, name, 100-1);
+  } else {
     strcpy(path->name, "");
+  }
 
   /* Allocate the point storage. */
   path->points = (PATH_POINT *)calloc(n_points, sizeof(PATH_POINT));

--- a/utils/rbm.cpp
+++ b/utils/rbm.cpp
@@ -164,20 +164,6 @@ static int dump_gradients(
   return (NO_ERROR);
 }
 
-#if 0
-static MRI *
-visible_to_mri(RBM *rbm)  
-{
-  MRI *mri ;
-  int k1, k2, i ;
-  
-  mri = MRIalloc(rbm->ksize, rbm->ksize, 1, MRI_FLOAT) ;
-  for (i = k1 = 0 ; k1 < rbm->ksize ; k1++)
-    for (k2 = 0 ; k2 < rbm->ksize ; k2++, i++)
-      MRIsetVoxVal(mri, k1, k2, 0, 0, rbm->visible[i]) ;
-  return(mri) ;
-}
-#endif
 double RBMfreeEnergy(RBM *rbm, double *visible)
 {
   double free_energy[MAX_RBM_LABELS], total;
@@ -235,31 +221,35 @@ int RBMwriteNetwork(RBM *rbm, int n, RBM_PARMS *parms, int layer)
 
   mri = weights_to_mri(rbm);
   if (layer < 0) {
-    if (n < 0)
-      sprintf(fname, "%s.wts.mgz", parms->base_name);
-    else
-      sprintf(fname, "%s.%3.3d.wts.mgz", parms->base_name, n);
+    if (n < 0) {
+      int req = snprintf(fname, STRLEN, "%s.wts.mgz", parms->base_name);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    } else {
+      int req = snprintf(fname, STRLEN, "%s.%3.3d.wts.mgz", parms->base_name, n);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
   }
   else {
-    if (n < 0)
-      sprintf(fname, "%s.layer%d.wts.mgz", parms->base_name, layer);
-    else
-      sprintf(fname, "%s.%3.3d.layer%d.wts.mgz", parms->base_name, n, layer);
+    if (n < 0) {
+      int req = snprintf(fname, STRLEN, "%s.layer%d.wts.mgz", parms->base_name, layer);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    } else {
+      int req = snprintf(fname, STRLEN, "%s.%3.3d.layer%d.wts.mgz", parms->base_name, n, layer);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
   }
 
   printf("saving weights to %s\n", fname);
   MRIwrite(mri, fname);
   MRIfree(&mri);
-
-#if 0
-  if (n < 0)
-    sprintf(fname, "%s.V.mgz", parms->base_name) ;
-  else
-    sprintf(fname, "%s.%3.3d.V.mgz", parms->base_name, n) ;
-  mri = visible_to_mri(rbm) ;
-  printf("saving visible to %s\n", fname) ;
-  MRIwrite(mri, fname) ; MRIfree(&mri) ;
-#endif
 
   return (NO_ERROR);
 }
@@ -757,9 +747,15 @@ double RBMvoxlistHistoRMS(RBM *rbm, VOXLIST *vl, RBM_PARMS *parms, int *indices,
     HISTOsmooth(histo_data[v], histo_data[v], sigma);
     HISTOsmooth(histo_recon[v], histo_recon[v], sigma);
     if (!((callno + 1) % parms->write_iterations)) {
-      sprintf(fname, "hist.data.%3.3d.%2.2d.log", callno, v);
+      int req = snprintf(fname, STRLEN, "hist.data.%3.3d.%2.2d.log", callno, v);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       HISTOplot(histo_data[v], fname);
-      sprintf(fname, "hist.recon.%3.3d.%2.2d.log", callno, v);
+      req = snprintf(fname, STRLEN, "hist.recon.%3.3d.%2.2d.log", callno, v);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       HISTOplot(histo_recon[v], fname);
     }
     rms += HISTOksDistance(histo_data[v], histo_recon[v]);
@@ -936,7 +932,10 @@ int RBMtrainFromImage(RBM *rbm, MRI *mri_inputs, MRI *mri_labels, RBM_PARMS *par
   rbm->mri_inputs = mri_inputs;
   if (parms->write_iterations > 0) {
     char fname[STRLEN];
-    sprintf(fname, "%s.V%3.3d.mgz", parms->base_name, 0);
+    int req = snprintf(fname, STRLEN, "%s.V%3.3d.mgz", parms->base_name, 0);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing snapshot to %s\n", fname);
     MRIwrite(mri_inputs, fname);
   }
@@ -1202,10 +1201,16 @@ MRI *RBMreconstruct(RBM *rbm, MRI *mri_inputs, MRI *mri_reconstructed, MRI **pmr
             for (h = 0; h < rbm->nhidden; h++) hidden_counts[h] += rbm->hidden_state[h];
           }
       }
-    sprintf(fname, "%s.hidden.plt", parms->base_name);
+    int req = snprintf(fname, STRLEN, "%s.hidden.plt", parms->base_name);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("saving %s\n", fname);
     HISTOplot(histo, fname);
-    sprintf(fname, "%s.hidden_labels.plt", parms->base_name);
+    req = snprintf(fname, STRLEN, "%s.hidden_labels.plt", parms->base_name);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("saving %s\n", fname);
     HISTO2Dplot(histo_labels, fname);
   }
@@ -1333,7 +1338,10 @@ int DBNtrainFromImage(DBN *dbn, MRI *mri_inputs, MRI *mri_labels, RBM_PARMS *par
 
   if (parms->write_iterations > 0) {
     char fname[STRLEN];
-    sprintf(fname, "%s.V%3.3d.mgz", parms->base_name, 0);
+    int req = snprintf(fname, STRLEN, "%s.V%3.3d.mgz", parms->base_name, 0);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing snapshot to %s\n", fname);
     MRIwrite(mri_inputs, fname);
   }
@@ -1518,10 +1526,17 @@ int DBNwriteNetwork(DBN *dbn, int n, RBM_PARMS *parms)
   RBMwriteNetwork(dbn->rbms[0], n, parms, 0);
   for (layer = 1; layer < dbn->nlayers; layer++) {
     mri = layer_weights_to_mri(dbn, layer);
-    if (n < 0)
-      sprintf(fname, "%s.layer%d.wts.mgz", parms->base_name, layer);
-    else
-      sprintf(fname, "%s.%3.3d.layer%d.wts.mgz", parms->base_name, n, layer);
+    if (n < 0) {
+      int req = snprintf(fname, STRLEN, "%s.layer%d.wts.mgz", parms->base_name, layer);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    } else {
+      int req = snprintf(fname, STRLEN, "%s.%3.3d.layer%d.wts.mgz", parms->base_name, n, layer);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
     printf("saving weights to %s\n", fname);
     MRIwrite(mri, fname);
     MRIfree(&mri);
@@ -1674,13 +1689,7 @@ int DBNcomputeGradients(DBN *dbn,
     //    dhidden_bias[h] += parms->l_sparsity*(parms->sparsity - db_sparsity[h]) ;
     rbm->active_pvals[h] = parms->sparsity_decay * rbm->active_pvals[h] + (1 - parms->sparsity_decay) * active[h];
     delta = parms->l_sparsity[layer] * (parms->sparsity[layer] - rbm->active_pvals[h]);
-#if 0
-#define MAX_DELTA .01
-    if (delta > MAX_DELTA)
-      delta = MAX_DELTA ;
-    else if (delta < -MAX_DELTA)
-      delta = -MAX_DELTA ;
-#endif
+
     dhidden_bias[h] += delta;
     delta /= rbm->nvisible;
     for (v = 0; v < rbm->nvisible; v++) dw[v][h] += delta;
@@ -1764,55 +1773,28 @@ MRI *DBNreconstruct(DBN *dbn, MRI *mri_inputs, MRI *mri_reconstructed, MRI **pmr
           }
       }
     for (n = 0; n < dbn->nlayers; n++) {
-      sprintf(fname, "%s.hidden.layer%d.plt", parms->base_name, n);
+      int req = snprintf(fname, STRLEN, "%s.hidden.layer%d.plt", parms->base_name, n);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("saving %s\n", fname);
       HISTOplot(histo[n], fname);
     }
-    sprintf(fname, "%s.hidden_labels.plt", parms->base_name);
+    int req = snprintf(fname, STRLEN, "%s.hidden_labels.plt", parms->base_name);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("saving %s\n", fname);
     HISTO2Dplot(histo_labels, fname);
   }
-#if 0
-  else
-  {
-    int v ;
-
-    for (rms = 0.0, f = 0 ; f < mri_inputs->nframes ; f++)
-      for (x = 0 ; x < mri_inputs->width ; x++)
-      {
-	if (!((x+1) % 100))
-	{
-	  printf("x = %d of %d\n", x, mri_inputs->width) ;
-	  MRIwrite(mri_reconstructed, "r.mgz") ;
-	}
-	for (y = 0 ; y < mri_inputs->height ; y++)
-	  for (z = 0 ; z < mri_inputs->depth ; z++)
-	  {
-	    RBMfillVisible(rbm, mri_inputs, rbm->visible, x, y, z, f, parms->ksize);
-	    RBMactivateForward(rbm, rbm->visible) ;
-	    RBMactivateBackward(rbm) ;
-	    for (n = 0 ; n < Ncd ; n++)
-	    {
-	      RBMactivateForward(rbm, NULL) ;
-	      RBMactivateBackward(rbm) ;
-	    }
-	    for (v = 0 ; v < rbm->nvisible ; v++)
-	    {
-	      V0 = MRIgetVoxVal(mri_inputs, x, y, z, v) ;
-	      Vn = rbm->visible[v] ;
-	      rms += SQR(Vn-V0) ;
-	      MRIsetVoxVal(mri_reconstructed, x, y, z, v, Vn) ;
-	    }
-	  }
-      }
-  }
-#endif
 
   nvox = mri_inputs->width * mri_inputs->height * mri_inputs->depth * mri_inputs->nframes;
   printf("final RMS = %2.3f\n", sqrt(rms / nvox));
   if (pmri_labeled) *pmri_labeled = mri_labeled;
   return (mri_reconstructed);
 }
+
+
 double DBNvoxlistRMS(DBN *dbn, int layer, VOXLIST *vl, RBM_PARMS *parms, int *indices, int index, int num)
 {
   int i, x, y, z, f, n, ind, v, nvox;
@@ -1874,7 +1856,10 @@ int CDBNtrainFromImage(CDBN *cdbn, MRI *mri_inputs, MRI *mri_labels, RBM_PARMS *
 
   if (parms->write_iterations > 0) {
     char fname[STRLEN];
-    sprintf(fname, "%s.V%3.3d.mgz", parms->base_name, 0);
+    int req = snprintf(fname, STRLEN, "%s.V%3.3d.mgz", parms->base_name, 0);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing snapshot to %s\n", fname);
     MRIwrite(mri_inputs, fname);
   }
@@ -1925,9 +1910,6 @@ CDBN *CDBNalloc(int type, int nlayers, int *ksizes, int *ngroups, int nlabels, M
 static int reset_hidden_nodes(CDBN *cdbn, int layer, double min_active, double max_active)
 {
   int h, num_off, num_on;
-#if 0
-  int    v ;
-#endif
   RBM *rbm;
 
   rbm = cdbn->rbms[layer];
@@ -1935,23 +1917,11 @@ static int reset_hidden_nodes(CDBN *cdbn, int layer, double min_active, double m
   for (num_off = num_on = h = 0; h < rbm->nhidden; h++) {
     if (rbm->active[h] < min_active || rbm->active[h] > max_active)  // always on or off
     {
-      if (rbm->active[h] < min_active)
+      if (rbm->active[h] < min_active) {
         num_off++;
-      else
+      } else {
         num_on++;
-#if 0
- // double wt_lim = 1.0 / rbm->nhidden;
-      rbm->hidden_bias[h] = 0 ;
-      for (v = 0 ; v < rbm->nvisible ; v++)
-	rbm->weights[v][h] *= .9 ;
-//	rbm->weights[v][h] = randomNumber(-wt_lim, wt_lim) ;
-      if (rbm->nlabels > 0)
-      {
-	for (v = 0 ; v < rbm->nlabels ; v++)
-	  rbm->label_weights[v][h] *= .9 ;
-//	  rbm->label_weights[v][h] = randomNumber(-wt_lim, wt_lim) ;
       }
-#endif
     }
   }
   if (num_off + num_on > 0)
@@ -2655,13 +2625,6 @@ int CDBNcomputeDiscriminativeGradients(CDBN *cdbn,
 
     dhidden_bias[h] *= scale;
 //    rbm->active_pvals[h] = parms->sparsity_decay*rbm->active_pvals[h] + (1-parms->sparsity_decay)*active[h];
-#if 0
-    delta = parms->l_sparsity[layer] * (parms->sparsity[layer] - rbm->active_pvals[h]) ;
-    dhidden_bias[h] += delta ;
-    delta /= rbm->nvisible ;
-    for (v = 0 ; v < rbm->nvisible ; v++)
-      dw[v][h] += delta ;
-#endif
   }
 
   free(visible);
@@ -2785,14 +2748,6 @@ int CDBNcomputeLabelGradients(CDBN *cdbn,
     //    double delta ;
 
     dhidden_bias[h] *= scale;
-//    rbm->active_pvals[h] = parms->sparsity_decay*rbm->active_pvals[h] + (1-parms->sparsity_decay)*active[h];
-#if 0
-    delta = parms->l_sparsity[layer] * (parms->sparsity[layer] - rbm->active_pvals[h]) ;
-    dhidden_bias[h] += delta ;
-    delta /= rbm->nvisible ;
-    for (v = 0 ; v < rbm->nvisible ; v++)
-      dw[v][h] += delta ;
-#endif
   }
 
   free(visible);
@@ -2909,7 +2864,11 @@ MRI *CDBNcreateOutputs(
       FILE *fp;
       int nvox, always, never;
 
-      sprintf(fname, "%s.%3.3d.layer%d.hidden_counts.txt", parms->base_name, callno, layer);
+      int req = snprintf(fname, STRLEN, "%s.%3.3d.layer%d.hidden_counts.txt",
+			 parms->base_name, callno, layer);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       fp = fopen(fname, "w");
       always = never = 0;
       nvox = mri_inputs->height * mri_inputs->width * mri_inputs->depth;
@@ -3004,10 +2963,17 @@ int CDBNwriteNetwork(CDBN *cdbn, int n, RBM_PARMS *parms, int layer)
   char fname[STRLEN];
 
   mri = cdbn_layer_weights(cdbn, layer);
-  if (n < 0)
-    sprintf(fname, "%s.layer%d.wts.mgz", parms->base_name, layer);
-  else
-    sprintf(fname, "%s.%3.3d.layer%d.wts.mgz", parms->base_name, n, layer);
+  if (n < 0) {
+    int req = snprintf(fname, STRLEN, "%s.layer%d.wts.mgz", parms->base_name, layer);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+  } else {
+    int req = snprintf(fname, STRLEN, "%s.%3.3d.layer%d.wts.mgz", parms->base_name, n, layer);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+  }
   printf("saving weights to %s\n", fname);
   MRIwrite(mri, fname);
   MRIfree(&mri);

--- a/utils/rgb.cpp
+++ b/utils/rgb.cpp
@@ -9,7 +9,7 @@
 #define OPEN_GL_CODE  1
 
 void isetname(RGB_IMAGE *image, const char *name) {
-  strncpy(image->name,name,80);
+  strncpy(image->name,name,80-1);
 }
 
 void isetcolormap(RGB_IMAGE *image, int colormap) {
@@ -440,6 +440,7 @@ int putrow_uc(RGB_IMAGE *image, unsigned char *buffer, unsigned int y, unsigned 
         return cnt;
     case 2:
       printf("ERROR: this rgb save function BPP=2 is not implemented\n");
+      [[gnu::fallthrough]];
     default:
       i_errhdlr("putrow: weird bpp\n",0,0,0,0);
     }

--- a/utils/rgb.cpp
+++ b/utils/rgb.cpp
@@ -436,11 +436,14 @@ int putrow_uc(RGB_IMAGE *image, unsigned char *buffer, unsigned int y, unsigned 
       if (img_write(image,(char *)(image->tmpbuf),cnt) != cnt) {
         i_errhdlr("putrow: error on write of row\n",0,0,0,0);
         return -1;
-      } else
+      } else {
         return cnt;
+      }
     case 2:
       printf("ERROR: this rgb save function BPP=2 is not implemented\n");
+#if __GNUC__  >= 8
       [[gnu::fallthrough]];
+#endif
     default:
       i_errhdlr("putrow: weird bpp\n",0,0,0,0);
     }

--- a/utils/stats.cpp
+++ b/utils/stats.cpp
@@ -264,7 +264,10 @@ fMRI_REG *StatReadRegistration(const char *fname)
   err = regio_read_register(
       fname, &subject, &reg->in_plane_res, &reg->slice_thickness, &reg->brightness_scale, &reg->mri2fmri, &float2int);
   if (err) return (NULL);
-  sprintf(reg->name, "%s", subject);
+  int req = snprintf(reg->name, STRLEN, "%s", subject);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   free(subject);
   reg->fmri2mri = MatrixInverse(reg->mri2fmri, NULL);
   return (reg);
@@ -304,16 +307,26 @@ SV *StatReadVolume(const char *prefix)
   if (!sv) ErrorExit(ERROR_NOMEMORY, "StatReadVolume(%s): could not allocate sv", prefix);
 
   /* read in register.dat */
-  if (regfile != NULL)
-    sprintf(fname, "%s", regfile);
-  else
-    sprintf(fname, "%s/register.dat", path);
+  if (regfile != NULL) {
+    int req = snprintf(fname, STRLEN, "%s", regfile);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+  } else {
+    int req = snprintf(fname, STRLEN, "%s/register.dat", path);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+  }
 
   sv->reg = StatReadRegistration(fname);
   if (!sv->reg) return (NULL);
 
   /* read the selavg/selxavg dat file, if it exists */
-  sprintf(fname, "%s.dat", prefix);
+  int req = snprintf(fname, STRLEN, "%s.dat", prefix);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fp = fopen(fname, "r");
   which_alloc = ALLOC_MEANS;
   if (fp) /* means there are time points and means and sigmas */
@@ -559,10 +572,17 @@ SV *StatReadVolume2(const char *prefix)
   if (!sv) ErrorExit(ERROR_NOMEMORY, "StatReadVolume(%s): could not allocate sv", prefix);
 
   /* read in register.dat */
-  if (regfile != NULL)
-    sprintf(fname, "%s", regfile);
-  else
-    sprintf(fname, "%s/register.dat", path);
+  if (regfile != NULL) {
+    int req = snprintf(fname, STRLEN, "%s", regfile);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+  } else {
+    int req = snprintf(fname, STRLEN, "%s/register.dat", path);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+  }
 
   sv->reg = StatReadRegistration(fname);
   if (!sv->reg) return (NULL);
@@ -1168,13 +1188,20 @@ int StatWriteVolume(SV *sv, const char *prefix)
   height = sv->slice_height;
   nslices = sv->nslices;
   FileNamePath(prefix, path);
-  sprintf(fname, "%s/register.dat", path);
+  int req = snprintf(fname, STRLEN, "%s/register.dat", path);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   StatWriteRegistration(sv->reg, fname);
 
   if (sv->voltype != 0) /* not a raw stats file (sel averaged) */
   {
     /* write the global header file */
-    sprintf(fname, "%s.dat", prefix);
+    int req = snprintf(fname, STRLEN, "%s.dat", prefix);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fp = fopen(fname, "w");
     if (!fp) ErrorReturn(ERROR_NOFILE, (ERROR_NOFILE, "StatWriteVolume: could not open dat file %s", fname));
     fprintf(fp, "tr %f\n", sv->tr);
@@ -1368,7 +1395,10 @@ int StatReadTransform(STAT_VOLUME *sv, const char *name)
     exit(1);
   }
   strcpy(subjects, sd);
-  sprintf(fname, "%s/%s/mri/transforms/talairach.xfm", subjects, name);
+  int req = snprintf(fname, STRLEN, "%s/%s/mri/transforms/talairach.xfm", subjects, name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
 
   if (input_transform_file(fname, &sv->transform) != OK)
     ErrorPrintf(ERROR_NO_FILE, "%s: could not read xform file '%s'\n", Progname, fname);
@@ -1388,7 +1418,10 @@ int StatVolumeExists(const char *prefix)
   char fname[STRLEN];
   FILE *fp;
 
-  sprintf(fname, "%s_%3.3d.bfloat", prefix, 0);
+  int req = snprintf(fname, STRLEN, "%s_%3.3d.bfloat", prefix, 0);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fp = fopen(fname, "r");
   if (!fp) return (0);
   fclose(fp);
@@ -1408,11 +1441,15 @@ MATRIX *StatLoadTalairachXFM(const char *subjid, const char *xfmfile)
   FILE *fp;
 
   cp = getenv("SUBJECTS_DIR");
-  if (cp)
+  if (cp) {
     strcpy(subjects, cp);
-  else
+  } else {
     strcpy(subjects, "~inverse/subjects");
-  sprintf(fname, "%s/%s/mri/transforms/%s", subjects, subjid, xfmfile);
+  }
+  int req = snprintf(fname, STRLEN, "%s/%s/mri/transforms/%s", subjects, subjid, xfmfile);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
 
   fp = fopen(fname, "r");
   if (fp == NULL) {

--- a/utils/surfgrad.cpp
+++ b/utils/surfgrad.cpp
@@ -1859,6 +1859,10 @@ long double MRIStargetCostVertex(const MRIS *surf, const int vno, long double *d
   are stored in v->d{xyz}. The total cost and gradients are normalized
   by the number of edges. Uses OpenMP.
 */
+#if GCC_VERSION > 80000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 long double MRIStargetCost(MRIS *surf, const double weight, int DoGrad)
 {
   int vno, nhits;
@@ -1937,6 +1941,10 @@ long double MRIStargetCost(MRIS *surf, const double weight, int DoGrad)
 
   return(totcost);
 }
+#if GCC_VERSION > 80000
+#pragma GCC diagnostic pop
+#endif
+
 
 int MRIStargetCostTest(MRIS *surf, const double delta, const double anglethresh, const double magthresh)
 {

--- a/utils/utils.cpp
+++ b/utils/utils.cpp
@@ -1310,8 +1310,23 @@ char *GetNthItemFromString(const char *str, int nth)
     return (NULL);
   }
 
-  for (n = 0; n < nth; n++) sprintf(fmt, "%s %%*s", fmt);
-  sprintf(fmt, "%s %%s", fmt);
+#if GCC_VERSION > 80000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wrestrict"
+#endif
+  for (n = 0; n < nth; n++) {
+    int req = snprintf(fmt, 2000, "%s %%*s", fmt);
+    if( req >= 2000 ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+  }
+  int req = snprintf(fmt, 2000, "%s %%s", fmt);
+  if( req >= 2000 ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+#if GCC_VERSION > 80000
+#pragma GCC diagnostic pop
+#endif
   // printf("fmt %s\n",fmt);
   sscanf(str, fmt, tmpstr);
 

--- a/utils/xDebug.cpp
+++ b/utils/xDebug.cpp
@@ -136,8 +136,8 @@ void xDbg_PopStack()
   if (mCurrentStackDepth - 1 >= 0) {
     --mCurrentStackDepth;
 
-    strncpy(xDbg_sStackDesc, masStackTitle[mCurrentStackDepth], xDbg_knMaxDescLength);
-    strncpy(xDbg_sCurNoteDesc, masStackNote[mCurrentStackDepth], xDbg_knMaxDescLength);
+    strncpy(xDbg_sStackDesc, masStackTitle[mCurrentStackDepth], xDbg_knMaxDescLength-1);
+    strncpy(xDbg_sCurNoteDesc, masStackNote[mCurrentStackDepth], xDbg_knMaxDescLength-1);
   }
   else {
     DebugPrint(("ERROR: xDbg_PopStack call when stack is empty.\n"));


### PR DESCRIPTION
Get remainder of `utils` compiling with GCC 8

- Most issues were fixed by changing `sprintf` to `snprintf` and checking the return value
- The new constructor for `INTEGRATION_PARMS` allowed a few `memset()` calls to be eliminated (apart from one which had to be avoided with a `#pragma`
- Several other issues (mainly switch-case-fallthroughs) dealt with with `#pragma`

If future improvements are made in the code, devising a proper solution for the various `#pragma GCC diagnostic ignored` directives should be given a high priority.