### PR TITLE
Updates for gcc8

### DIFF
--- a/include/argparse.h
+++ b/include/argparse.h
@@ -222,7 +222,7 @@ public:
     // try to cast the arguments
     try {
       retrieved = variables[N].castTo<T>();
-    } catch (std::bad_cast) {
+    } catch (std::bad_cast&) {
       // if casting fails, print out a VERY detailed debug message
       String fulltype, sentence_starter;
       if (arguments[N].fixed && (arguments[N].fixed_nargs <= 1)) {

--- a/include/gca.h
+++ b/include/gca.h
@@ -33,9 +33,6 @@
 
 #include "affine.h"
 
-#if 0
-extern double MIN_PRIOR_FACTOR, MAX_PRIOR_FACTOR, PRIOR_FACTOR ;   // sorry, too hard to propagate this everywhere for now
-#endif
 
 
 #define GCA_RESTART      1
@@ -345,11 +342,6 @@ int  GCAnodeToSourceVoxel(GCA *gca, MRI *mri, TRANSFORM *transform,
 int  GCAnodeToSourceVoxelFloat(GCA *gca, MRI *mri, TRANSFORM *transform,
                                int xv, int yv, int zv,
                                float *pxn, float *pyn, float *pzn) ;
-#if 0
-int    GCAsampleStats(GCA *gca, MRI *mri, TRANSFORM *transform, int class,
-                      double x, double y, double z,
-                      double *pmean, double *pvar, double *pprior) ;
-#endif
 
 
 

--- a/include/gcamorph.h
+++ b/include/gcamorph.h
@@ -456,13 +456,6 @@ int GCAMnormalizeIntensities(GCA_MORPH *gcam, MRI *mr_target) ;
 MRI *GCAMcreateDistanceTransforms(MRI *mri_source, MRI *mri_target,
 				  MRI *mri_all_dtrans, float max_dist,
 				  GCA_MORPH *gcam, MRI **pmri_atlas_dist_map) ;
-#if 0
-MRI *GCAMcreateDistanceTransforms(GCA_MORPH *gcam,
-                                  MRI *mri_target,
-                                  MRI *mri_all_dtrans, 
-                                  MRI **pmri_atlas_dtrans,
-                                  float max_dist);
-#endif
 
 #define MAX_LTT_LABELS 1000
 typedef struct

--- a/include/mrisurf.h
+++ b/include/mrisurf.h
@@ -228,12 +228,6 @@ typedef struct
 {
   MRI_SURFACE  *mris ;        /* surface it came from (if any) */
   IMAGE        *Ip ;
-#if 0
-  /* 2-d array of curvature, or sulc in parms */
-  float        data[X_DIM][Y_DIM] ;
-  float        distances[X_DIM][Y_DIM] ;
-  int          vertices[X_DIM][Y_DIM] ;   /* vertex numbers */
-#endif
   float        sigma ;                    /* blurring scale */
   float        radius ;
   float        scale ;
@@ -734,11 +728,6 @@ int          MRISvertexCoordToVoxel(MRI_SURFACE *, VERTEX *v, MRI *mri,
                                     int coord,
                                     double *pxv, double *pyv,
                                     double *pzv) ;
-#if 0
-int          MRISworldToTalairachVoxel(MRI_SURFACE *mris, MRI *mri,
-                                       double xw, double yw, double zw,
-                                       double *pxv, double *pyv, double *pzv) ;
-#endif
 
 int          MRISsurfaceRASToVoxel(MRI_SURFACE *mris, MRI *mri, double r, 
                                    double a, double s, 
@@ -1038,26 +1027,15 @@ int MRISsaveNormals   (MRIS *mris, int which) ;
 #define NO_HEMISPHERE           2
 #define BOTH_HEMISPHERES        3
 
-#if 0
-#define DEFAULT_A  44.0f
-#define DEFAULT_B  122.0f
-#define DEFAULT_C  70.0f
-#else
 #define DEFAULT_A  122.0f
 #define DEFAULT_B  122.0f
 #define DEFAULT_C  122.0f
-#endif
 #define DEFAULT_RADIUS  100.0f
 
 #define MAX_DIM    DEFAULT_B
 
-#if 1
 #define DT_INCREASE  1.1 /* 1.03*/
 #define DT_DECREASE  0.5
-#else
-#define DT_INCREASE  1.0 /* 1.03*/
-#define DT_DECREASE  1.0
-#endif
 #define DT_MIN       0.01
 #ifdef ERROR_RATIO
 #undef ERROR_RATIO
@@ -1104,13 +1082,8 @@ int   MRISsoapBubbleOrigVertexPositions(MRI_SURFACE *mris, int navgs) ;
 int   MRISsoapBubbleTargetVertexPositions(MRI_SURFACE *mris, int navgs) ;
 MRI   *MRISwriteSurfaceIntoVolume(MRI_SURFACE *mris, MRI *mri_template,
                                   MRI *mri) ;
-#if 0
-int   MRISmeasureCorticalThickness(MRI_SURFACE *mris, MRI *mri_brain,
-                                   MRI *mri_wm, float nsigma) ;
-#else
 int   MRISmeasureCorticalThickness(MRI_SURFACE *mris, int nbhd_size,
                                    float max_thickness) ;
-#endif
 
 int  MRISmeasureThicknessFromCorrespondence(MRI_SURFACE *mris, MHT *mht, float max_thick) ;
 int MRISfindClosestOrigVertices(MRI_SURFACE *mris, int nbhd_size) ;
@@ -1456,7 +1429,6 @@ typedef struct
                                          surface in mris_total vertices */
 }
 MRI_SURFACE_ARRAY, MSA ;
-#if 1
 float  MRISdistanceToSurface(MRI_SURFACE *mris, MHT *mht,
                              float x0, float y0, float z0,
                              float nx, float ny, float nz) ;
@@ -1465,7 +1437,6 @@ int    MRISexpandSurface(MRI_SURFACE *mris,
                          INTEGRATION_PARMS *parms, int use_thickness, int nsurfaces) ;
 int MRISripZeroThicknessRegions(MRI_SURFACE *mris) ;
 
-#endif
 
 /* cortical ribbon */
 MRI   *MRISribbon(MRI_SURFACE *inner_mris,
@@ -1743,21 +1714,6 @@ MRIS*  MRISfromVerticesAndFaces(const float *vertices, int nvertices, const int 
 
 #define MRISgetCoords(v,c,vx,vy,vz) \
  MRISvertexCoord2XYZ_float(v,c,vx,vy,vz)
-#if 0 
- switch(c) { \
-   case ORIGINAL_VERTICES:  (*vx) = (v)->origx;  (*vy) = (v)->origy;  (*vz) = (v)->origz; break; \
-   case TMP_VERTICES:       (*vx) = (v)->tx;     (*vy) = (v)->ty;     (*vz) = (v)->tz; break; \
-   case CANONICAL_VERTICES: (*vx) = (v)->cx;     (*vy) = (v)->cy;     (*vz) = (v)->cz; break; \
-   case CURRENT_VERTICES:   (*vx) = (v)->x;      (*vy) = (v)->y;      (*vz) = (v)->z; break; \
-   case TARGET_VERTICES:    (*vx) = (v)->targx;  (*vy) = (v)->targy;  (*vz) = (v)->targz; break; \
-   case INFLATED_VERTICES:  (*vx) = (v)->infx;   (*vy) = (v)->infy;   (*vz) = (v)->infz; break; \
-   case FLATTENED_VERTICES: (*vx) = (v)->fx;     (*vy) = (v)->fy;     (*vz) = (v)->fz; break; \
-   case PIAL_VERTICES:      (*vx) = (v)->pialx;  (*vy) = (v)->pialy;  (*vz) = (v)->pialz; break; \
-   case TMP2_VERTICES:      (*vx) = (v)->t2x;    (*vy) = (v)->t2y;    (*vz) = (v)->t2z; break; \
-   case WHITE_VERTICES:     (*vx) = (v)->whitex; (*vy) = (v)->whitey; (*vz) = (v)->whitez; break; \
-   default: break; \
- }
-#endif
 
 int MRISlogOdds(MRI_SURFACE *mris, LABEL *area, double slope)  ;
 MRI_SP  *MRISPorLabel(MRI_SP *mrisp, MRI_SURFACE *mris, LABEL *area) ;
@@ -2472,16 +2428,6 @@ struct face_topology_type_ {    // not used much yet
 
 // Static function implementations
 //
-#if 0
-static CONST_EXCEPT_MRISURF_TOPOLOGY short* pVERTEXvnum(VERTEX_TOPOLOGY CONST_EXCEPT_MRISURF_TOPOLOGY * v, int i) {
-  switch (i) {
-  case 1: return &v->vnum;
-  case 2: return &v->v2num;
-  case 3: return &v->v3num;
-  default: cheapAssert(false); return NULL;
-  }    
-}
-#endif
 
 short        modVnum  (MRIS const *mris, int vno, short add, bool clearFirst = false);
 static short setVnum  (MRIS const *mris, int vno, short to)     { return modVnum(mris,vno, to,true );     }

--- a/mri_ca_register/mri_ca_register.cpp
+++ b/mri_ca_register/mri_ca_register.cpp
@@ -287,12 +287,6 @@ main(int argc, char *argv[])
     TRs[input] = mri_tmp->tr ;
     fas[input] = mri_tmp->flip_angle ;
     TEs[input] = mri_tmp->te ;
-#if 0
-    if (mri_tmp->type == MRI_FLOAT)
-    {
-      MRIchangeType(mri_tmp, MRI_SHORT, 0, 10000,  1) ;
-    }
-#endif
 
     // -mask option
     if (mask_fname)
@@ -1058,31 +1052,6 @@ main(int argc, char *argv[])
     LTA _lta, *lta = &_lta ;
 
     lta->num_xforms = 0 ;
-#if 0
-    sprintf(fname, "%s.gca", parms.base_name) ;
-    gca = GCAread(fname) ;
-    sprintf(fname, "%s.lta", parms.base_name) ;
-    lta = LTAread(fname) ;
-
-    if (Gdiag & DIAG_WRITE)
-    {
-      char fname[STRLEN] ;
-      sprintf(fname, "%s.log", parms.base_name) ;
-      parms.log_fp = fopen(fname, "w") ;
-    }
-    {
-      MRI *mri_seg, *mri_aligned ;
-      int l ;
-      mri_seg = MRIclone(mri_inputs, NULL) ;
-      l = lta->xforms[0].label ;
-      GCAbuildMostLikelyVolumeForStructure(gca, mri_seg, l, 0, transform,NULL);
-      mri_aligned = MRIlinearTransform(mri_seg, NULL, lta->xforms[0].m_L) ;
-      MRIwrite(mri_seg, "s.mgz")  ;
-      MRIwrite(mri_aligned, "a.mgz") ;
-      MRIfree(&mri_seg) ;
-      MRIfree(&mri_aligned) ;
-    }
-#else
     if (Gdiag & DIAG_WRITE)
     {
       char fname[STRLEN] ;
@@ -1118,20 +1087,7 @@ main(int argc, char *argv[])
           Gdiag &= ~DIAG_WRITE ;
         }
 
-#if 0
-        {
-          parms.tol *= 10 ;
-          parms.l_smoothness *= 10 ;
-          printf("---------------- doing initial registration ----------------------\n") ;
-          GCAMregister(gcam, mri_inputs, &parms) ;
-          parms.tol /= 10 ;
-          parms.l_smoothness /= 10 ;
-          mri_morphed = GCAMmorphToAtlas(mri_inputs, gcam, NULL, -1) ;
-          printf("---------------- initial registration complete ----------------------\n") ;
-        }
-#else
         mri_morphed = mri_inputs ;
-#endif
 
 
         // GCA Renormalization with Alignment:
@@ -1264,7 +1220,6 @@ main(int argc, char *argv[])
       MRIfree(&mri_seg) ;
       MRIfree(&mri_aligned) ;
     }
-#endif
     if (reinit && (xform_name == NULL) && (lta != NULL))
     {
       GCAMreinitWithLTA(gcam, lta, mri_inputs, &parms) ;
@@ -1620,24 +1575,7 @@ main(int argc, char *argv[])
     GCAMregister(gcam, mri_inputs, &parms) ;
   }
 
-#if 0
-  for (iter = 0 ; iter < 3 ; iter++)
-  {
-    parms.relabel_avgs = 1 ;
-    GCAMcopyNodePositions(gcam, CURRENT_POSITIONS, ORIGINAL_POSITIONS) ;
-    GCAMstoreMetricProperties(gcam) ;
-    parms.levels = 2 ;
-    parms.navgs = 1 ;
-    GCAMregister(gcam, mri_inputs, &parms) ;
-  }
-#endif
 
-#if 0
-  parms.l_distance = 0 ;
-  parms.relabel = 1 ;
-  GCAMcomputeLabels(mri_inputs, gcam) ;
-  GCAMregister(gcam, mri_inputs, &parms) ;
-#endif
 
   //record GCA filename to gcam
   strcpy(gcam->atlas.fname, gca_fname);
@@ -1652,12 +1590,6 @@ main(int argc, char *argv[])
     ErrorExit(Gerror, "%s: GCAMwrite(%s) failed", Progname, out_fname) ;
   }
 
-#if 0
-  if (gca)
-  {
-    GCAfree(&gca) ;
-  }
-#endif
   GCAMfree(&gcam) ;
   if (mri_inputs)
   {

--- a/mri_ca_register/mri_ca_register.cpp
+++ b/mri_ca_register/mri_ca_register.cpp
@@ -757,12 +757,18 @@ main(int argc, char *argv[])
     {
       char fname[STRLEN] ;
       MRI  *mri ;
-      sprintf(fname, "%s.invalid.mgz", parms.base_name) ;
+      int req = snprintf(fname, STRLEN, "%s.invalid.mgz", parms.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      } 
       mri = GCAMwriteMRI(gcam, NULL, GCAM_INVALID) ;
       printf("writing %s\n", fname) ;
       MRIwrite(mri, fname) ;
       MRIfree(&mri) ;
-      sprintf(fname, "%s.status.mgz", parms.base_name) ;
+      req = snprintf(fname, STRLEN, "%s.status.mgz", parms.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      } 
       mri = GCAMwriteMRI(gcam, NULL, GCAM_STATUS) ;
       printf("writing %s\n", fname) ;
       MRIwrite(mri, fname) ;
@@ -838,9 +844,15 @@ main(int argc, char *argv[])
         MRIfree(&mri_gca) ;
         mri_gca = mri_tmp ;
       }
-      sprintf(fname, "%s_target", parms.base_name) ;
+      int req = snprintf(fname, STRLEN, "%s_target", parms.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      } 
       MRIwriteImageViews(mri_gca, fname, IMAGE_SIZE) ;
-      sprintf(fname, "%s_target.mgz", parms.base_name) ;
+      req = snprintf(fname, STRLEN, "%s_target.mgz", parms.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      } 
       printf("writing target volume to %s...\n", fname) ;
       MRIwrite(mri_gca, fname) ;
       MRIfree(&mri_gca) ;
@@ -944,9 +956,15 @@ main(int argc, char *argv[])
       MRI  *mri_gca, *mri_tmp ;
       if (parms.diag_morph_from_atlas )
       {
-        sprintf(fname, "%s_target", parms.base_name) ;
+        int req = snprintf(fname, STRLEN, "%s_target", parms.base_name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	} 
         MRIwriteImageViews(mri_inputs, fname, IMAGE_SIZE) ;
-        sprintf(fname, "%s_target.mgz", parms.base_name) ;
+        req = snprintf(fname, STRLEN, "%s_target.mgz", parms.base_name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	} 
         printf("writing target volume to %s...\n", fname) ;
         MRIwrite(mri_inputs, fname) ;
       }
@@ -961,9 +979,15 @@ main(int argc, char *argv[])
           MRIfree(&mri_gca) ;
           mri_gca = mri_tmp ;
         }
-        sprintf(fname, "%s_target_after_histo", parms.base_name) ;
+        int req = snprintf(fname, STRLEN, "%s_target_after_histo", parms.base_name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	} 
         MRIwriteImageViews(mri_gca, fname, IMAGE_SIZE) ;
-        sprintf(fname, "%s_target_after_histo.mgz", parms.base_name) ;
+        req = snprintf(fname, STRLEN, "%s_target_after_histo.mgz", parms.base_name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	} 
         printf("writing target volume to %s...\n", fname) ;
         MRIwrite(mri_gca, fname) ;
         MRIfree(&mri_gca) ;
@@ -1062,12 +1086,18 @@ main(int argc, char *argv[])
     if (Gdiag & DIAG_WRITE)
     {
       char fname[STRLEN] ;
-      sprintf(fname, "%s.log", parms.base_name) ;
+      int req = snprintf(fname, STRLEN, "%s.log", parms.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       parms.log_fp = fopen(fname, "w") ;
     }
     if (read_lta)
     {
-      sprintf(fname, "%s_array.lta", parms.base_name) ;
+      int req = snprintf(fname, STRLEN, "%s_array.lta", parms.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       lta = LTAread(fname) ;
     }
     else
@@ -1200,13 +1230,19 @@ main(int argc, char *argv[])
     }
     if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON)
     {
-      sprintf(fname, "%s.gca", parms.base_name) ;
+      int req = snprintf(fname, STRLEN, "%s.gca", parms.base_name) ; 
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("writing gca to %s...\n", fname) ;
       GCAwrite(gca, fname) ;
     }
     if (lta && !read_lta)
     {
-      sprintf(fname, "%s_array.lta", parms.base_name) ;
+      int req = snprintf(fname, STRLEN, "%s_array.lta", parms.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      } 
 
       // should put volume geometry into file,
       // and probably change to RAS->RAS xform
@@ -1261,9 +1297,15 @@ main(int argc, char *argv[])
 
     if (parms.diag_morph_from_atlas )
     {
-      sprintf(fname, "%s_target", parms.base_name) ;
+      int req = snprintf(fname, STRLEN, "%s_target", parms.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      } 
       MRIwriteImageViews(mri_inputs, fname, IMAGE_SIZE) ;
-      sprintf(fname, "%s_target.mgz", parms.base_name) ;
+      req = snprintf(fname, STRLEN, "%s_target.mgz", parms.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      } 
       printf("writing target volume to %s...\n", fname) ;
       MRIwrite(mri_inputs, fname) ;
     }
@@ -1274,19 +1316,15 @@ main(int argc, char *argv[])
       mri_gca = MRIalloc(gcam->atlas.width, gcam->atlas.height, gcam->atlas.depth, MRI_FLOAT) ;
       MRIcopyHeader(mri_inputs, mri_gca) ;
       GCAMbuildMostLikelyVolume(gcam, mri_gca) ;
-#if 0
-      if (mri_gca->nframes > 1)
-      {
-	 MRI *mri_tmp ;
-        printf("careg: extracting %dth frame\n", mri_gca->nframes-1) ;
-        mri_tmp = MRIcopyFrame(mri_gca, NULL, mri_gca->nframes-1, 0) ;
-        MRIfree(&mri_gca) ;
-        mri_gca = mri_tmp ;
-      }
-#endif
-      sprintf(fname, "%s_target", parms.base_name) ;
+      int req = snprintf(fname, STRLEN, "%s_target", parms.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      } 
       MRIwriteImageViews(mri_gca, fname, IMAGE_SIZE) ;
-      sprintf(fname, "%s_target.mgz", parms.base_name) ;
+      req = snprintf(fname, STRLEN, "%s_target.mgz", parms.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      } 
       printf("writing target volume to %s...\n", fname) ;
       MRIwrite(mri_gca, fname) ;
       MRIfree(&mri_gca) ;
@@ -1439,7 +1477,10 @@ main(int argc, char *argv[])
     if (Gdiag & DIAG_WRITE)
     {
       char fname[STRLEN] ;
-      sprintf(fname, "%s.log", parms.base_name) ;
+      int req = snprintf(fname, STRLEN, "%s.log", parms.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      } 
       parms.log_fp = fopen(fname, "a") ;
     }
 
@@ -1459,9 +1500,15 @@ main(int argc, char *argv[])
         MRI  *mri_gca, *mri_tmp ;
         if (parms.diag_morph_from_atlas )
         {
-          sprintf(fname, "%s_target", parms.base_name) ;
+          int req = snprintf(fname, STRLEN, "%s_target", parms.base_name) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  } 
           MRIwriteImageViews(mri_inputs, fname, IMAGE_SIZE) ;
-          sprintf(fname, "%s_target.mgz", parms.base_name) ;
+          req = snprintf(fname, STRLEN, "%s_target.mgz", parms.base_name) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  } 
           printf("writing target volume to %s...\n", fname) ;
           MRIwrite(mri_inputs, fname) ;
         }
@@ -1477,9 +1524,15 @@ main(int argc, char *argv[])
             MRIfree(&mri_gca) ;
             mri_gca = mri_tmp ;
           }
-          sprintf(fname, "%s_target", parms.base_name) ;
+          int req = snprintf(fname, STRLEN, "%s_target", parms.base_name) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  } 
           MRIwriteImageViews(mri_gca, fname, IMAGE_SIZE) ;
-          sprintf(fname, "%s_target1.mgz", parms.base_name) ;
+          req = snprintf(fname, STRLEN, "%s_target1.mgz", parms.base_name) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  } 
           printf("writing target volume to %s...\n", fname) ;
           MRIwrite(mri_gca, fname) ;
           MRIfree(&mri_gca) ;

--- a/mris_anatomical_stats/mris_anatomical_stats.cpp
+++ b/mris_anatomical_stats/mris_anatomical_stats.cpp
@@ -176,7 +176,11 @@ main(int argc, char *argv[])
   {
     mri_kernel = MRIgaussian1d(sigma, 100) ;
   }
-  sprintf(fname, "%s/%s/mri/wm", sdir, sname) ;
+  int req = snprintf(fname, STRLEN, "%s/%s/mri/wm", sdir, sname) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   if (MGZ)
   {
     strcat(fname, ".mgz");
@@ -203,7 +207,10 @@ main(int argc, char *argv[])
     MRIfree(&mri_kernel);
   }
 
-  sprintf(fname, "%s/%s/surf/%s.%s", sdir, sname, hemi, surf_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, sname, hemi, surf_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fprintf(stderr, "reading input surface %s...\n", fname) ;
   mris = MRISread(fname) ;
   if (!mris)
@@ -225,13 +232,22 @@ main(int argc, char *argv[])
     LABEL *label;
     double totvol;
     printf("Using TH3 vertex volume calc\n");
-    sprintf(fname,"%s/%s/surf/%s.white", sdir, sname, hemi);
+    int req = snprintf(fname,STRLEN,"%s/%s/surf/%s.white", sdir, sname, hemi);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     mrisw = MRISread(fname);
     if(!mrisw) exit(1);
-    sprintf(fname,"%s/%s/surf/%s.pial", sdir, sname, hemi);
+    req = snprintf(fname,STRLEN,"%s/%s/surf/%s.pial", sdir, sname, hemi);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     mrisp = MRISread(fname);
     if(!mrisp) exit(1);
-    sprintf(fname,"%s/%s/label/%s.cortex.label",sdir,sname,hemi);
+    req = snprintf(fname,STRLEN,"%s/%s/label/%s.cortex.label",sdir,sname,hemi);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     label = LabelRead(NULL, fname);
     if(label == NULL) exit(1);
     ctxmask = MRISlabel2Mask(mrisw, label, NULL);
@@ -247,13 +263,19 @@ main(int argc, char *argv[])
   MRISsaveVertexPositions(mris, ORIGINAL_VERTICES) ;
   // read in white and pial surfaces
   MRISsaveVertexPositions(mris, TMP_VERTICES) ;
-  sprintf(fname, "%s/%s/surf/%s.%s", sdir, sname, hemi, pial_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, sname, hemi, pial_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fprintf(stderr, "reading input pial surface %s...\n", fname) ;
   if (MRISreadVertexPositions(mris, fname) != NO_ERROR)
     ErrorExit(ERROR_NOFILE, "%s: could not read surface file %s",
               Progname, fname) ;
   MRISsaveVertexPositions(mris, PIAL_VERTICES) ;
-  sprintf(fname, "%s/%s/surf/%s.%s", sdir, sname, hemi, white_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, sname, hemi, white_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fprintf(stderr, "reading input white surface %s...\n", fname) ;
   if (MRISreadVertexPositions(mris, fname) != NO_ERROR)
     ErrorExit(ERROR_NOFILE, "%s: could not read surface file %s",
@@ -323,7 +345,10 @@ main(int argc, char *argv[])
 
   if (histo_flag)
   {
-    sprintf(fname, "%s/%s/mri/%s", sdir, sname, mri_name) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, sname, mri_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (MGZ)
     {
       strcat(fname, ".mgz");
@@ -364,11 +389,17 @@ main(int argc, char *argv[])
     LABEL  *area ;
     char   fname[STRLEN] ;
 
-    sprintf(fname, "%s/%s/label/%s", sdir, sname, label_name) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/label/%s", sdir, sname, label_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     // If that does not exist, use label_name as absolute path.
     if (! fio_FileExistsReadable(fname))
     {
-      sprintf(fname, "%s", label_name) ;
+      int req = snprintf(fname, STRLEN, "%s", label_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
 
     area = LabelRead(NULL, fname) ;
@@ -401,11 +432,17 @@ main(int argc, char *argv[])
       // build the full path string
       if (strstr(label_name, ".label") == NULL)
       {
-        sprintf(full_name, "%s/%s/label/%s.label", sdir, sname, label_name) ;
+        int req = snprintf(full_name, STRLEN, "%s/%s/label/%s.label", sdir, sname, label_name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
       else
       {
-        sprintf(full_name, "%s/%s/label/%s", sdir, sname, label_name) ;
+        int req = snprintf(full_name, STRLEN, "%s/%s/label/%s", sdir, sname, label_name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
     }
     if (! fio_FileExistsReadable(full_name))
@@ -426,24 +463,44 @@ main(int argc, char *argv[])
     else  // build the full path string
     {
       char tmp[STRLEN] ;
-      sprintf(tmp, "%s.", hemi) ;
+      int req = snprintf(tmp, STRLEN, "%s.", hemi) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (strstr(annotation_name, tmp) == NULL) // no hemi in string
       {
-        if (strstr(annotation_name, ".annot") == NULL)
-          sprintf(full_name, "%s/%s/label/%s.%s.annot", sdir, sname,
-                  hemi, annotation_name) ;
-        else
-          sprintf(full_name, "%s/%s/label/%s.%s", sdir, sname,
-                  hemi,annotation_name) ;
+        if (strstr(annotation_name, ".annot") == NULL) {
+          int req = snprintf(full_name, STRLEN, "%s/%s/label/%s.%s.annot",
+			     sdir, sname, hemi, annotation_name) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
+        } else {
+          int req = snprintf(full_name, STRLEN,
+			     "%s/%s/label/%s.%s",
+			     sdir, sname, hemi,annotation_name) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
+	}
       }
       else
       {
-        if (strstr(annotation_name, ".annot") == NULL)
-          sprintf(full_name, "%s/%s/label/%s.annot", sdir, sname,
-                  annotation_name) ;
-        else
-          sprintf(full_name, "%s/%s/label/%s", sdir, sname,
-                  annotation_name) ;
+        if (strstr(annotation_name, ".annot") == NULL) {
+          int req = snprintf(full_name, STRLEN, 
+			     "%s/%s/label/%s.annot", 
+			     sdir, sname, annotation_name) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
+        } else {
+          int req = snprintf(full_name, STRLEN, 
+			     "%s/%s/label/%s", 
+			     sdir, sname,  annotation_name) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
+	}
       }
 
     }
@@ -1118,7 +1175,11 @@ get_option(int argc, char *argv[])
     strcpy(sdir, argv[2]) ;
     printf("using  %s as  SUBJECTS_DIR...\n", sdir)  ;
     nargs = 1 ;
-    sprintf(str, "SUBJECTS_DIR=%s", sdir) ;
+    int req = snprintf(str, STRLEN, "SUBJECTS_DIR=%s", sdir) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+
     putenv(str) ;
   }
   else if (!stricmp(option, "mgz"))

--- a/mris_register/mris_register.cpp
+++ b/mris_register/mris_register.cpp
@@ -158,7 +158,6 @@ main(int argc, char *argv[])
   printf("\ncwd %s\n",cwd);
   printf("cmdline %s\n\n",cmdline2);
 
-  memset(&parms, 0, sizeof(parms)) ;
   parms.projection = PROJECT_SPHERE ;
   parms.flags |= IP_USE_CURVATURE ;
   parms.trinarize_thresh = 0.0 ;  // disabled by default
@@ -346,7 +345,10 @@ main(int argc, char *argv[])
       mrisp_template = MRISPalloc(scale, IMAGES_PER_SURFACE*noverlays);
       for (sno = 0; sno < noverlays ; sno++)
       {
-        sprintf(fname, "%s/../label/%s.%s", surf_dir, hemi, overlays[sno]) ;
+        int req = snprintf(fname, STRLEN, "%s/../label/%s.%s", surf_dir, hemi, overlays[sno]) ; 
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         if (MRISreadValues(mris_template, fname)  != NO_ERROR)
           ErrorExit(ERROR_NOFILE,
                     "%s: could not read overlay from %s",
@@ -368,7 +370,10 @@ main(int argc, char *argv[])
       {
         if (curvature_names[sno])  /* read in precomputed curvature file */
         {
-          sprintf(fname, "%s/%s.%s", surf_dir, hemi, curvature_names[sno]) ;
+          int req = snprintf(fname, STRLEN, "%s/%s.%s", surf_dir, hemi, curvature_names[sno]) ; 
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           if (MRISreadCurvatureFile(mris_template, fname) != NO_ERROR)
             ErrorExit(Gerror,
                       "%s: could not read curvature file '%s'\n",
@@ -380,7 +385,10 @@ main(int argc, char *argv[])
         }
         else                         /* compute curvature of surface */
         {
-          sprintf(fname, "%s/%s.%s", surf_dir, hemi, surface_names[sno]) ;
+          int req = snprintf(fname, STRLEN, "%s/%s.%s", surf_dir, hemi, surface_names[sno]) ; 
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           if (MRISreadVertexPositions(mris_template, fname) != NO_ERROR)
             ErrorExit(ERROR_NOFILE,
                       "%s: could not read surface file %s",

--- a/mris_smooth/mris_smooth.cpp
+++ b/mris_smooth/mris_smooth.cpp
@@ -342,14 +342,21 @@ main(int argc, char *argv[])
   {
     MRISnormalizeCurvature(mris, which_norm) ;
   }
-  sprintf(fname, "%s.%s", mris->hemisphere == LEFT_HEMISPHERE?"lh":"rh",
-          curvature_fname);
+  int req = snprintf(fname, STRLEN, "%s.%s", mris->hemisphere == LEFT_HEMISPHERE?"lh":"rh",
+		     curvature_fname);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   if (no_write == 0)
   {
     fprintf(stderr, "writing smoothed curvature to %s/%s\n", path,fname) ;
     MRISwriteCurvature(mris, fname) ;
-    sprintf(fname, "%s.%s", mris->hemisphere == LEFT_HEMISPHERE?"lh":"rh",
-            area_fname);
+    int req = snprintf(fname, STRLEN, "%s.%s", mris->hemisphere == LEFT_HEMISPHERE?"lh":"rh",
+		       area_fname);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stderr, "writing smoothed area to %s/%s\n", path, fname) ;
     MRISwriteArea(mris, fname) ;
   }

--- a/utils/autoencoder.cpp
+++ b/utils/autoencoder.cpp
@@ -158,12 +158,6 @@ static AE *AEalloc(AE *prev, int ninputs, int nhidden, int noutputs)
       norm += (w * w);
       *MATRIX_RELT(ae->m_input_to_hidden, j, i) = w;
     }
-#if 0
-  norm = sqrt(norm) ;
-  for (i = 1 ; i <= ninputs ; i++)
-    for (j = 1 ; j <= nhidden ; j++)
-      *MATRIX_RELT(ae->m_input_to_hidden, j, i) /= norm ;
-#endif
 
   for (norm = 0.0, j = 1; j <= nhidden; j++)
     for (k = 1; k <= noutputs; k++) {
@@ -172,12 +166,6 @@ static AE *AEalloc(AE *prev, int ninputs, int nhidden, int noutputs)
       norm += (w * w);
       *MATRIX_RELT(ae->m_hidden_to_output, k, j) = w;
     }
-#if 0
-  norm = sqrt(norm) ;
-  for (j = 1 ; j <= nhidden ; j++)
-    for (k = 1 ; k <= noutputs ; k++)
-      *MATRIX_RELT(ae->m_hidden_to_output, k, j) /= norm ;
-#endif
 
   for (norm = 0.0, j = 1; j <= nhidden; j++) {
     w = randomNumber(-1, 1);
@@ -524,12 +512,8 @@ double SAEtrainFromMRI(SAE *sae, MRI **mri_pyramid, SAE_INTEGRATION_PARMS *parms
         }
       }
     }
-#if 0
-    total_rms = SAEcomputeTotalRMS(sae, mri_pyramid) ;
-#else
     total_rms /= visited;
     last_total_rms = running_last_rms / visited;
-#endif
     pct_decrease = 100 * (last_total_rms - total_rms) / (last_total_rms + total_rms);
     last_total_rms = total_rms;
     printf("%3.3d: rms = %2.4f (%2.3f%%)\n", ++iter, total_rms, pct_decrease);
@@ -700,12 +684,8 @@ double SAEtrainFromVoxlist(SAE *sae, VOXEL_LIST *vl, MRI **mri_pyramid, SAE_INTE
         }
       }
     }
-#if 0
-    total_rms = SAEcomputeTotalRMS(sae, mri_pyramid) ;
-#else
     total_rms /= visited;
     last_total_rms = running_last_rms / visited;
-#endif
     pct_decrease = 100 * (last_total_rms - total_rms) / (last_total_rms + total_rms);
     last_total_rms = total_rms;
     printf("%3.3d: rms = %2.4f (%2.3f%%)\n", ++iter, total_rms, pct_decrease);
@@ -1004,10 +984,6 @@ static double AEaccumulateGradient(AE *ae, SAE_INTEGRATION_PARMS *parms)
   for (j = 0; j < nhidden;
        j++)  // keep track of average hidden node activation for use in sparsity gradient calculated later
     ae->average_act[j] += VECTOR_ELT(ae->v_hidden, j + 1);
-#if 0
-  for (j = 0 ; j < nhidden ; j++)   // keep track of average hidden node activation for use in sparsity gradient calculated later
-    ae->average_act[j] = .999 * ae->average_act[j] + (1-.999)*VECTOR_ELT(ae->v_hidden, j+1) ;
-#endif
 
   return (rms);
 }
@@ -1107,11 +1083,6 @@ static double aeApplyAccumulatedGradient(AE *ae, SAE_INTEGRATION_PARMS *parms)
     }
     aeApplyGradient(ae, parms, best_dt);
     parms->dt = best_dt;
-#if 0
-    parms->v_prev_grad_change_hidden_bias = VectorSubtract(ae->v_grad_hidden_bias, parms->v_prev_grad_hidden_bias, parms->v_prev_grad_change_hidden_bias);
-    VectorCopy(ae->v_grad_hidden_bias, parms->v_prev_grad_hidden_bias) ;
-    parms->norm_hidden_bias = VectorLen(parms->v_prev_grad_hidden_bias) ; parms->norm_hidden_bias *= parms->norm_hidden_bias ;
-#endif
   }
   else if (parms->integration_type == INTEGRATE_BOLTZMANN_MACHINE) {
     static MATRIX *m_hidden_to_output_delta = NULL, *m_input_to_hidden_delta = NULL, *v_hidden_bias_delta = NULL,
@@ -1445,11 +1416,6 @@ static double AEtrain(AE *ae, SAE_INTEGRATION_PARMS *parms)
     }
     aeApplyGradient(ae, parms, best_dt);
     parms->dt = best_dt;
-#if 0
-    parms->v_prev_grad_change_hidden_bias = VectorSubtract(ae->v_grad_hidden_bias, parms->v_prev_grad_hidden_bias, parms->v_prev_grad_change_hidden_bias);
-    VectorCopy(ae->v_grad_hidden_bias, parms->v_prev_grad_hidden_bias) ;
-    parms->norm_hidden_bias = VectorLen(parms->v_prev_grad_hidden_bias) ; parms->norm_hidden_bias *= parms->norm_hidden_bias ;
-#endif
   }
   else if (parms->integration_type == INTEGRATE_BOLTZMANN_MACHINE) {
     static MATRIX *m_hidden_to_output_delta = NULL, *m_input_to_hidden_delta = NULL, *v_hidden_bias_delta = NULL,
@@ -1928,11 +1894,7 @@ double CSAEtrainLayerFromVoxlist(CSAE *csae, int layer, VOXEL_LIST *vl, MRI **mr
         }
       }
     }
-#if 0
-    total_rms = CSAEcomputeTotalRMS(ae, mri_pyramid) ;
-#else
 //    total_rms /= visited ; last_total_rms = running_last_rms / visited ;
-#endif
     //    total_rms = CSAEcomputeVoxlistRMS(csae, parms, layer, mri_pyramid, vl, indices, end_index+1, vl->nvox,
     //    &always, &never) ;
     total_rms = CSAEcomputeVoxlistRMS(csae, parms, layer, mri_pyramid, vl, indices, 0, end_index, &always, &never);
@@ -1973,38 +1935,6 @@ double CSAEtrainLayerFromVoxlist(CSAE *csae, int layer, VOXEL_LIST *vl, MRI **mr
     }
   } while ((nbad < parms->max_no_progress) && iter < parms->max_iter);
 
-#if 0
-  if (Gx >= 0)
-  {
-    int wsize, ind, i, j ;
-    float in, out, total_rms, init_total_rms ;
-    wsize = sae->whalf*2+1 ; ind = (wsize*wsize*wsize)/2 + 1 ;
-    
-    init_total_rms = CSAEcomputeTotalRMS(csae, mri_pyramid) ;
-    for (j = 0 ; j < 10 ; j++)
-    {
-      total_rms = CSAEcomputeTotalRMS(csae, mri_pyramid) ;
-      SAEfillInputVector(mri_pyramid, sae->nlevels, Gx, Gy, Gz, sae->whalf, sae->first->v_input) ;
-      SAEactivateNetwork(sae) ;
-      last_rms = SAEcomputeRMS(sae) ;
-
-      for (i = 0 ; i < 100 ; i++)
-      {
-	AEtrain(sae->first, parms) ;
-	SAEactivateNetwork(sae) ;
-	rms = SAEcomputeRMS(sae) ;
-      }
-    }
-
-    G_rms = SAEcomputeRMS(csae->sae) ;
-    if (G_rms > G_last_rms)
-      DiagBreak() ;
-    G_last_rms = G_rms ;
-    in = sae->first->v_input->rptr[ind][1] ;
-    out = sae->first->v_output->rptr[ind][1] ;
-    DiagBreak() ;
-  }
-#endif
 
   parms->acceptance_sigma = acceptance_sigma;
   parms->proposal_sigma = proposal_sigma;
@@ -2232,11 +2162,6 @@ double CSAEcomputeVoxlistRMS(CSAE *csae,
     z = vl->zi[ind];
     parms->class_label = vl->vsrc[ind];
 
-#if 0
-    // doesn't make sense anymore since we would need to look across all frames
-    if (FZERO(MRIgetVoxVal(mri[0], x, y, z, 0)))
-      continue ;
-#endif
     CSAEfillInputs(csae, mri[0], ae->v_input, x, y, z, ae->ksize);
     AEactivateLayer(ae, ae->v_input);
     for (h = 0; h < nhidden; h++)

--- a/utils/mrimorph.cpp
+++ b/utils/mrimorph.cpp
@@ -67,10 +67,6 @@ static float computeEMAlignmentErrorFunctional(float *p);
 static void computeEMAlignmentGradient(float *p, float *g);
 static int m3dPositionBorderNodes(MORPH_3D *m3d);
 static float m3dNodeAverageExpansion(MORPH_3D *m3d, int i, int j, int k);
-#if 0
-static float  m3dAverageNodeDistance(MORPH_3D *m3d, int i, int j, int k) ;
-static int    m3dPutExpansionFactorInDx(MORPH_3D *m3d) ;
-#endif
 
 static int m3dblurDx(MORPH_3D *m3d, float sigma);
 static int m3dTranslate(MORPH_3D *m3d, float dx, float dy, float dz);
@@ -80,16 +76,6 @@ static int m3dcheck(MORPH_3D *m3d);
 static MRI *find_midline(MRI *mri_src, MRI *mri_thresh, float *px);
 static int find_spinal_fusion(MRI *mri_thresh, float *px, float *py, float *pz);
 static int mriLinearAlignPyramidLevel(MRI *mri_in, MRI *mri_ref, MP *parms);
-#if 0
-static void computeRigidAlignmentErrorFunctionalAndGradient(int index,
-    float *p,
-    float *yret,
-    float *dydp,
-    int nparms);
-static int mriLevenbergMarquardtLinearAlignPyramidLevel(MRI *mri_in,
-    MRI *mri_ref,
-    MP *parms);
-#endif
 static int mriQuasiNewtonLinearAlignPyramidLevel(MRI *mri_in, MRI *mri_ref, MP *parms);
 static int mriQuasiNewtonEMAlignPyramidLevel(MRI *mri_in, GCA *gca, MP *parms);
 static int m3dAlignPyramidLevel(MRI *mri_in, MRI *mri_ref, MRI *mri_ref_blur, MP *parms, MORPH_3D *m3d);
@@ -625,10 +611,6 @@ MRI *MRIfindNeck(MRI *mri_src, MRI *mri_dst, int thresh_low, int thresh_hi, MP *
 
   /* find coordinates for cutting plane in rotated system */
   find_spinal_fusion(mri_thresh, &x0, &y0, &z0);
-#if 0
-  if (!parms)  /* 1 cm below for morph. HACK - should be fixed */
-    y0 += DISTANCE_BELOW_SPINAL_FUSION / thick ;
-#endif
 
   /* transform them into original voxel coordinates */
   VECTOR_ELT(v, 4) = 1.0 / mri_thresh->thick;
@@ -898,10 +880,6 @@ static int find_spinal_fusion(MRI *mri_thresh, float *px, float *py, float *pz)
 
     /* make sure it is much bigger than anything else close to it */
     if (spinal_area > MIN_SPINAL_AREA) {
-#if 0
-      for (l = 1 ; l < nlabels ; l++)
-        fprintf(stdout, "slice %d, areas[%d] = %2.1f\n", y, l, areas[l]) ;
-#endif
       for (found = l = 1; found && l < nlabels; l++) {
         if ((l == spinal_l) || FZERO(areas[l])) continue;
         corner_dist = REGIONminCornerDistance(&bboxes[l], &bboxes[spinal_l]);
@@ -1028,11 +1006,6 @@ int MRIinitScaling(MRI *mri_in, MRI *mri_ref, MATRIX *m_L)
   *MATRIX_RELT(m_scaling, 2, 2) = sy;
   *MATRIX_RELT(m_scaling, 3, 3) = sz;
 
-#if 0
-  *MATRIX_RELT(m_L, 1, 4) = dx ;
-  *MATRIX_RELT(m_L, 2, 4) = dy ;
-  *MATRIX_RELT(m_L, 3, 4) = dz ;
-#endif
   MatrixMultiply(m_scaling, m_L, m_L);
   fflush(stdout);
   return (NO_ERROR);
@@ -1075,37 +1048,6 @@ int MRIlinearAlign(MRI *mri_in, MRI *mri_ref, MP *parms)
   if (FZERO(mri_ref->mean)) mri_ref->mean = 1.0f;
   if (parms->lta->num_xforms == 1) /* one (global) transformation */
   {
-#if 0
-    MRI    *mri_tmp, *mri_in_erased, *mri_ref_erased ;
-    mri_in_erased = MRIcopy(mri_in, NULL) ;
-    MRIeraseNeck(mri_in_erased, &parms->in_np) ;
-    if (Gdiag & DIAG_SHOW /*&& DIAG_VERBOSE_ON*/)
-    {
-      rms = mriIntensityRMS(mri_in, mri_ref, parms->lta, 1.0f, &parms->in_np);
-      fprintf(stdout, "before initial alignment rms = %2.3f\n", rms) ;
-    }
-    if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON)
-    {
-      MRIwriteImageViews(parms->mri_ref, "ref", IMAGE_SIZE) ;
-      writeSnapshot(parms->mri_in, parms, 0) ;
-    }
-    mri_tmp = LTAtransform(mri_in_erased, NULL, parms->lta) ;
-    mri_ref_erased = MRIcopy(mri_ref, NULL) ;
-    MRIeraseNeck(mri_ref_erased, &parms->ref_np) ;
-    MRIinitTranslation(mri_tmp, mri_ref_erased, parms->lta->xforms[0].m_L) ;
-    if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON)
-      writeSnapshot(parms->mri_in, parms, 1) ;
-    MRIinitScaling(mri_tmp, mri_ref_erased, parms->lta->xforms[0].m_L) ;
-    if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON)
-      writeSnapshot(parms->mri_in, parms, 2) ;
-    LTAtransform(mri_in, mri_tmp, parms->lta) ;
-    MRIinitTranslation(mri_tmp, mri_ref_erased, parms->lta->xforms[0].m_L) ;
-    if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON)
-      writeSnapshot(parms->mri_in, parms, 3) ;
-    MRIfree(&mri_tmp) ;
-    MRIfree(&mri_in_erased) ;
-    MRIfree(&mri_ref_erased) ;
-#endif
 
     if (Gdiag & DIAG_SHOW /*&& DIAG_VERBOSE_ON*/) {
       rms = mriIntensityRMS(mri_in, mri_ref, parms->lta, 1.0f, &parms->in_np);
@@ -1234,7 +1176,6 @@ int MRIfindMeans(MRI *mri, float *means)
 ------------------------------------------------------*/
 int MRIfindCenterOfBrain(MRI *mri, float *px0, float *py0, float *pz0)
 {
-#if 1
   int x, y, z, width, height, depth;
   float x0, y0, z0, total, val;
 
@@ -1267,14 +1208,6 @@ int MRIfindCenterOfBrain(MRI *mri, float *px0, float *py0, float *pz0)
     *py0 = height / 2;
     *pz0 = depth / 2;
   }
-#else
-  MRI_REGION box;
-
-  MRIboundingBox(mri, 140, &box);
-  *px0 = box.x + box.dx / 2;
-  *py0 = box.y + 75 / mri->ysize;
-  *pz0 = box.z + box.dz / 2;
-#endif
   return (NO_ERROR);
 }
 /*-----------------------------------------------------
@@ -1315,13 +1248,7 @@ static int mriLinearAlignPyramidLevel(MRI *mri_in, MRI *mri_ref, MORPH_PARMS *pa
   }
 
   ncalls++; /* for diagnostics */
-#if 0
-  dt = parms->dt * mri_in->thick /** mri_in->thick*/ ;
-  if (mri_in->thick <= 4.0)
-    dt /= 2.0 ;
-#else
   dt = parms->dt;
-#endif
 
   m_L = parms->lta->xforms[0].m_L;
   old_rms = rms = mriIntensityRMS(mri_in, mri_ref, parms->lta, 1.0f, &parms->in_np);
@@ -1350,11 +1277,6 @@ static int mriLinearAlignPyramidLevel(MRI *mri_in, MRI *mri_ref, MORPH_PARMS *pa
     writeSnapshot(parms->mri_in, parms, 0);
 
     if (ncalls == 1) {
-#if 0
-      sprintf(fname, "%sref.mgh", base_name) ;
-      fprintf(stdout, "writing reference volume to %s...\n", fname) ;
-      MRIwrite(parms->mri_ref, fname) ;
-#endif
 #if USE_INVERSE == 0
       int req = snprintf(fname, STRLEN, "%sref", base_name);  
       if( req >= STRLEN ) {
@@ -1503,11 +1425,7 @@ static int writeSnapshot(MRI *mri, MORPH_PARMS *parms, int n)
   }
   mri_tmp = MRIinverseLinearTransform(parms->mri_ref, NULL, parms->lta->xforms[0].m_L);
 #else
-#if 0
-  mri_tmp = MRIlinearTransform(mri, NULL, parms->lta->xforms[0].m_L) ;
-#else
   mri_tmp = LTAtransform(mri, NULL, parms->lta);
-#endif
 #endif
   gca = parms->gca_red;
   if (mri->xsize < gca->xsize || mri->ysize < gca->ysize || mri->zsize < gca->zsize) {
@@ -1650,15 +1568,6 @@ static double ltaGradientStep(
           MatrixCheck(m_tmp);
           MatrixAdd(m_tmp, lt->m_dL, lt->m_dL);
           MatrixCheck(lt->m_dL);
-#if 0
-          if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
-          {
-            fprintf(stdout, "m_tmp ") ;
-            MatrixAsciiWriteInto(stdout, m_tmp) ;
-            fprintf(stdout, "m_dL ") ;
-            MatrixAsciiWriteInto(stdout, m_dL) ;
-          }
-#endif
           n++;
         }
       }
@@ -1683,18 +1592,10 @@ static double ltaGradientStep(
           if (fabs(*MATRIX_RELT(lt->m_dL, r, c)) > max_val) max_val = fabs(*MATRIX_RELT(lt->m_dL, r, c));
         }
       }
-#if 0
-      if (dt*max_val > (MAX_LINEAR_DEL))
-        dt = MAX_LINEAR_DEL / (max_val) ;
-#endif
 
       for (max_val = 0.0, r = 1; r <= lt->m_dL->rows; r++) {
         if (fabs(*MATRIX_RELT(lt->m_dL, r, 4)) > max_val) max_val = fabs(*MATRIX_RELT(lt->m_dL, r, 4));
       }
-#if 0
-      if (dt*max_val > (MAX_TRANSLATION_DEL))
-        dt = MAX_TRANSLATION_DEL / max_val ;
-#endif
 
       MatrixScalarMul(lt->m_dL, -dt, lt->m_dL);
       MatrixScalarMul(lt->m_last_dL, momentum, lt->m_last_dL);
@@ -1839,10 +1740,6 @@ static int m3dapplyGradient(MORPH_3D *m3d, double dt);
 static double m3dscaleDeltaT(MORPH_3D *m3d, double dt, double max_grad, MORPH_PARMS *parms);
 static int MRIsample3Dmorph(MORPH_3D *m3d, float x, float y, float z, float *pxd, float *pyd, float *pzd);
 static MORPH_3D *m3dscaleUp2(MORPH_3D *m3d_in, MORPH_3D *m3d_out, MORPH_PARMS *parms);
-#if 0
-static MORPH_3D *m3dscaleDown2(MORPH_3D *m3d_in, MORPH_3D *m3d_out,
-                               MORPH_PARMS *parms) ;
-#endif
 
 /*-----------------------------------------------------
         Parameters:
@@ -1895,10 +1792,6 @@ static double m3dCorrelationSSE(MRI *mri_in, MRI *mri_ref, MORPH_3D *m3d, NECK_P
 
   mean_std = mri_ref->mean;
   thick = mri_in->thick;
-#if 0
-  mri_in = m3d->mri_in ;
-  mri_ref = m3d->mri_ref ;  /* non-blurred versions */
-#endif
   width = mri_in->width;
   height = mri_in->height;
   depth = mri_in->depth;
@@ -2064,19 +1957,12 @@ static double m3dNonlinearAreaSSE(MRI *mri_in, MRI *mri_ref, MORPH_3D *m3d, MORP
       for (k = 0; k < depth; k++) {
         mn = &m3d->nodes[i][j][k];
         mnp = &m3d->pnodes[i][j][k];
-#if 0
-        if ((mnp->area <= 0) && !FZERO(mnp->orig_area))
-          m3d->neg++ ;
-#endif
         /* scale up the area coefficient if the area of the current node is
            close to 0 or already negative */
         if (!FZERO(mnp->orig_area))
           ratio = mnp->area / mnp->orig_area;
         else {
           ratio = 1;
-#if 0
-          fprintf(stdout, "orig area = 0 at (%d, %d, %d)!!!\n", i, j, k) ;
-#endif
         }
         exponent = -parms->exp_k * ratio;
         if (exponent > MAX_EXP)
@@ -2121,10 +2007,6 @@ static double m3dAreaSSE(MRI *mri_in, MRI *mri_ref, MORPH_3D *m3d)
       for (k = 0; k < depth; k++) {
         mn = &m3d->nodes[i][j][k];
         mnp = &m3d->pnodes[i][j][k];
-#if 0
-        if ((mnp->area <= 0) || !FZERO(mnp->orig_area))
-          m3d->neg++ ;
-#endif
         delta = (mnp->area - mnp->orig_area) / n3;
         sse += delta * delta * mri_in->thick;
         if (!finitep(delta) || !finitep(sse)) DiagBreak();
@@ -2182,11 +2064,6 @@ static MORPH_3D *m3dalloc(int width, int height, int depth, float node_spacing)
   m3d->width = width;
   m3d->height = height;
   m3d->depth = depth;
-#if 0
-  m3d->mri_in = mri_in ;
-  m3d->mri_ref = mri_ref ;
-  m3d->m_L = parms->lta->xforms[0].m_L ;
-#endif
 
   m3d->nodes = (MORPH_NODE ***)calloc(width, sizeof(MORPH_NODE **));
   if (!m3d->nodes) ErrorExit(ERROR_NOMEMORY, "m3dalloc: could not allocate node width");
@@ -2326,61 +2203,6 @@ static int m3dStoreMetricProperties(MORPH_3D *m3d)
   m3dInitAreas(m3d);
   return (NO_ERROR);
 }
-#if 0
-/*-----------------------------------------------------
-        Parameters:
-
-        Returns value:
-
-        Description
-------------------------------------------------------*/
-int
-m3dinit(MORPH_3D *m3d)
-{
-  int        width, height, depth, x, y, i, j, k ;
-  float      scale ;
-  VECTOR     *v_X, *v_Y ;
-  MORPH_NODE *mn ;
-  MNP        *mnp ;
-
-  v_X = VectorAlloc(4, MATRIX_REAL) ;
-  v_Y = VectorAlloc(4, MATRIX_REAL) ;
-  width = m3d->width ;
-  height = m3d->height ;
-  depth = m3d->depth ;
-
-  /* now initialize node positions */
-  v_X->rptr[4][1] = 1.0f ;
-  for (k = 0 ; k < depth ; k++)
-  {
-    V3_Z(v_X) = (float)k * m3d->node_spacing ;
-    for (j = 0 ; j < height ; j++)
-    {
-      V3_Y(v_X) = (float)j * m3d->node_spacing ;
-      for (i = 0 ; i < width ; i++)
-      {
-        mn = &m3d->nodes[i][j][k] ;
-        mnp = &m3d->pnodes[i][j][k] ;
-        V3_X(v_X) = (float)i * m3d->node_spacing ;
-#if !USE_ORIGINAL_PROPERTIES
-        LTAtransformPoint(parms->lta, v_X, v_Y) ;
-#else
-        MatrixCopy(v_X, v_Y) ;
-#endif
-        mnp->ox = V3_X(v_Y) ;
-        mnp->oy = V3_Y(v_Y) ;
-        mnp->oz = V3_Z(v_Y) ;
-      }
-    }
-  }
-
-  m3dInitDistances(m3d) ;
-  m3dInitAreas(m3d) ;
-  VectorFree(&v_X) ;
-  VectorFree(&v_Y) ;
-  return(NO_ERROR) ;
-}
-#endif
 /*-----------------------------------------------------
         Parameters:
 
@@ -2406,7 +2228,6 @@ MORPH_3D *MRI3Dmorph(MRI *mri_in, MRI *mri_ref, MORPH_PARMS *parms)
     max_levels = parms->levels;
   else
     max_levels = MAX_LEVELS;
-#if 1
   if (MRIfindNeck(mri_in, mri_in, 90, 120, NULL, 0, &parms->in_np) != NO_ERROR)
     parms->disable_neck = 1;
   else if (MRIfindNeck(mri_ref, mri_ref, 90, 120, NULL, 0, &parms->ref_np) != NO_ERROR)
@@ -2433,12 +2254,7 @@ MORPH_3D *MRI3Dmorph(MRI *mri_in, MRI *mri_ref, MORPH_PARMS *parms)
     parms->ref_np.neck_y0 += parms->ref_np.neck_dy * DISTANCE_BELOW_SPINAL_FUSION;
     parms->ref_np.neck_z0 += parms->ref_np.neck_dz * DISTANCE_BELOW_SPINAL_FUSION;
     fprintf(stdout, "(%2.0f,%2.0f,%2.0f)\n", parms->in_np.neck_x0, parms->in_np.neck_y0, parms->in_np.neck_z0);
-#if 0
-    MRIeraseNeck(parms->mri_in, &parms->in_np) ;
-    MRIeraseNeck(parms->mri_ref, &parms->ref_np) ;
-#endif
   }
-#endif
 
   openLogFile(parms);
 
@@ -2465,15 +2281,6 @@ MORPH_3D *MRI3Dmorph(MRI *mri_in, MRI *mri_ref, MORPH_PARMS *parms)
       MRIrasXformToVoxelXform(mri_in_pyramid[MAX_LEVEL], mri_ref_pyramid[MAX_LEVEL], m_tmp, NULL);
   MatrixFree(&m_tmp);
   m3d = m3dInit(mri_in_pyramid[MAX_LEVEL], mri_ref_pyramid[MAX_LEVEL], parms, max_thick);
-#if 0
-  if (Gdiag & DIAG_WRITE)
-  {
-    MRI *mri_tmp ;
-    mri_tmp = MRIapply3DMorph(parms->mri_in, m3d, NULL) ;
-    MRIwrite(mri_tmp, "lta_via_m3d.mgh") ;
-    MRIfree(&mri_tmp) ;
-  }
-#endif
 
   if (parms->morph_skull) /* apply radial morph to account for skull shapes */
   {
@@ -2542,29 +2349,7 @@ MORPH_3D *MRI3Dmorph(MRI *mri_in, MRI *mri_ref, MORPH_PARMS *parms)
         MRISwrite(mris_in_skull, "post_skull_morph.geo");
       }
     }
-#if 1
     m3RecomputeTranslation(m3d, mri_in_pyramid[MIN_LEVEL], mri_ref_pyramid[MIN_LEVEL], parms);
-#else
-    m3RecomputeTranslation(m3d, parms->mri_in, parms->mri_ref, parms);
-#endif
-#if 0
-    if (Gdiag & DIAG_WRITE && parms->write_iterations > 0)
-    {
-      MRI *mri_tmp ;
-      fprintf(stdout, "writing volume after skull morphing...\n") ;
-      mri_tmp = MRIapply3DMorph(parms->mri_in, m3d, NULL) ;
-      MRIwrite(mri_tmp, "in_skull_morphed.mgh") ;
-      MRIfree(&mri_tmp) ;
-      mri_tmp = MRIapplyInverse3DMorph(mri_ref, m3d, NULL) ;
-      MRIwriteImageViews(mri_tmp, "postformed", IMAGE_SIZE) ;
-      MRIfree(&mri_tmp) ;
-      fprintf(stdout, "writing out skull-normalized volumes...\n") ;
-      mri_tmp = MRIapplyInverse3DMorph(mri_ref, m3d, NULL) ;
-      MRIwrite(mri_ref, "in.mgh") ;
-      MRIwrite(mri_tmp, "xformed.mgh") ;
-      MRIfree(&mri_tmp) ;
-    }
-#endif
     MRISfree(&mris_ref_skull);
     MRISfree(&mris_in_skull);
   } /* end of skull morphing */
@@ -2653,29 +2438,10 @@ MORPH_3D *MRI3Dmorph(MRI *mri_in, MRI *mri_ref, MORPH_PARMS *parms)
     }
   }
 
-#if 0
-  /* one more time - do at highest resolution */
-  m3d->mri_in = mri_in ;
-  m3d->mri_ref = mri_ref ;
-  sprintf(parms->base_name, "%s_level", base_name) ;
-  sprintf(parms->base_name, "%s_", base_name) ;
-  fprintf(stdout, "aligning base level.\n") ;
-  if ((Gdiag & DIAG_WRITE) && parms->log_fp)
-    fprintf(parms->log_fp, "aligning base level.\n") ;
-  parms->l_compression *= 10.0 ;
-  m3dAlignPyramidLevel(mri_in, mri_ref, mri_ref, parms, m3d) ;
-#endif
 
   strcpy(parms->base_name, base_name);
 
 /* free Gaussian pyramid */
-#if 0
-  for (i = 1 ; i < nlevels ; i++)
-  {
-    MRIfree(&mri_in_pyramid[i]) ;
-    MRIfree(&mri_ref_pyramid[i]) ;
-  }
-#endif
   if (parms->log_fp) {
     fclose(parms->log_fp);
     parms->log_fp = NULL;
@@ -2730,11 +2496,7 @@ MRI *MRIapply3DMorph(MRI *mri_in, MORPH_3D *m3d, MRI *mri_morphed)
         xd /= thick;
         yd /= thick;
         zd /= thick; /* voxel coords */
-#if 0
-        MRIsampleVolume(mri_in, xd, yd, zd, &orig_val);
-#else
         orig_val = MRIgetVoxVal(mri_in, x, y, z, 0);
-#endif
         if (orig_val > 40) DiagBreak();
 
         /* now use trilinear interpolation */
@@ -2832,11 +2594,7 @@ MRI *MRIapply3DMorph(MRI *mri_in, MORPH_3D *m3d, MRI *mri_morphed)
   MRIfree(&mri_s_morphed);
 
 /* run soap bubble to fill in remaining holes */
-#if 0
-  mri_ctrl = MRIclone(mri_in, NULL) ;
-#else
   mri_ctrl = mri_weights;
-#endif
   for (x = 0; x < width; x++) {
     for (y = 0; y < height; y++) {
       for (z = 0; z < depth; z++) {
@@ -2850,9 +2608,6 @@ MRI *MRIapply3DMorph(MRI *mri_in, MORPH_3D *m3d, MRI *mri_morphed)
     }
   }
 
-#if 0
-  MRIfree(&mri_weights) ;
-#endif
   MRIbuildVoronoiDiagram(mri_morphed, mri_ctrl, mri_morphed);
   MRIsoapBubble(mri_morphed, mri_ctrl, mri_morphed, 5, -1);
 
@@ -3240,14 +2995,6 @@ static int m3dAreaTerm(MORPH_3D *m3d, double l_area, int i, int j, int k, double
   int n, width, height, depth, num, invert;
   static VECTOR *v_i = NULL, *v_j, *v_k, *v_k_x_j, *v_j_x_i, *v_i_x_k, *v_grad, *v_tmp;
 
-#if 0
-  mnp = &m3d->pnodes[i][j][k] ;
-  if (FZERO(mnp->orig_area))
-  {
-    *pdx = *pdy = *pdz = 0.0 ;
-    return(NO_ERROR) ;
-  }
-#endif
 
   width = m3d->width;
   height = m3d->height;
@@ -3384,37 +3131,6 @@ static int m3dAreaTerm(MORPH_3D *m3d, double l_area, int i, int j, int k, double
     MN_SUB(mnj, mn, v_j);
     MN_SUB(mnk, mn, v_k);
 
-#if 0
-    odx = mnpi->ox-mnp->ox ;
-    ody = mnpi->oy-mnp->oy ;
-    odz = mnpi->oz-mnp->oz;
-    if (!FZERO(odx))
-      V3_X(v_i) /= odx ;
-    if (!FZERO(ody))
-      V3_Y(v_i) /= ody ;
-    if (!FZERO(odz))
-      V3_Z(v_i) /= odz ;
-
-    odx = mnpj->ox-mnp->ox ;
-    ody = mnpj->oy-mnp->oy ;
-    odz = mnpj->oz-mnp->oz;
-    if (!FZERO(odx))
-      V3_X(v_j) /= odx ;
-    if (!FZERO(ody))
-      V3_Y(v_j) /= ody ;
-    if (!FZERO(odz))
-      V3_Z(v_j) /= odz ;
-
-    odx = mnpk->ox-mnp->ox ;
-    ody = mnpk->oy-mnp->oy ;
-    odz = mnpk->oz-mnp->oz;
-    if (!FZERO(odx))
-      V3_X(v_k) /= odx ;
-    if (!FZERO(ody))
-      V3_Y(v_k) /= ody ;
-    if (!FZERO(odz))
-      V3_Z(v_k) /= odz ;
-#endif
 
     delta = invert * (mnp->orig_area - mnp->area) / n3;
     if (mnp->area < 0) DiagBreak();
@@ -3666,11 +3382,7 @@ static int m3dAlignPyramidLevel(MRI *mri_in, MRI *mri_ref, MRI *mri_ref_blur, MP
     mri_ref->mean = 1.0;
   }
 
-#if 0
-  dt = parms->dt * mri_in->thick /** mri_in->thick*/ ;
-#else
   dt = parms->dt;
-#endif
   nvox = m3d->width * m3d->height * m3d->depth;
   m3dComputeMetricProperties(m3d);
   sse = m3dSSE(mri_in, mri_ref, parms, m3d, &intensity_rms, &distance_rms, &area_rms);
@@ -3683,33 +3395,12 @@ static int m3dAlignPyramidLevel(MRI *mri_in, MRI *mri_ref, MRI *mri_ref_blur, MP
     /*    char fname[STRLEN] ;*/
     write3DSnapshot(m3d->mri_in, m3d->mri_ref, parms, m3d, 0);
 
-#if 0
-    sprintf(fname, "%sref.mgh", parms->base_name) ;
-    MRIwrite(mri_ref, fname) ;
-#endif
   }
 
   last_avg = old_rms;
   current_avg = rms;
   for (n = parms->start_t; n < parms->start_t + parms->niterations; n++) {
-#if 0
-    if (n - parms->start_t == 5)
-    {
-      parms->l_nlarea = parms->l_dist = parms->l_intensity = 0 ;
-      parms->l_area = 1.0f ;
-      fprintf(stdout, "resetting everything but area to 0...\n") ;
-    }
-#endif
 
-#if 0
-    if (((n+1)%5) == 0)
-    {
-      if (((n+1)%15) == 0)
-        parms->l_area = 0.0 ;
-      else
-        parms->l_area = 0.1 ;
-    }
-#endif
     m3dPositionBorderNodes(m3d);
     d = m3dIntegrationStep(mri_in, mri_ref, mri_ref_blur, parms, m3d, dt);
     m3dComputeMetricProperties(m3d);
@@ -4111,24 +3802,11 @@ static int write3DSnapshot(MRI *mri_in, MRI *mri_ref, MORPH_PARMS *parms, MORPH_
   if (!n) {
     sprintf(fname, "in_%s", parms->base_name);
     MRIwriteImageViews(mri_in, fname, IMAGE_SIZE);
-#if 0
-    sprintf(fname, "in_%s.mgh", parms->base_mriWriteImageViewname) ;
-    fprintf(stdout, "writing volume to %s...\n", fname) ;
-    MRIwrite(mri_in, fname) ;
-#endif
   }
 
   mri_tmp = MRIapplyInverse3DMorph(mri_ref, m3d, NULL);
   sprintf(fname, "%s%3.3d", parms->base_name, n);
   MRIwriteImageViews(mri_tmp, fname, IMAGE_SIZE);
-#if 0
-  if (((n) % (10*parms->write_iterations)) == 0)
-  {
-    sprintf(fname, "%s%3.3d.mgh", parms->base_name, n) ;
-    fprintf(stdout, "writing volume to %s...\n", fname) ;
-    MRIwrite(mri_tmp, fname) ;
-  }
-#endif
   MRIfree(&mri_tmp);
 
   return (NO_ERROR);
@@ -4216,45 +3894,6 @@ static int mriWriteImageView(MRI *mri, const char *base_name, int target_size, i
       break;
   }
 
-#if 0
-  if (slice < 0)    /* pick middle slice */
-  {
-    slice_direction = getSliceDirection(mri);
-    switch (slice_direction)
-    {
-    default:
-    case MRI_CORONAL:
-      switch (view)
-      {
-      default:
-      case MRI_CORONAL:
-        slice = mri->depth/2;
-        break ;
-      case MRI_SAGITTAL:
-        slice = 6*mri->width/10 ;
-        break ;
-      case MRI_HORIZONTAL:
-        slice = mri->height/2 ;
-        break ;
-      }
-      break ;
-    case MRI_SAGITTAL:
-      switch (view)
-      {
-      default:
-      case MRI_CORONAL:
-        slice = mri->width/2;
-        break ;  //??
-      case MRI_SAGITTAL:
-        slice = 6*mri->depth/10 ;
-        break ;
-      case MRI_HORIZONTAL:
-        slice = mri->height/2 ;
-        break ; //??
-      }
-    }
-  }
-#endif
   I = MRItoImageView(mri, NULL, slice, view, 0);
   if (!I) ErrorReturn(Gerror, (Gerror, "MRItoImageView failed"));
 
@@ -4626,269 +4265,6 @@ MORPH_3D *MRI3Dread(char *fname)
         Description
            Read a 3d morph from a file, and initialize it.
 ------------------------------------------------------*/
-#if 0
-static MORPH_3D *
-m3dscaleUp2(MORPH_3D *m3d_in, MORPH_3D *m3d_out, MORPH_PARMS *parms)
-{
-  int         width, height, depth, i, j, k, alloced = 0 ;
-  MORPH_NODE  *mn ;
-  float       x, y, z, node_spacing ;
-  VECTOR     *v_X, *v_Y ;
-#if 0
-  float      dx, dy, dz ;
-  int        n ;
-#endif
-  v_X = VectorAlloc(4, MATRIX_REAL) ;
-  v_Y = VectorAlloc(4, MATRIX_REAL) ;
-
-  width  = m3d_in->width *2-1 ;
-  height = m3d_in->height*2-1 ;
-  depth  = m3d_in->depth *2-1 ;
-  node_spacing = m3d_in->node_spacing/2.0 ;
-  if (!m3d_out)
-  {
-    alloced = 1 ;
-    m3d_out = m3dalloc(width, height, depth, node_spacing) ;
-  }
-
-  for (i = 0 ; i < width ; i++)
-  {
-    x = V3_X(v_X) = (float)i * node_spacing ;
-    for (j = 0 ; j < height ; j++)
-    {
-      y = V3_Y(v_X) = (float)j * node_spacing ;
-      for (k = 0 ; k < depth ; k++)
-      {
-        z = V3_Z(v_X) = (float)k * node_spacing ;
-        mn = &m3d_out->nodes[i][j][k] ;
-        MRIsample3Dmorph(m3d_in, x, y, z, &mn->x, &mn->y, &mn->z) ;
-        if (alloced)
-        {
-          LTAtransformPoint(parms->lta, v_X, v_Y) ;
-          mn->ox = V3_X(v_Y) ;
-          mn->oy = V3_Y(v_Y) ;
-          mn->oz = V3_Z(v_Y) ;
-        }
-
-#if 0
-        /* handle boundary conditions */
-        dx = dy = dz = 0.0f ;
-        n = 0 ;
-        if (i == width-1)
-        {
-          dx += m3d_out->nodes[i-1][j][k].x - m3d_out->nodes[i-2][j][k].x ;
-          dy += m3d_out->nodes[i-1][j][k].y - m3d_out->nodes[i-2][j][k].y ;
-          dz += m3d_out->nodes[i-1][j][k].z - m3d_out->nodes[i-2][j][k].z ;
-          n++ ;
-        }
-        if (j == height-1)
-        {
-          dx += m3d_out->nodes[i][j-1][k].x - m3d_out->nodes[i][j-2][k].x ;
-          dy += m3d_out->nodes[i][j-1][k].y - m3d_out->nodes[i][j-2][k].y ;
-          dz += m3d_out->nodes[i][j-1][k].z - m3d_out->nodes[i][j-2][k].z ;
-          n++ ;
-        }
-        if (k == depth-1)
-        {
-          dx += m3d_out->nodes[i][j][k-1].x - m3d_out->nodes[i][j][k-2].x ;
-          dy += m3d_out->nodes[i][j][k-1].y - m3d_out->nodes[i][j][k-2].y ;
-          dz += m3d_out->nodes[i][j][k-1].z - m3d_out->nodes[i][j][k-2].z ;
-          n++ ;
-        }
-        if (n > 0)  /* on one of the outside borders */
-        {
-          dx /= (float)n ;
-          dy /= (float)n ;
-          dz /= (float)n ;
-          mn->x += dx ;
-          mn->y += dy ;
-          mn->z += dz ;
-        }
-#endif
-        if (!finitep(mn->x) || !finitep(mn->y) || !finitep(mn->z) ||
-            !finitep(mn->ox) || !finitep(mn->oy) || !finitep(mn->oz))
-          DiagBreak() ;
-      }
-    }
-  }
-  if (alloced)
-  {
-    m3dAllocProperties(m3d_out) ;
-    m3dInitDistances(m3d_out) ;
-    m3dInitAreas(m3d_out) ;
-  }
-  return(m3d_out) ;
-}
-#else
-#if 0
-static MORPH_3D *
-m3dscaleUp2(MORPH_3D *m3d_in, MORPH_3D *m3d_out, MORPH_PARMS *parms)
-{
-  int         width, height, depth, i, j, k, alloced = 0 ;
-  MORPH_NODE  *mn, *mn0, *mn1 ;
-  MNP         *mnp ;
-  float       x, y, z, node_spacing ;
-  VECTOR     *v_X, *v_Y ;
-  float      dx, dy, dz ;
-#if 0
-  int        n ;
-#endif
-  v_X = VectorAlloc(4, MATRIX_REAL) ;
-  v_Y = VectorAlloc(4, MATRIX_REAL) ;
-
-  width  = m3d_in->width *2-1 ;
-  height = m3d_in->height*2-1 ;
-  depth  = m3d_in->depth *2-1 ;
-  node_spacing = m3d_in->node_spacing/2.0 ;
-  if (!m3d_out)
-  {
-    alloced = 1 ;
-    m3d_out = m3dalloc(width, height, depth, node_spacing) ;
-  }
-  m3d_out->lta = m3d_in->lta ;
-
-  width = m3d_in->width ;
-  height = m3d_in->height ;
-  depth = m3d_in->depth ;
-  for (i = 0 ; i < width ; i++)
-  {
-    for (j = 0 ; j < height ; j++)
-    {
-      for (k = 0 ; k < depth ; k++)
-      {
-        mn = &m3d_out->nodes[i*2][j*2][k*2] ;
-        mn0 = &m3d_in->nodes[i][j][k] ;
-        mn->x = mn0->x ;
-        mn->y = mn0->y ;
-        mn->z = mn0->z ;
-        if (i < width-1)
-        {
-          mn = &m3d_out->nodes[i*2+1][j*2][k*2] ;
-          mn1 = &m3d_in->nodes[i+1][j][k] ;
-          dx = mn1->x - mn0->x ;
-          dy = mn1->y - mn0->y ;
-          dz = mn1->z - mn0->z ;
-          mn->x = mn0->x+dx/2 ;
-          mn->y = mn0->y+dy/2 ;
-          mn->z = mn0->z+dz/2 ;
-        }
-        if (j < height-1)
-        {
-          mn = &m3d_out->nodes[i*2][j*2+1][k*2] ;
-          mn1 = &m3d_in->nodes[i][j+1][k] ;
-          dx = mn1->x - mn0->x ;
-          dy = mn1->y - mn0->y ;
-          dz = mn1->z - mn0->z ;
-          mn->x = mn0->x+dx/2 ;
-          mn->y = mn0->y+dy/2 ;
-          mn->z = mn0->z+dz/2 ;
-        }
-        if (k < depth-1)
-        {
-          mn = &m3d_out->nodes[i*2][j*2][k*2+1] ;
-          mn1 = &m3d_in->nodes[i][j][k+1] ;
-          dx = mn1->x - mn0->x ;
-          dy = mn1->y - mn0->y ;
-          dz = mn1->z - mn0->z ;
-          mn->x = mn0->x+dx/2 ;
-          mn->y = mn0->y+dy/2 ;
-          mn->z = mn0->z+dz/2 ;
-        }
-        if (i < width-1 && j < height-1)
-        {
-          mn = &m3d_out->nodes[i*2+1][j*2+1][k*2] ;
-          mn1 = &m3d_in->nodes[i+1][j+1][k] ;
-          dx = mn1->x - mn0->x ;
-          dy = mn1->y - mn0->y ;
-          dz = mn1->z - mn0->z ;
-          mn->x = mn0->x+dx/2 ;
-          mn->y = mn0->y+dy/2 ;
-          mn->z = mn0->z+dz/2 ;
-        }
-        if (i < width-1 && k < depth-1)
-        {
-          mn = &m3d_out->nodes[i*2+1][j*2][k*2+1] ;
-          mn1 = &m3d_in->nodes[i+1][j][k+1] ;
-          dx = mn1->x - mn0->x ;
-          dy = mn1->y - mn0->y ;
-          dz = mn1->z - mn0->z ;
-          mn->x = mn0->x+dx/2 ;
-          mn->y = mn0->y+dy/2 ;
-          mn->z = mn0->z+dz/2 ;
-        }
-        if (j < height-1 && k < depth-1)
-        {
-          mn = &m3d_out->nodes[i*2][j*2+1][k*2+1] ;
-          mn1 = &m3d_in->nodes[i][j+1][k+1] ;
-          dx = mn1->x - mn0->x ;
-          dy = mn1->y - mn0->y ;
-          dz = mn1->z - mn0->z ;
-          mn->x = mn0->x+dx/2 ;
-          mn->y = mn0->y+dy/2 ;
-          mn->z = mn0->z+dz/2 ;
-        }
-        if (i < width-1 && j < height-1 && k < depth-1)
-        {
-          mn = &m3d_out->nodes[i*2+1][j*2+1][k*2+1] ;
-          mn1 = &m3d_in->nodes[i+1][j+1][k+1] ;
-          dx = mn1->x - mn0->x ;
-          dy = mn1->y - mn0->y ;
-          dz = mn1->z - mn0->z ;
-          mn->x = mn0->x+dx/2 ;
-          mn->y = mn0->y+dy/2 ;
-          mn->z = mn0->z+dz/2 ;
-        }
-      }
-    }
-  }
-
-
-  width  = m3d_in->width *2-1 ;
-  height = m3d_in->height*2-1 ;
-  depth  = m3d_in->depth *2-1 ;
-  MRI3DmorphFree(&m3d_in) ;
-
-  m3dAllocProperties(m3d_out) ;
-  for (i = 0 ; i < width ; i++)
-  {
-    x = V3_X(v_X) = (float)i * node_spacing ;
-    for (j = 0 ; j < height ; j++)
-    {
-      y = V3_Y(v_X) = (float)j * node_spacing ;
-      for (k = 0 ; k < depth ; k++)
-      {
-        z = V3_Z(v_X) = (float)k * node_spacing ;
-        mn  = &m3d_out->nodes[i][j][k] ;
-        mnp = &m3d_out->pnodes[i][j][k] ;
-        /*        MRIsample3Dmorph(m3d_in, x, y, z, &mn->x, &mn->y, &mn->z) ;*/
-        if (alloced)
-        {
-#if !USE_ORIGINAL_PROPTERIES
-          LTAtransformPoint(parms->lta, v_X, v_Y) ;
-#else
-MatrixCopy(v_X, v_Y) ;
-#endif
-          mnp->ox = V3_X(v_Y) ;
-          mnp->oy = V3_Y(v_Y) ;
-          mnp->oz = V3_Z(v_Y) ;
-        }
-
-        if (!finitep(mn->x) || !finitep(mn->y) || !finitep(mn->z) ||
-            !finitep(mnp->ox) || !finitep(mnp->oy) || !finitep(mnp->oz))
-          DiagBreak() ;
-      }
-    }
-  }
-
-  m3dComputeMetricProperties(m3d_out) ;
-  if (alloced)
-  {
-    m3dInitDistances(m3d_out) ;
-    m3dInitAreas(m3d_out) ;
-  }
-  return(m3d_out) ;
-}
-#else
 static MORPH_3D *m3dscaleUp2(MORPH_3D *m3d_in, MORPH_3D *m3d_out, MORPH_PARMS *parms)
 {
   int width, height, depth, i, j, k, alloced = 0;
@@ -4958,120 +4334,6 @@ static MORPH_3D *m3dscaleUp2(MORPH_3D *m3d_in, MORPH_3D *m3d_out, MORPH_PARMS *p
   }
   return (m3d_out);
 }
-#endif
-#endif
-#if 0
-/*-----------------------------------------------------
-        Parameters:
-
-        Returns value:
-
-        Description
-           Read a 3d morph from a file, and initialize it.
-------------------------------------------------------*/
-static MORPH_3D *
-m3dscaleDown2(MORPH_3D *m3d_in, MORPH_3D *m3d_out, MORPH_PARMS *parms)
-{
-  int         width, height, depth, i, j, k, alloced = 0 ;
-  MORPH_NODE  *mn ;
-  float       x, y, z, node_spacing ;
-  VECTOR     *v_X, *v_Y ;
-
-  v_X = VectorAlloc(4, MATRIX_REAL) ;
-  v_Y = VectorAlloc(4, MATRIX_REAL) ;
-  width  = m3d_in->width /2 ;
-  height = m3d_in->height/2 ;
-  depth  = m3d_in->depth /2 ;
-  node_spacing = m3d_in->node_spacing*2.0 ;
-  if (!m3d_out)
-  {
-    alloced = 1 ;
-    m3d_out = m3dalloc(width, height, depth, node_spacing) ;
-  }
-
-  v_X->rptr[4][1] = 1.0f ;
-  for (i = 0 ; i < width ; i++)
-  {
-    x = V3_X(v_X) = (float)i * node_spacing ;
-    for (j = 0 ; j < height ; j++)
-    {
-      y = V3_Y(v_X) = (float)j * node_spacing ;
-      for (k = 0 ; k < depth ; k++)
-      {
-        z = V3_Z(v_X) = (float)k * node_spacing ;
-        LTAtransformPoint(parms->lta, v_X, v_Y) ;
-        mn = &m3d_out->nodes[i][j][k] ;
-        MRIsample3Dmorph(m3d_in, x, y, z, &mn->x, &mn->y, &mn->z) ;
-        if (alloced)
-          MRIsample3DmorphOrig(m3d_in, x, y, z, &mn->ox, &mn->oy, &mn->oz) ;
-      }
-    }
-  }
-  if (alloced)
-  {
-    m3dInitDistances(m3d_out) ;
-    m3dInitAreas(m3d_out) ;
-  }
-  return(m3d_out) ;
-}
-#endif
-#if 0
-static float
-m3dComputeOrigCoords(MORPH_3D *m3d, int i, int j, int k,
-                     float *pox, float *poy, float *poz)
-{
-  static VECTOR  *v_X, *v_Y = NULL ;
-
-  if (v_Y == NULL)
-  {
-    v_X = VectorAlloc(4, MATRIX_REAL) ;
-    v_Y = VectorAlloc(4, MATRIX_REAL) ;
-  }
-  v_X->rptr[4][1] = 1.0f /*/ mri_in->thick*/ ;
-  V3_Z(v_X) = (float)k * m3d->node_spacing ;
-  V3_Y(v_X) = (float)j * m3d->node_spacing ;
-  V3_X(v_X) = (float)i * m3d->node_spacing ;
-  LTAtransformPoint(m3d->lta, v_X, v_Y) ;
-
-  *pox = V3_X(v_Y) ;
-  *poy = V3_Y(v_Y) ;
-  *poz = V3_Z(v_Y) ;
-  return(NO_ERROR) ;
-}
-/*-----------------------------------------------------
-        Parameters:
-
-        Returns value:
-
-        Description
-
-------------------------------------------------------*/
-static float
-m3dComputeOrigArea(MORPH_3D *m3d, int i, int j, int k)
-{
-  static VECTOR  *v_i = NULL, *v_j, *v_k ;
-  float          mn_ox, mn_oy, mn_oz, mni_ox, mni_oy, mni_oz,
-  mnj_ox, mnj_oy, mnj_oz, mnk_ox, mnk_oy, mnk_oz, area ;
-
-  if (v_i == NULL)
-  {
-    v_i = VectorAlloc(3, MATRIX_REAL) ;
-    v_j = VectorAlloc(3, MATRIX_REAL) ;
-    v_k = VectorAlloc(3, MATRIX_REAL) ;
-  }
-
-  m3dComputeOrigCoords(m3d, i, j, k, &mn_ox, &mn_oy, &mn_oz) ;
-  m3dComputeOrigCoords(m3d, i+1, j, k, &mni_ox, &mni_oy, &mni_oz) ;
-  m3dComputeOrigCoords(m3d, i, j+1, k, &mnj_ox, &mnj_oy, &mnj_oz) ;
-  m3dComputeOrigCoords(m3d, i, j, k+1, &mnk_ox, &mnk_oy, &mnk_oz) ;
-  V3_LOAD(v_i, mni_ox - mn_ox, mni_oy - mn_oy, mni_oz - mn_oz) ;
-  V3_LOAD(v_j, mnj_ox - mn_ox, mnj_oy - mn_oy, mnj_oz - mn_oz) ;
-  V3_LOAD(v_k, mnk_ox - mn_ox, mnk_oy - mn_oy, mnk_oz - mn_oz) ;
-  area = VectorTripleProduct(v_j, v_k, v_i) ;
-
-  return(area) ;
-}
-#endif
 int MRIeraseBorders(MRI *mri, int width)
 {
   int i;
@@ -5686,75 +4948,6 @@ static int m3dNonlinearDistanceTerm(
 
         Description
 ------------------------------------------------------*/
-#if 0
-static float
-m3dAverageNodeDistance(MORPH_3D *m3d, int i, int j, int k)
-{
-  int         n, num ;
-  double      dx, dy, dz, dist, xgrad, ygrad, zgrad, avg_dist ;
-  MORPH_NODE  *mn, *mn_nbr ;
-  MNP         *mnp ;
-
-  mn = &m3d->nodes[i][j][k] ;
-  mnp = &m3d->pnodes[i][j][k] ;
-  avg_dist = 0 ;
-  for (xgrad = ygrad = zgrad = 0.0, num = n = 0 ; n < NEIGHBORS ; n++)
-  {
-    switch (n)
-    {
-    default:
-    case 0:      /* i-1 */
-      if (i > 0)
-        mn_nbr = &m3d->nodes[i-1][j][k] ;
-      else
-        mn_nbr = NULL ;
-      break ;
-    case 1:      /* i+1 */
-      if (i < m3d->width-1)
-        mn_nbr = &m3d->nodes[i+1][j][k] ;
-      else
-        mn_nbr = NULL ;
-      break ;
-    case 2:      /* j-1 */
-      if (j > 0)
-        mn_nbr = &m3d->nodes[i][j-1][k] ;
-      else
-        mn_nbr = NULL ;
-      break ;
-    case 3:      /* j+1 */
-      if (j < m3d->height-1)
-        mn_nbr = &m3d->nodes[i][j+1][k] ;
-      else
-        mn_nbr = NULL ;
-      break ;
-    case 4:      /* k-1 */
-      if (k > 0)
-        mn_nbr = &m3d->nodes[i][j][k-1] ;
-      else
-        mn_nbr = NULL ;
-      break ;
-    case 5:      /* k+1 */
-      if (k < m3d->depth-1)
-        mn_nbr = &m3d->nodes[i][j][k+1] ;
-      else
-        mn_nbr = NULL ;
-      break ;
-    }
-    if (mn_nbr)
-    {
-      dx = mn_nbr->x - mn->x ;
-      dy = mn_nbr->y - mn->y ;
-      dz = mn_nbr->z-mn->z;
-      dist = sqrt(dx*dx + dy*dy + dz*dz) ;
-      avg_dist += dist ;
-      num++ ;
-    }
-  }
-  avg_dist /= (float)num ;
-
-  return(avg_dist) ;
-}
-#endif
 /*-----------------------------------------------------
         Parameters:
 
@@ -5822,17 +5015,6 @@ static float m3dNodeAverageExpansion(MORPH_3D *m3d, int i, int j, int k)
     }
   }
   avg_expansion /= (float)num;
-#if 0
-  {
-    char *cp ;
-    float k ;
-    if ((cp = getenv("K")) != NULL)
-      k = atof(cp) ;
-    else
-      k = 10.0 ;
-    avg_expansion = .5 + 1 / (1+exp(k*(avg_expansion-1))) ;
-  }
-#endif
   return (avg_expansion);
 }
 /*-----------------------------------------------------
@@ -5924,41 +5106,6 @@ static double m3dCompressionSSE(MRI *mri_in, MRI *mri_ref, MORPH_3D *m3d)
 
         Description
 ------------------------------------------------------*/
-#if 0
-static int
-m3dPutExpansionFactorInDx(MORPH_3D *m3d)
-{
-  MNP        *mnp ;
-  int        i, j, k, width, height, depth, avg_dist, n, num ;
-
-  width = m3d->width ;
-  height = m3d->height ;
-  depth = m3d->depth ;
-
-  for (i = 0 ; i < width ; i++)
-  {
-    for (j = 0 ; j < height ; j++)
-    {
-      for (k = 0 ; k < depth ; k++)
-      {
-        avg_dist = m3dAverageNodeDistance(m3d,  i,  j,  k) ;
-        mnp = &m3d->pnodes[i][j][k] ;
-        if (FZERO(avg_dist))
-          mnp->dx = 1.0f ;
-        else
-        {
-          for (n = 0 ; n < NEIGHBORS ; n++, num++)
-            mnp->dx += mnp->dist / avg_dist ;
-
-          mnp->dx /= (float)NEIGHBORS ;
-        }
-      }
-    }
-  }
-  return(NO_ERROR) ;
-}
-
-#endif
 /*-----------------------------------------------------
         Parameters:
 
@@ -5990,110 +5137,6 @@ int MRIeraseNeck(MRI *mri, NECK_PARMS *np)
 ------------------------------------------------------*/
 static int m3dPositionBorderNodes(MORPH_3D *m3d)
 {
-#if 0
-  int         i, j, k, width, height, depth, n, num ;
-  double      dx, dy, dz, xavg, yavg, zavg ;
-  MORPH_NODE  *mn, *mn_nbr ;
-  MNP         *mnp, *mnp_nbr = NULL ;
-
-  width = m3d->width ;
-  height = m3d->height ;
-  depth = m3d->depth ;
-
-  for (i = 0 ; i < width ; i++)
-  {
-    for (j = 0 ; j < height ; j++)
-    {
-      for (k = 0 ; k < depth ; k++)
-      {
-        mn = &m3d->nodes[i][j][k] ;
-        mnp = &m3d->pnodes[i][j][k] ;
-        if (!FZERO(mnp->orig_area))
-          continue ;
-        for (xavg = yavg = zavg = 0.0, num = n = 0 ; n < NEIGHBORS ; n++)
-        {
-          switch (n)
-          {
-          default:
-          case 0:      /* i-1 */
-            if (i > 0)
-            {
-              mn_nbr = &m3d->nodes[i-1][j][k] ;
-              mnp_nbr = &m3d->pnodes[i-1][j][k] ;
-            }
-            else
-              mn_nbr = NULL ;
-            break ;
-          case 1:      /* i+1 */
-            if (i < m3d->width-1)
-            {
-              mn_nbr = &m3d->nodes[i+1][j][k] ;
-              mnp_nbr = &m3d->pnodes[i+1][j][k] ;
-            }
-            else
-              mn_nbr = NULL ;
-            break ;
-          case 2:      /* j-1 */
-            if (j > 0)
-            {
-              mn_nbr = &m3d->nodes[i][j-1][k] ;
-              mnp_nbr = &m3d->pnodes[i][j-1][k] ;
-            }
-            else
-              mn_nbr = NULL ;
-            break ;
-          case 3:      /* j+1 */
-            if (j < m3d->height-1)
-            {
-              mn_nbr = &m3d->nodes[i][j+1][k] ;
-              mnp_nbr = &m3d->pnodes[i][j+1][k] ;
-            }
-            else
-              mn_nbr = NULL ;
-            break ;
-          case 4:      /* k-1 */
-            if (k > 0)
-            {
-              mn_nbr = &m3d->nodes[i][j][k-1] ;
-              mnp_nbr = &m3d->pnodes[i][j][k-1] ;
-            }
-            else
-              mn_nbr = NULL ;
-            break ;
-          case 5:      /* k+1 */
-            if (k < m3d->depth-1)
-            {
-              mn_nbr = &m3d->nodes[i][j][k+1] ;
-              mnp_nbr = &m3d->pnodes[i][j][k+1] ;
-            }
-            else
-              mn_nbr = NULL ;
-            break ;
-          }
-          if (mn_nbr)
-          {
-            num++ ;
-            dx = mnp->ox - mnp_nbr->ox ;
-            dy = mnp->oy - mnp_nbr->oy ;
-            dz = mnp->oz - mnp_nbr->oz ;
-            xavg += mn_nbr->x + dx ;
-            yavg += mn_nbr->y + dy ;
-            zavg += mn_nbr->z + dz ;
-          }
-        }
-        if (num)
-        {
-          xavg /= (float)num ;
-          yavg /= (float)num ;
-          zavg /= (float)num ;
-          mn->x = xavg ;
-          mn->y = yavg ;
-          mn->z = zavg ;
-        }
-      }
-    }
-  }
-#endif
   return (NO_ERROR);
 }
 
@@ -6283,10 +5326,6 @@ static int m3dMorphSkull(MORPH_3D *m3d, MRI_SURFACE *mris_in_skull, MRI_SURFACE 
   dy = ref_y0 - in_y0;
   dz = ref_z0 - in_z0;
 /*  MRIStranslate(mris_in_skull, -dx, -dy, -dz) ;*/
-#if 0
-  MRISscaleBrain(mris_in_skull, mris_in_skull, .5) ;
-  MRISscaleBrain(mris_ref_skull, mris_ref_skull, .5) ;
-#endif
   mht_in  = MHTcreateFaceTable(mris_in_skull);
   mht_ref = MHTcreateFaceTable(mris_ref_skull);
 
@@ -6346,16 +5385,9 @@ static int m3dMorphSkull(MORPH_3D *m3d, MRI_SURFACE *mris_in_skull, MRI_SURFACE 
         }
         else {
           scale = 1.0;
-#if 1
           fprintf(stdout, "warning: node (%d,%d,%d) has zero in dist\n", i, j, k);
-#endif
         }
         mnp->dx = scale;
-#if 0
-        mn->x = (mn->x-ref_v_x0)*scale + ref_v_x0 ;
-        mn->y = (mn->y-ref_v_y0)*scale + ref_v_y0 ;
-        mn->z = (mn->z-ref_v_z0)*scale + ref_v_z0 ;
-#endif
       }
     }
   }
@@ -6407,12 +5439,6 @@ static int m3dMorphSkull(MORPH_3D *m3d, MRI_SURFACE *mris_in_skull, MRI_SURFACE 
     }
   }
 
-#if 0
-  dx = ref_x0-in_x0 ;
-  dy = ref_y0-in_y0 ;
-  dz = ref_z0-in_z0 ;
-  m3dTranslate(m3d, dx, dy, dz) ;
-#endif
   MHTfree(&mht_in);
   MHTfree(&mht_ref);
   m3dComputeMetricProperties(m3d);
@@ -6447,23 +5473,6 @@ int MRIrigidAlign(MRI *mri_in, MRI *mri_ref, MORPH_PARMS *parms, MATRIX *m_L)
   strcpy(base_name, parms->base_name);
   openLogFile(parms);
 
-#if 0
-  if (Gdiag & DIAG_SHOW /*&& DIAG_VERBOSE_ON*/)
-  {
-    double rms ;
-
-    rms = mriIntensityRMS(mri_in, mri_ref, parms->lta, 1.0f, &parms->in_np);
-    fprintf(stdout, "before initial alignment rms = %2.3f\n", rms) ;
-  }
-  MRIinitTranslation(mri_in, mri_ref, parms->lta->xforms[0].m_L) ;
-  if (Gdiag & DIAG_SHOW /*&& DIAG_VERBOSE_ON*/)
-  {
-    double rms ;
-
-    rms = mriIntensityRMS(mri_in, mri_ref, parms->lta, 1.0f, &parms->in_np);
-    fprintf(stdout, "after initial alignment  rms = %2.3f\n", rms) ;
-  }
-#endif
 
   /* disable all the neck "don't care" stuff */
   parms->ref_np.neck_x0 = parms->ref_np.neck_y0 = parms->ref_np.neck_z0 = 1000;
@@ -6518,16 +5527,7 @@ int MRIrigidAlign(MRI *mri_in, MRI *mri_ref, MORPH_PARMS *parms, MATRIX *m_L)
 
     fprintf(stdout, "aligning pyramid level %d.\n", i);
     if ((Gdiag & DIAG_WRITE) && parms->log_fp) fprintf(parms->log_fp, "aligning pyramid level %d.\n", i);
-#if 0
-    parms->trans_mul = 1 ;
-    mriLinearAlignPyramidLevel(mri_in_pyramid[i], mri_ref_pyramid[i], parms);
-#else
-#if 1
     mriQuasiNewtonLinearAlignPyramidLevel(mri_in_pyramid[i], mri_ref_pyramid[i], parms);
-#else
-    mriLevenbergMarquardtLinearAlignPyramidLevel(mri_in_pyramid[i], mri_ref_pyramid[i], parms);
-#endif
-#endif
 
     /* convert transform to RAS coordinate representation */
     MRIvoxelXformToRasXform(
@@ -6597,11 +5597,6 @@ static int mriOrthonormalizeTransform(MATRIX *m_L)
     *MATRIX_RELT(m_L, i + 1, 2) = c2[i];
     *MATRIX_RELT(m_L, i + 1, 3) = c3[i];
   }
-#if 0
-  /* remove translation component */
-  for (i = 1 ; i <= 3 ; i++)
-    *MATRIX_RELT(m_L, i, 4) = 0 ;
-#endif
 
   return (NO_ERROR);
 }
@@ -6620,36 +5615,6 @@ static GCA *g_gca;
 static double g_clamp;
 extern void (*user_call_func)(float[]);
 
-#if 0
-static void integration_step(float *p) ;
-static void
-integration_step(float *p)
-{
-  MATRIX *m_L ;
-  int    row, col, i ;
-
-
-  m_L = MatrixAlloc(4,4, MATRIX_REAL) ;
-
-  for (i = row = 1 ; row <= 4 ; row++)
-  {
-    for (col = 1 ; col <= 4 ; col++)
-    {
-      m_L->rptr[row][col] = p[i++] ;
-    }
-  }
-
-  mriOrthonormalizeTransform(m_L) ;
-  for (i = row = 1 ; row <= 4 ; row++)
-  {
-    for (col = 1 ; col <= 4 ; col++)
-    {
-      p[i++] = m_L->rptr[row][col] ;
-    }
-  }
-  MatrixFree(&m_L) ;
-}
-#endif
 
 static void dfp_step_func(int itno, float rms, void *vparms, float *p);
 static void dfp_em_step_func(int itno, float rms, void *vparms, float *p);
@@ -6718,13 +5683,6 @@ static void dfp_em_step_func(int itno, float sse, void *vparms, float *p)
     }
   }
 //////////////////////////// new //////////////////////////
-#if 0
-  parms->lta->xforms[0].m_L->rptr[4][1] = 0.;
-  parms->lta->xforms[0].m_L->rptr[4][2] = 0.;
-  parms->lta->xforms[0].m_L->rptr[4][3] = 0.;
-  parms->lta->xforms[0].m_L->rptr[4][4] = 1.;
-  MatrixPrintHires(stdout, parms->lta->xforms[0].m_L);
-#endif
   ///////////////////////////////////////////////////////////
   if ((parms->write_iterations > 0) && Gdiag & DIAG_WRITE && (((itno + 1) % parms->write_iterations) == 0)) {
     MATRIX *m_tmp, *m_save, *m_voxel;
@@ -6834,10 +5792,6 @@ static void computeRigidAlignmentGradient(float *p, float *g)
   m_L->rptr[4][1] = m_L->rptr[4][2] = m_L->rptr[4][3] = 0;
   m_L->rptr[4][4] = 1.0;
   m_L_inv = MatrixInverse(m_L, NULL);
-#if 0
-  if (parms->rigid)
-    mriOrthonormalizeTransform(m_L) ;
-#endif
 
   if (parms->mri_crop) {
     MATRIX *m_tmp;
@@ -6899,10 +5853,6 @@ static void computeRigidAlignmentGradient(float *p, float *g)
             if (in_val > 0) continue;
           }
           MRIsampleVolume(mri_in, x1, x2, x3, &in_val);
-#if 0
-          if (FZERO(in_val))  /* don't compute errors from cropping */
-            continue ;
-#endif
         }
         else
           in_val = 0.0;
@@ -6950,20 +5900,6 @@ static void computeRigidAlignmentGradient(float *p, float *g)
     MatrixScalarMul(m_dL, parms->factor, m_dL);
   }
 
-#if 0
-  if (parms->rigid)  /* make gradient have 0 determinant */
-  {
-    float  d ;
-    MATRIX *m_offset ;
-
-    d = MatrixDeterminant(m_dL) ;
-    m_offset = MatrixIdentity(4, NULL) ;
-    MatrixScalarMul(m_offset, d, m_offset) ;
-    MatrixSubtract(m_dL, m_offset, m_dL) ;
-    MatrixFree(&m_offset) ;
-    d = MatrixDeterminant(m_dL) ;
-  }
-#endif
 
   if (parms->m_xform_mean) {
     MATRIX *m_diff;
@@ -7067,10 +6003,6 @@ static float computeRigidAlignmentErrorFunctional(float *p)
             if (in_val > 0) continue;
           }
           MRIsampleVolume(mri_in, x1, x2, x3, &in_val);
-#if 0
-          if (FZERO(in_val))  /* don't compute errors from cropping */
-            continue ;
-#endif
         }
         else /* out of bounds, assume in val is 0 */
           in_val = 0;
@@ -7128,7 +6060,6 @@ static float computeRigidAlignmentErrorFunctional(float *p)
 static void  // in         out
 computeEMAlignmentGradient(float *p, float *g)
 {
-#if 1
   int width, height, depth, row, col, i, xn, yn, zn, xv, yv, zv, n, ndets = 0;
   VECTOR *v_X, *v_Y, *v_means, *v_X_T; /* original and transformed coordinate systems */
   MATRIX *m_L, *m_dL, *m_dI_X_T, *m_delI, *m_inv_cov, *m_tmp1, *m_tmp2;
@@ -7157,11 +6088,6 @@ computeEMAlignmentGradient(float *p, float *g)
   m_L->rptr[4][1] = m_L->rptr[4][2] = m_L->rptr[4][3] = 0;
   m_L->rptr[4][4] = 1.0;
 #ifndef __OPTIMIZE__
-#if 0
-  printf("g_mri_in c_(r,a,s) = (%.3f, %.3f, %.3f)\n", mri_in->c_r, mri_in->c_a, mri_in->c_s);
-  printf("Transform in EMAlignmentGradient\n");
-  MatrixPrintHires(stdout, m_L);
-#endif
 #endif
   width = mri_in->width;
   height = mri_in->height;
@@ -7217,11 +6143,7 @@ computeEMAlignmentGradient(float *p, float *g)
         *MATRIX_RELT(m_delI, 1, n + 1) = dx;
         *MATRIX_RELT(m_delI, 2, n + 1) = dy;
         *MATRIX_RELT(m_delI, 3, n + 1) = dz;
-#if 1
         *MATRIX_RELT(m_delI, 4, n + 1) = 1.;
-#else
-        *MATRIX_RELT(m_delI, 4, n + 1) = 0.;
-#endif
         VECTOR_ELT(v_means, n + 1) -= vals[n];
       }
       // m_tmp1 = ninputs (x) 4
@@ -7259,7 +6181,6 @@ computeEMAlignmentGradient(float *p, float *g)
   MatrixFree(&m_dL);
   MatrixFree(&m_delI);
   VectorFree(&v_means);
-#endif
 }
 static float computeEMAlignmentErrorFunctional(float *p)
 {
@@ -7290,10 +6211,6 @@ static float computeEMAlignmentErrorFunctional(float *p)
   m_L->rptr[4][1] = m_L->rptr[4][2] = m_L->rptr[4][3] = 0;
   m_L->rptr[4][4] = 1.0;
 #ifndef __OPTIMIZE__
-#if 0
-  printf("Transform at EMAlignmentErrorFunctional:\n");
-  MatrixPrintHires(stdout, m_L);
-#endif
 #endif
   old_lta = (LTA *)parms->transform->xform;
   parms->transform->xform = (void *)lta;
@@ -7303,172 +6220,6 @@ static float computeEMAlignmentErrorFunctional(float *p)
   return (-log_p);
 }
 
-#if 0
-#define NPARMS (3 * 4)
-static int
-mriLevenbergMarquardtLinearAlignPyramidLevel(MRI *mri_in, MRI *mri_ref,
-    MP *parms)
-{
-  float p[5*5], chisq_new, chisq_old, lambda, **covar, **alpha, rms ;
-  int   row, col, i, steps, fitted_flags[NPARMS+1], npix, nsmall ;
-
-  covar = matrix(1, NPARMS, 1, NPARMS) ;
-  alpha = matrix(1, NPARMS, 1, NPARMS) ;
-  npix = mri_in->width*mri_in->height*mri_in->depth ;
-  memset(fitted_flags, 0, sizeof(fitted_flags)) ;
-  for (i = 1 ; i <= NPARMS ; i++)
-    fitted_flags[i] = 1 ;
-
-  /*  user_call_func = integration_step ;*/
-  for (i = row = 1 ; row <= 3 ; row++)
-  {
-    for (col = 1 ; col <= 4 ; col++)
-    {
-      p[i++] = parms->lta->xforms[0].m_L->rptr[row][col] ;
-    }
-  }
-  g_mri_in = mri_in ;
-  g_mri_ref = mri_ref ;
-  g_parms = parms ;
-  lambda = -1.0f ;
-  mrqmin((float *)mri_in->slices, (float *)mri_ref->slices, NULL, npix, p,
-         fitted_flags, NPARMS, covar, alpha, &chisq_new,
-         computeRigidAlignmentErrorFunctionalAndGradient, &lambda) ;
-#define MAX_SMALL 5
-  steps = nsmall = 0 ;
-  do
-  {
-    chisq_old = chisq_new ;
-    rms = sqrt(chisq_old/(float)npix) ;
-    fprintf(stdout,"%03d: %2.3f, lambda=%2.2e\n",steps,rms,lambda);
-    logIntegration(parms, steps++, (double)rms) ;
-    mrqmin((float *)mri_in->slices, (float *)mri_ref->slices, NULL, npix, p,
-           fitted_flags, NPARMS, covar, alpha, &chisq_new,
-           computeRigidAlignmentErrorFunctionalAndGradient, &lambda) ;
-    if ((chisq_old-chisq_new)/chisq_old > parms->tol)
-      nsmall++ ;
-    else
-      nsmall = 0 ;
-  }
-  while (nsmall < MAX_SMALL) ;
-
-  /* read out current transform */
-  for (i = row = 1 ; row <= 4 ; row++)
-  {
-    for (col = 1 ; col <= 4 ; col++)
-    {
-      parms->lta->xforms[0].m_L->rptr[row][col] = p[i++] ;
-    }
-  }
-  lambda = 0.0f ;
-  mrqmin((float *)mri_in->slices, (float *)mri_ref->slices, NULL, npix, p,
-         fitted_flags, NPARMS, covar, alpha, &chisq_new,
-         computeRigidAlignmentErrorFunctionalAndGradient, &lambda) ;
-  free_matrix(covar,1,NPARMS,1,NPARMS) ;
-  free_matrix(alpha,1,NPARMS,1,NPARMS) ;
-  return(NO_ERROR) ;
-}
-
-static void
-computeRigidAlignmentErrorFunctionalAndGradient(int index, float *p,
-    float *pdy,
-    float *dydp, int nparms)
-{
-  int    width, height, depth, i, row, col, x1, x2, x3, npix ;
-  static MATRIX *m_L = NULL, *m_dL = NULL  ;
-  static VECTOR *v_X = NULL, *v_Y = NULL, *v_dT = NULL, *v_X_T = NULL ;
-  static MATRIX *m_dT_X_T = NULL ;
-  static float mean_std = 1.0 ;
-  double   val, y1, y2, y3 ;
-  double delta, std, dx, dy, dz ;
-
-  index-- ;  /* make it zero-based */
-  if (!m_L)   /* do some initialization */
-  {
-    m_L = MatrixAlloc(4,4,1) ;
-    m_dL = MatrixAlloc(4,4,1) ;
-    m_dT_X_T = MatrixAlloc(4,4,1) ;
-    mean_std = g_mri_ref->mean ;
-    v_X  = VectorAlloc(4, MATRIX_REAL) ;  /* input (src) coordinates */
-    v_Y  = VectorAlloc(4, MATRIX_REAL) ;  /* transformed (dst) coordinates */
-    v_dT  = VectorAlloc(4, MATRIX_REAL) ;
-    v_X_T = RVectorAlloc(4, MATRIX_REAL) ;
-  }
-
-  if (FZERO(mean_std))
-    mean_std = 1.0 ;
-  for (i = row = 1 ; row <= 3 ; row++)
-  {
-    for (col = 1 ; col <= 4 ; col++)
-    {
-      m_L->rptr[row][col] = p[i++] ;
-    }
-  }
-  m_L->rptr[4][1] = 0 ;
-  m_L->rptr[4][2] = 0 ;
-  m_L->rptr[4][3] = 0 ;
-  m_L->rptr[4][4] = 1 ;
-
-  width = g_mri_ref->width ;
-  height = g_mri_ref->height ;
-  depth = g_mri_ref->depth ;
-  npix = width * height * depth ;
-  x3 = (double)(index % depth) ;
-  x1 = (double)(index / (depth*height)) ;
-  x2 = (double)((index - (x1*depth*height)) / depth) ;
-
-  v_X->rptr[4][1] = 1.0f ;
-  V3_Z(v_X) = x3 ;
-  V3_Y(v_X) = x2 ;
-  V3_X(v_X) = x1 ;
-  v_Y = MatrixMultiply(m_L, v_X, v_Y) ;
-  MatrixTranspose(v_X, v_X_T) ;
-
-  y1 = V3_X(v_Y) ;
-  y2 = V3_Y(v_Y) ;
-  y3 = V3_Z(v_Y) ;
-
-  if (y1 > -1 && y1 < width &&
-      y2 > -1 && y2 < height &&
-      y3 > -1 && y3 < depth)
-  {
-    MRIsampleVolume(g_mri_ref, y1, y2, y3, &val);
-    MRIsampleVolumeGradient(g_mri_ref, y1, y2, y3, &dx, &dy, &dz) ;
-    if (g_mri_ref->nframes > 1)
-      MRIsampleVolumeFrame(g_mri_ref, y1, y2, y3, 1, &std);
-    else
-      std = mean_std ;
-    std /= mean_std ;
-    if (DZERO(std))
-      std = 1.0 ;
-    delta = (val - (double)MRIgetVoxVal(g_mri_in,x1,x2,x3,0)) / std ;
-  }
-  else   /* out of bounds, assume in val is 0 */
-  {
-    delta = (0.0 - (double)MRIgetVoxVal(g_mri_in,x1,x2,x3,0)) / mean_std ;
-    dx = dy = dz = 0.0 ;
-  }
-  if (fabs(delta) > 20)
-    DiagBreak() ;
-  V3_X(v_dT) = dx ;
-  V3_Y(v_dT) = dy ;
-  V3_Z(v_dT) = dz ;
-  MatrixMultiply(v_dT, v_X_T, m_dT_X_T) ;
-
-  MatrixScalarMul(m_dT_X_T, delta, m_dL) ;
-  MatrixCheck(m_dL) ;
-
-  for (i = row = 1 ; row <= 3 ; row++)
-  {
-    for (col = 1 ; col <= 4 ; col++)
-    {
-      dydp[i++] = m_dL->rptr[row][col] /*/ npix*/  ;
-    }
-  }
-  *pdy = delta ;
-}
-
-#endif
 
 #define HANNING_RADIUS 100
 int MRIsampleReferenceWeightingGradient(MRI *mri, int x, int y, int z, double *pdx, double *pdy, double *pdz)
@@ -7497,20 +6248,7 @@ int MRIsampleReferenceWeightingGradient(MRI *mri, int x, int y, int z, double *p
 #define T0_Z -17
 double MRIsampleReferenceWeighting(MRI *mri, int x, int y, int z)
 {
-#if 0
-  double wt, dist  ;
-  double   x_ras, y_ras, z_ras, dx, dy, dz ;
-
-  MRIvoxelToWorld(mri, (double)x, (double)y, (double)z, &x_ras, &y_ras, &z_ras) ;
-  dx = x_ras - T0_X ;
-  dy = y_ras - T0_Y ;
-  dz = y_ras - T0_Z ;
-  dist = sqrt(dx*dx + dy*dy + dz*dz) ;
-  wt = .5*cos(M_PI*dist/HANNING_RADIUS)+.5 ;
-  return(wt) ;
-#else
   return (1.0);
-#endif
 }
 
 #define MAX_CLASSES 4
@@ -7676,36 +6414,6 @@ static int powell_minimize(VOXEL_LIST *vl_source,
 static float compute_powell_sse(float *p);
 static double compute_likelihood(
     VOXEL_LIST *vl_source, VOXEL_LIST *vl_target, MATRIX *m_L, float scale_factor, int map_both_ways);
-#if 0
-static int write_snapshot(MRI *mri_source, MRI *mri_target,
-                          MATRIX *m_vox_xform, char *base_name, int fno) ;
-
-static int
-write_snapshot(MRI *mri_source, MRI *mri_target, MATRIX *m_vox_xform,
-               char *base_name, int fno)
-{
-  MRI *mri_aligned ;
-  char fname[STRLEN] ;
-  LTA  *lta ;
-
-  if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
-  {
-    printf("source->target vox->vox transform:\n") ;
-    MatrixPrint(stdout, m_vox_xform) ;
-  }
-  lta = LTAalloc(1, NULL) ;
-  MatrixCopy(m_vox_xform, lta->xforms[0].m_L) ;
-  mri_aligned = MRITransformedCenteredMatrix(mri_source, mri_target, m_vox_xform) ;
-  sprintf(fname, "%s%3.3d", base_name, fno) ;
-  MRIwriteImageViews(mri_aligned, fname, IMAGE_SIZE) ;
-  strcat(fname, ".mgz") ;
-  printf("writing snapshot to %s...\n", fname) ;
-  MRIwrite(mri_aligned, fname) ;
-  MRIfree(&mri_aligned) ;
-
-  return(NO_ERROR) ;
-}
-#endif
 /* compute mean squared error of two images with a transform */
 static double compute_likelihood(
     VOXEL_LIST *vl_source, VOXEL_LIST *vl_target, MATRIX *m_L, float scale_factor, int map_both_ways)
@@ -7773,7 +6481,6 @@ static double compute_likelihood(
     sse += error * error;
   }
 
-#if 1
   /* now count target voxels that weren't mapped to in union */
   if (map_both_ways)
     for (i = 0; i < vl_target->nvox; i++) {
@@ -7805,7 +6512,6 @@ static double compute_likelihood(
       error = d1 - d2;
       sse += error * error;
     }
-#endif
 
   VectorFree(&v1);
   VectorFree(&v2);
@@ -7897,77 +6603,6 @@ static int powell_minimize(VOXEL_LIST *vl_source,
     }
   }
 
-#if 0
-  {
-    float scale, sse, min_scale ;
-    MATRIX *m_scale = NULL, *m_tot = NULL, *m_min, *m_origin, *m_origin_inv,
-                                     *m_tmp = NULL;
-    double   in_means[3] ;
-
-    MRIcenterOfMass(vl_source->mri2, in_means, 0) ;
-    m_origin = MatrixIdentity(4, NULL) ;
-    *MATRIX_RELT(m_origin, 1, 4) = in_means[0] ;
-    *MATRIX_RELT(m_origin, 2, 4) = in_means[1] ;
-    *MATRIX_RELT(m_origin, 3, 4) = in_means[2] ;
-    *MATRIX_RELT(m_origin, 4, 4) = 1 ;
-    m_origin_inv = MatrixCopy(m_origin, NULL) ;
-    *MATRIX_RELT(m_origin_inv, 1, 4) *= -1 ;
-    *MATRIX_RELT(m_origin_inv, 2, 4) *= -1 ;
-    *MATRIX_RELT(m_origin_inv, 3, 4) *= -1 ;
-
-    min_sse = compute_powell_sse(p) ;
-    m_min = MatrixCopy(mat, NULL) ;
-    min_scale = 1.0 ;
-
-    printf("starting sse before global scale: %2.3f\n", min_sse) ;
-    for (scale = 0.25 ; scale <= 4.0 ; scale += 0.025)
-    {
-      m_scale = MatrixIdentity(4, m_scale) ;
-      MatrixScalarMul(m_scale, scale, m_scale) ;
-      *MATRIX_RELT(m_scale, 4, 4) = 1 ;
-      m_tmp = MatrixMultiply(m_scale, m_origin_inv, m_tmp) ;
-      MatrixMultiply(m_origin, m_tmp, m_scale) ;
-      m_tot = MatrixMultiply(m_scale, mat, m_tot) ;
-      for (i = r = 1 ; r <= 4 ; r++)
-      {
-        for (c = 1 ; c <= 4 ; c++)
-        {
-          p[i++] = *MATRIX_RELT(m_tot, r, c) ;
-        }
-      }
-      sse = compute_powell_sse(p) ;
-      if (sse < min_sse)
-      {
-        min_sse = sse ;
-        MatrixCopy(m_tot, m_min) ;
-        min_scale = scale ;
-      }
-      if (DIAG_VERBOSE_ON)
-      {
-        MRI *mri_aligned ;
-        mri_aligned = MRIlinearTransform(vl_source->mri2, NULL, m_tot) ;
-        MRIwrite(mri_aligned, "a.mgz") ;
-        MRIfree(&mri_aligned) ;
-      }
-    }
-    MatrixCopy(m_min, mat) ;
-    MatrixFree(&m_scale) ;
-    MatrixFree(&m_tot) ;
-    MatrixFree(&m_min) ;
-    MatrixFree(&m_origin) ;
-    MatrixFree(&m_origin_inv) ;
-    MatrixFree(&m_tmp) ;
-    for (i = r = 1 ; r <= 4 ; r++)
-    {
-      for (c = 1 ; c <= 4 ; c++)
-      {
-        p[i++] = *MATRIX_RELT(mat, r, c) ;
-      }
-    }
-    printf("after global search, min scale %2.3f, sse: %2.3f\n",
-           min_scale, min_sse) ;
-  }
-#endif
 
   min_sse = compute_powell_sse(p);
   if (pscale_factor)
@@ -8166,11 +6801,7 @@ static int ComputeStepTransform(
 #ifdef NPARMS
 #undef NPARMS
 #endif
-#if 1
 #define NPARMS 13  // remove offset at 14
-#else
-#define NPARMS 14  // scale is 13 and offset is 14
-#endif
   float Mvec[NPARMS];
 
   //  float  evalues[4] ;

--- a/utils/mrisurf_defect.cpp
+++ b/utils/mrisurf_defect.cpp
@@ -117,11 +117,6 @@ int MRISdivideEdges(MRIS *mris, int nsubdivisions)
             nadded,
             mris->nvertices,
             mris->nfaces);
-#if 0
-    eno = MRIScomputeEulerNumber(mris, &nvertices, &nfaces, &nedges) ;
-    fprintf(stdout, "euler # = v-e+f = 2g-2: %d - %d + %d = %d --> %d holes\n",
-            nvertices, nedges, nfaces, eno, 2-eno) ;
-#endif
   }
   return (nadded);
 }
@@ -167,11 +162,6 @@ int MRISdivideLongEdges(MRIS *mris, double thresh)
             nadded,
             mris->nvertices,
             mris->nfaces);
-#if 0
-    eno = MRIScomputeEulerNumber(mris, &nvertices, &nfaces, &nedges) ;
-    fprintf(stdout, "euler # = v-e+f = 2g-2: %d - %d + %d = %d --> %d holes\n",
-            nvertices, nedges, nfaces, eno, 2-eno) ;
-#endif
   }
   
   return (nadded);
@@ -739,7 +729,6 @@ static void vertexPseudoNormal(MRIS *mris1, int vn1, MRIS *mris2, int vn2, float
       n1 = (n0 == 2) ? 0 : n0 + 1;
       n2 = (n0 == 0) ? 2 : n0 - 1;
 
-  #if 1
       if ((face->v[n0] != vn1) || (face->v[n1] == vn1) || (face->v[n2] == vn1) || (face->v[n2] == face->v[n1])) {
         if (1) {
           // verbose>=VERBOSE_MODE_MEDIUM){
@@ -772,7 +761,6 @@ static void vertexPseudoNormal(MRIS *mris1, int vn1, MRIS *mris2, int vn2, float
           }
         }
       }
-  #endif
       v1[0] = mris1->vertices[face->v[n1]].origx - v->origx;
       v1[1] = mris1->vertices[face->v[n1]].origy - v->origy;
       v1[2] = mris1->vertices[face->v[n1]].origz - v->origz;
@@ -801,7 +789,6 @@ static void vertexPseudoNormal(MRIS *mris1, int vn1, MRIS *mris2, int vn2, float
       n0 = vt->n[n];
       n1 = (n0 == 2) ? 0 : n0 + 1;
       n2 = (n0 == 0) ? 2 : n0 - 1;
-#if 1
       if ((face->v[n0] != vn2) || (face->v[n1] == vn2) || (face->v[n2] == vn2) || (face->v[n2] == face->v[n1])) {
         if (1) {
           // verbose>=VERBOSE_MODE_MEDIUM){
@@ -834,7 +821,6 @@ static void vertexPseudoNormal(MRIS *mris1, int vn1, MRIS *mris2, int vn2, float
           }
         }
       }
-  #endif
       v1[0] = mris2->vertices[face->v[n1]].origx - v->origx;
       v1[1] = mris2->vertices[face->v[n1]].origy - v->origy;
       v1[2] = mris2->vertices[face->v[n1]].origz - v->origz;
@@ -943,17 +929,6 @@ static void computeDefectSecondFundamentalForm(MRIS *mris, TP *tp)
     computeDefectTangentPlaneAtVertex(mris, vno);
 
 // FLO TO BE CHECKED !!!
-#if 0
-    mrisFindSecondNeighborhood(mris, vno, nbrs, &num_nbrs) ;
-    if (num_nbrs < 3)
-    {
-      continue ;
-    }
-    nvertices++;
-
-    /* need ex,ey,ez */
-    MRIScomputeSecondFundamentalFormAtVertex(mris, vno, nbrs, num_nbrs) ;
-#endif
 
     VECTOR_LOAD(v_n,  vertex->nx,  vertex->ny,  vertex->nz);
     VECTOR_LOAD(v_e1, vertex->e1x, vertex->e1y, vertex->e1z);
@@ -1234,11 +1209,6 @@ double MRIScomputeFitness(MRIS *mris, TOPOFIX_PARMS *parms, int verbose)
   DP *dp;
   TP *tp;
 
-#if 0
-  static int now = 0;
-  static int def = -1;
-  static int when = 0;
-#endif
 
   fitness = unmri_ll = curv_ll = 0.0;
 
@@ -1266,23 +1236,6 @@ double MRIScomputeFitness(MRIS *mris, TOPOFIX_PARMS *parms, int verbose)
   if (!FZERO(l_vol) && dp->mri_defect->width >= 5 && dp->mri_defect->height >= 5 && dp->mri_defect->depth >= 5) {
     /* compute the signed distance volume */
     MRIScomputeDistanceVolume(parms, 2.0);
-#if 0
-    if (def == parms->defect_number && when == 1)
-    {
-      now = 1;
-    }
-    if (def != parms->defect_number)
-    {
-      def = parms->defect_number;
-      when = 1;
-    }
-    if (now)
-    {
-      MRISsaveLocal(parms->mris_defect,parms,"./defect");
-      now=0;
-      when=0;
-    }
-#endif
     unmri_ll = computeVolumeLikelihood(dp, parms->contrast, 0);
     fitness += l_vol * unmri_ll;
   }
@@ -1329,7 +1282,6 @@ float mrisDefectFaceMRILogLikelihood(
   double fll, t_area, tf_area;
   VERTEX *v0, *v1, *v2;
 
-#if 1
 
   t_area = tf_area = 0.0;
 
@@ -1398,232 +1350,6 @@ float mrisDefectFaceMRILogLikelihood(
 
   return tp->face_ll;
 
-#else
-  double x, y z, xa, ya, za, xc, yc, zc, t0, t1, adx, ady, adz, dx, dy, dz, grad, cdx, cdy, cdz, alen, clen, delta_t0,
-      delta_t1, len, nx, ny, nz, xv, yv, zv, white_val, gray_val, cnx, cny, cnz, dot, val;
-  double ll = 0.0, jll = 0.0;
-
-  adx = v1->x - v0->x;
-  ady = v1->y - v0->y;
-  adz = v1->z - v0->z;
-  alen = sqrt(SQR(adx) + SQR(ady) + SQR(adz));
-  cdx = v2->x - v0->x;
-  cdy = v2->y - v0->y;
-  cdz = v2->z - v0->z;
-  clen = sqrt(SQR(cdx) + SQR(cdy) + SQR(cdz));
-
-  /*
-  sample along legs of the triangle making sure the maximum spacing
-  between samples (along the longer leg) is SAMPLE_DIST.
-  */
-
-  /*
-  move along v0->v1 and v3->v2 lines and draw in crossing line to fill face
-  t0 parameterizes lines from v0->v1 and v0->v2
-  */
-  if (FZERO(alen) && FZERO(clen)) {
-    delta_t0 = 0.99;
-  }
-  else {
-    delta_t0 = (alen > clen) ? (SAMPLE_DIST / alen) : (SAMPLE_DIST / clen);
-  }
-  if (FZERO(delta_t0))
-    ErrorReturn(ERROR_BADPARM,
-                (ERROR_BADPARM, "mrisDefectFaceMRILogLikelihood: face has infinite leg (%d, %d)\n", alen, clen));
-
-  if (delta_t0 >= 1.0) {
-    delta_t0 = 0.99;
-  }
-
-  /* delta_t0 is % of alen or clen (whichever is bigger) of SAMPLE_DIST */
-  for (nsamples = 0, ll = 0.0f, t0 = 0; t0 <= 1.0f; t0 += delta_t0) {
-    /* compute points (xa,ya,za) and (xc,yc,zc) on the a and c lines resp. */
-    xa = v0->x + t0 * adx;
-    ya = v0->y + t0 * ady;
-    za = v0->z + t0 * adz;
-    xc = v0->x + t0 * cdx;
-    yc = v0->y + t0 * cdy;
-    zc = v0->z + t0 * cdz;
-    dx = xc - xa;
-    dy = yc - ya;
-    dz = zc - za;
-    len = sqrt(SQR(dx) + SQR(dy) + SQR(dz));
-    if (FZERO(len)) {
-      delta_t1 = 0.99;
-    }
-    else {
-      delta_t1 = SAMPLE_DIST / len; /* sample at SAMPLE_DIST intervals */
-      if (delta_t1 >= 1.0f) {
-        delta_t1 = 0.99;
-      }
-    }
-
-    /* now draw a line from (xa,ya,za) to (xc, yc, zc) */
-    for (t1 = 0; t1 <= 1.0f; t1 += delta_t1, nsamples++) {
-      /* compute a point on the line connecting a and c */
-      x = xa + t1 * dx;
-      y = ya + t1 * dy;
-      z = za + t1 * dz;
-// MRIworldToVoxel(mri, x+.5*nx, y+.5*ny, z+.5*nz, &xv, &yv, &zv) ;
-#if MATRIX_ALLOCATION
-      mriSurfaceRASToVoxel(x + .5 * nx, y + .5 * ny, z + .5 * nz, &xv, &yv, &zv);
-#else
-      MRISsurfaceRASToVoxelCached(mris, mri, x + .5 * nx, y + .5 * ny, z + .5 * nz, &xv, &yv, &zv);
-#endif
-
-      MRIsampleVolume(mri, xv, yv, zv, &gray_val);
-      ll += log(h_gray->counts[nint(gray_val)]);
-// MRIworldToVoxel(mri, x-.5*nx, y-.5*ny, z-.5*nz, &xv, &yv, &zv) ;
-#if MATRIX_ALLOCATION
-      mriSurfaceRASToVoxel(x - .5 * nx, y - .5 * ny, z - .5 * nz, &xv, &yv, &zv);
-#else
-      MRISsurfaceRASToVoxelCached(mris, mri, x - .5 * nx, y - .5 * ny, z - .5 * nz, &xv, &yv, &zv);
-#endif
-      MRIsampleVolume(mri, xv, yv, zv, &white_val);
-      ll += log(h_white->counts[nint(white_val)]);
-      grad = white_val - gray_val;
-      bin = nint((grad - h_grad->bins[0]) / h_grad->bin_size);
-      if (bin < 0) {
-        bin = 0;
-      }
-      else if (bin >= h_grad->nbins) {
-        bin = h_grad->nbins - 1;
-      }
-      ll += log(h_grad->counts[bin]);
-      MRIsampleVolume(mri_gray_white, white_val, gray_val, 0, &val);
-      jll += log(val);
-    }
-    /* compute last point on line */
-    t1 = 1.0f;
-    x = xa + t1 * dx;
-    y = ya + t1 * dy;
-    z = za + t1 * dz;
-// MRIworldToVoxel(mri, x+.5*nx, y+.5*ny, z+.5*nz, &xv, &yv, &zv) ;
-#if MATRIX_ALLOCATION
-    mriSurfaceRASToVoxel(x + .5 * nx, y + .5 * ny, z + .5 * nz, &xv, &yv, &zv);
-#else
-    MRISsurfaceRASToVoxelCached(mris, mri, x + .5 * nx, y + .5 * ny, z + .5 * nz, &xv, &yv, &zv);
-#endif
-    MRIsampleVolume(mri, xv, yv, zv, &gray_val);
-    ll += log(h_gray->counts[nint(gray_val)]);
-// MRIworldToVoxel(mri, x-.5*nx, y-.5*ny, z-.5*nz, &xv, &yv, &zv) ;
-#if MATRIX_ALLOCATION
-    mriSurfaceRASToVoxel(x - .5 * nx, y - .5 * ny, z - .5 * nz, &xv, &yv, &zv);
-#else
-    MRISsurfaceRASToVoxelCached(mris, mri, x - .5 * nx, y - .5 * ny, z - .5 * nz, &xv, &yv, &zv);
-#endif
-    MRIsampleVolume(mri, xv, yv, zv, &white_val);
-    ll += log(h_white->counts[nint(white_val)]);
-    grad = white_val - gray_val;
-    bin = nint((grad - h_grad->bins[0]) / h_grad->bin_size);
-    if (bin < 0) {
-      bin = 0;
-    }
-    else if (bin >= h_grad->nbins) {
-      bin = h_grad->nbins - 1;
-    }
-    ll += log(h_grad->counts[bin]);
-    nsamples++;
-    MRIsampleVolume(mri_gray_white, white_val, gray_val, 0, &val);
-    jll += log(val);
-  }
-
-  /* compute last line on the a and c lines resp. */
-  t0 = 1.0f;
-  xa = v0->x + t0 * adx;
-  ya = v0->y + t0 * ady;
-  za = v0->z + t0 * adz;
-  xc = v0->x + t0 * cdx;
-  yc = v0->y + t0 * cdy;
-  zc = v0->z + t0 * cdz;
-  dx = xc - xa;
-  dy = yc - ya;
-  dz = zc - za;
-  len = sqrt(SQR(dx) + SQR(dy) + SQR(dz));
-  if (FZERO(len)) {
-    delta_t1 = 0.99;
-  }
-  else {
-    delta_t1 = SAMPLE_DIST / len; /* sample at SAMPLE_DIST intervals */
-    if (delta_t1 >= 1.0f) {
-      delta_t1 = 0.99;
-    }
-  }
-
-  /* now draw a line from (xa,ya,za) to (xc, yc, zc) */
-  for (t1 = 0; t1 <= 1.0f; t1 += delta_t1, nsamples++) {
-    /* compute a point on the line connecting a and c */
-    x = xa + t1 * dx;
-    y = ya + t1 * dy;
-    z = za + t1 * dz;
-// MRIworldToVoxel(mri, x+.5*nx, y+.5*ny, z+.5*nz, &xv, &yv, &zv) ;
-#if MATRIX_ALLOCATION
-    mriSurfaceRASToVoxel(x + .5 * nx, y + .5 * ny, z + .5 * nz, &xv, &yv, &zv);
-#else
-    MRISsurfaceRASToVoxelCached(mris, mri, x + .5 * nx, y + .5 * ny, z + .5 * nz, &xv, &yv, &zv);
-#endif
-    MRIsampleVolume(mri, xv, yv, zv, &gray_val);
-    ll += log(h_gray->counts[nint(gray_val)]);
-// MRIworldToVoxel(mri, x-.5*nx, y-.5*ny, z-.5*nz, &xv, &yv, &zv) ;
-#if MATRIX_ALLOCATION
-    mriSurfaceRASToVoxel(x - .5 * nx, y - .5 * ny, z - .5 * nz, &xv, &yv, &zv);
-#else
-    MRISsurfaceRASToVoxelCached(mris, mri, x - .5 * nx, y - .5 * ny, z - .5 * nz, &xv, &yv, &zv);
-#endif
-    MRIsampleVolume(mri, xv, yv, zv, &white_val);
-    ll += log(h_white->counts[nint(white_val)]);
-    grad = white_val - gray_val;
-    bin = nint((grad - h_grad->bins[0]) / h_grad->bin_size);
-    if (bin < 0) {
-      bin = 0;
-    }
-    else if (bin >= h_grad->nbins) {
-      bin = h_grad->nbins - 1;
-    }
-    ll += log(h_grad->counts[bin]);
-    MRIsampleVolume(mri_gray_white, white_val, gray_val, 0, &val);
-    jll += log(val);
-  }
-  /* compute last point on line */
-  t1 = 1.0f;
-  x = xa + t1 * dx;
-  y = ya + t1 * dy;
-  z = za + t1 * dz;
-// MRIworldToVoxel(mri, x+.5*nx, y+.5*ny, z+.5*nz, &xv, &yv, &zv) ;
-#if MATRIX_ALLOCATION
-  mriSurfaceRASToVoxel(x + .5 * nx, y + .5 * ny, z + .5 * nz, &xv, &yv, &zv);
-#else
-  MRISsurfaceRASToVoxelCached(mris, mri, x + .5 * nx, y + .5 * ny, z + .5 * nz, &xv, &yv, &zv);
-#endif
-  MRIsampleVolume(mri, xv, yv, zv, &gray_val);
-  ll += log(h_gray->counts[nint(gray_val)]);
-// MRIworldToVoxel(mri, x-.5*nx, y-.5*ny, z-.5*nz, &xv, &yv, &zv) ;
-#if MATRIX_ALLOCATION
-  mriSurfaceRASToVoxel(x - .5 * nx, y - .5 * ny, z - .5 * nz, &xv, &yv, &zv);
-#else
-  MRISsurfaceRASToVoxelCached(mris, mri, x - .5 * nx, y - .5 * ny, z - .5 * nz, &xv, &yv, &zv);
-#endif
-  MRIsampleVolume(mri, xv, yv, zv, &white_val);
-  ll += log(h_white->counts[nint(white_val)]);
-  grad = white_val - gray_val;
-  bin = nint((grad - h_grad->bins[0]) / h_grad->bin_size);
-  if (bin < 0) {
-    bin = 0;
-  }
-  else if (bin >= h_grad->nbins) {
-    bin = h_grad->nbins - 1;
-  }
-  ll += log(h_grad->counts[bin]);
-  MRIsampleVolume(mri_gray_white, white_val, gray_val, 0, &val);
-  jll += log(val);
-  nsamples++;
-
-#if 0
-  return(ll/nsamples) ;
-#else
-  return (jll / nsamples);
-#endif
-#endif
 }
 
 float mrisDefectVertexMRILogLikelihood(
@@ -2115,7 +1841,6 @@ static double mrisComputeDefectMRILogUnlikelihood_wkr(
     DEFECT_PATCH * const dp_nonconst, 
     HISTOGRAM    * const h_border_nonconst)
 {
-#if 1
   // The tests themselves are expensive, so eliminate them except when developing
   //
   static const bool 
@@ -2127,59 +1852,6 @@ static double mrisComputeDefectMRILogUnlikelihood_wkr(
     	    	    	            	        use_fast_avoidable_prediction = true,	// no test
     test_avoidable_prediction = false, 	        use_avoidable_prediction = true,
     test_sharedVertexPseudoNormalCache = false, use_sharedVertexPseudoNormalCache = true;
-#else
-  // Allow comparing different options quickly, but the times are affected compared to unconditional
-  //
-  static bool 
-    keep_sign_bug,  	    	    	    	    	    	    	    	// no test
-    do_new_MRIDistance,     	    	    	    	    	    	    	// if both set, that tests the new
-    do_old_MRIDistance,
-    do_new_loop3,   	    	    	    	    	    	    	    	// if both set, that tests the new
-    do_old_loop3, 
-    	    	    	            	    use_fast_avoidable_prediction,	// no test
-    test_avoidable_prediction,      	    use_avoidable_prediction,
-    test_sharedVertexPseudoNormalCache,     use_sharedVertexPseudoNormalCache;
-    
-  static bool once;
-  if (!once) { once = true;
-    keep_sign_bug             	    	= !!getenv("FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_fix_sign_bug"); 
-    do_old_loop3              	    	= !!getenv("FREESURFER_mrisComputeDefectMRILogUnlikelihood_loop3_old");
-    do_new_loop3              	    	= !!getenv("FREESURFER_mrisComputeDefectMRILogUnlikelihood_loop3_new") || !do_old_loop3;
-    do_old_MRIDistance  	    	= !!getenv("FREESURFER_mrisComputeDefectMRILogUnlikelihood_MRIDistance_old");	
-    do_new_MRIDistance  	    	= !!getenv("FREESURFER_mrisComputeDefectMRILogUnlikelihood_MRIDistance_new") || !do_old_MRIDistance;
-    test_avoidable_prediction 	    	= !!getenv("FREESURFER_mrisComputeDefectMRILogUnlikelihood_test_avoidable_prediction");
-    use_avoidable_prediction  	    	=  !getenv("FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_avoidable_prediction") 
-    	    	    	    	    	    || test_avoidable_prediction;
-    use_fast_avoidable_prediction   	=  !getenv("FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_fast_avoidable_prediction") 
-    	    	    	    	    	    && use_avoidable_prediction;
-    
-    test_sharedVertexPseudoNormalCache	= !!getenv("FREESURFER_mrisComputeDefectMRILogUnlikelihood_test_sharedVertexPseudoNormalCache"),
-    use_sharedVertexPseudoNormalCache	=  !getenv("FREESURFER_mrisComputeDefectMRILogUnlikelihood_dont_use_sharedVertexPseudoNormalCache")
-    	    	    	    	    	    || test_sharedVertexPseudoNormalCache;
-
-    if (do_old_loop3) {
-      fprintf(stdout, "mrisComputeDefectMRILogUnlikelihood using old loop3 algorithm with the %s\n",keep_sign_bug?"sign bug still there":"sign bug fixed");
-      if (do_new_loop3) 
-        fprintf(stdout, "mrisComputeDefectMRILogUnlikelihood comparing old and new loop3 algorithm\n");
-    }
-    if (do_old_MRIDistance) {
-      fprintf(stdout, "mrisComputeDefectMRILogUnlikelihood using old mris_distance\n");
-      if (do_new_MRIDistance) {
-        fprintf(stdout, "mrisComputeDefectMRILogUnlikelihood comparing old and new mris_distance\n");
-      }
-    }
-    if (!use_avoidable_prediction) {
-      fprintf(stdout, "mrisComputeDefectMRILogUnlikelihood using old tests only\n");
-    }
-    if (!use_fast_avoidable_prediction) {
-      fprintf(stdout, "mrisComputeDefectMRILogUnlikelihood using slower prediction code only\n");
-    }
-    if (!use_sharedVertexPseudoNormalCache) {
-      fprintf(stdout, "mrisComputeDefectMRILogUnlikelihood not using sharedVertexPseudoNormalCache%s\n",
-        test_sharedVertexPseudoNormalCache?" only, but testing it":"");
-    }
-  }
-#endif
 
   MRI_SURFACE  const * const mris     = mris_nonconst;			// find where the modifiers are
   DEFECT_PATCH const * const dp       = dp_nonconst;
@@ -2304,11 +1976,7 @@ static double mrisComputeDefectMRILogUnlikelihood_wkr(
   int   const fnosCapacity = !realm ? 0    : realmNumberOfMightTouchFno(realm);
   int * const fnos         = !realm ? NULL : (int*)malloc(fnosCapacity*sizeof(int));
   int   const fnosSize     = !realm ? 0    : realmMightTouchFno(realm, fnos, fnosCapacity);
-#if 0
-  qsort(fnos, fnosSize, sizeof(int), int_compare);
-#else
   sort_int(fnos, fnosSize, true);
-#endif
   
   bool const   iterateOverFnos =
 #ifndef mrisComputeDefectMRILogUnlikelihood_CHECK_USE_OF_REALM
@@ -2883,9 +2551,6 @@ static double mrisComputeDefectMRILogUnlikelihood_wkr(
 	  float distanceToCxyzSquared = 0.0; bool predictedIrrelevant = false;
 	    
       	  static long pointCount, pointLimit = 1000000, irrelevantPointCount;
-#if 0
-	  pointCount++;
-#endif
 
           // Calculate the distance to center, and ignore when no chance of providing a new least distance
 	  //
@@ -3486,33 +3151,6 @@ int MRISripDefectiveFaces(MRI_SURFACE *mris)
   first remove all faces with negative areas as they will be
   the 'underside' of a defect.
 */
-#if 0
-  for (fno = 0 ; fno < mris->nfaces ; fno++)
-  {
-    if (mris->faces[177616].v[2] > mris->nfaces)
-    {
-      DiagBreak() ;
-    }
-    f = &mris->faces[fno] ;
-    if (f->ripflag)
-    {
-      continue ;
-    }
-    if (f->area < 0)
-    {
-      f->ripflag = 1 ;  /* part of a defect! */
-      if (Gdiag & DIAG_SHOW)
-      {
-        fprintf(stdout, "ripping face %d\n", fno) ;
-      }
-      nripped++ ;
-      for (i = 0 ; i < VERTICES_PER_FACE ; i++)
-      {
-        mris->vertices[f->v[i]].curv = -2.0f ;
-      }
-    }
-  }
-#endif
   for (nripped = fno = 0; fno < mris->nfaces; fno++) {
     f = &mris->faces[fno];
     if (f->ripflag) {
@@ -3590,35 +3228,9 @@ int MRISripDefectiveFaces(MRI_SURFACE *mris)
 
   MRISscaleBrain(mris, mris, r / 100.0);
   fprintf(stdout, "removing %d ripped faces from tessellation\n", nripped);
-#if 0
-  mrisRipVertices(mris) ;
-#else
   {
-#if 0
-    int vno ;
-
-    for (vno = 0 ; vno < mris->nvertices ; vno++)
-    {
-      v = &mris->vertices[vno] ;
-      v->curv = 0 ;
-      for (fno = 0 ; fno < v->num ; fno++)
-      {
-        f = &mris->faces[v->f[fno]] ;
-        if (f->ripflag == 1)
-        {
-          v->curv = -1 ;
-          break ;
-        }
-        else if (f->ripflag == 2)
-        {
-          v->curv = 1.0 ;
-        }
-      }
-    }
-#endif
     MRISwriteCurvature(mris, "defects");
   }
-#endif
   /*  MRISremoveRipped(mris) ;*/
   return (NO_ERROR);
 }
@@ -3893,18 +3505,6 @@ static int mrisComputeJointGrayWhiteBorderDistributions(MRI_SURFACE *mris, MRI *
 #endif
     MRIsampleVolumeType(mri, xv, yv, zv, &white_val, SAMPLE_NEAREST);
 
-#if 0
-    //to be checked
-#if 0
-    if (gray_val >= MIN_WM_VAL &&
-        white_val >= MIN_WM_VAL)  /* white on both sides */
-    {
-      continue ;
-    }
-#endif
-
-    MRIFvox(mri_gray_white, nint(white_val), nint(gray_val), 0) += 1.0f ;
-#else
     // set the value
     if (nint(v->val2) < 0 || nint(v->val2bak < 0) || nint(v->val2) >= mri_gray_white->width ||
         nint(v->val2bak) >= mri_gray_white->height)
@@ -3912,7 +3512,6 @@ static int mrisComputeJointGrayWhiteBorderDistributions(MRI_SURFACE *mris, MRI *
     MRIFvox(mri_gray_white, nint(v->val2), nint(v->val2bak), 0) += 1.0f;
 
 //      if ((nint(nint(v->val2)) == 110) && (nint(v->val2bak) == 110)) DiagBreak() ;
-#endif
   }
 
   for (x = 0; x < 256; x++)
@@ -3979,15 +3578,9 @@ static int mrisFindGrayWhiteBorderMean(MRI_SURFACE *mris, MRI *mri)
     v->val2bak = gray_val;
     v->val = (white_val + gray_val) / 2;
   }
-#if 0
-  MRISaverageVals(mris, 10) ;
-  MRISaverageVal2s(mris, 10) ;
-  MRISaverageVal2baks(mris, 10) ;
-#else
   MRISmedianFilterVals(mris, 2);
   MRISmedianFilterVal2s(mris, 2);
   MRISmedianFilterVal2baks(mris, 2);
-#endif
   return (NO_ERROR);
 }
 
@@ -4813,36 +4406,6 @@ static SEGMENTATION *segmentIntersectingEdges(MRIS *mris, DEFECT *defect, int *v
   }
 
 /* first consider the inside edges */
-#if 0
-
-  for ( ndiscarded = n = 0 ; n < nes ; n++ )
-  {
-    if (mris->vertices[es[n].vno1].marked==0)
-    {
-      if (n<nes-1)
-      {
-        memmove(&es[n], &es[n+1], (nes-n-1)*sizeof(ES)) ;
-      }
-      nes--;
-      n--;
-      ndiscarded++;
-      continue;
-    }
-    if (mris->vertices[es[n].vno2].marked==0)
-    {
-      if (n<nes-1)
-      {
-        memmove(&es[n], &es[n+1], (nes-n-1)*sizeof(ES)) ;
-      }
-      nes--;
-      n--;
-      ndiscarded++;
-      continue;
-    }
-  }
-  fprintf(WHICH_OUTPUT,
-          "%d out of %d edges were discarded \n",ndiscarded,nes+ndiscarded);
-#else
   {
     ES *new_es;
     new_es = (ES *)malloc(nes * sizeof(ES));
@@ -4876,7 +4439,6 @@ static SEGMENTATION *segmentIntersectingEdges(MRIS *mris, DEFECT *defect, int *v
     memmove(es, new_es, nes * sizeof(ES));
     free(new_es);
   }
-#endif
 
   /* unmark the inside vertices */
   for (n = 0; n < defect->nvertices; n++) {
@@ -4945,15 +4507,6 @@ static SEGMENTATION *segmentIntersectingEdges(MRIS *mris, DEFECT *defect, int *v
         es[n].xedges[es[n].nxedges++] = m;
       }
     }
-#if 0
-    fprintf(stdout,"%d and %d:",n,es[n].nxedges);
-    if (es[n].nxedges)
-      for ( m = 0  ; m <es[n].nxedges ; m++)
-      {
-        fprintf(stdout," %d",es[n].xedges[m]);
-      }
-    fprintf(stdout,"\n");
-#endif
   }
 
   /* allocating structure */
@@ -5054,12 +4607,6 @@ static SEGMENTATION *segmentIntersectingEdges(MRIS *mris, DEFECT *defect, int *v
             segmentation->nsegments,
             ndiscarded);
 
-#if 0
-  for ( n = 0 ; n < segmentation->max_segments ; n++)
-    if (segmentation->segments[n].nedges>0)
-      fprintf(WHICH_OUTPUT,
-              "#%d (%d edges) -",n,segmentation->segments[n].nedges);
-#endif
   //  fprintf(WHICH_OUTPUT,"\nclustering...\n");
 
   /* merging edges into the smallest neighboring component */
@@ -5730,14 +5277,6 @@ static int deleteWorstVertices(MRIS *mris, RP *rp, DEFECT *defect, int *vertex_t
     }
     niters--;
   }
-#if 0
-  /* reset vertex statistics */
-  for (i = 0 ; i < defect->nvertices ; i++)
-  {
-    rp->vertex_fitness[i]=0;
-    rp->nused[i]=0;
-  }
-#endif
 
   return nvoxels;
 }
@@ -5753,10 +5292,6 @@ static MRI *mriDefectVolume(MRIS *mris, EDGE_TABLE *etable, TOPOLOGY_PARMS *parm
 {
   MRI *mri;
   VERTEX *v;
-#if 0
-  int i,j,p,numu,numv,u,w;
-  float px0,px1,py0,py1,pz0,pz1,px,py,pz,d0,d1,d2,dmax,x0,y0,z0;
-#endif
   int k, vno1, vno2, l, p, q, n, nmax;
   int width, height, depth;
   float len, dx, dy, dz, x, y, z, x1, y1, z1, x2, y2, z2, xmin, xmax, ymin, ymax, zmin, zmax, scale;
@@ -5905,103 +5440,6 @@ static MRI *mriDefectVolume(MRIS *mris, EDGE_TABLE *etable, TOPOLOGY_PARMS *parm
     MRIvox(mri, l, p, q) = 1;
   }
 
-#if 0
-  /* then, mark the correct surface in the volume */
-  for ( k = 0 ; k < mris->nfaces ; k++)
-  {
-    // calculate three vertices
-    //fprintf(WHICH_OUTPUT,
-    //"\r  %f            ",100.0*(float)k/(float)mris->nfaces);
-    x0 =mris->vertices[mris->faces[k].v[0]].origx;
-    y0 =mris->vertices[mris->faces[k].v[0]].origy;
-    z0 =mris->vertices[mris->faces[k].v[0]].origz;
-    x1 =mris->vertices[mris->faces[k].v[1]].origx;
-    y1 =mris->vertices[mris->faces[k].v[1]].origy;
-    z1 =mris->vertices[mris->faces[k].v[1]].origz;
-    x2 =mris->vertices[mris->faces[k].v[2]].origx;
-    y2 =mris->vertices[mris->faces[k].v[2]].origy;
-    z2 =mris->vertices[mris->faces[k].v[2]].origz;
-
-    i=iVOL(mri,x0);
-    j=iVOL(mri,x1);
-    p=iVOL(mri,x2);
-    if ((i<0) && (j<0) && (p<0))
-    {
-      continue;
-    }
-    if ((i>=mri->width) && (j>=mri->width) && (p>=mri->width))
-    {
-      continue;
-    }
-
-    i=jVOL(mri,y0);
-    j=jVOL(mri,y1);
-    p=jVOL(mri,y2);
-    if ((i<0) && (j<0) && (p<0))
-    {
-      continue;
-    }
-    if ((i>=mri->height) && (j>=mri->height) && (p>=mri->height))
-    {
-      continue;
-    }
-
-    i=kVOL(mri,z0);
-    j=kVOL(mri,z1);
-    p=kVOL(mri,z2);
-    if ((i<0) && (j<0) && (p<0))
-    {
-      continue;
-    }
-    if ((i>=mri->depth) && (j>=mri->depth) && (p>=mri->depth))
-    {
-      continue;
-    }
-
-    // calculate the sides
-    d0 = mri->xsize*sqrt(SQR(x1-x0)+SQR(y1-y0)+SQR(z1-z0));
-    d1 = mri->ysize*sqrt(SQR(x2-x1)+SQR(y2-y1)+SQR(z2-z1));
-    d2 = mri->zsize*sqrt(SQR(x0-x2)+SQR(y0-y2)+SQR(z0-z2));
-
-    //fprintf(WHICH_OUTPUT,
-    // "(%f,%f,%f)and (%f,%f,%f)",x0,x1,x2,d0,d1,mri->xsize);
-
-    dmax = (d0>=d1&&d0>=d2)?d0:(d1>=d0&&d1>=d2)?d1:d2;
-
-    numu = (int)(ceil(2*d0));
-    numv = (int)(ceil(2*dmax));
-
-    for ( w = 0 ; w <= numv ; w++ )
-    {
-      px0 = x0 + (x2-x0)*w/numv;
-      py0 = y0 + (y2-y0)*w/numv;
-      pz0 = z0 + (z2-z0)*w/numv;
-      px1 = x1 + (x2-x1)*w/numv;
-      py1 = y1 + (y2-y1)*w/numv;
-      pz1 = z1 + (z2-z1)*w/numv;
-
-      for ( u = 0 ; u <= numu ; u++ )
-      {
-        px = px0 + (px1-px0)*u/numu;
-        py = py0 + (py1-py0)*u/numu;
-        pz = pz0 + (pz1-pz0)*u/numu;
-
-        i=iVOL(mri,px);
-        j=jVOL(mri,py);
-        p=kVOL(mri,pz);
-
-        if ((i<0)||(i>=mri->width) ||
-            (j<0)||(j>=mri->height)||
-            (p<0)||(p>=mri->depth))
-        {
-          continue;
-        }
-
-        MRIvox(mri,i,j,p) = 0;
-      }
-    }
-  }
-#endif
   return mri;
 }
 
@@ -6680,28 +6118,7 @@ static void defectSmooth(MRI_SURFACE *mris, DP *dp, int niter, double alpha, int
         }
       }
 
-#if 0
-    fprintf(WHICH_OUTPUT,"%d (out of %d) vertices with high curvature\n",
-            nvertices,dp->tp.ninside);
 
-    MRISclearAnnotations(mris);
-
-    for (i = 0 ; i < nvertices; i++)
-    {
-      VERTEX * const v = &mris->vertices[dp->tp.vertices[vertices[i]]] ;
-      v->annotation=100;
-    }
-#endif
-
-#if 0
-    {
-      static int counter=0;
-      char fname[100];
-      sprintf(fname,"./rh.test_%d",counter);
-      MRISwriteAnnotation(mris,fname);
-      counter++;
-    }
-#endif
       // smooth these vertices
       while (niter--) {
         /* using the tmp vertices */
@@ -6863,11 +6280,7 @@ static void defectMaximizeLikelihood_old(MRI *mri, MRI_SURFACE *mris, DP *dp, in
 
 static void defectMaximizeLikelihood(MRI *mri, MRI_SURFACE *mris, DP *dp, int niter, double alpha) {
     return
-#if 1
         defectMaximizeLikelihood_new
-#else
-        defectMaximizeLikelihood_old
-#endif
             (mri, mris, dp, niter, alpha);
 }
 
@@ -7071,14 +6484,6 @@ static void detectDefectFaces(MRIS *mris, DEFECT_PATCH *dp)
 
   /* will use the border flag to mark modified vertices */
   nvertices = tp->nvertices;
-#if 0
-  for (nthings = i = 0 ; i < nvertices ; i++)
-  {
-    vno=tp->vertices[i];
-    VERTEX * const v = &mris->vertices[vno] ;
-    v->border=1;
-  }
-#endif
   /* detect faces only for modified vertices */
   for (nthings = i = 0; i < nvertices; i++) {
     vno = tp->vertices[i];
@@ -8506,10 +7911,6 @@ MRI_SURFACE *MRIScorrectTopology(
 
   /* at this point : canonical vertices */
   MRIScomputeMetricProperties(mris);
-#if 0
-  /* should not modify anything about canonical vertices */
-  mrisScaleMaxDimension(mris, FIELD_OF_VIEW*.9f) ;
-#endif
   MRISclearMarks(mris);
   MRISclearCurvature(mris);
 
@@ -8781,9 +8182,6 @@ MRI_SURFACE *MRIScorrectTopology(
   mris_corrected->status         = mris->status;            // this should have been done
   mris_corrected->origxyz_status = mris->origxyz_status;    // this is new 
 
-#if 0
-  MRISrestoreVertexPositions(mris, ORIGINAL_VERTICES) ;
-#endif
   MRISrestoreVertexPositions(mris, TMP_VERTICES); /* inflated */
   MRIScomputeMetricProperties(mris);
 
@@ -9042,23 +8440,10 @@ MRI_SURFACE *MRIScorrectTopology(
     if (i == Gdiag_no) {
       DiagBreak();
     }
-#if 0
-    fprintf(WHICH_OUTPUT,
-            "\rretessellating defect %d with %d vertices (chull=%d).    ",
-            i, defect->nvertices+defect->nborder, defect->nchull) ;
-#endif
     mrisMarkAllDefects(mris, dl, 1);
     mrisComputeGrayWhiteBorderDistributions(mris, mri, defect, h_white, h_gray, h_border, h_grad);
     mrisMarkAllDefects(mris, dl, 0);
 
-#if 0
-    MRIwrite(mri_gray_white,"mri_gw.mgh");
-    MRIwrite(mri_k1_k2,"mri_k1_k2.mgh");
-    HISTOplot(h_k1, "k1.plt") ;
-    HISTOplot(h_k2, "k2.plt") ;
-    HISTOplot(h_white, "hw.plt") ;
-    HISTOplot(h_gray, "hg.plt") ;
-#endif
 
 #define TESTING_OPTIMAL 1
 
@@ -9104,7 +8489,6 @@ MRI_SURFACE *MRIScorrectTopology(
                            h_dot,
                            parms);
 
-#if 1
       {
         int ne, nv, nf, tt, theoric_euler, euler_nb;
         nf = mris_corrected->nfaces;
@@ -9139,7 +8523,6 @@ MRI_SURFACE *MRIScorrectTopology(
         }
 #endif
       }
-#endif
 
       /* validation : no self-intersection and good retessellation */
       //... to be implemented
@@ -9239,7 +8622,6 @@ MRI_SURFACE *MRIScorrectTopology(
                                h_dot,
                                parms);
 
-#if 1
           {
             int ne, nv, nf, tt, theoric_euler, euler_nb;
             nf = mris_corrected->nfaces;
@@ -9275,22 +8657,6 @@ MRI_SURFACE *MRIScorrectTopology(
             }
 #endif
           }
-#endif
-#if 0
-          /* save solution */
-          sprintf(fname,"./lh.final_%d",p);
-          fprintf(stderr,"writting solution into %s",fname);
-          MRISrestoreVertexPositions(mris_corrected,ORIGINAL_VERTICES);
-#if 0
-
-          MRISwrite(mris_corrected,fname);
-#else
-          mris_small=extractDefect(mris_corrected,defect);
-          MRISwrite(mris_small,fname);
-          MRISfree(&mris_small);
-#endif
-          MRISrestoreVertexPositions(mris_corrected,TMP_VERTICES);
-#endif
 
           /* restore border positions */
           for (n = 0; n < defect->nborder; n++) {
@@ -9444,36 +8810,6 @@ MRI_SURFACE *MRIScorrectTopology(
     MRISrestoreVertexPositions(mris_corrected, TMP_VERTICES);
   }
 
-#if 0
-  for (i = 0 ; i < dl->ndefects ; i++)
-  {
-    defect = &dl->defects[i] ;
-    for (n = 0 ; n < defect->nvertices ; n++)
-    {
-      vno = vertex_trans[defect->vertices[n]] ;
-      if (vno == Gdiag_no)
-      {
-        DiagBreak() ;
-      }
-      if (vno < 0)
-      {
-        continue ;
-      }
-      v = &mris_corrected->vertices[vno] ;
-      if (v->vnum < 2)
-      {
-        fprintf(WHICH_OUTPUT,
-                "Warning: vertex %d has only %d neighbors!\n",
-                vno, v->vnum) ;
-        DiagBreak() ;
-      }
-    }
-  }
-  if (Gdiag & DIAG_SHOW)
-  {
-    fprintf(WHICH_OUTPUT, "\n") ;
-  }
-#endif
 
   mrisForgetNeighborhoods(mris_corrected);
   
@@ -9669,9 +9005,6 @@ FACE_DEFECT_LIST *MRISmarkAmbiguousVertices(MRI_SURFACE *mris, int mark)
   VERTEX *v;
   int fno, flist[MAX_INT_FACES], i, nfaces, nmarked, n /*, vno, neg*/;
   double area_scale;
-#if 0
-  double r;
-#endif
   MHT *mht;
   FILE *fp = NULL;
   FDL *fdl;
@@ -9697,14 +9030,6 @@ FACE_DEFECT_LIST *MRISmarkAmbiguousVertices(MRI_SURFACE *mris, int mark)
   MRISclearCurvature(mris);
   mrisMarkBadEdgeVertices(mris, mark);
 
-#if 0
-  /*
-    should not reproject vertices on to sphere
-    should not recenter the canonical sphere !
-  */
-  r = MRISaverageRadius(mris) ;
-  MRISscaleBrain(mris, mris, 100.0/r) ;
-#endif
 
   mht = MHTcreateFaceTable(mris);
 
@@ -9737,18 +9062,9 @@ FACE_DEFECT_LIST *MRISmarkAmbiguousVertices(MRI_SURFACE *mris, int mark)
       }
       flist[nfaces++] = fno;
     }
-#if 1
     if (nfaces > 1)
-#else
-    if ((nfaces > 1 || area_scale * f->area < 0.001) || ((fno <= 5) && Gdiag & DIAG_SAVE_DIAGS)) /* part of a defect */
-#endif
     {
       nmarked++;
-#if 0
-      if (Gdiag & DIAG_SHOW)
-        fprintf(WHICH_OUTPUT, "\r%d of %d faces processed, %d ambiguous",
-                fno, mris->nfaces-1, nmarked) ;
-#endif
 
       if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON) {
         fprintf(WHICH_OUTPUT, "%d faces @ fno %d\n", nfaces, fno);
@@ -9785,28 +9101,6 @@ FACE_DEFECT_LIST *MRISmarkAmbiguousVertices(MRI_SURFACE *mris, int mark)
     }
   }
 // TO BE CHECKED : ... pbm when "#if 1...
-#if 0
-  /* expand defective vertices outwards by one */
-  for (vno = 0 ; vno < mris->nvertices ; vno++)
-  {
-    v = &mris->vertices[vno] ;
-    if (v->marked == mark)
-    {
-      for (n = 0 ; n < v->vnum ; n++)
-      {
-        mris->vertices[v->v[n]].marked = mark+1 ;
-      }
-    }
-  }
-  for (vno = 0 ; vno < mris->nvertices ; vno++)
-  {
-    v = &mris->vertices[vno] ;
-    if (v->marked == mark+1)
-    {
-      v->marked = mark ;
-    }
-  }
-#endif
 
   if (Gdiag & DIAG_SHOW) {
     fprintf(WHICH_OUTPUT, "\n");
@@ -9815,10 +9109,6 @@ FACE_DEFECT_LIST *MRISmarkAmbiguousVertices(MRI_SURFACE *mris, int mark)
     fclose(fp);
   }
 
-#if 0
-  /* should not reproject vertices on to sphere */
-  MRISscaleBrain(mris, mris, r/100.0) ;
-#endif
 
   fprintf(WHICH_OUTPUT, "%d ambiguous faces found in tessellation\n", nmarked);
   MHTfree(&mht);
@@ -10557,7 +9847,6 @@ static int mrisSimplyConnectedDefect(MRI_SURFACE *mris, DEFECT *defect, int mark
 #define MIN_SPHERE_DIST .01
 #define MIN_ORIG_DIST .75
 
-#if 1
 int mrisMarkRetainedPartOfDefect(MRI_SURFACE *mris,
                                  DEFECT *defect,
                                  FACE_DEFECT_LIST *fdl,
@@ -10567,12 +9856,6 @@ int mrisMarkRetainedPartOfDefect(MRI_SURFACE *mris,
                                  MHT *mht,
                                  int mode)
 {
-#if 0
-  int      n, i, j, nfaces, fno, flist[100000], n2, vno, retain;
-  FACE     *f ;
-  VERTEX   *v, *vn ;
-  float    dot, x0, y0, z0, x, y, z, dx, dy, dz, dist, fn, dot0, len ;
-#endif
 
   mrisMarkDefect(mris, defect, 0);
 
@@ -10589,533 +9872,8 @@ int mrisMarkRetainedPartOfDefect(MRI_SURFACE *mris,
     mrisDefectRemoveDegenerateVertices(mris, MIN_SPHERE_DIST, defect);
   }
 
-#if 0
-  /* throw out anything in a negative face */
-  for (i = 0 ; i < defect->nvertices ; i++)
-  {
-    if (defect->status[i] == DISCARD_VERTEX)
-    {
-      continue ;
-    }
-    v = &mris->vertices[defect->vertices[i]] ;
-    for (n = 0 ; n < v->num ; n++)
-      if (mris->faces[v->f[n]].area < 0.05)
-      {
-        defect->status[i] = DISCARD_VERTEX ;
-      }
-  }
-
-  /* compute centroid and average normal of defect using border vertices */
-  defect->cx = defect->cy = defect->cz = 0.0f ;
-  defect->nx = defect->ny = defect->nz = 0.0f ;
-  for (fn = 0.0f, i = 0 ; i < defect->nborder ; i++, fn += 1.0f)
-  {
-    v = &mris->vertices[defect->border[i]] ;
-    defect->nx += v->nx ;
-    defect->ny += v->ny ;
-    defect->nz += v->nz ;
-    defect->cx += v->x  ;
-    defect->cy += v->y  ;
-    defect->cz += v->z ;
-  }
-  len = sqrt(SQR(defect->nx) + SQR(defect->ny) + SQR(defect->nz)) ;
-  defect->nx /= len ;
-  defect->ny /= len ;
-  defect->nz /= len ;
-  defect->cx /= fn  ;
-  defect->cy /= fn  ;
-  defect->cz /= fn  ;
-
-  /* discard vertices that are too close to another vertex */
-  for (i = 0 ; i < defect->nvertices+defect->nborder ; i++)
-  {
-    float  dx, dy, dz ;
-
-    if (i < defect->nvertices)
-    {
-      if (defect->status[i] == DISCARD_VERTEX)
-      {
-        continue ;
-      }
-      v = &mris->vertices[defect->vertices[i]] ;
-    }
-    else
-    {
-      v = &mris->vertices[defect->border[i-defect->nvertices]] ;
-    }
-    for (j = i+1 ; j < defect->nvertices ; j++)
-    {
-      if (defect->status[j] == DISCARD_VERTEX)
-      {
-        continue ;
-      }
-      vn = &mris->vertices[defect->vertices[j]] ;
-      dx = vn->origx-v->origx ;
-      dy = vn->origy-v->origy ;
-      dz = vn->origz-v->origz ;
-      dist = sqrt(dx*dx+dy*dy+dz*dz) ;
-      if (dist <= 0.75)
-      {
-        if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
-          fprintf(WHICH_OUTPUT, "discarding proximal vertex %d\n",
-                  defect->vertices[j]);
-        defect->status[j] = DISCARD_VERTEX ;
-        vn->imag_val = -1.0f ;
-      }
-    }
-  }
-
-  /* build a list of all faces in this defect */
-  for (nfaces = n = 0 ; n < defect->nvertices ; n++)
-  {
-    if (defect->status[n] == DISCARD_VERTEX)
-    {
-      continue ;
-    }
-
-    vno = defect->vertices[n] ;
-    v = &mris->vertices[vno] ;
-
-    /* build a list of faces */
-    for (n2 = 0 ; n2 < v->num ; n2++)
-    {
-      if (mris->faces[v->f[n2]].ripflag == 0)
-      {
-        if (nfaces == 7127)
-        {
-          DiagBreak() ;
-        }
-        if (nfaces == 100000)
-        {
-          ErrorExit(ERROR_BADPARM, "Too many faces");
-        }
-        flist[nfaces++] = v->f[n2] ;
-        mris->faces[v->f[n2]].ripflag = 1 ;  /* temporary */
-      }
-    }
-  }
-
-  /* for really big defects throw out 'inside' vertices */
-  for (n = 0 ; n < nfaces ; n++)
-  {
-    fno = flist[n] ;
-    f = &mris->faces[fno] ;
-    mrisCalculateFaceCentroid(mris, fno, &x0, &y0, &z0) ;
-    dx = x0 - defect->cx ;
-    dy = y0 - defect->cy ;
-    dz = z0 - defect->cz ;
-    dot0 = dx*defect->nx + dy*defect->ny + dz*defect->nz ;
-
-    /* see if there are any faces inside (outside) of this one */
-    retain = 1 ;
-    for (n2 = 0 ; n2 < fdl->nfaces[fno] ; n2++)
-    {
-      if (triangleNeighbors(mris, fno, fdl->faces[fno][n2]) >= 1)
-      {
-        continue ;
-      }
-      mrisCalculateFaceCentroid(mris, fdl->faces[fno][n2], &x, &y, &z);
-      dx = x - defect->cx ;
-      dy = y - defect->cy ;
-      dz = z - defect->cz ;
-      dot = dx*defect->nx + dy*defect->ny + dz*defect->nz ;
-#define HUGE_DEFECT 10000
-#define BIG_DEFECT 5000
-      if ((defect->nvertices > HUGE_DEFECT) && (dot > dot0))
-      {
-        retain = 0 ;
-        break ;   /* found a face outside of this one - discard it */
-      }
-      if (defect->nvertices > BIG_DEFECT &&
-          defect->nvertices < HUGE_DEFECT)
-      {
-        if (dot < dot0)  /* found a face inside this one - keep it */
-        {
-          retain = 1 ;
-          break ;
-        }
-        else
-        {
-          retain =  0 ;
-        }
-      }
-    }
-    if (!retain)  /* no faces outside of this one */
-    {
-      for (n2 = 0 ; n2 < VERTICES_PER_FACE ; n2++)
-      {
-        if (f->v[n2] == 1245 || f->v[n2] == Gdiag_no)
-        {
-          DiagBreak() ;
-        }
-        mris->vertices[f->v[n2]].marked = 1 ;
-        mris->vertices[f->v[n2]].imag_val = -1 ;
-      }
-    }
-  }
-
-  /* discard all marked vertices */
-  for (i = 0 ; i < defect->nvertices ; i++)
-  {
-    if (defect->status[i] == DISCARD_VERTEX)
-    {
-      continue ;
-    }
-    v = &mris->vertices[defect->vertices[i]] ;
-    if (v->marked)
-    {
-      v->marked = 0 ;
-      defect->status[i] = DISCARD_VERTEX ;
-    }
-  }
-
-  /* unmark the faces */
-  for (n = 0 ; n < nfaces ; n++)
-  {
-    fno = flist[n] ;
-    f = &mris->faces[fno] ;
-    f->ripflag = 0 ;
-  }
-
-  /* discard vertices that are too close to another vertex */
-  for (i = 0 ; i < defect->nvertices+defect->nborder ; i++)
-  {
-    float  dx, dy, dz ;
-
-    if (i < defect->nvertices)
-    {
-      if (defect->status[i] == DISCARD_VERTEX)
-      {
-        continue ;
-      }
-      v = &mris->vertices[defect->vertices[i]] ;
-    }
-    else
-    {
-      v = &mris->vertices[defect->border[i-defect->nvertices]] ;
-    }
-    for (j = i+1 ; j < defect->nvertices ; j++)
-    {
-      if (defect->status[j] == DISCARD_VERTEX)
-      {
-        continue ;
-      }
-      vn = &mris->vertices[defect->vertices[j]] ;
-      dx = vn->cx-v->cx ;
-      dy = vn->cy-v->cy ;
-      dz = vn->cz-v->cz ;
-      dist = (dx*dx+dy*dy+dz*dz) ;  /* no sqrt */
-      if (dist < MIN_SPHERE_DIST)
-      {
-        if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
-          fprintf(WHICH_OUTPUT, "discarding proximal vertex %d\n",
-                  defect->vertices[j]);
-        defect->status[j] = DISCARD_VERTEX ;
-        vn->imag_val = -1.0f ;
-      }
-    }
-  }
-#endif
   return (NO_ERROR);
 }
-#else
-static int mrisMarkRetainedPartOfDefect(MRI_SURFACE *mris,
-                                        DEFECT *defect,
-                                        FACE_DEFECT_LIST *fdl,
-                                        float area_threshold,
-                                        int mark_retain,
-                                        int mark_discard,
-                                        MHT *mht)
-{
-#define USING_CUBE 0
-#if USING_CUBE || 1
-  /* based on faces */
-  int n, n2, inside, vno, flist[100000], nfaces, fno, i, j;
-  VERTEX *v, *vn;
-  FACE *f;
-  float dot, x0, y0, z0, x, y, z, dx, dy, dz, fn, len, dist;
-
-  defect->cx = defect->cy = defect->cz = 0.0f;
-  inside = defect->area < area_threshold;
-  mrisMarkDefect(mris, defect, 1);
-  for (fn = 0.0, nfaces = n = 0; n < defect->nvertices; n++) {
-    vno = defect->vertices[n];
-    v = &mris->vertices[vno];
-
-    /* build a list of faces */
-    for (n2 = 0; n2 < v->num; n2++) {
-      if (mris->faces[v->f[n2]].ripflag == 0) {
-        if (nfaces == 100000) {
-          ErrroExit(ERROR_BADPARM, "Too many faces");
-        }
-        flist[nfaces++] = v->f[n2];
-        mris->faces[v->f[n2]].ripflag = 1; /* temporary */
-      }
-    }
-    v->val = inside ? -1.0f : 1.0;
-    v->imag_val = 1.0f; /* assume kept until found otherwise */
-    defect->cx += v->x;
-    defect->cy += v->y;
-    defect->cz += v->z;
-  }
-  defect->nx = defect->ny = defect->nz = 0.0f;
-  for (n = 0; n < defect->nborder; n++) {
-    vno = defect->border[n];
-    v = &mris->vertices[vno];
-    defect->nx += v->nx;
-    defect->ny += v->ny;
-    defect->nz += v->nz;
-  }
-  mrisMarkDefect(mris, defect, 0);
-  len = sqrt(defect->nx * defect->nx + defect->ny * defect->ny + defect->nz * defect->nz);
-  if (FZERO(len)) {
-    len = 1.0f;
-  }
-  defect->nx /= len;
-  defect->ny /= len;
-  defect->nz /= len;
-  fn = (float)defect->nvertices;
-  defect->cx /= fn;
-  defect->cy /= fn;
-  defect->cz /= fn;
-
-  /* unrip the faces (used really as a mark, but don't want to add to
-  face struct).
-  */
-  for (n = 0; n < defect->nvertices; n++) {
-    v = &mris->vertices[defect->vertices[n]];
-
-    for (n2 = 0; n2 < v->num; n2++) {
-      mris->faces[v->f[n2]].ripflag = 0;
-    }
-  }
-
-  if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON) {
-    fprintf(WHICH_OUTPUT, "%d faces found in defect\n", nfaces);
-  }
-#if USING_CUBE
-  for (n = 0; n < nfaces; n++) {
-    fno = flist[n];
-    f = &mris->faces[fno];
-    mrisCalculateFaceCentroid(mris, fno, &x0, &y0, &z0);
-
-    /* see if there are any faces inside (outside) of this one */
-    for (dot = 0.0f, n2 = 0; n2 < fdl->nfaces[fno]; n2++) {
-      if (triangleNeighbors(mris, fno, fdl->faces[fno][n2]) >= 1) {
-        continue;
-      }
-      mrisCalculateFaceCentroid(mris, fdl->faces[fno][n2], &x, &y, &z);
-      dx = -15.5 - x;
-      dot = dx * dx;
-      if (dot < ((-15.5 - x0) * (-15.5 - x0))) {
-        break;
-      }
-    }
-    if (n2 < fdl->nfaces[fno]) /* found a face inside
-     (outside) of this one */
-    {
-      for (n2 = 0; n2 < VERTICES_PER_FACE; n2++) {
-        if (f->v[n2] == 1245 || f->v[n2] == Gdiag_no) {
-          DiagBreak();
-        }
-        mris->vertices[f->v[n2]].marked = 1;
-        mris->vertices[f->v[n2]].imag_val = -1;
-      }
-    }
-  }
-#else
-  for (n = 0; n < nfaces; n++) {
-    fno = flist[n];
-    f = &mris->faces[fno];
-    mrisCalculateFaceCentroid(mris, fno, &x0, &y0, &z0);
-
-    /* see if there are any faces inside (outside) of this one */
-    for (dot = 0.0f, n2 = 0; n2 < fdl->nfaces[fno]; n2++) {
-      if (triangleNeighbors(mris, fno, fdl->faces[fno][n2]) >= 1) {
-        continue;
-      }
-      mrisCalculateFaceCentroid(mris, fdl->faces[fno][n2], &x, &y, &z);
-      dx = x - x0;
-      dy = y - y0;
-      dz = z - z0;
-      dot = dx * defect->nx + dy * defect->ny + dz * defect->nz;
-      if ((inside && dot < 0) || (!inside && dot > 0)) {
-        break;
-      }
-    }
-    if (n2 < fdl->nfaces[fno]) /* found a face inside
-   (outside) of this one */
-    {
-      for (n2 = 0; n2 < VERTICES_PER_FACE; n2++) {
-        if (f->v[n2] == 1245 || f->v[n2] == Gdiag_no) {
-          DiagBreak();
-        }
-        mris->vertices[f->v[n2]].marked = 1;
-        mris->vertices[f->v[n2]].imag_val = -1;
-      }
-    }
-  }
-#endif
-  for (n = 0; n < defect->nvertices; n++) {
-    vno = defect->vertices[n];
-    v = &mris->vertices[vno];
-    defect->status[n] = v->marked ? DISCARD_VERTEX : KEEP_VERTEX;
-  }
-  mrisMarkDefect(mris, defect, 0);
-#else
-  int n, n2, inside, vno;
-  VERTEX *v, *v2;
-  float fn, len;
-
-  defect->cx = defect->cy = defect->cz = defect->nx = defect->ny = defect->nz = 0.0;
-  inside = defect->area < area_threshold;
-  mrisMarkDefect(mris, defect, 1);
-  for (fn = 0.0, n = 0; n < defect->nvertices; n++) {
-    vno = defect->vertices[n];
-    v = &mris->vertices[vno];
-    if (vno == Gdiag_no) {
-      DiagBreak();
-    }
-    if (inside) {
-      v->val = -1.0f;
-    }
-    else {
-      v->val = 1.0f;
-    }
-    defect->cx += v->x;
-    defect->cy += v->y;
-    defect->cz += v->z;
-
-    /* use surrounding unmarked vertices as estimate of local normal */
-    for (n2 = 0; n2 < v->vnum; n2++) {
-      v2 = &mris->vertices[v->v[n2]];
-      if (!v2->marked) {
-        defect->nx += v2->nx;
-        defect->ny += v2->ny;
-        defect->nz += v2->nz;
-        fn += 1.0;
-      }
-    }
-  }
-  mrisMarkDefect(mris, defect, 0);
-  defect->nx /= fn;
-  defect->ny /= fn;
-  defect->nz /= fn;
-  len = sqrt(defect->nx * defect->nx + defect->ny * defect->ny + defect->nz * defect->nz);
-  if (FZERO(len)) {
-    len = 1.0f;
-  }
-  defect->nx /= len;
-  defect->ny /= len;
-  defect->nz /= len;
-  fn = (float)defect->nvertices;
-  defect->cx /= fn;
-  defect->cy /= fn;
-  defect->cz /= fn;
-
-  for (n = 0; n < defect->nvertices; n++) /* for each vertex in defect */
-  {
-    vno = defect->vertices[n];
-    v = &mris->vertices[vno];
-    if (vno == Gdiag_no) {
-      DiagBreak();
-    }
-    defect->status[n] = KEEP_VERTEX;
-    v->imag_val = 1.0;
-    v->nx = defect->nx;
-    v->ny = defect->ny;
-    v->nz = defect->nz;
-    if (inside) {
-      if (mrisFindNextInwardFace(mris, mht, vno, 20.0f) >= 0) {
-        defect->status[n] = DISCARD_VERTEX;
-        defect->status[n] = KEEP_VERTEX;
-        v->imag_val = -1.0;
-      }
-    }
-    else {
-      if (mrisFindNextOutwardFace(mris, mht, vno, 20.0f) >= 0) {
-        defect->status[n] = DISCARD_VERTEX;
-        v->imag_val = -1.0;
-      }
-    }
-  }
-#endif
-
-  /* throw out anything in a negative face */
-  for (i = 0; i < defect->nvertices; i++) {
-    if (defect->status[i] == DISCARD_VERTEX) {
-      continue;
-    }
-    v = &mris->vertices[defect->vertices[i]];
-    for (n = 0; n < v->num; n++)
-      if (mris->faces[v->f[n]].area < 0) {
-        defect->status[i] = DISCARD_VERTEX;
-      }
-  }
-
-  /* discard vertices that are too close to another vertex */
-  for (i = 0; i < defect->nvertices + defect->nborder; i++) {
-    float dx, dy, dz;
-
-    if (i < defect->nvertices) {
-      if (defect->status[i] == DISCARD_VERTEX) {
-        continue;
-      }
-      v = &mris->vertices[defect->vertices[i]];
-    }
-    else {
-      v = &mris->vertices[defect->border[i - defect->nvertices]];
-    }
-    for (j = i + 1; j < defect->nvertices; j++) {
-      if (defect->status[j] == DISCARD_VERTEX) {
-        continue;
-      }
-      vn = &mris->vertices[defect->vertices[j]];
-      dx = vn->origx - v->origx;
-      dy = vn->origy - v->origy;
-      dz = vn->origz - v->origz;
-      dist = sqrt(dx * dx + dy * dy + dz * dz);
-      if (dist <= 0.5) {
-        if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
-          fprintf(WHICH_OUTPUT, "discarding proximal vertex %d\n", defect->vertices[j]);
-        defect->status[j] = DISCARD_VERTEX;
-        vn->imag_val = -1.0f;
-      }
-    }
-  }
-  /* discard vertices that are too close to another vertex on sphere */
-  for (i = 0; i < defect->nvertices + defect->nborder; i++) {
-    float dx, dy, dz;
-
-    if (i < defect->nvertices) {
-      if (defect->status[i] == DISCARD_VERTEX) {
-        continue;
-      }
-      v = &mris->vertices[defect->vertices[i]];
-    }
-    else {
-      v = &mris->vertices[defect->border[i - defect->nvertices]];
-    }
-    for (j = i + 1; j < defect->nvertices; j++) {
-      if (defect->status[j] == DISCARD_VERTEX) {
-        continue;
-      }
-      vn = &mris->vertices[defect->vertices[j]];
-      dx = vn->cx - v->cx;
-      dy = vn->cy - v->cy;
-      dz = vn->cz - v->cz;
-      dist = (dx * dx + dy * dy + dz * dz); /* no sqrt */
-      if (dist < MIN_SPHERE_DIST) {
-        if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
-          fprintf(WHICH_OUTPUT, "discarding proximal vertex %d\n", defect->vertices[j]);
-        defect->status[j] = DISCARD_VERTEX;
-        vn->imag_val = -1.0f;
-      }
-    }
-  }
-  return (NO_ERROR);
-}
-#endif
 
 static int mrisRipDefect(MRI_SURFACE *mris, DEFECT *defect, int ripflag)
 {
@@ -11844,18 +10602,6 @@ static int clusterDefectVertices(MRIS *mris)
     /* compute distance with first cluster */
     dist = 1000;
     v->fixedval = 1;
-#if 0
-    for (q = 0 ; q < mris->nvertices ; q++ )
-    {
-      vq=&mris->vertices[q];
-      if (vq->flags==VERTEX_INTERIOR)
-      {
-        continue;
-      }
-      dist=MIN(dist,SQR(vq->origx-v->origx)+
-               SQR(vq->origy-v->origy)+SQR(vq->origz-v->origz));
-    }
-#endif
     /* compute distance for the remaining clusters */
     for (q = 1; q < nclusters; q++) {
       vq = &mris->vertices[clusters[q]];
@@ -11920,19 +10666,6 @@ static int clusterDefectVertices(MRIS *mris)
       /* find the correct cluster */
       /* compute distance with first cluster */
       dist = 1000;
-#if 0
-      v->fixedval=1;
-      for (q=0; q<mris->nvertices; q++)
-      {
-        vq=&mris->vertices[q];
-        if (vq->flags==VERTEX_INTERIOR)
-        {
-          continue;
-        }
-        dist=MIN(dist,SQR(vq->origx-v->origx)+
-                 SQR(vq->origy-v->origy)+SQR(vq->origz-v->origz));
-      }
-#endif
       /* compute distance for the remaining clusters */
       for (q = 1; q < nclusters; q++) {
         vq = &mris->vertices[clusters[q]];
@@ -12042,31 +10775,6 @@ static void generateDefectMapping(MRIS *mris, int option)
   double dt = 0.1;
   VERTEX *v;
 
-#if 0
-  {
-    int n,vlist[8];
-    for (n=0; n<mris->nvertices; n++)
-    {
-      mris->vertices[n].fixedval=0;
-    }
-    //option=2;
-    vlist[0]=508;
-    vlist[1]=509;
-    vlist[2]=538;
-    vlist[3]=539;
-    vlist[4]=540;
-    vlist[5]=541;
-    vlist[6]=569;
-    vlist[7]=510;
-    for (n=0; n<8; n++)
-    {
-      mris->vertices[vlist[n]].fixedval=option;
-    }
-  }
-  /*    fprintf(stderr," label is %d or %d or %d :
-        option=%d\n",mris->vertices[361].fixedval,
-        mris->vertices[392].fixedval,mris->vertices[391].fixedval,option); */
-#endif
 
   while (niter--) {
     if (niter % 20 == 0) {
@@ -12405,10 +11113,6 @@ static OPTIMAL_DEFECT_MAPPING *mrisFindOptimalDefectMapping(MRIS *mris_src, DEFE
 #endif
   }
 
-#if 0
-  free(e_l_i.border_edges);
-  free(e_l_i.inside_edges);
-#endif
   free(vertex_list);
 
   return o_d_m;
@@ -12816,35 +11520,10 @@ static int mrisTessellateDefect_wkr(MRI_SURFACE *mris,
 
   ROMP_SCOPE_begin
   
-#if 0
-  //modify initial ordering, just for fun...
-  {
-    int k,m,tmp,rd;
-
-    fprintf(WHICH_OUTPUT,"generating random ordering\n");
-
-    ordering=(int*)calloc(nedges,sizeof(int));
-    for (j=0; j< nedges; j++)
-    {
-      ordering[j]=nedges-j-1;
-    }
-
-    for (m=0; m<11; m++)
-      for (j=0; j< nedges; j++)
-      {
-        k=nint(randomNumber(0.0, (double)nedges-1)) ;
-
-        tmp=ordering[j];
-        ordering[j]=ordering[k];
-        ordering[k]=tmp;
-      }
-  }
-#else  // no modification
   ordering = (int *)calloc(nedges, sizeof(int));
   for (j = 0; j < nedges; j++) {
     ordering[j] = j;  // nedges-j-1;
   }
-#endif
 
   /* list the edges used in the original tessellation */
   es = (ES *)malloc(nes * sizeof(ES));
@@ -13034,7 +11713,6 @@ static int mrisCrossoverDefectPatches(DEFECT_PATCH *dp1, DEFECT_PATCH *dp2, DEFE
   return (NO_ERROR);
 }
 #define NTRY 0
-#if 1
 static int mrisMutateDefectPatch(DEFECT_PATCH *dp, EDGE_TABLE *etable, double pmutation)
 {
   int i, j, eti, etj, tmp, *dp_indices, ntry;
@@ -13127,49 +11805,6 @@ static int mrisMutateDefectPatch(DEFECT_PATCH *dp, EDGE_TABLE *etable, double pm
   free(dp_indices);
   return (NO_ERROR);
 }
-#else
-static int mrisMutateDefectPatch(DEFECT_PATCH *dp, EDGE_TABLE *etable, double pmutation)
-{
-  int i, j, eti, etj, tmp, *dp_indices;
-  double p;
-
-  dp_indices = (int *)calloc(dp->nedges, sizeof(int));
-  for (i = 0; i < dp->nedges; i++) {
-    dp_indices[dp->ordering[i]] = i;
-  }
-
-  for (i = 0; i < dp->nedges; i++) {
-    p = randomNumber(0.0, 1.0);
-    eti = dp->ordering[i];
-    if (p < pmutation && etable->noverlap[eti] > 0) {
-      if (etable->flags[eti] & ET_OVERLAP_LIST_INCOMPLETE) /* swap any two */
-      {
-        j = (int)randomNumber(0.0, dp->nedges - .1);
-        tmp = dp->ordering[i];
-        dp->ordering[i] = dp->ordering[j];
-        dp->ordering[j] = tmp;
-      }
-      else /* swap two edges that intersect */
-      {
-        j = (int)randomNumber(0.0, etable->noverlap[eti] - 0.0001);
-        etj = etable->overlapping_edges[eti][j]; /* index of jth
-                                                    overlapping edge */
-        j = dp_indices[etj];                     /* find where it is in this
-                                                    defect patch ordering */
-
-        tmp = dp->ordering[i];
-        dp->ordering[i] = dp->ordering[j];
-        dp->ordering[j] = tmp;
-        dp_indices[dp->ordering[i]] = i;
-        dp_indices[dp->ordering[j]] = j;
-      }
-    }
-  }
-
-  free(dp_indices);
-  return (NO_ERROR);
-}
-#endif
 
 static int mrisCopyDefectPatch(DEFECT_PATCH *dp_src, DEFECT_PATCH *dp_dst)
 {
@@ -13410,52 +12045,11 @@ int mrisCountIntersectingFaces(MRIS *mris, int *flist, int nfaces)
       intersect = tri_tri_intersect(v0, v1, v2, u0, u1, u2);
 
       if (intersect) {
-#if 0
-        fprintf(stderr,"face %d intersect face %d\n",
-                flist[n],flist[m]);
-        fprintf(stderr,"face %d : vertex %d [ %f , %f , %f ]\n",
-                flist[n],f1->v[0],v0[0],v0[1],v0[2]);
-        fprintf(stderr,"face %d : vertex %d [ %f , %f , %f ]\n",
-                flist[n],f1->v[1],v1[0],v1[1],v1[2]);
-        fprintf(stderr,"face %d : vertex %d [ %f , %f , %f ]\n",
-                flist[n],f1->v[2],v2[0],v2[1],v2[2]);
-        fprintf(stderr,"face %d : vertex %d [ %f , %f , %f ]\n",
-                flist[m],f2->v[0],u0[0],u0[1],u0[2]);
-        fprintf(stderr,"face %d : vertex %d [ %f , %f , %f ]\n",
-                flist[m],f2->v[1],u1[0],u1[1],u1[2]);
-        fprintf(stderr,"face %d : vertex %d [ %f , %f , %f ]\n",
-                flist[m],f2->v[2],u2[0],u2[1],u2[2]);
-        fprintf(stderr,"\nXXXXXXXXXX\n");
-#endif
         count++;
         break;
       }
     }
   }
-#if 0
-  fprintf(stderr,"\n\nYYYYYYYYYYYYYYYYYYYYY LIST FACES \n");
-  for (n=0; n < nfaces ; n++)
-  {
-    f1 = &mris->faces[flist[n]];
-    /* fill vertices of 1st triangle */
-    v0[0] = (double)mris->vertices[f1->v[0]].origx ;
-    v0[1] = (double)mris->vertices[f1->v[0]].origy ;
-    v0[2] = (double)mris->vertices[f1->v[0]].origz ;
-    v1[0] = (double)mris->vertices[f1->v[1]].origx ;
-    v1[1] = (double)mris->vertices[f1->v[1]].origy ;
-    v1[2] = (double)mris->vertices[f1->v[1]].origz ;
-    v2[0] = (double)mris->vertices[f1->v[2]].origx ;
-    v2[1] = (double)mris->vertices[f1->v[2]].origy ;
-    v2[2] = (double)mris->vertices[f1->v[2]].origz ;
-
-    fprintf(stderr,"face %d : vertex %d [ %f , %f , %f ]\n",
-            flist[n],f1->v[0],v0[0],v0[1],v0[2]);
-    fprintf(stderr,"face %d : vertex %d [ %f , %f , %f ]\n",
-            flist[n],f1->v[1],v1[0],v1[1],v1[2]);
-    fprintf(stderr,"face %d : vertex %d [ %f , %f , %f ]\n",
-            flist[n],f1->v[2],v2[0],v2[1],v2[2]);
-  }
-#endif
 
   return count;
 }
@@ -13620,16 +12214,6 @@ static NOINLINE int mrisComputeOptimalRetessellation_wkr(MRI_SURFACE *mris,
     }
   }
 
-#if 0
-
-  dno++ ;  /* for debugging */
-  tessellatePatch(mri,mris, mris_corrected, defect,
-                  vertex_trans, et, nedges, NULL, NULL,parms);
-  MRIScheckIsPolyhedron(mris_corrected, __FILE__,__LINE__);
-
-  return(NO_ERROR) ;
-
-#endif
 
   if (!max_patches) {
     dno++; /* for debugging */
@@ -13644,7 +12228,6 @@ static NOINLINE int mrisComputeOptimalRetessellation_wkr(MRI_SURFACE *mris,
   dno++; /* for debugging */
 
   if (nedges > 200000) {
-#if 1
     printf("An extra large defect has been detected...\n");
     printf("This often happens because cerebellum or dura has not been removed from wm.mgz.\n");
     printf("This may cause recon-all to run very slowly or crash.\n");
@@ -13652,14 +12235,6 @@ static NOINLINE int mrisComputeOptimalRetessellation_wkr(MRI_SURFACE *mris,
     max_unchanged = MIN(max_unchanged, 1);
     max_patches = MAX(MIN(max_patches, 3), 1);
     max_edges = MIN(max_edges, 25);
-#else
-    // add some code here to select a good tessellation (ordering) FLO
-    mrisRetessellateDefect(mris, mris_corrected, defect, vertex_trans, et, nedges, NULL, NULL);
-    //    tessellatePatch(mri,mris, mris_corrected,
-    //                    defect,vertex_trans, et, nedges, NULL, NULL,parms);
-
-    return (NO_ERROR);
-#endif
   }
   else if (nedges > 100000) {
     printf("A large defect has been detected...\n");
@@ -15507,70 +14082,6 @@ static int mrisRetessellateDefect(MRI_SURFACE *mris,
   return (NO_ERROR);
 }
 
-#if 0
-static int
-mrisCheckDefectEdges(MRI_SURFACE *mris, DEFECT *defect, int vno,
-                     int *vertex_trans)
-{
-  int    i, n1, n2, n3, vno2, fno1, fno2 ;
-  EDGE   edge1, edge2 ;
-  VERTEX *v, *vn ;
-  FACE   *f ;
-
-  v = &mris->vertices[vno] ;
-  edge1.vno1 = vno ;
-  for (n1 = 0 ; n1 < v->num ; n1++)
-  {
-    n2 = v->n[n1] == VERTICES_PER_FACE-1 ? 0 : v->n[n1]+1 ;
-    fno1 = v->f[n1] ;
-    edge1.vno2 = mris->faces[fno1].v[n2] ;
-    for (i = 0 ; i < defect->nborder ; i++)
-    {
-      vno2 = vertex_trans[defect->border[i]] ;
-      if (vno2 < 0)
-      {
-        continue ;
-      }
-      vn = &mris->vertices[vno2] ;
-      for (n2 = 0 ; n2 < vn->num ; n2++)
-      {
-        fno2 = vn->f[n2] ;
-        f = &mris->faces[fno2] ;
-        if (fno2 == Gdiag_no)
-        {
-          DiagBreak() ;
-        }
-        if ((fno2 == 103815 && fno1 == 101608) ||
-            (fno1 == 103815 && fno2 == 101608))
-        {
-          DiagBreak() ;
-        }
-        for (n3 = 0 ; n3 < VERTICES_PER_FACE ; n3++)
-        {
-          edge2.vno1 = f->v[n3] ;
-          edge2.vno2 = f->v[n3 == VERTICES_PER_FACE-1 ? 0 : n3+1] ;
-          if (edge2.vno1 == edge1.vno1 || edge2.vno1 == edge1.vno2 ||
-              edge2.vno2 == edge1.vno1 || edge2.vno2 == edge1.vno2)
-          {
-            continue ;
-          }
-          if (edgesIntersect(mris, &edge1, &edge2))
-          {
-            fprintf
-            (WHICH_OUTPUT,
-             "triangles %d (a=%f) and %d (a=%f) intersect!\n",
-             fno1, mris->faces[fno1].area, fno2,
-             mris->faces[fno2].area) ;
-            mrisDumpTriangle(mris, fno1) ;
-            mrisDumpTriangle(mris, fno2) ;
-          }
-        }
-      }
-    }
-  }
-  return(NO_ERROR) ;
-}
-#endif
 
 /*-----------------------------------------------------
   Parameters:
@@ -16212,7 +14723,6 @@ static int mrisAddAllDefectFaces(MRI_SURFACE *mris, DEFECT_LIST *dl, int *vertex
   point outward (i.e. in the same direction as the original
   surface).
   ------------------------------------------------------*/
-#if 1
 static int mrisOrientRetessellatedSurface(MRI_SURFACE *mris, DEFECT_LIST *dl, int *vtrans)
 {
   int vno, n, fno, m, vno0, vno1; /*n0, n1;*/
@@ -16302,474 +14812,6 @@ static int mrisOrientRetessellatedSurface(MRI_SURFACE *mris, DEFECT_LIST *dl, in
   MRIScomputeMetricProperties(mris);
   return (NO_ERROR);
 }
-#else
-static int mrisOrientRetessellatedSurface(MRI_SURFACE *mris, DEFECT_LIST *dl, int *vtrans)
-{
-#if 1
-  int dno, fno, vno, i, n, m, vno0, vno1, n0, n1, oriented, nreversed;
-  VERTEX *v, *vn;
-  FACE *f;
-  DEFECT *defect;
-  float dot, norm[3], len, nx, ny, nz;
-
-  MRISsaveVertexPositions(mris, TMP_VERTICES);
-  MRISrestoreVertexPositions(mris, ORIG_VERTICES);
-  MRISaverageVertexPositions(mris, 200);
-  MRIScomputeMetricProperties(mris);
-
-  /* compute average boundary normal in the smoothed space */
-  for (dno = 0; dno < dl->ndefects; dno++) {
-    defect = &dl->defects[dno];
-    nx = ny = nz = 0.0f;
-    for (i = 0; i < defect->nborder; i++) {
-      vno = vtrans[defect->border[i]];
-      if (vno < 0) /* not in new tessellation */
-      {
-        continue;
-      }
-      v = &mris->vertices[vno];
-      nx += v->nx;
-      ny += v->ny;
-      nz += v->nz;
-    }
-    len = sqrt(nx * nx + ny * ny + nz * nz);
-    if (FZERO(len)) {
-      len = 1.0f;
-    }
-    defect->nx = nx / len;
-    defect->ny = ny / len;
-    defect->nz = nz / len;
-  }
-
-  /* orient defect faces so that the outward direction agrees with boundary */
-  for (oriented = dno = 0; dno < dl->ndefects; dno++) {
-    defect = &dl->defects[dno];
-    for (i = 0; i < defect->nvertices; i++) {
-      vno = vtrans[defect->vertices[i]];
-      if (vno < 0) /* not in new tessellation */
-      {
-        continue;
-      }
-      v = &mris->vertices[vno];
-      if (vno == Gdiag_no) {
-        DiagBreak();
-      }
-
-      /* go through each face and orient it to agree with defect normal */
-      for (m = 0; m < v->num; m++) {
-        fno = v->f[m];
-        f = &mris->faces[fno];
-        if (fno == Gdiag_no) {
-          DiagBreak();
-        }
-        for (n = 0; n < VERTICES_PER_FACE; n++) {
-          mrisNormalFace(mris, fno, n, norm); /*compute face normal */
-          dot = norm[0] * defect->nx + norm[1] * defect->ny + norm[2] * defect->nz;
-          if (dot < 0) /* they disagree - change
-          order of vertices in face */
-          {
-            oriented++;
-            n0 = (n == 0) ? VERTICES_PER_FACE - 1 : n - 1;
-            n1 = (n == VERTICES_PER_FACE - 1) ? 0 : n + 1;
-            vno0 = f->v[n0];
-            vno1 = f->v[n1];
-            f->v[n0] = vno1;
-            f->v[n1] = vno0;
-            mrisSetVertexFaceIndex(mris, vno0, fno);
-            mrisSetVertexFaceIndex(mris, vno1, fno);
-            if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON) fprintf(stdout, "reversing face %d orientation\n", fno);
-          }
-        }
-      }
-    }
-  }
-
-  MRISsetNeighborhoodSizeAndDist(mris, 2);
-
-  i = 0;
-  do {
-    MRIScomputeMetricProperties(mris);
-    nreversed = 0;
-    for (vno = 0; vno < mris->nvertices; vno++) {
-      v = &mris->vertices[vno];
-      if (vno == Gdiag_no) {
-        DiagBreak();
-      }
-      for (nx = ny = nz = 0.0, n = 0; n < v->vtotal; n++) {
-        vn = &mris->vertices[v->v[n]];
-        dot = vn->nx * v->nx + vn->ny * v->ny + vn->nz * v->nz;
-        if (dot < 0) {
-          DiagBreak();
-        }
-        nx += vn->nx;
-        ny += vn->ny;
-        nz += vn->nz;
-      }
-      dot = nx * v->nx + ny * v->ny + nz * v->nz;
-      if (dot < 0) {
-        v->nx *= -1.0;
-        v->ny *= -1.0;
-        v->nz *= -1.0;
-        DiagBreak();
-      }
-
-      for (m = 0; m < v->num; m++) {
-        fno = v->f[m];
-        f = &mris->faces[fno];
-        if (fno == Gdiag_no) {
-          DiagBreak();
-        }
-        dot = nx * f->nx + ny * f->ny + nz * f->nz;
-        if (dot < 0) /* they disagree - change order
-        of vertices in face */
-        {
-          DiagBreak();
-        }
-        for (n = 0; n < VERTICES_PER_FACE; n++) {
-          mrisNormalFace(mris, fno, n, norm); /* compute
-         face normal */
-          dot = norm[0] * nx + norm[1] * ny + norm[2] * nz;
-          if (dot < 0) /* they disagree - change
-          order of vertices in face */
-          {
-            nreversed++;
-            n0 = (n == 0) ? VERTICES_PER_FACE - 1 : n - 1;
-            n1 = (n == VERTICES_PER_FACE - 1) ? 0 : n + 1;
-            vno0 = f->v[n0];
-            vno1 = f->v[n1];
-            f->v[n0] = vno1;
-            f->v[n1] = vno0;
-            mrisSetVertexFaceIndex(mris, vno0, fno);
-            mrisSetVertexFaceIndex(mris, vno1, fno);
-            if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON) fprintf(stdout, "reversing face %d orientation\n", fno);
-          }
-        }
-      }
-    }
-    if (Gdiag & DIAG_SHOW) {
-      fprintf(stdout, "\rpass %d: %d oriented   ", i + 1, nreversed);
-    }
-
-    oriented += nreversed;
-    if (++i > 20) /* shouldn't happen, but... */
-    {
-      break;
-    }
-  } while (nreversed > 0);
-
-  if (Gdiag & DIAG_SHOW) {
-    fprintf(stdout, "orientation complete in %d passes\n", i);
-  }
-
-  for (vno = 0; vno < mris->nvertices; vno++) {
-    v = &mris->vertices[vno];
-    if (vno == Gdiag_no) {
-      DiagBreak();
-    }
-    for (m = 0; m < v->num; m++) {
-      fno = v->f[m];
-      f = &mris->faces[fno];
-      if (fno == Gdiag_no) {
-        DiagBreak();
-      }
-      for (n = 0; n < VERTICES_PER_FACE; n++) {
-        mrisNormalFace(mris, fno, n, norm); /* compute face normal */
-        dot = norm[0] * v->nx + norm[1] * v->ny + norm[2] * v->nz;
-        if (dot < 0) /* they disagree - change order
-        of vertices in face */
-        {
-          DiagBreak();
-        }
-        dot = norm[0] * f->nx + norm[1] * f->ny + norm[2] * f->nz;
-        if (dot < 0) /* they disagree - change order
-        of vertices in face */
-        {
-          DiagBreak();
-        }
-      }
-    }
-  }
-
-#if 0
-  MRISrestoreVertexPositions(mris, TMP_VERTICES) ;  /* back to inflated */
-#endif
-  MRIScomputeMetricProperties(mris);
-  return (oriented);
-#else
-  int vno, vno0, vno1, i, n, fno, oriented, num, dno, m, blist[MAX_DEFECT_VERTICES], nb, tmp[MAX_DEFECT_VERTICES],
-      nbnew, n0, n1;
-  FACE *f;
-  VERTEX *v, *vn;
-  float norm[3], dot, len;
-  DEFECT *defect;
-
-  oriented = 0;
-  MRISsaveVertexPositions(mris, TMP_VERTICES);
-  MRIScomputeMetricProperties(mris);
-  MRISsetNeighborhoodSizeAndDist(mris, 2);
-
-  /* first orient vertices */
-
-  /* mark all defective vertices */
-  for (nb = dno = 0; dno < dl->ndefects; dno++) {
-    defect = &dl->defects[dno];
-    for (n = 0; n < defect->nvertices; n++) {
-      vno = vtrans[defect->vertices[n]];
-      if (vno == Gdiag_no) {
-        DiagBreak();
-      }
-      if (vno < 0) {
-        continue;
-      }
-      mris->vertices[vno].marked = 1;
-    }
-    for (n = 0; n < defect->nborder; n++) {
-      mris->vertices[vtrans[defect->border[n]]].marked = 1;
-    }
-    memmove(blist + nb, defect->border, defect->nborder * sizeof(int));
-    nb += defect->nborder;
-  }
-
-  /* starts out as a list of border vertices and will grow inwards */
-  for (i = 0; i < nb; i++) {
-    blist[i] = vtrans[blist[i]];
-  }
-
-  do /* grow border inwards one edge length at each iteration */
-  {
-    for (nbnew = i = 0; i < nb; i++) {
-      vno = blist[i];
-      if (vno < 0) /* not in new tessellation - shouldn't happen */
-      {
-        continue;
-      }
-      v = &mris->vertices[vno];
-      if (vno == Gdiag_no || vno == 135681) {
-        DiagBreak();
-      }
-      v->nx = v->ny = v->nz = 0;
-      for (dot = 0.0, num = n = 0; n < v->vtotal; n++) {
-        vn = &mris->vertices[v->v[n]];
-
-        /* only use already oriented (or non-defective) vertices */
-        if (vn->marked) {
-          continue;
-        }
-        v->nx += vn->nx;
-        v->ny += vn->ny;
-        v->nz += vn->nz;
-        num++;
-      }
-      if (!num) /* surrounded by unoriented defective vertices */
-      {
-        tmp[nbnew++] = vno; /* so it will be processed
-   next time again */
-        continue;
-      }
-      len = sqrt(v->nx * v->nx + v->ny * v->ny + v->nz * v->nz);
-      if (FZERO(len)) {
-        len = 1.0f;
-      }
-      v->nx /= len;
-      v->ny /= len;
-      v->nz /= len;
-      v->marked = 3; /* it's proper orientation has been established */
-    }
-    for (i = 0; i < nb; i++) {
-      vno = blist[i];
-      if (vno < 0) /* not in new tessellation - shouldn't happen */
-      {
-        continue;
-      }
-      v = &mris->vertices[vno];
-      if (v->marked == 3) /* was oriented properly */
-      {
-        v->marked = 0;
-      }
-    }
-
-    /* now build new list of vertices, moving inward by one vertex */
-    for (i = 0; i < nb; i++) {
-      vno = blist[i];
-      v = &mris->vertices[vno];
-      if (vno == Gdiag_no) {
-        DiagBreak();
-      }
-      for (n = 0; n < v->vnum; n++) {
-        vn = &mris->vertices[v->v[n]];
-
-        /* only use already oriented (or non-defective) vertices */
-        if (vn->marked == 1) {
-          vn->marked = 2; /* don't add it more than once */
-          tmp[nbnew++] = v->v[n];
-        }
-      }
-    }
-    nb = nbnew;
-    if (nb > 0) {
-      memmove(blist, tmp, nb * sizeof(int));
-    }
-  } while (nb > 0);
-
-  MRISclearMarks(mris);
-
-  /* now orient faces to agree with their vertices */
-  for (fno = 0; fno < mris->nfaces; fno++) {
-    f = &mris->faces[fno];
-    if (fno == Gdiag_no) {
-      DiagBreak();
-    }
-    for (n = 0; n < VERTICES_PER_FACE; n++) {
-      mrisNormalFace(mris, fno, n, norm); /* how about vertex 2 ???? */
-      vno = f->v[n];
-      v = &mris->vertices[vno];
-      dot = norm[0] * v->nx + norm[1] * v->ny + norm[2] * v->nz;
-      if (dot < 0) /* change order of vertices in face */
-      {
-        oriented++;
-        n0 = (n == 0) ? VERTICES_PER_FACE - 1 : n - 1;
-        n1 = (n == VERTICES_PER_FACE - 1) ? 0 : n + 1;
-        vno0 = f->v[n0];
-        vno1 = f->v[n1];
-        f->v[n0] = vno1;
-        f->v[n1] = vno0;
-        mrisSetVertexFaceIndex(mris, vno0, fno);
-        mrisSetVertexFaceIndex(mris, vno1, fno);
-        if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON) {
-          fprintf(stdout, "reversing face %d orientation\n", fno);
-        }
-      }
-    }
-  }
-
-  MRIScomputeMetricProperties(mris);
-  MRISclearMarks(mris);
-
-  /* mark all vertices that have a normal which disagrees with any neighbor */
-  for (dno = 0; dno < dl->ndefects; dno++) {
-    defect = &dl->defects[dno];
-    for (i = 0; i < defect->nvertices; i++) {
-      vno = vtrans[defect->vertices[i]];
-      if (vno < 0) {
-        continue;
-      }
-      v = &mris->vertices[vno];
-      for (n = 0; n < v->vnum; n++) {
-        vn = &mris->vertices[v->v[n]];
-        dot = vn->nx * v->nx + vn->ny * v->ny + vn->nz * v->nz;
-        if (dot < 0) {
-          v->marked = 1;
-          if (!vn->marked) {
-            vn->marked = 1;
-          }
-          break;
-        }
-      }
-    }
-  }
-
-  /* go back and orient the ambiguous vertices based on the normal of
-  the defect.
-  */
-  for (dno = 0; dno < dl->ndefects; dno++) {
-    defect = &dl->defects[dno];
-    for (i = 0; i < defect->nvertices; i++) {
-      vno = vtrans[defect->vertices[i]];
-      if (vno == Gdiag_no) {
-        DiagBreak();
-      }
-      if (vno < 0) {
-        continue;
-      }
-      v = &mris->vertices[vno];
-      if (!v->marked) {
-        continue;
-      }
-      dot = defect->nx * v->nx + defect->ny * v->ny + defect->nz * v->nz;
-      if (dot < 0) {
-        v->nx *= -1;
-        v->ny *= -1;
-        v->nz *= -1;
-      }
-    }
-  }
-  MRISclearMarks(mris);
-
-  /* now orient faces to agree with their vertices */
-  for (fno = 0; fno < mris->nfaces; fno++) {
-    f = &mris->faces[fno];
-    if (fno == Gdiag_no) {
-      DiagBreak();
-    }
-    for (n = 0; n < VERTICES_PER_FACE; n++) {
-      mrisNormalFace(mris, fno, n, norm); /* how about vertex 2 ???? */
-      vno = f->v[n];
-      v = &mris->vertices[vno];
-      dot = norm[0] * v->nx + norm[1] * v->ny + norm[2] * v->nz;
-      if (dot < 0) /* change order of vertices in face */
-      {
-        oriented++;
-        m = (n + 1) >= VERTICES_PER_FACE ? 0 : n + 1;
-        vno0 = f->v[n];
-        vno1 = f->v[m];
-        f->v[n] = vno1;
-        f->v[m] = vno0;
-        mrisSetVertexFaceIndex(mris, vno0, fno);
-        mrisSetVertexFaceIndex(mris, vno1, fno);
-        if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON) {
-          fprintf(stdout, "reversing face %d orientation\n", fno);
-        }
-        mrisNormalFace(mris, fno, n, norm); /* how about
-    vertex 2 ???? */
-        dot = norm[0] * v->nx + norm[1] * v->ny + norm[2] * v->nz;
-      }
-    }
-  }
-
-  MRIScomputeMetricProperties(mris);
-
-  if (Gdiag_no >= 0) {
-    v = &mris->vertices[Gdiag_no];
-    for (dot = 0.0, n = 0; n < v->vnum; n++) {
-      vn = &mris->vertices[v->v[n]];
-
-      /* only use already oriented (or non-defective) vertices */
-      dot += v->nx * vn->nx + v->ny * vn->ny + v->nz * vn->nz;
-    }
-    if (dot < 0) {
-      DiagBreak();
-    }
-    for (dot = 0.0, n = 0; n < v->num; n++) {
-      fno = v->f[n];
-      f = &mris->faces[fno];
-
-      /* only use already oriented (or non-defective) vertices */
-      dot += v->nx * f->nx + v->ny * f->ny + v->nz * f->nz;
-    }
-    if (dot < 0) {
-      DiagBreak();
-    }
-    MRISrestoreVertexPositions(mris, ORIG_VERTICES);
-    MRIScomputeMetricProperties(mris);
-    v = &mris->vertices[Gdiag_no];
-    for (dot = 0.0, n = 0; n < v->vnum; n++) {
-      vn = &mris->vertices[v->v[n]];
-
-      /* only use already oriented (or non-defective) vertices */
-      dot += v->nx * vn->nx + v->ny * vn->ny + v->nz * vn->nz;
-    }
-    if (dot < 0) {
-      DiagBreak();
-    }
-  }
-
-#if 0
-  MRISrestoreVertexPositions(mris, TMP_VERTICES) ;
-#endif
-  return (oriented);
-#endif
-}
-#endif
 
 
 /*-----------------------------------------------------

--- a/utils/mrisurf_metricProperties.cpp
+++ b/utils/mrisurf_metricProperties.cpp
@@ -256,56 +256,6 @@ int MRISimportVertexCoords(MRIS * const mris, float * locations[3], int const wh
         v->y = locations[1][vno];
         v->z = locations[2][vno];
         break;
-#if 0
-      // These are all consequences of the orig[xyz]
-      // and hence should not be replaceable
-      //
-      case LAYERIV_VERTICES:
-        v->l4x = locations[0][vno];
-        v->l4y = locations[1][vno];
-        v->l4z = locations[2][vno];
-        break;
-      case TARGET_VERTICES:
-        v->targx = locations[0][vno];
-        v->targy = locations[1][vno];
-        v->targz = locations[2][vno];
-        break;
-      case WHITE_VERTICES:
-        v->whitex = locations[0][vno];
-        v->whitey = locations[1][vno];
-        v->whitez = locations[2][vno];
-        break;
-      case PIAL_VERTICES:
-        v->pialx = locations[0][vno];
-        v->pialy = locations[1][vno];
-        v->pialz = locations[2][vno];
-        break;
-      case INFLATED_VERTICES:
-        v->infx = locations[0][vno];
-        v->infy = locations[1][vno];
-        v->infz = locations[2][vno];
-        break;
-      case FLATTENED_VERTICES:
-        v->fx = locations[0][vno];
-        v->fy = locations[1][vno];
-        v->fz = locations[2][vno];
-        break;
-      case CANONICAL_VERTICES:
-        v->cx = locations[0][vno];
-        v->cy = locations[1][vno];
-        v->cz = locations[2][vno];
-        break;
-      case TMP2_VERTICES:
-        v->t2x = locations[0][vno];
-        v->t2y = locations[1][vno];
-        v->t2z = locations[2][vno];
-        break;
-      case TMP_VERTICES:
-        v->tx = locations[0][vno];
-        v->ty = locations[1][vno];
-        v->tz = locations[2][vno];
-        break;
-#endif
     }
   }
   return (NO_ERROR);
@@ -2272,12 +2222,7 @@ int MRIStransform(MRIS *mris, MRI *mri, TRANSFORM *transform, MRI *mri_dst)
       xv = V3_X(v2);
       yv = V3_Y(v2);
       zv = V3_Z(v2);
-#if 0
-      TransformSampleInverse
-      (transform, (float)xv, (float)yv, (float)zv, &xv2, &yv2, &zv2) ;
-#else
       GCAMsampleMorph(gcam, xv, yv, zv, &xv2, &yv2, &zv2);
-#endif
       MRIvoxelToSurfaceRAS(mri_dst, xv2, yv2, zv2, &xs, &ys, &zs);
       v->x = xs;
       v->y = ys;
@@ -3091,10 +3036,6 @@ int MRISstoreMetricProperties(MRIS *mris)
   int vno, nvertices, fno, n;
   FACE *f;
 
-#if 0
-  MRIScomputeNormals(mris);              /* update vertex areas */
-  MRIScomputeTriangleProperties(mris) ;  /* update triangle properties */
-#endif
   nvertices = mris->nvertices;
   for (vno = 0; vno < nvertices; vno++) {
     VERTEX                * const v  = &mris->vertices         [vno];
@@ -3102,7 +3043,6 @@ int MRISstoreMetricProperties(MRIS *mris)
       continue;
     }
     v->origarea = v->area;
-#if 1
     if (v->dist) {
       
       if (!v->dist_orig)
@@ -3114,7 +3054,6 @@ int MRISstoreMetricProperties(MRIS *mris)
         v->dist_orig[n] = v->dist[n];
       }
     }
-#endif
   }
   for (fno = 0; fno < mris->nfaces; fno++) {
     f = &mris->faces[fno];
@@ -3229,12 +3168,6 @@ int MRISsaveVertexPositions(MRIS *mris, int which)
     int vno;
     for (vno = 0; vno < nvertices; vno++) {
       VERTEX * const v = &mris->vertices[vno];
-  #if 0
-      if (v->ripflag)
-      {
-        continue ;
-      }
-  #endif
       switch (which) {
         case LAYERIV_VERTICES:
           v->l4x = v->x;
@@ -3312,12 +3245,6 @@ int MRISrestoreVertexPositions(MRIS *mris, int which)
   int vno;
   for (vno = 0; vno < nvertices; vno++) {
     VERTEX * const v = &mris->vertices[vno];
-#if 0
-    if (v->ripflag)
-    {
-      continue ;
-    }
-#endif
     switch (which) {
       case TARGET_VERTICES:
         v->x = v->targx;
@@ -4185,11 +4112,6 @@ double MRIScomputeVertexSpacingStats(
         case CURRENT_VERTICES:
           dist = sqrt(SQR(vn->x - v->x) + SQR(vn->y - v->y) + SQR(vn->z - v->z));
           break;
-#if 0
-      case PIAL_VERTICES:
-        dist = sqrt(SQR(vn->px - v->px) + SQR(vn->py - v->py) + SQR(vn->pz - v->pz));
-        break ;
-#endif
         case WHITE_VERTICES:
           dist = sqrt(SQR(vn->whitex - v->whitex) + SQR(vn->whitey - v->whitey) + SQR(vn->whitez - v->whitez));
           break;
@@ -5017,9 +4939,6 @@ int MRIStalairachToVertex(MRIS *mris, double xt, double yt, double zt)
   double xw, yw, zw;
 
   TransformWithMatrix(mris->TalSRASToSRAS_, xt, yt, zt, &xw, &yw, &zw);
-#if 0
-  transform_point(mris->inverse_linear_transform, xt, yt, zt, &xw, &yw, &zw) ;
-#endif
 
   vno = MRISfindClosestOriginalVertex(mris, xw, yw, zw);
 
@@ -5054,29 +4973,6 @@ float MRISdistanceToSurface(MRIS *mris, MHT *mht, float x0, float y0, float z0, 
 {
   double dist, len;
 
-#if 0
-  {
-    FACE   *f = &mris->faces[0] ;
-    VERTEX *v0, *v1, *v2 ;
-
-    v0 = &mris->vertices[f->v[0]] ;
-    v1 = &mris->vertices[f->v[1]] ;
-    v2 = &mris->vertices[f->v[2]] ;
-
-    x0 = (v1->x + v0->x) / 2 ;
-    y0 = (v1->y + v0->y) / 2 ;
-    z0 = (v1->z + v0->z) / 2 ;
-    x0 += (v2->x - x0) / 2 ;
-    y0 += (v2->y - y0) / 2 ;
-    z0 += (v2->z - z0) / 2 ;
-    x0 -= f->nx ;
-    y0 -= f->ny ;
-    z0 -= f->nz ;
-    nx = f->nx ;
-    ny = f->ny ;
-    nz = f->nz ;
-  }
-#endif
 
   len = sqrt(nx * nx + ny * ny + nz * nz);
   nx /= len;
@@ -5309,13 +5205,6 @@ double MRIScomputeAnalyticDistanceError(MRIS *mris, int which, FILE *fp)
             100.0 * pct,
             mean_error,
             measured_error);
-#if 0
-    fprintf(fp,
-            "mean orig = %2.3f mm (%%%2.2f), final = %2.3f mm (%%%2.2f)\n",
-            mean_orig_error, 100.0*pct_orig, mean_error, 100.0*pct) ;
-    fprintf(fp, "signed mean orig error = %2.3f, final mean error = %2.3f\n",
-            smean_orig_error, smean_error) ;
-#endif
   }
   VectorFree(&v1);
   VectorFree(&v2);
@@ -5475,37 +5364,6 @@ int MRISdistanceTransform(MRIS *mris, LABEL *area, int mode)
     }
   }
 
-#if 0
-  if (area->lv[0].vno == Gdiag_no)
-  {
-    FILE *fp ;
-    fp = fopen("test.log", "w") ;
-    v = &mris->vertices[16156] ;
-    fprintf(fp, "vno %d:\n", (int)(v-mris->vertices)) ;
-    for (j = 0 ; j < v->vnum ; j++)
-    {
-      //      if (mris->vertices[v->v[j]].ripflag)
-      // continue ;
-      index = index_2D_array(j, vno, max_nbrs) ;
-      fprintf(fp, "vno %d, index %d, j %d, dist %2.4f, nbr %d\n", v->v[j], index, j, v->dist[j], v->v[j]+1) ;
-      vertDists[index] = v->dist[j] ;
-      vertNbrs[index] = v->v[j]+1 ;  // nbrs is 1-based
-    }
-
-    v = &mris->vertices[16244] ;
-    fprintf(fp, "vno %d:\n", (int)(v-mris->vertices)) ;
-    for (j = 0 ; j < v->vnum ; j++)
-    {
-      //      if (mris->vertices[v->v[j]].ripflag)
-      // continue ;
-      index = index_2D_array(j, vno, max_nbrs) ;
-      fprintf(fp, "vno %d, index %d, j %d, dist %2.4f, nbr %d\n", v->v[j], index, j, v->dist[j], v->v[j]+1) ;
-      vertDists[index] = v->dist[j] ;
-      vertNbrs[index] = v->v[j]+1 ;  // nbrs is 1-based
-    }
-    fclose(fp) ;
-  }
-#endif
 
   for (vno = 0; vno < area->n_points; vno++)
     if (area->lv[vno].vno >= 0 && area->lv[vno].deleted == 0) {
@@ -8207,7 +8065,6 @@ int containsAnotherVertexOnSphere(MRIS *mris, int vno0, int vno1, int vno2, int 
 #else
 int containsAnotherVertex(
     MRIS *mris, int vno0, int vno1, int vno2, double e0[3], double e1[3], double origin[3])
-#if 1
 {
   int n, vno, i, n1;
   VERTEX *vn, *v0, *v1, *v2, *v;
@@ -8360,117 +8217,6 @@ int containsAnotherVertex(
   }
   return (0);
 }
-#else
-{
-  int n, vno, i;
-  VERTEX *v0, *v1, *v2, *v;
-  double U0[3], U1[3], U2[3], dot, L0[3], L1[3], *V0, *V1, *V2, desc[3], cx, cy, cz, Point[3], len, norm_proj[3], U[3];
-
-  /* compute planar coordinate representation of triangle vertices */
-  v0 = &mris->vertices[vno0];
-  v1 = &mris->vertices[vno1];
-  v2 = &mris->vertices[vno2];
-  cx = v0->cx - origin[0];
-  cy = v0->cy - origin[1];
-  cz = v0->cz - origin[2];
-  U0[0] = cx * e0[0] + cy * e0[1] + cz * e0[2];
-  U0[1] = cx * e1[0] + cy * e1[1] + cz * e1[2];
-  U0[2] = 0;
-  cx = v1->cx - origin[0];
-  cy = v1->cy - origin[1];
-  cz = v1->cz - origin[2];
-  U1[0] = cx * e0[0] + cy * e0[1] + cz * e0[2];
-  U1[1] = cx * e1[0] + cy * e1[1] + cz * e1[2];
-  U1[2] = 0;
-  cx = v2->cx - origin[0];
-  cy = v2->cy - origin[1];
-  cz = v2->cz - origin[2];
-  U2[0] = cx * e0[0] + cy * e0[1] + cz * e0[2];
-  U2[1] = cx * e1[0] + cy * e1[1] + cz * e1[2];
-  U2[2] = 0;
-
-  for (n = 0; n < v0->vnum; n++) {
-    vno = v0->v[n];
-    if (vno == vno1 || vno == vno2) {
-      continue;
-    }
-    v = &mris->vertices[vno];
-    cx = v->cx - origin[0];
-    cy = v->cy - origin[1];
-    cz = v->cz - origin[2];
-    U[0] = cx * e0[0] + cy * e0[1] + cz * e0[2];
-    U[1] = cx * e1[0] + cy * e1[1] + cz * e1[2];
-    U[2] = 0;
-
-    for (i = 0; i < 3; i++) {
-      /*
-      build a coordinate system with V0 as the origin, then construct
-      the vector connecting V2 with it's normal projection onto V0->V1.
-      This will be a descriminant vector for dividing the plane by the
-      V0->V1 line. A positive dot product with the
-      desc. vector indicates
-      that the point is on the positive side of the plane and therefore
-      may be contained within the triangle. Doing this for each of the
-      legs in sequence gives a test for being inside the triangle.
-      */
-
-      switch (i) {
-        default:
-        case 0:
-          V0 = U0;
-          V1 = U1;
-          V2 = U2;
-          break;
-        case 1:
-          V0 = U1;
-          V1 = U2;
-          V2 = U0;
-          break;
-        case 2:
-          V0 = U2;
-          V1 = U0;
-          V2 = U1;
-          break;
-      }
-      SUB(L0, V1, V0);
-      SUB(L1, V2, V0);
-
-      /* compute normal projection onto base of triangle */
-      len = VLEN(L0);
-      L0[0] /= len;
-      L0[1] /= len;
-      L0[2] /= len;
-      dot = DOT(L0, L1);
-      SCALAR_MUL(norm_proj, dot, L0);
-
-      /* build descriminant vector */
-      SUB(desc, L1, norm_proj);
-
-      /*
-      transform point in question into local coordinate system and build
-      the vector from the point in question to the normal
-      projection point.
-      The dot product of this vector with the
-      descrimant vector will then
-      indicate which side of the V0->V1 line the point is on.
-      */
-      SUB(Point, U, V0);
-      SUB(Point, Point, norm_proj);
-      dot = DOT(desc, Point);
-      if (dot < 0 && !DZERO(dot)) /* not in triangle */
-      {
-        break;
-      }
-    }
-    if (i >= 3) /* contained in triangle */
-    {
-      return (1);
-    }
-  }
-
-  return (0);
-}
-#endif
 #endif
 
 /*-----------------------------------------------------
@@ -8562,10 +8308,6 @@ int MRISsurfaceRASToTalairachVoxel(
   MatrixFree(&talRASToTalVol);
   MatrixFree(&SRASToTalVol);
 
-#if 0
-  transform_point(mris->linear_transform, xw, yw, zw, &xt, &yt, &zt) ;
-  MRIworldToVoxel(mri, xt, yt, zt, pxv, pyv, pzv) ;
-#endif
   return (NO_ERROR);
 }
 /*-----------------------------------------------------
@@ -8816,9 +8558,6 @@ int mrisComputePrincipalCurvatureDistributions(MRIS *mris,
   VERTEX *v;
   float k1_bin_size, k2_bin_size, min_k1, max_k1, min_k2, max_k2, bin_val, norm;
 
-#if 0
-  HISTOGRAM *h_k1_raw, *h_k2_raw ;
-#endif
 
   MRIScomputeSecondFundamentalForm(mris);
   min_k1 = min_k2 = 100000;
@@ -8845,12 +8584,10 @@ int mrisComputePrincipalCurvatureDistributions(MRIS *mris,
 //    fprintf(stderr,"     k1: (min,max)=(%f,%f)\n",min_k1,max_k1);
 //    fprintf(stderr,"     k2: (min,max)=(%f,%f)\n",min_k2,max_k2);
 
-#if 1 /* we limit the span  */
   min_k1 = MAX(-3, min_k1);
   max_k1 = MIN(3, max_k1);
   min_k2 = MAX(-3, min_k2);
   max_k2 = MIN(3, max_k2);
-#endif
 
   k1_bin_size = (max_k1 - min_k1) / h_k1->nbins;
   k2_bin_size = (max_k2 - min_k2) / h_k2->nbins;
@@ -8920,17 +8657,6 @@ int mrisComputePrincipalCurvatureDistributions(MRIS *mris,
       MRIFvox(mri_k1_k2, x, y, 0) = MRIFvox(mri_k1_k2, x, y, 0) / norm;
     }
 
-#if 0
-  h_k1_raw = HISTOcopy(h_k1, NULL) ;
-  h_k2_raw = HISTOcopy(h_k2, NULL) ;
-  // to correct the bug in HISTOcopy
-  h_k1_raw->bin_size=h_k1->bin_size;
-  h_k2_raw->bin_size=h_k2->bin_size;
-  HISTOsmooth(h_k1_raw, h_k1, 2.0) ;
-  HISTOsmooth(h_k2_raw, h_k2, 2.0) ;
-  HISTOplot(h_k1_raw, "k1r.plt") ;
-  HISTOplot(h_k2_raw, "k2r.plt") ;
-#endif
 
   if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON) {
     HISTOplot(h_k1, "k1.plt");
@@ -9073,7 +8799,6 @@ static double ashburnerTriangleEnergy(MRIS *mris, int fno, double lambda)
   int tid = 0;
 #endif
 
-#if 1
   m_x = _m_x[tid];
   m_m = _m_m[tid];
   m_x_inv = _m_x_inv[tid];
@@ -9082,7 +8807,6 @@ static double ashburnerTriangleEnergy(MRIS *mris, int fno, double lambda)
   m_U = _m_U[tid];
   m_V = _m_V[tid];
   m_evectors = _m_evectors[tid];
-#endif
 
   if (m_x == NULL) {
     m_x = MatrixAlloc(3, 3, MATRIX_REAL);
@@ -9164,15 +8888,6 @@ static double ashburnerTriangleEnergy(MRIS *mris, int fno, double lambda)
   s22 = evalues[1];
   _m_evectors[tid] = m_evectors;
 
-#if 0
-  a = *MATRIX_RELT(m_m, 1, 1) ;
-  b = *MATRIX_RELT(m_m, 1, 2) ;
-  c = *MATRIX_RELT(m_m, 2, 1) ;
-  d = *MATRIX_RELT(m_m, 2, 2) ;
-  det = a*d - b*c ;
-  s11 = ((a+d)/2) + sqrt((4*b*c + (a-d)*(a-d)) / 2);
-  s22 = ((a+d)/2) - sqrt((4*b*c + (a-d)*(a-d)) / 2);
-#endif
   if (!std::isfinite(s11)) return (log(SMALL) * log(SMALL));
 
   if (!std::isfinite(s22)) return (log(SMALL) * log(SMALL));
@@ -10336,17 +10051,6 @@ int mrisAverageSignedGradients(MRIS *mris, int num_avgs)
           dx += vn->dx;
           dy += vn->dy;
           dz += vn->dz;
-#if 0
-          if (vno == Gdiag_no)
-          {
-            float dot ;
-            dot = vn->dx*v->dx + vn->dy*v->dy + vn->dz*v->dz ;
-            if (dot < 0)
-              fprintf(stdout,
-                      "vn %d: dot = %2.3f, dx = (%2.3f, %2.3f, %2.3f)\n",
-                      v->v[vnb], dot, vn->dx, vn->dy, vn->dz) ;
-          }
-#endif
         }
         num++;
         v->tdx = dx / (float)num;
@@ -10466,63 +10170,6 @@ int MRISsmoothSurfaceNormals(MRIS *mris, int navgs)
   ------------------------------------------------------*/
 int mrisComputeBoundaryNormals(MRIS *mris)
 {
-#if 0
-  int      k,m,n;
-  VERTEX   *v;
-  float    sumx,sumy,r,nx,ny,f;
-
-  for (k=0; k<mris->nvertices; k++)
-    if ((!mris->vertices[k].ripflag)&&mris->vertices[k].border)
-    {
-      v = &mris->vertices[k];
-      n = 0;
-      sumx = 0;
-      sumy = 0;
-      for (m=0; m<v->vnum; m++)
-        if (!mris->vertices[v->v[m]].ripflag)
-        {
-          sumx += v->x-mris->vertices[v->v[m]].x;
-          sumy += v->y-mris->vertices[v->v[m]].y;
-          n++;
-        }
-      v->bnx = (n>0)?sumx/n:0;
-      v->bny = (n>0)?sumy/n:0;
-    }
-  for (k=0; k<mris->nvertices; k++)
-    if ((!mris->vertices[k].ripflag)&&mris->vertices[k].border)
-    {
-      v = &mris->vertices[k];
-      n = 0;
-      sumx = 0;
-      sumy = 0;
-      for (m=0; m<v->vnum; m++)
-        if ((!mris->vertices[v->v[m]].ripflag)&&
-            mris->vertices[v->v[m]].border)
-        {
-          nx = -(v->y-mris->vertices[v->v[m]].y);
-          ny = v->x-mris->vertices[v->v[m]].x;
-          f = nx*v->bnx+ny*v->bny;
-          /*
-            f = (f<0)?-1.0:(f>0)?1.0:0.0;
-          */
-          sumx += f*nx;
-          sumy += f*ny;
-          n++;
-        }
-      v->bnx = (n>0)?sumx/n:0;
-      v->bny = (n>0)?sumy/n:0;
-    }
-  for (k=0; k<mris->nvertices; k++)
-    if ((!mris->vertices[k].ripflag)&&mris->vertices[k].border)
-    {
-      r = sqrt(SQR(mris->vertices[k].bnx)+SQR(mris->vertices[k].bny));
-      if (r>0)
-      {
-        mris->vertices[k].bnx /= r;
-        mris->vertices[k].bny /= r;
-      }
-    }
-#endif
   return (NO_ERROR);
 }
 
@@ -10762,32 +10409,11 @@ int MRIScomputeSecondFundamentalFormThresholded(MRIS *mris, double pct_thresh)
 
       if (cond_no >= ILL_CONDITIONED) {
 
-#if 0
-        MatrixSVDEigenValues(m_Q, evalues) ;
-        vertex->k1 = k1 = evalues[0] ;
-        vertex->k2 = k2 = evalues[1] ;
-#else
         vertex->k1 = k1 = kmax;
         vertex->k2 = k2 = kmin;
-#endif
 
-#if 1
         vertex->K = k1 * k2;
         vertex->H = (k1 + k2) / 2;
-#else
-        // k1 and k2 are usually very large, resulting in
-        // K >> mris->Kmax and H >> mris->Hmax, which skews
-        // statistics on the surface. This hardlimits the
-        // K and H curvatures to not exceed the current maxima.
-        if (k1 * k2 < 0) {
-          vertex->K = mris->Kmin;
-          vertex->H = mris->Hmin;
-        }
-        else {
-          vertex->K = mris->Kmax;
-          vertex->H = mris->Hmax;
-        }
-#endif
         MatrixFree(&m_Ut);
         MatrixFree(&m_tmp2);
         MatrixFree(&m_U);
@@ -11145,11 +10771,7 @@ int MRIScomputeSecondFundamentalFormAtVertex(MRIS *mris, int vno, int *vertices,
   m_Ut = MatrixTranspose(m_U, NULL);        /* Ut */
   m_tmp2 = MatrixMultiply(m_Ut, m_U, NULL); /* Ut U */
   cond_no = MatrixConditionNumber(m_tmp2);
-#if 0
-  m_inverse = MatrixInverse(m_tmp2, NULL) ;    /* (Ut U)^-1 */
-#else
   m_inverse = MatrixSVDInverse(m_tmp2, NULL); /* (Ut U)^-1 */
-#endif
   if (!m_inverse) /* singular matrix - must be planar?? */
   {
     nbad++;
@@ -11165,14 +10787,8 @@ int MRIScomputeSecondFundamentalFormAtVertex(MRIS *mris, int vno, int *vertices,
     *MATRIX_RELT(m_Q, 2, 2) = 2 * VECTOR_ELT(v_c, 3);
 
     if (cond_no >= ILL_CONDITIONED) {
-#if 0
-      MatrixSVDEigenValues(m_Q, evalues) ;
-      vertex->k1 = k1 = evalues[0] ;
-      vertex->k2 = k2 = evalues[1] ;
-#else
       vertex->k1 = k1 = kmax;
       vertex->k2 = k2 = kmin;
-#endif
       // vertex->K = k1*k2 ; vertex->H = (k1+k2)/2 ;
       if (k1 * k2 < 0) {
         vertex->K = mris->Kmin;
@@ -11618,12 +11234,6 @@ double MRISmaxRadius(MRIS *mris)
   xlo = ylo = zlo = 10000;
   for (vno = 0; vno < mris->nvertices; vno++) {
     vertex = &mris->vertices[vno];
-#if 0
-    if (vertex->ripflag)
-    {
-      continue ;
-    }
-#endif
     x = (double)vertex->x;
     y = (double)vertex->y;
     z = (double)vertex->z;
@@ -11657,12 +11267,6 @@ double MRISmaxRadius(MRIS *mris)
   z0 = (zlo + zhi) / 2.0f;
   for (radius = 0.0, n = vno = 0; vno < mris->nvertices; vno++) {
     vertex = &mris->vertices[vno];
-#if 0
-    if (vertex->ripflag)
-    {
-      continue ;
-    }
-#endif
     n++;
     x = (double)vertex->x - x0;
     y = (double)vertex->y - y0;
@@ -11693,12 +11297,6 @@ double MRISaverageRadius(MRIS *mris)
   xlo = ylo = zlo = 10000;
   for (vno = 0; vno < mris->nvertices; vno++) {
     vertex = &mris->vertices[vno];
-#if 0
-    if (vertex->ripflag)
-    {
-      continue ;
-    }
-#endif
     x = (double)vertex->x;
     y = (double)vertex->y;
     z = (double)vertex->z;
@@ -11729,12 +11327,6 @@ double MRISaverageRadius(MRIS *mris)
   z0 = (zlo + zhi) / 2.0f;
   for (radius = 0.0, n = vno = 0; vno < mris->nvertices; vno++) {
     vertex = &mris->vertices[vno];
-#if 0
-    if (vertex->ripflag)
-    {
-      continue ;
-    }
-#endif
     n++;
     x = (double)vertex->x - x0;
     y = (double)vertex->y - y0;
@@ -11839,12 +11431,6 @@ double MRISaverageCanonicalRadius(MRIS *mris)
   xlo = ylo = zlo = 10000;
   for (vno = 0; vno < mris->nvertices; vno++) {
     vertex = &mris->vertices[vno];
-#if 0
-    if (vertex->ripflag)
-    {
-      continue ;
-    }
-#endif
     x = (double)vertex->cx;
     y = (double)vertex->cy;
     z = (double)vertex->cz;
@@ -11872,12 +11458,6 @@ double MRISaverageCanonicalRadius(MRIS *mris)
   z0 = (zlo + zhi) / 2.0f;
   for (radius = 0.0, n = vno = 0; vno < mris->nvertices; vno++) {
     vertex = &mris->vertices[vno];
-#if 0
-    if (vertex->ripflag)
-    {
-      continue ;
-    }
-#endif
     n++;
     x = (double)vertex->cx - x0;
     y = (double)vertex->cy - y0;
@@ -12088,13 +11668,6 @@ MRI *MRISbinarizeVolume(MRIS *mris, MRI_REGION *region, float resolution, float 
     kmin = kVOL(mri_distance, MIN3(z0, z1, z2)) - delta;
     kmax = kVOL(mri_distance, MAX3(z0, z1, z2)) + delta;
 
-#if 0
-    /* we don't count faces that are outside the volume - should not change the sign */ //TO BE CHECKED it some defects are close from each other!
-    if (imin > mri_distance->width-1 || jmin > mri_distance->height-1 || kmin > mri_distance->depth-1 || imax < 0 || jmax < 0 || kmax < 0)
-    {
-      continue;
-    }
-#endif
 
     imin = MAX(imin, 0);
     imax = MIN(imax, mri_distance->width - 1);
@@ -12150,15 +11723,9 @@ MRI *MRISbinarizeVolume(MRIS *mris, MRI_REGION *region, float resolution, float 
     computeVertexPseudoNormal(mris, face->v[2], n_v2, 0);
 
 /* finding distance to surface */
-#if 1
     for (k = kmin; k <= kmax; k++)
       for (j = jmin; j <= jmax; j++)
         for (i = imin; i <= imax; i++)
-#else
-    for (k = 0; k <= mri_distance->depth - 1; k++)
-      for (j = 0; j <= mri_distance->height - 1; j++)
-        for (i = 0; i <= mri_distance->width - 1; i++)
-#endif
         {
           x = xSURF(mri_distance, i);
           y = ySURF(mri_distance, j);
@@ -12268,17 +11835,6 @@ MRI *MRISbinarizeVolume(MRIS *mris, MRI_REGION *region, float resolution, float 
         }
   }
 
-#if 0  // debugging
-  for ( p = 0 ; p < mris->nvertices ; p++)
-  {
-    VERTEX *v;
-    v=&mris->vertices[p];
-
-    v->x=iVOL(mri_distance,v->x);
-    v->y=jVOL(mri_distance,v->y);
-    v->z=kVOL(mri_distance,v->z);
-  }
-#endif
 
   return mri_distance;
 }
@@ -12443,72 +11999,6 @@ static int mrisComputeCanonicalEdgeBasis(
   ------------------------------------------------------*/
 static int mrisDumpDefectiveEdge(MRIS *mris, int vno1, int vno2)
 {
-#if 0
-  FILE   *fp ;
-  char   fname[STRLEN] ;
-  int    n, m, fno, first = 1 ;
-  VERTEX *v1, *v2, *vn ;
-  double origin[3], e0[3], e1[3], cx, cy, cz, x, y ;
-  FACE   *f ;
-
-  sprintf(fname, "edge%d_%d.log", vno1, vno2) ;
-  fp = fopen(fname, "w") ;
-
-
-  v1 = &mris->vertices[vno1] ;
-  v2 = &mris->vertices[vno2] ;
-  for (n = 0 ; n < v1->vnum ; n++)
-  {
-    if (v1->v[n] == vno2)
-    {
-      continue ;
-    }
-    fno = findFace(mris, vno1, vno2, v1->v[n]) ;
-    if ((fno >= 0) && vertexNeighbor(mris, vno2, v1->v[n]))
-    {
-      f = &mris->faces[fno] ;
-      if (first)
-      {
-        mrisComputeCanonicalBasis(mris, fno, origin, e0, e1) ;
-        first = 0 ;
-      }
-      fprintf(fp, "# triangle %d\n", fno) ;
-      for (m = 0 ; m < VERTICES_PER_FACE ; m++)
-      {
-        vn = &mris->vertices[f->v[m]] ;
-        cx = vn->cx-origin[0];
-        cy = vn->cy-origin[1];
-        cz = vn->cz-origin[2];
-        x = cx*e0[0] + cy*e0[1] + cz*e0[2] ;
-        y = cx*e1[0] + cy*e1[1] + cz*e1[2] ;
-        fprintf(fp, "# vertex %d\n", f->v[m]) ;
-        fprintf(fp, "%f %f\n", x, y) ;
-      }
-      vn = &mris->vertices[f->v[0]] ;
-      cx = vn->cx-origin[0];
-      cy = vn->cy-origin[1];
-      cz = vn->cz-origin[2];
-      x = cx*e0[0] + cy*e0[1] + cz*e0[2] ;
-      y = cx*e1[0] + cy*e1[1] + cz*e1[2] ;
-      fprintf(fp, "#%d\n", f->v[0]) ;
-      fprintf(fp, "%f %f\n", x, y) ;
-      fprintf(fp, "\n") ;
-    }
-  }
-  cx = v1->cx-origin[0];
-  cy = v1->cy-origin[1];
-  cz = v1->cz-origin[2];
-  x = cx*e0[0] + cy*e0[1] + cz*e0[2] ;
-  y = cx*e1[0] + cy*e1[1] + cz*e1[2] ;
-  fprintf(fp, "%f %f\n", x, y) ;
-  cx = v2->cx-origin[0];
-  cy = v2->cy-origin[1];
-  cz = v2->cz-origin[2];
-  x = cx*e0[0] + cy*e0[1] + cz*e0[2] ;
-  y = cx*e1[0] + cy*e1[1] + cz*e1[2] ;
-  fprintf(fp, "%f %f\n", x, y) ;
-  fclose(fp) ;
-#endif
   return (NO_ERROR);
 }
 
@@ -12622,56 +12112,6 @@ int mrisCheckSurface(MRIS *mris)
 
   Description
   ------------------------------------------------------*/
-#if 0
-static int
-mrisDumpTriangle(MRIS *mris, int fno)
-{
-  char   fname[STRLEN] ;
-  VERTEX *v0, *v1, *v2 ;
-  FACE   *f ;
-  FILE   *fp ;
-  double cx, cy, cz, x, y, origin[3], e0[3], e1[3] ;
-
-  mrisComputeCanonicalBasis(mris, fno, origin, e0, e1) ;
-  f = &mris->faces[fno] ;
-  sprintf(fname, "triangle%d.log", fno) ;
-  fp = fopen(fname, "w") ;
-
-  v0 = &mris->vertices[f->v[0]] ;
-  v1 = &mris->vertices[f->v[1]] ;
-  v2 = &mris->vertices[f->v[2]] ;
-  fprintf(fp, "# triangle %d, vertices %d, %d, %d\n",
-          fno, f->v[0], f->v[1], f->v[2]) ;
-
-  cx = v0->cx-origin[0];
-  cy = v0->cy-origin[1];
-  cz = v0->cz-origin[2];
-  x = cx*e0[0] + cy*e0[1] + cz*e0[2] ;
-  y = cx*e1[0] + cy*e1[1] + cz*e1[2] ;
-  fprintf(fp, "%f  %f\n", x, y) ;
-  cx = v1->cx-origin[0];
-  cy = v1->cy-origin[1];
-  cz = v1->cz-origin[2];
-  x = cx*e0[0] + cy*e0[1] + cz*e0[2] ;
-  y = cx*e1[0] + cy*e1[1] + cz*e1[2] ;
-  fprintf(fp, "%f  %f\n", x, y) ;
-  cx = v2->cx-origin[0];
-  cy = v2->cy-origin[1];
-  cz = v2->cz-origin[2];
-  x = cx*e0[0] + cy*e0[1] + cz*e0[2] ;
-  y = cx*e1[0] + cy*e1[1] + cz*e1[2] ;
-  fprintf(fp, "%f  %f\n", x, y) ;
-  cx = v0->cx-origin[0];
-  cy = v0->cy-origin[1];
-  cz = v0->cz-origin[2];
-  x = cx*e0[0] + cy*e0[1] + cz*e0[2] ;
-  y = cx*e1[0] + cy*e1[1] + cz*e1[2] ;
-  fprintf(fp, "%f  %f\n", x, y) ;
-
-  fclose(fp) ;
-  return(NO_ERROR) ;
-}
-#endif
 
 
 /*-----------------------------------------------------
@@ -13422,10 +12862,6 @@ MRI *MRIcomputeLaminarVolumeFractions(MRIS *mris, double resolution, MRI *mri_sr
   MRI *mri_layers, *mri_interior_pial, *mri_tmp;
   MATRIX *m_vox2vox;
   static MRI *mri_interior_wm = NULL;
-#if 0
-  MATRIX *m_tmp, *m_src_vox2ras, *m_layers_vox2ras, *m_trans ;
-  double trans[4] ;
-#endif
 
   MRISsaveVertexPositions(mris, TMP2_VERTICES);
 
@@ -13435,44 +12871,7 @@ MRI *MRIcomputeLaminarVolumeFractions(MRIS *mris, double resolution, MRI *mri_sr
   width = (int)ceil(mri_src->width * nvox);
   height = (int)ceil(mri_src->height * nvox);
   depth = (int)ceil(mri_src->depth * nvox);
-#if 0
-  mri_layers = MRIalloc(width, height, depth, MRI_UCHAR) ;
-  MRIsetResolution(mri_layers, resolution, resolution, resolution) ;
-  mri_layers->xstart = mri_src->xstart ; mri_layers->xend = mri_src->xend ;
-  mri_layers->ystart = mri_src->ystart ; mri_layers->yend = mri_src->yend ;
-  mri_layers->zstart = mri_src->zstart ; mri_layers->zend = mri_src->zend ;
-  mri_layers->x_r = mri_src->x_r ; mri_layers->x_a = mri_src->x_a ; mri_layers->x_s = mri_src->x_s ;
-  mri_layers->y_r = mri_src->y_r ; mri_layers->y_a = mri_src->y_a ; mri_layers->y_s = mri_src->y_s ;
-  mri_layers->z_r = mri_src->z_r ; mri_layers->z_a = mri_src->z_a ; mri_layers->z_s = mri_src->z_s ;
-  mri_layers->c_r = mri_src->c_r ; mri_layers->c_a = mri_src->c_a ; mri_layers->c_s = mri_src->c_s ;
-  MRIreInitCache(mri_layers) ; 
-  // compute vox2ras for highres by vox2vox low->high and vox2ras of low
-  m_vox2vox = MRIgetVoxelToVoxelXform(mri_src, mri_layers) ;  // v2v low->high
-  trans[0] = (nvox-1.0)/2.0 ; trans[1] = (nvox-1.0)/2.0 ; trans[2] = (nvox-1.0)/2.0 ;
-  m_trans = MatrixAllocTranslation(4, trans) ;
-  m_tmp = MatrixMultiply(m_trans, m_vox2vox, NULL) ;   // correct vox2vox low->high
-  MatrixFree(&m_vox2vox) ; m_vox2vox = MatrixInverse(m_tmp, NULL) ; 
-  if (Gdiag & DIAG_VERBOSE_ON)
-  {
-    printf("correct high->low vox2vox\n") ;
-    MatrixPrint(stdout, m_vox2vox) ;
-  }
-  m_src_vox2ras = MRIgetVoxelToRasXform(mri_src) ;  // lowres vox2ras
-  m_layers_vox2ras = MatrixMultiply(m_src_vox2ras, m_vox2vox, NULL) ;
-
-  if (Gdiag & DIAG_VERBOSE_ON)
-  {
-    printf("hires vox2ras:\n") ;
-    MatrixPrint(stdout, m_layers_vox2ras) ;
-    printf("lowres vox2ras:\n") ;
-    MatrixPrint(stdout, m_src_vox2ras) ;
-  }
-  MRIsetVoxelToRasXform(mri_layers, m_layers_vox2ras) ;
-  MatrixFree(&m_layers_vox2ras) ; MatrixFree(&m_src_vox2ras) ; MatrixFree(&m_vox2vox) ;
-  MatrixFree(&m_trans) ; MatrixFree(&m_tmp) ;
-#else
   mri_layers = MRIupsampleN(mri_src, NULL, nvox);
-#endif
 
   mri_interior_pial = MRIclone(mri_layers, NULL);
   if (mri_interior_wm == NULL) {
@@ -13677,11 +13076,6 @@ MRIS* MRISclone(MRIS const * mris_src)
     vdst->curv = vsrc->curv;
     vdstt->num = vsrct->num;
 
-#if 0
-    vdst->ox = vsrc->ox ;
-    vdst->oy = vsrc->oy ;
-    vdst->oz = vsrc->oz ;
-#endif
 
     if (vdstt->num) {
       vdstt->f = (int *)calloc(vdstt->num, sizeof(int));
@@ -13731,11 +13125,6 @@ MRIS* MRISclone(MRIS const * mris_src)
     vdst->border   = vsrc->border;
     vdst->area     = vsrc->area;
     vdst->origarea = vsrc->origarea;
-#if 0
-    vdst->oripflag = vsrc->oripflag ;
-    vdst->origripflag = vsrc->origripflag ;
-    memmove(vdst->coord, vsrc->coord, sizeof(vsrc->coord)) ;
-#endif
   }
 
   for (fno = 0; fno < mris_src->nfaces; fno++) {

--- a/utils/offset.cpp
+++ b/utils/offset.cpp
@@ -116,12 +116,7 @@ IMAGE *ImageCalculateNitShiOffset(IMAGE *Ix, IMAGE *Iy, int wsize, float mu, flo
   vsq = 0.0f; /* prevent compiler warning */
 
   whalf = (wsize - 1) / 2;
-#if 1
   c1 = c;
-#else
-  c1 = NS_FSCALE * c / (float)wsize;
-  c1 = NS_FSCALE * c;
-#endif
 
   /* create a local gaussian window */
   if (wsize != w) {
@@ -184,13 +179,11 @@ IMAGE *ImageCalculateNitShiOffset(IMAGE *Ix, IMAGE *Iy, int wsize, float mu, flo
         }
       }
 
-#if 1
       /* calculated phi(V), only needed for original NitShi algorithm */
       vsq = vx * vx + vy * vy;
 
       vx = vx * c1 / (float)sqrt((double)(mu * mu + vsq));
       vy = vy * c1 / (float)sqrt((double)(mu * mu + vsq));
-#endif
       x_plus_off = x0 - vx;
       y_plus_off = y0 - vy;
       if (x_plus_off < 0)
@@ -294,20 +287,9 @@ IMAGE *ImageNormalizeOffsetDistances(IMAGE *Isrc, IMAGE *Idst, int maxsteps)
               offset.
 ----------------------------------------------------------------------*/
 
-#if 0
-static float avg[] =
-  {
-    1.0f/9.0f, 1.0f/9.0f, 1.0f/9.0f,
-    1.0f/9.0f, 1.0f/9.0f, 1.0f/9.0f,
-    1.0f/9.0f, 1.0f/9.0f, 1.0f/9.0f
-  } ;
-#endif
 
 IMAGE *ImageSmoothOffsets(IMAGE *Isrc, IMAGE *Idst, int wsize)
 {
-#if 0
-  ImageConvolve3x3(Isrc, avg, Idst) ;
-#else
   float *src_xpix, *src_ypix, *dst_xpix, *dst_ypix, slope, dx, dy, f, xf, yf, *wdx, *wdy, *wphase, *wmag, dist, mag;
   int x0, y0, rows, cols, x = 0, y, delta, i, whalf, *wx, *wy;
 
@@ -409,20 +391,6 @@ neighbor's diirection is not bracketed by them, then modify it.
       {
         dist = angleDistance(wphase[0], wphase[2]);
         if (dist < MIN_ANGLE_DIST) {
-#if 0
-          if (wx[1] == 13 && wy[1] == 57)
-          {
-            fprintf(stderr, "left: (%d, %d) | (%d, %d) | (%d, %d)\n",
-                    wx[0], wy[0], wx[1], wy[1], x0, y0) ;
-            fprintf(stderr, "phase:  %2.0f -- %2.0f ===> %2.0f\n",
-                    DEGREES(wphase[2]), DEGREES(wphase[4]),
-                    DEGREES((wphase[2]+wphase[4])/2.0f)) ;
-            fprintf(stderr,
-                    "offset: (%2.2f, %2.2f) -- (%2.2f, %2.2f) ==> (%2.2f, %2.2f)\n",
-                    wdx[2], wdy[2], wdx[4],wdy[4], (wdx[2]+wdx[4])/2.0f,
-                    (wdy[2]+wdy[4])/2.0f) ;
-          }
-#endif
 
           dx = (wdx[2] + wdx[0]) / 2.0f;
           dy = (wdy[2] + wdy[0]) / 2.0f;
@@ -443,20 +411,6 @@ neighbor's diirection is not bracketed by them, then modify it.
       {
         dist = angleDistance(wphase[4], wphase[2]);
         if (dist < MIN_ANGLE_DIST) {
-#if 0
-          if (wx[3] == 13 && wy[3] == 57)
-          {
-            fprintf(stderr, "right: (%d, %d) | (%d, %d) | (%d, %d)\n",
-                    x0, y0, wx[3], wy[3], wx[4], wy[4]) ;
-            fprintf(stderr, "phase:  %2.0f -- %2.0f ===> %2.0f\n",
-                    DEGREES(wphase[2]), DEGREES(wphase[4]),
-                    DEGREES((wphase[2]+wphase[4])/2.0f)) ;
-            fprintf(stderr,
-                    "offset: (%2.2f, %2.2f) -- (%2.2f, %2.2f) ==> (%2.2f, %2.2f)\n",
-                    wdx[2], wdy[2], wdx[4],wdy[4], (wdx[2]+wdx[4])/2.0f,
-                    (wdy[2]+wdy[4])/2.0f) ;
-          }
-#endif
 
           dx = (wdx[2] + wdx[4]) / 2.0f;
           dy = (wdy[2] + wdy[4]) / 2.0f;
@@ -481,7 +435,6 @@ neighbor's diirection is not bracketed by them, then modify it.
   free(wdy);
   free(wphase);
   free(wmag);
-#endif
   return (Idst);
 }
 /*----------------------------------------------------------------------
@@ -558,10 +511,6 @@ IMAGE *ImageOffsetMedialAxis(IMAGE *Ioffset, IMAGE *Iedge)
   else
     Iout = Iedge;
 
-#if 0
-  if (!ImageCheckSize(Ioffset, Iout, 0, 0, 1))
-    ErrorReturn(NULL,(ERROR_SIZE,"ImageOffsetMedialAxis: dst not big enough"));
-#endif
 
   /* assume everything is an edge */
   ImageClearArea(Iout, -1, -1, -1, -1, 0.0f, -1);
@@ -583,7 +532,6 @@ IMAGE *ImageOffsetMedialAxis(IMAGE *Ioffset, IMAGE *Iedge)
   }
   return (Iedge);
 }
-#if 1
 /*----------------------------------------------------------------------
             Parameters:
 
@@ -673,7 +621,6 @@ IMAGE *ImageCalculateOffsetDirection(IMAGE *Ix, IMAGE *Iy, int wsize, IMAGE *Iof
 
   return (Ioffset);
 }
-#endif
 /*----------------------------------------------------------------------
             Parameters:
 
@@ -806,11 +753,6 @@ IMAGE *ImageOffsetScale(IMAGE *Isrc, IMAGE *Idst)
     }
   }
 
-#if 0
-  ImageWrite(Ioffset, "offset1.hipl") ;
-  ImageWrite(Ix, "ix.hipl") ;
-  ImageWrite(Iy, "iy.hipl") ;
-#endif
 
   ImageCopy(Ioffset, Ioffset2);
   /*
@@ -828,13 +770,9 @@ IMAGE *ImageOffsetScale(IMAGE *Isrc, IMAGE *Idst)
       dx = *IMAGEFpix(Ix, x0, y0); /* starting gradient values */
       dy = *IMAGEFpix(Iy, x0, y0);
 
-#if 0
-      if (FZERO(ox) && (FZERO(oy)))
-#else
 #define SMALL 0.00001f
 
       if ((fabs(ox) < SMALL) && (fabs(oy) < SMALL))
-#endif
       continue;
 
       if (fabs(ox) > fabs(oy)) /* use unit steps in x direction */
@@ -875,9 +813,6 @@ IMAGE *ImageOffsetScale(IMAGE *Isrc, IMAGE *Idst)
     }
   }
 
-#if 0
-  ImageWrite(Ioffset2, "offset2.hipl") ;
-#endif
 
   /* now use the offset field to scale the image with a median filter */
   xpix = IMAGEFpix(Ioffset2, 0, 0);
@@ -904,11 +839,7 @@ IMAGE *ImageOffsetScale(IMAGE *Isrc, IMAGE *Idst)
             xc = 0;
           else if (xc >= scols)
             xc = scols - 1;
-#if 0
-          *sptr++ = *IMAGEFseq_pix(inImage, xc, yc, frame) ;
-#else
           *sptr++ = *(spix + xc);
-#endif
         }
       }
       qsort(sort_array, 3 * 3, sizeof(float), compare_sort_array);
@@ -916,18 +847,7 @@ IMAGE *ImageOffsetScale(IMAGE *Isrc, IMAGE *Idst)
     }
   }
 
-#if 0
-  ImageWrite(Idst, "scale.hipl") ;
-#endif
 
-#if 0
-  ImageFree(&Igauss) ;
-  ImageFree(&Ismooth) ;
-  ImageFree(&Ix) ;
-  ImageFree(&Iy) ;
-  ImageFree(&Ioffset) ;
-  ImageFree(&Ioffset2) ;
-#endif
 
   return (Idst);
 }
@@ -1221,13 +1141,6 @@ IMAGE *ImageOffsetMagnitude(IMAGE *Isrc, IMAGE *Idst, int maxsteps)
         }
       }
 
-#if 0
-      if (dot == 0)  /* zero of vector field, not reversal */
-      {
-        xold = x ;
-        yold = y ;
-      }
-#endif
       *dst_xpix++ = (float)(xold - x1);
       *dst_ypix++ = (float)(yold - y1);
     }
@@ -1495,378 +1408,6 @@ IMAGE *ImageOffsetDirectionMagnitude(IMAGE *Isrc, IMAGE *Ix, IMAGE *Iy, int wsiz
   return (Idst);
 }
 
-#if 0
-
-
-/* code not worth using, but worth keeping */
-
-
-
-
-
-/*----------------------------------------------------------------------
-            Parameters:
-
-           Description:
-             use a Bresenham line drawing algorithm to do search
-----------------------------------------------------------------------*/
-#define FSCALE 1000.0f
-
-IMAGE *
-ImageOffsetDirectionMagnitude(IMAGE *Isrc, IMAGE *Idst, int maxsteps)
-{
-  int  rows, cols, x, y, ax, ay, sx, sy, x1, y1, pdx, pdy, odx, ody,
-  d, xn, yn, nsteps, psteps, steps, dx, dy, i, px, py, nx, ny ;
-  float *src_xpix, *src_ypix, *dst_xpix, *dst_ypix, *oxpix, *oypix, dot ;
-
-  if (!Idst)
-    Idst = ImageAlloc(Isrc->rows, Isrc->cols,Isrc->pixel_format,
-                      Isrc->num_frame);
-
-  rows = Isrc->rows ;
-  cols = Isrc->cols ;
-
-  nsteps = psteps = dx = dy = px = py = nx = ny = 0 ; /* compiler warnings */
-
-  src_xpix = IMAGEFpix(Isrc, 0, 0) ;
-  src_ypix = IMAGEFseq_pix(Isrc, 0, 0, 1) ;
-  dst_xpix = IMAGEFpix(Idst, 0, 0) ;
-  dst_ypix = IMAGEFseq_pix(Idst, 0, 0, 1) ;
-  for (y1 = 0 ; y1 < rows ; y1++)
-  {
-    for (x1 = 0 ; x1 < cols ; x1++, src_xpix++, src_ypix++)
-    {
-      if (x1 == 24 && y1 == 66)
-        DiagBreak() ;
-
-      /* do a Bresenham algorithm do find the offset line at this point */
-      pdx = nint(*src_xpix * FSCALE) ;
-      pdy = nint(*src_ypix * FSCALE) ;
-      ax = ABS(dx) << 1 ;
-      ay = ABS(dy) << 1 ;
-
-      for (i = -1 ; i <= 1 ; i += 2)
-      {
-        dx = i*pdx ;
-        dy = i*pdy ;
-        x = x1 ;
-        y = y1 ;
-        sx = SGN(dx) ;
-        sy = SGN(dy) ;
-
-        oxpix = src_xpix ;
-        oypix = src_ypix ;
-
-        if (ax > ay)  /* x dominant */
-        {
-          d = ay - (ax >> 1) ;
-          for (steps = 0 ; steps < maxsteps ; steps++)
-          {
-            odx = i*nint(*oxpix * FSCALE) ;
-            ody = i*nint(*oypix * FSCALE) ;
-            dot = odx * dx + ody * dy ;
-            if (dot <= 0)
-              break ;
-            if (d >= 0)
-            {
-              yn = y + sy ;
-              if (yn < 0 || yn >= rows)
-                break ;
-              oxpix += (sy * cols) ;
-              oypix += (sy * cols) ;
-              d -= ax ;
-            }
-            else
-              yn = y ;
-            oxpix += sx ;
-            oypix += sx ;
-            xn = x + sx ;
-            if (xn < 0 || xn >= cols)
-              break ;
-
-            x = xn ;
-            y = yn ;
-            d += ay ;
-          }
-        }
-        else    /* y dominant */
-        {
-          d = ax - (ay >> 1) ;
-          for (steps = 0 ; steps < maxsteps ; steps++)
-          {
-            odx = i*nint(*oxpix * FSCALE) ;
-            ody = i*nint(*oypix * FSCALE) ;
-            dot = odx * dx + ody * dy ;
-            if (dot <= 0)
-              break ;
-            if (d >= 0)
-            {
-              xn = x + sx ;
-              if (xn < 0 || xn >= cols)
-                break ;
-              oxpix += sx ;
-              oypix += sx ;
-              d -= ay ;
-            }
-            else
-              xn = x ;
-            yn = y + sy ;
-            if (yn < 0 || yn >= rows)
-              break ;
-
-            x = xn ;
-            y = yn ;
-            oypix += (sy * cols) ;
-            oxpix += (sy * cols) ;
-            d += ax ;
-          }
-        }
-        if (i > 0)  /* positive search ended */
-        {
-          px = x ;
-          py = y ;
-          psteps = steps ;
-        }
-        else     /* negative search ended */
-        {
-          nx = x ;
-          ny = y ;
-          nsteps = steps ;
-        }
-      }
-
-
-      if (nsteps > psteps)
-      {
-        x = px ;
-        y = py ;
-      }
-      else
-      {
-        x = nx ;
-        y = ny ;
-      }
-      *dst_xpix++ = (float)(x - x1) ;
-      *dst_ypix++ = (float)(y - y1) ;
-    }
-  }
-
-
-  return(Idst) ;
-}
-static IMAGE *imageOffsetFlipOrientations(IMAGE *Isrc, IMAGE *Idst) ;
-
-IMAGE *
-imageOffsetFlipOrientations(IMAGE *Isrc, IMAGE *Idst)
-{
-  /* don't need this */
-  return(Idst) ;
-}
-
-IMAGE *
-ImageOffsetOrientation(IMAGE *Ix, IMAGE *Iy, int wsize, IMAGE *Iorient)
-{
-  int    x0, y0, rows, cols, x, y, whalf, xc, yc, yoff, off ;
-  float  *xpix, *ypix, dx, dy, *or_xpix, *or_ypix ;
-
-  rows = Ix->rows ;
-  cols = Ix->cols ;
-
-  if (!Iorient)
-    Iorient = ImageAlloc(rows, cols, PFFLOAT, 2) ;
-
-  if (!ImageCheckSize(Ix, Iorient, 0, 0, 2))
-  {
-    ImageFree(&Iorient) ;
-    Iorient = ImageAlloc(rows, cols, PFFLOAT, 2) ;
-  }
-
-  whalf = (wsize-1)/2 ;
-  xpix = IMAGEFpix(Ix, 0, 0) ;
-  ypix = IMAGEFpix(Iy, 0, 0) ;
-  or_xpix = IMAGEFpix(Iorient, 0, 0) ;
-  or_ypix = IMAGEFseq_pix(Iorient, 0, 0, 1) ;
-  for (y0 = 0 ; y0 < rows ; y0++)
-  {
-    for (x0 = 0 ; x0 < cols ; x0++, xpix++, ypix++)
-    {
-
-      /*
-        Now calculate the orientation for this point by averaging local gradient
-        orientation within the specified window.
-
-        x and y are in window coordinates, while xc and yc are in image
-        coordinates.
-      */
-      dx = dy = 0.0f ;
-      for (y = -whalf ; y <= whalf ; y++)
-      {
-        /* reflect across the boundary */
-        yc = y + y0 ;
-        if ((yc < 0) || (yc >= rows))
-          continue ;
-
-        yoff = y*cols ;
-        for (x = -whalf ; x <= whalf ; x++)
-        {
-          xc = x0 + x ;
-          if ((xc < 0) || (xc >= cols))
-            continue ;
-
-          off = yoff + x ;
-          dx += *(xpix+off) ;
-          dy += *(ypix+off) ;
-        }
-      }
-      if (dx < 0)  /* if in left half-plane, flip by 180 */
-      {
-        dx = -dx ;
-        dy = -dy ;
-      }
-      *or_xpix++ = dx ;
-      *or_ypix++ = dy ;
-    }
-  }
-
-  return(Iorient) ;
-}
-
-IMAGE *
-ImageSmoothOffsets(IMAGE *Isrc, IMAGE *Idst, int wsize)
-{
-  float  *src_xpix, *src_ypix, *dst_xpix, *dst_ypix, slope, dx,dy, f,
-  xf, yf, *wdx, *wdy, *weights, *wphase, *wmag, dist, phase, maxw  ;
-  int    x0, y0, rows, cols, x, y, delta, i, j, whalf ;
-
-  if (!Idst)
-    Idst = ImageAlloc(Isrc->rows, Isrc->cols,Isrc->pixel_format,
-                      Isrc->num_frame);
-
-  whalf = (wsize-1) / 2 ;
-  /*
-    allocate five windows of the size specified by the user. Two to hold
-    the offset vectors, one for the magnitude, one for the phase, and 1 for
-    the voting weight.
-  */
-  weights = (float *)calloc(wsize, sizeof(float)) ;
-  wdx = (float *)calloc(wsize, sizeof(float)) ;
-  wdy = (float *)calloc(wsize, sizeof(float)) ;
-  wphase = (float *)calloc(wsize, sizeof(float)) ;
-  wmag = (float *)calloc(wsize, sizeof(float)) ;
-
-  rows = Isrc->rows ;
-  cols = Isrc->cols ;
-
-  src_xpix = IMAGEFpix(Isrc, 0, 0) ;
-  src_ypix = IMAGEFseq_pix(Isrc, 0, 0, 1) ;
-  dst_xpix = IMAGEFpix(Idst, 0, 0) ;
-  dst_ypix = IMAGEFseq_pix(Idst, 0, 0, 1) ;
-
-  /* for each point in the image */
-  for (y0 = 0 ; y0 < rows ; y0++)
-  {
-    for (x0 = 0 ; x0 < cols ; x0++,src_xpix++,src_ypix++,dst_ypix++,dst_xpix++)
-    {
-      /* fill the offset vector array */
-      dx = *src_xpix ;
-      dy = *src_ypix ;
-
-      /* calculate orthogonal slope = -dx/dy */
-      f = dx ;
-      dx = dy ;
-      dy = -f ;
-
-      /* if orientation is too small, don't know what direction to search in */
-      if (ISSMALL(dx) && (ISSMALL(dy)))
-      {
-        *dst_xpix = dx ;
-        *dst_ypix = dy ;
-        continue ;
-      }
-      else
-        if (fabs(dx) > fabs(dy))  /* use unit steps in x direction */
-        {
-          delta = dx / fabs(dx) ;
-          slope = delta  * dy / dx ;  /* orthogonal slope */
-
-          yf = (float)y0-(float)whalf*slope    ;
-          x = x0 - whalf * delta ;
-          for (i = -whalf ; i <= whalf ; x += delta, yf += slope, i++)
-          {
-            y = nint(yf) ;
-            if (y <= 0 || y >= (rows-1) || x <= 0 || x >= (cols-1))
-              wdx[i+whalf] = wdy[i+whalf] = wmag[i+whalf]=wphase[i+whalf] = 0.0f;
-            else
-            {
-              dx = *IMAGEFpix(Isrc, x, y) ;
-              dy = *IMAGEFseq_pix(Isrc, x, y, 1) ;
-              wdx[i+whalf] = dx ;
-              wdy[i+whalf] = dy ;
-              wmag[i+whalf] = (float)hypot((double)dx, (double)dy) ;
-              wphase[i+whalf] = latan2((double)dy, (double)dx) ;
-            }
-          }
-        }
-        else                     /* use unit steps in y direction */
-        {
-          delta = dy / fabs(dy) ;
-          slope = delta * dx /dy ;          /* orthogonal slope */
-          xf = (float)x0-(float)whalf*slope ;
-          y = y0 - whalf * delta ;
-          for (i = -whalf ; i <= whalf ; y += delta, xf += slope, i++)
-          {
-            x = nint(xf) ;
-            if (y <= 0 || y >= (rows-1) || x <= 0 || x >= (cols-1))
-              wdx[i+whalf] = wdy[i+whalf] = wmag[i+whalf]=wphase[i+whalf] = 0.0f;
-            else
-            {
-              dx = *IMAGEFpix(Isrc, x, y) ;
-              dy = *IMAGEFseq_pix(Isrc, x, y, 1) ;
-              wdx[i+whalf] = dx ;
-              wdy[i+whalf] = dy ;
-              wmag[i+whalf] = (float)hypot((double)dx, (double)dy) ;
-              wphase[i+whalf] = latan2((double)dy, (double)dx) ;
-            }
-          }
-        }
-
-      /* now fill in weight array */
-      for (i = 0 ; i < wsize ; i++)
-      {
-        phase = wphase[i] ;
-        weights[i] = 0.0f ;
-        for (j = 0 ; j < wsize ; j++)
-        {
-          dist = angleDistance(phase, wphase[j]) ;
-          weights[i] += (PI - dist) * wmag[j] ;
-        }
-      }
-
-      /* find maximum weight, and use that as offset vector */
-      for (maxw = 0.0f, i = j = 0 ; i < wsize ; i++)
-      {
-        if (weights[i] > maxw)
-        {
-          maxw = weights[i] ;
-          j = i ;
-        }
-      }
-      *dst_xpix = wdx[j] ;
-      *dst_ypix = wdy[j] ;
-
-    }
-  }
-
-  free(weights) ;
-  free(wdx) ;
-  free(wdy) ;
-  free(wphase) ;
-  free(wmag) ;
-
-  return(Idst) ;
-}
-
-#endif
 
 /*----------------------------------------------------------------------
             Parameters:

--- a/utils/rbf.cpp
+++ b/utils/rbf.cpp
@@ -348,21 +348,13 @@ int RBFprint(RBF *rbf, FILE *fp)
       fprintf(fp, "class %s:\n", rbf->class_names[i]);
     else
       fprintf(fp, "class %d:\n", i);
-#if 0
-    CSprint(rbf->cs[i], stderr) ;
-#else
     cs = rbf->cs[i];
     if (!cs) continue;
     for (c = 0; c < cs->nclusters; c++) {
       cluster = cs->clusters + c;
       fprintf(fp, "cluster %d has %d observations. Center: ", c, cluster->nsamples);
       MatrixPrintTranspose(fp, cluster->v_means);
-#if 0
-      fprintf(fp, "inverse covariance matrix:\n") ;
-      MatrixPrint(fp, cluster->m_inverse) ;
-#endif
     }
-#endif
   }
   return (NO_ERROR);
 }
@@ -461,12 +453,10 @@ static int rbfComputeHiddenActivations(RBF *rbf, VECTOR *v_obs)
     total += RVECTOR_ELT(rbf->v_hidden, c + 1) =
         rbfGaussian(cluster->m_inverse, cluster->v_means, v_obs, rbf->v_z[c], cluster->norm);
   }
-#if 1
   /* normalize hidden layer activations */
   if (FZERO(total)) /* shouldn't ever happen */
     total = 1.0f;
   for (c = 0; c < rbf->nhidden; c++) RVECTOR_ELT(rbf->v_hidden, c + 1) /= total;
-#endif
 
   return (NO_ERROR);
 }
@@ -494,10 +484,6 @@ static int rbfShowClusterCenters(RBF *rbf, FILE *fp)
       fprintf(fp, "cluster %d has %d observations. Center:", c, cluster->nsamples);
 
       MatrixPrintTranspose(fp, cluster->v_means);
-#if 0
-      fprintf(fp, "inverse covariance matrix:\n") ;
-      MatrixPrint(fp, cluster->m_inverse) ;
-#endif
     }
   }
   return (NO_ERROR);
@@ -531,11 +517,6 @@ static float rbfGaussian(MATRIX *m_sigma_inverse, VECTOR *v_means, VECTOR *v_obs
   else
     val = norm * exp(val);
 
-#if 0
-  MatrixFree(&m_tmp1) ;
-  MatrixFree(&m_tmp2) ;
-  VectorFree(&v_zT) ;
-#endif
   return (val);
 }
 /*-----------------------------------------------------
@@ -667,11 +648,6 @@ static int rbfAdjustHiddenCenters(RBF *rbf, VECTOR *v_error)
        */
     VectorScalarMul(v_delta_means, momentum, v_delta_means);
     VectorAdd(v_delta_means, v_dE_dui, v_delta_means);
-#if 0
-    if (Gdiag & DIAG_WRITE && (i == 2))
-      fprintf(stderr, "moving mean by (%f, %f)\n",
-              VECTOR_ELT(v_delta_means,1), VECTOR_ELT(v_delta_means,2)) ;
-#endif
     VectorAdd(v_delta_means, v_means, v_means);
   }
 
@@ -748,33 +724,9 @@ static int rbfAdjustHiddenSpreads(RBF *rbf, VECTOR *v_error)
 ------------------------------------------------------*/
 static int rbfComputeOutputs(RBF *rbf)
 {
-#if 0
-  int    i ;
-  float  min_out, val, total ;
-#endif
 
   MatrixMultiply(rbf->v_hidden, rbf->m_wij, rbf->v_outputs);
 
-#if 0
-  /* normalize the outputs to sum to 1 and be in [0,1] */
-  min_out = RVECTOR_ELT(rbf->v_outputs, 1) ;
-  for (i = 2 ; i <= rbf->noutputs ; i++)
-  {
-    val = RVECTOR_ELT(rbf->v_outputs, i) ;
-    if (val < min_out)
-      min_out = val ;
-  }
-  for (total = 0.0f, i = 1 ; i <= rbf->noutputs ; i++)
-  {
-    val = RVECTOR_ELT(rbf->v_outputs, i) - min_out ;
-    total += val ;
-    RVECTOR_ELT(rbf->v_outputs, i) = val ;
-  }
-  if (FZERO(total))   /* should never happen */
-    total = 1.0f ;
-  for (i = 1 ; i <= rbf->noutputs ; i++)
-    RVECTOR_ELT(rbf->v_outputs, i) /= total ;
-#endif
 
   return (NO_ERROR);
 }
@@ -844,28 +796,15 @@ static float rbfTrain(RBF *rbf,
       rbf_save = RBFcopyWeights(rbf, rbf_save);
       memset(rbf->observed, 0, rbf->nobs * sizeof(unsigned char));
       for (sse = 0.0f, nobs = 0; nobs < rbf->nobs; nobs++) {
-#if 1
         do {
           obs_no = nint(randomNumber(0.0, (double)(rbf->nobs - 1)));
         } while (rbf->observed[obs_no] != 0);
-#else
-        obs_no = nobs;
-#endif
         if ((*get_observation_func)(v_obs, obs_no, parm, 0, &classnum) != NO_ERROR)
           ErrorExit(ERROR_BADPARM,
                     "rbfTrain: observation function failed to"
                     " obtain training sample # %d",
                     obs_no);
         rbf->observed[obs_no] = 1; /* mark this sample as used this epoch */
-#if 0
-        if (which & TRAIN_CENTERS)
-        {
-          fprintf(stderr, "\nepoch %d, obs %d: cluster 0 means:\n", epoch, obs_no) ;
-          MatrixPrintTranspose(stderr, rbf->clusters[0]->v_means) ;
-          fprintf(stderr, "cluster 0 inverse scatter matrix:\n") ;
-          MatrixPrint(stderr, rbf->clusters[0]->m_inverse) ;
-        }
-#endif
 
         rbfNormalizeObservation(rbf, v_obs, v_obs);
         rbfComputeHiddenActivations(rbf, v_obs);
@@ -873,19 +812,10 @@ static float rbfTrain(RBF *rbf,
         error = RBFcomputeErrors(rbf, classnum, v_error);
         sse += error;
         if (which & TRAIN_CENTERS) rbfAdjustHiddenCenters(rbf, v_error);
-#if 1
         if (which & TRAIN_SPREADS) rbfAdjustHiddenSpreads(rbf, v_error);
-#endif
         if (which & TRAIN_OUTPUTS) rbfAdjustOutputWeights(rbf, v_error);
       }
       delta_sse = sse - old_sse;
-#if 0
-      if (Gdiag & DIAG_SHOW)
-      {
-        fprintf(stderr, "wij:\n") ;
-        MatrixPrint(stderr, rbf->m_wij) ;
-      }
-#endif
       if (sse > old_sse * ERROR_RATIO) /* increased by a fair amount */
       {
         rbf->momentum = 0.0f;
@@ -1082,11 +1012,6 @@ RBF *RBFcopyWeights(RBF *rbf_src, RBF *rbf_dst)
   rbf_dst->ninputs = rbf_src->ninputs;
   rbf_dst->nhidden = rbf_src->nhidden;
   rbf_dst->nobs = rbf_src->nobs;
-#if 0
-  rbf_dst->trate = rbf_src->trate ;
-  rbf_dst->base_momentum = rbf_src->base_momentum ;
-  rbf_dst->momentum = rbf_src->momentum ;
-#endif
   rbf_dst->current_class = rbf_src->current_class;
 
   /* save output weights */
@@ -1186,16 +1111,6 @@ static int rbfCalculateOutputWeights(
     }
   }
 
-#if 0
-  {
-    FILE *fp ;
-    fp = fopen("gtg.dat", "w") ;
-    MatrixPrint(fp, m_Gt_G) ;
-    fclose(fp) ;
-    MatrixPrint(fp, m_Gt_D) ;
-    fclose(fp) ;
-  }
-#endif
 
   if (MatrixSingular(m_Gt_G)) {
     fprintf(stderr, "regularizing matrix...\n");
@@ -1208,32 +1123,6 @@ static int rbfCalculateOutputWeights(
 
   MatrixMultiply(m_Gt_G_inv, m_Gt_D, rbf->m_wij);
 
-#if 0
-  fprintf(stderr, "Gt G:\n") ;
-  MatrixPrint(stderr, m_Gt_G) ;
-  fprintf(stderr, "Gt G inverse:\n") ;
-  MatrixPrint(stderr, m_Gt_G_inv) ;
-  fprintf(stderr, "Gt D:\n") ;
-  MatrixPrint(stderr, m_Gt_D) ;
-  fprintf(stderr, "wij:\n") ;
-  MatrixPrint(stderr, rbf->m_wij) ;
-
-  {
-    FILE *fp ;
-    fp = fopen("gtg.dat", "w") ;
-    MatrixPrint(fp, m_Gt_G) ;
-    fclose(fp) ;
-    fp = fopen("gtg_inv.dat", "w") ;
-    MatrixPrint(fp, m_Gt_G_inv) ;
-    fclose(fp) ;
-    fp = fopen("gtd.dat", "w") ;
-    MatrixPrint(fp, m_Gt_D) ;
-    fclose(fp) ;
-    fp = fopen("wij.dat", "w") ;
-    MatrixPrint(fp, rbf->m_wij) ;
-    fclose(fp) ;
-  }
-#endif
 
   MatrixFree(&m_Gt_G);
   MatrixFree(&m_Gt_D);
@@ -1341,73 +1230,3 @@ RBF *RBFreadFrom(FILE *fp)
   return (rbf);
 }
 
-#if 0
-int
-RBFbuildScatterPlot(RBF *rbf, int classnum, MATRIX *m_scatter,
-                    char *training_file_name)
-{
-  static int       first = 0 ;
-  int              obs_no = 0, i, x, y, nbins, half_bins, bin_offset ;
-  VECTOR           *v_obs ;
-  float            *means, *stds, v, mean, std, z[2] ;
-  RBF              *rbf ;
-  GET_INPUT_PARMS  parms ;
-  FILE             *fp ;
-
-  nbins = m_scatter->rows ;
-  half_bins = (nbins-1)/2 ;
-  bin_offset = half_bins ;
-  if (!first)
-  {
-    first = 1 ;
-    MRICexamineTrainingSet(mric, training_file_name, SCATTER_ROUND) ;
-  }
-
-  fp = fopen(training_file_name, "r") ;
-  if (!fp)
-    ErrorReturn(ERROR_NO_FILE,
-                (ERROR_NO_FILE,
-                 "MRICbuildScatterPlot(%s): could not open file",
-                 training_file_name));
-  parms.fp = fp ;
-  parms.mric = mric ;
-  parms.round = SCATTER_ROUND ;
-
-
-  rbf = mric->classifier[SCATTER_ROUND].rbf ;
-
-  v_obs = VectorAlloc(rbf->ninputs, MATRIX_REAL) ;
-
-  /* not really a good idea to be messing with the CS internal parameters,
-     but it's much easier than the alternative, because all the other CS stuff
-     is class-specific, but the means and stds for normalizing the inputs
-     should be across all classes.
-     */
-  means = rbf->cs[0]->means ;
-  stds = rbf->cs[0]->stds ;
-
-  /* now fill in scatter plot */
-  while (mricGetClassifierInput(v_obs, obs_no++, &parms,1,&classnum) == NO_ERROR)
-  {
-    for (i = 0 ; i < rbf->ninputs ; i++)
-    {
-      mean = means[i] ;
-      std = stds[i] ;
-      v = VECTOR_ELT(v_obs, i+1) ;
-      z[i] = (v - mean) / std ;
-    }
-
-    /* map 0 to half_bins, -MAX_SIGMA*sigma to 0, MAX_SIGMA*sigma to nbins */
-    x = z[0]/MAX_SIGMA*half_bins + bin_offset ;
-    y = z[1]/MAX_SIGMA*half_bins + bin_offset ;
-    if (x < 0) x = 0 ;
-    else if (x >= nbins) x = nbins-1 ;
-    if (y < 0) y = 0 ;
-    else if (y >= nbins) y = nbins-1 ;
-    m_scatter->rptr[x][y] += 1.0f ;
-  }
-
-  VectorFree(&v_obs) ;
-  return(NO_ERROR) ;
-}
-#endif

--- a/utils/transform.cpp
+++ b/utils/transform.cpp
@@ -577,46 +577,6 @@ LINEAR_TRANSFORM_ARRAY *LTAalloc(int nxforms, MRI *mri)
 int LTAwrite(LTA *lta, const char *fname)
 {
   return (LTAwriteEx(lta, fname));
-#if 0
-
-  FILE             *fp;
-  char             *user;
-  LINEAR_TRANSFORM *lt ;
-  int              i ;
-  char             ext[STRLEN] ;
-
-  if (!stricmp(FileNameExtension(fname, ext), "XFM"))
-    return(ltaMNIwrite(lta, fname)) ;
-
-  fp = fopen(fname,"w");
-  if (fp==NULL)
-    ErrorReturn(ERROR_BADFILE,
-                (ERROR_BADFILE, "LTAwrite(%s): can't create file",fname));
-  user = getenv("USER") ;
-  if (!user)
-    user = getenv("LOGNAME") ;
-  if (!user)
-    user = "UNKNOWN" ;
-  fprintf(fp, "# transform file %s\n# created by %s on %s\n",
-          fname, user, currentDateTime().c_str()) ;
-  fprintf(fp, "type      = %d ", lta->type) ;
-  if(lta->type == LINEAR_VOX_TO_VOX) fprintf(fp, "# LINEAR_VOX_TO_VOX");
-  if(lta->type == LINEAR_RAS_TO_RAS) fprintf(fp, "# LINEAR_RAS_TO_RAS");
-  if(lta->type == REGISTER_DAT) fprintf(fp, "# REGISTER_DAT");
-  fprintf(fp, "\n");
-
-  fprintf(fp, "nxforms   = %d\n", lta->num_xforms) ;
-  for (i = 0 ; i < lta->num_xforms ; i++)
-  {
-    lt = &lta->xforms[i] ;
-    fprintf(fp, "mean      = %2.3f %2.3f %2.3f\n", lt->x0, lt->y0, lt->z0) ;
-    fprintf(fp, "sigma     = %2.3f\n", lt->sigma) ;
-    MatrixAsciiWriteInto(fp, lt->m_L) ;
-    fprintf(fp, "label     = %d\n", lt->label) ;
-  }
-  fclose(fp) ;
-  return(NO_ERROR) ;
-#endif
 }
 
 /*-----------------------------------------------------
@@ -640,34 +600,7 @@ LTA *LTAread(const char *fname)
       lta = ltaReadRegisterDat(fname, NULL, NULL);
       if (!lta) return (NULL);
 
-#if 0
-    V = MatrixAlloc(4, 4, MATRIX_REAL) ;  /* world to voxel transform */
-    W = MatrixAlloc(4, 4, MATRIX_REAL) ;  /* voxel to world transform */
-    *MATRIX_RELT(V, 1, 1) = -1 ;
-    *MATRIX_RELT(V, 1, 4) = 128 ;
-    *MATRIX_RELT(V, 2, 3) = -1 ;
-    *MATRIX_RELT(V, 2, 4) = 128 ;
-    *MATRIX_RELT(V, 3, 2) = 1 ;
-    *MATRIX_RELT(V, 3, 4) = 128 ;
-    *MATRIX_RELT(V, 4, 4) = 1 ;
-
-    *MATRIX_RELT(W, 1, 1) = -1 ;
-    *MATRIX_RELT(W, 1, 4) = 128 ;
-    *MATRIX_RELT(W, 2, 3) = 1 ;
-    *MATRIX_RELT(W, 2, 4) = -128 ;
-    *MATRIX_RELT(W, 3, 2) = -1 ;
-    *MATRIX_RELT(W, 3, 4) = 128 ;
-    *MATRIX_RELT(W, 4, 4) = 1 ;
-
-    m_tmp = MatrixMultiply(lta->xforms[0].m_L, W, NULL) ;
-    MatrixMultiply(V, m_tmp, lta->xforms[0].m_L) ;
-    MatrixFree(&V) ;
-    MatrixFree(&W) ;
-    MatrixFree(&m_tmp) ;
-    lta->type = LINEAR_VOX_TO_VOX ;
-#else
       lta->type = LINEAR_CORONAL_RAS_TO_CORONAL_RAS;
-#endif
       break;
     case MNI_TRANSFORM_TYPE:
       lta = ltaMNIread(fname);
@@ -1088,12 +1021,7 @@ MRI *LTAtransformInterp(MRI *mri_src, MRI *mri_dst, LTA *lta, int interp)
         */
         if (lta->num_xforms > 1) {
           LTAtransformAtPoint(lta, y1, y2, y3, m_L);
-#if 0
-          if (MatrixSVDInverse(m_L, m_L_inv) == NULL)
-            continue ;
-#else
           if (MatrixInverse(m_L, m_L_inv) == NULL) continue;
-#endif
         }
         MatrixMultiply(m_L_inv, v_Y, v_X);
         x1 = V3_X(v_X);
@@ -1107,10 +1035,6 @@ MRI *LTAtransformInterp(MRI *mri_src, MRI *mri_dst, LTA *lta, int interp)
           MRIsetVoxVal(mri_dst, y1, y2, y3, f, MRIgetVoxVal(mri_src, xi, yi, zi, f));
       }
     }
-#if 0
-    if (y3 > 10)
-      exit(0) ;
-#endif
   }
 
   MatrixFree(&v_X);
@@ -1321,12 +1245,7 @@ MRI *LTAinverseTransformInterp(MRI *mri_src, MRI *mri_dst, LTA *lta, int interp)
         */
         if (lta->num_xforms > 1) {
           LTAtransformAtPoint(lta, y1, y2, y3, m_L);
-#if 0
-          if (MatrixSVDInverse(m_L, m_L_inv) == NULL)
-            continue ;
-#else
           if (MatrixInverse(m_L, m_L_inv) == NULL) continue;
-#endif
         }
         MatrixMultiply(m_L_inv, v_Y, v_X);
         x1 = V3_X(v_X);
@@ -1340,10 +1259,6 @@ MRI *LTAinverseTransformInterp(MRI *mri_src, MRI *mri_dst, LTA *lta, int interp)
           MRIsetVoxVal(mri_dst, y1, y2, y3, f, MRIgetVoxVal(mri_src, xi, yi, zi, f));
       }
     }
-#if 0
-    if (y3 > 10)
-      exit(0) ;
-#endif
   }
 
   MatrixFree(&v_X);
@@ -1387,11 +1302,7 @@ MATRIX *LTAtransformAtPoint(LTA *lta, float x, float y, float z, MATRIX *m_L)
   }
 
   if (DZERO(wtotal)) /* no transforms in range??? */
-#if 0
-    MatrixIdentity(4, m_L) ;
-#else
     MatrixCopy(lta->xforms[0].m_L, m_L);
-#endif
     else /* now calculate linear combination of transforms at this point */
     {
       wmin = 0.1 / (double)lta->num_xforms;
@@ -1755,28 +1666,16 @@ int LTAworldToWorld(LTA *lta, float x, float y, float z, float *px, float *py, f
   }
   /* world to voxel */
   v_X->rptr[4][1] = 1.0f;
-#if 0
-  V3_X(v_X) = 128.0 - x ;
-  V3_Z(v_X) = (y + 128.0) ;
-  V3_Y(v_X) = (-z + 128.0) ;
-#else
   V3_X(v_X) = x;
   V3_Y(v_X) = y;
   V3_Z(v_X) = z;
-#endif
 
   LTAtransformPoint(lta, v_X, v_Y);
 
 /* voxel to world */
-#if 0
-  *px = 128.0 - V3_X(v_Y) ;
-  *py = V3_Z(v_Y)  - 128.0 ;
-  *pz = -(V3_Y(v_Y) - 128.0) ;
-#else
   *px = V3_X(v_Y);
   *py = V3_Y(v_Y);
   *pz = V3_Z(v_Y);
-#endif
 
   return (NO_ERROR);
 }
@@ -2268,11 +2167,6 @@ int TransformSample(TRANSFORM *transform, float xv, float yv, float zv, float *p
     yt = V3_Y(v_canon);
     zt = V3_Z(v_canon);
 
-#if 0
-    if (xt < 0) xt = 0;
-    if (yt < 0) yt = 0;
-    if (zt < 0) zt = 0;
-#endif
   }
   *px = xt;
   *py = yt;
@@ -2491,12 +2385,7 @@ int TransformSampleInverse(TRANSFORM *transform, int xv, int yv, int zv, float *
     V3_X(v_canon) = (float)xv;
     V3_Y(v_canon) = (float)yv;
     V3_Z(v_canon) = (float)zv;
-#if 0
-    MatrixInverse(lta->xforms[0].m_L, m_L_inv) ;
-    MatrixMultiply(m_L_inv, v_canon, v_input) ;
-#else
     MatrixMultiply(lta->inv_xforms[0].m_L, v_canon, v_input);
-#endif
     xt = V3_X(v_input);
     yt = V3_Y(v_input);
     zt = V3_Z(v_input);
@@ -2548,12 +2437,7 @@ int TransformSampleInverseFloat(const TRANSFORM *transform, float xv, float yv,
     V3_X(v_canon) = (float)xv;
     V3_Y(v_canon) = (float)yv;
     V3_Z(v_canon) = (float)zv;
-#if 0
-    MatrixInverse(lta->xforms[0].m_L, m_L_inv) ;
-    MatrixMultiply(m_L_inv, v_canon, v_input) ;
-#else
     MatrixMultiply(lta->inv_xforms[0].m_L, v_canon, v_input);
-#endif
     *px = V3_X(v_input);
     *py = V3_Y(v_input);
     *pz = V3_Z(v_input);
@@ -2649,16 +2533,6 @@ int TransformInvert(TRANSFORM *transform, MRI *mri)
     default:
       lta = (LTA *)transform->xform;
       LTAfillInverse(lta);
-#if 0
-    if (MatrixInverse(lta->xforms[0].m_L, lta->inv_xforms[0].m_L) == NULL)
-      ErrorExit(ERROR_BADPARM, "TransformInvert: xform noninvertible") ;
-    memmove(&lta->inv_xforms[0].src,
-            &lta->xforms[0].dst,
-            sizeof(lta->xforms[0].dst)) ;
-    memmove(&lta->inv_xforms[0].dst,
-            &lta->xforms[0].src,
-            sizeof(lta->xforms[0].dst)) ;
-#endif
       break;
     case MORPH_3D_TYPE:
       if (!mri) return (NO_ERROR);
@@ -3182,9 +3056,6 @@ LTA *LTAreadExType(const char *fname, int type)
 {
   char fname_no_path[STRLEN];
   LTA *lta = NULL;
-#if 0
-  MATRIX *V, *W, *m_tmp;
-#endif
 
   FileNameOnly(fname, fname_no_path);
   // firstly, check for filename 'identify.nofile', which does not exist
@@ -3211,37 +3082,10 @@ LTA *LTAreadExType(const char *fname, int type)
       lta = ltaReadRegisterDat((char *)fname, NULL, NULL);
       if (!lta) return (NULL);
 
-#if 0
-    V = MatrixAlloc(4, 4, MATRIX_REAL) ;  /* world to voxel transform */
-    W = MatrixAlloc(4, 4, MATRIX_REAL) ;  /* voxel to world transform */
-    *MATRIX_RELT(V, 1, 1) = -1 ;
-    *MATRIX_RELT(V, 1, 4) = 128 ;
-    *MATRIX_RELT(V, 2, 3) = -1 ;
-    *MATRIX_RELT(V, 2, 4) = 128 ;
-    *MATRIX_RELT(V, 3, 2) = 1 ;
-    *MATRIX_RELT(V, 3, 4) = 128 ;
-    *MATRIX_RELT(V, 4, 4) = 1 ;
-
-    *MATRIX_RELT(W, 1, 1) = -1 ;
-    *MATRIX_RELT(W, 1, 4) = 128 ;
-    *MATRIX_RELT(W, 2, 3) = 1 ;
-    *MATRIX_RELT(W, 2, 4) = -128 ;
-    *MATRIX_RELT(W, 3, 2) = -1 ;
-    *MATRIX_RELT(W, 3, 4) = 128 ;
-    *MATRIX_RELT(W, 4, 4) = 1 ;
-
-    m_tmp = MatrixMultiply(lta->xforms[0].m_L, W, NULL) ;
-    MatrixMultiply(V, m_tmp, lta->xforms[0].m_L) ;
-    MatrixFree(&V) ;
-    MatrixFree(&W) ;
-    MatrixFree(&m_tmp) ;
-    lta->type = LINEAR_VOX_TO_VOX ;
-#else
 // (mr) I dont think CORONAL_RAS_TO_CORONAL_RAS is the same here,
 // it did not work for me so I changed it to the REGISTER_DAT
 // if you change it back, make sure lta_convert does not break
 // lta->type = LINEAR_CORONAL_RAS_TO_CORONAL_RAS ;
-#endif
       break;
 
     case MNI_TRANSFORM_TYPE:


### PR DESCRIPTION
Continued updates for gcc8. Mainly continued transformations of `sprintf()` to `snprintf()` with a conversion to catch-by-reference in an exception handler to provide a little variety. Also several files processed for `#if 0` blocks.