### PR TITLE
Updates for gcc8

### DIFF
--- a/fem_elastic/morph.cpp
+++ b/fem_elastic/morph.cpp
@@ -188,6 +188,7 @@ void DenseDisplacementField::doInput(std::istream& is)
         start[ui] = TRead<int>(ss);
       region.SetIndex(start);
     }
+    break;
     case tagSpacing:
     {
       double spacing[3];

--- a/mri_annotation2label/mri_annotation2label.cpp
+++ b/mri_annotation2label/mri_annotation2label.cpp
@@ -293,9 +293,9 @@ int main(int argc, char **argv)
       sprintf(labelfile,"%s-%03d.label",labelbase,ani);
     }
     if (outdir != NULL)  {
-      int req = snprintf(labelfile,STRLEN,"%s/%s.%s.label",outdir,hemi,
+      int req = snprintf(labelfile,1000,"%s/%s.%s.label",outdir,hemi,
 			 Surf->ct->entries[ani]->name);
-      if( req >= STRLEN ) {
+      if( req >= 1000 ) {
 	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
       }
     }

--- a/mri_annotation2label/mri_annotation2label.cpp
+++ b/mri_annotation2label/mri_annotation2label.cpp
@@ -292,8 +292,13 @@ int main(int argc, char **argv)
     if (labelbase != NULL) {
       sprintf(labelfile,"%s-%03d.label",labelbase,ani);
     }
-    if (outdir != NULL)     sprintf(labelfile,"%s/%s.%s.label",outdir,hemi,
-                                      Surf->ct->entries[ani]->name);
+    if (outdir != NULL)  {
+      int req = snprintf(labelfile,STRLEN,"%s/%s.%s.label",outdir,hemi,
+			 Surf->ct->entries[ani]->name);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
 
     printf("%3d  %5d %s\n",ani,nperannot[ani],labelfile);
     label = annotation2label(ani, Surf);

--- a/mri_aparc2aseg/mri_aparc2aseg.cpp
+++ b/mri_aparc2aseg/mri_aparc2aseg.cpp
@@ -1025,7 +1025,10 @@ int main(int argc, char **argv)
 	  {
 	    char fname[STRLEN], fonly[STRLEN] ;
 	    FileNameRemoveExtension(OutASegFile, fonly) ;
-	    sprintf(fname, "%s.%3.3d.mgz", fonly, i) ;
+	    int req = snprintf(fname, STRLEN, "%s.%3.3d.mgz", fonly, i) ;  
+	    if( req >= STRLEN ) {
+	      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	    }
 	    printf("writing iter %d to %s\n", i, fname) ;
 	    MRIwrite(ASeg, fname) ;
 	  }
@@ -1119,7 +1122,10 @@ int main(int argc, char **argv)
 	  {
 	    char fname[STRLEN], fonly[STRLEN] ;
 	    FileNameRemoveExtension(OutASegFile, fonly) ;
-	    sprintf(fname, "%s.%3.3d.mgz", fonly, i) ;
+	    int req = snprintf(fname, STRLEN, "%s.%3.3d.mgz", fonly, i) ; 
+	    if( req >= STRLEN ) {
+	      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	    }
 	    printf("writing iter %d to %s\n", i, fname) ;
 	    MRIwrite(ASeg, fname) ;
 	  }

--- a/mri_ca_label/mri_ca_label.cpp
+++ b/mri_ca_label/mri_ca_label.cpp
@@ -2577,6 +2577,9 @@ edit_hippocampus( MRI *mri_inputs, MRI *mri_labeled,
           {
           case Left_Cerebral_Cortex:
             left = 1 ;
+#if __GNUC__  >= 8
+	    [[gnu::fallthrough]];
+#endif
           case Right_Cerebral_Cortex:
             /*
               if the current label is gray,
@@ -2637,6 +2640,9 @@ edit_hippocampus( MRI *mri_inputs, MRI *mri_labeled,
         {
         case Left_Hippocampus:
           left = 1 ;
+#if __GNUC__  >= 8
+      [[gnu::fallthrough]];
+#endif
         case Right_Hippocampus:
 #define MIN_UNKNOWN 5
           for (i = 1 ; i <= MIN_UNKNOWN+3 ; i++)
@@ -2711,6 +2717,9 @@ edit_hippocampus( MRI *mri_inputs, MRI *mri_labeled,
         {
         case Left_Hippocampus:
           left = 1 ;
+#if __GNUC__  >= 8
+      [[gnu::fallthrough]];
+#endif
         case Right_Hippocampus:
           for (i = 1 ; i <= 10 ; i++)
           {
@@ -2997,6 +3006,9 @@ edit_amygdala( MRI *mri_inputs,
         {
         case Left_Amygdala:
           left = 1 ;
+#if __GNUC__  >= 8
+      [[gnu::fallthrough]];
+#endif
         case Right_Amygdala:
           for (i = 1 ; i <= 10 ; i++)
           {

--- a/mri_ca_train/mri_ca_train.cpp
+++ b/mri_ca_train/mri_ca_train.cpp
@@ -270,7 +270,10 @@ main(int argc, char *argv[])
         continue ;
       }
       // reading this subject segmentation
-      sprintf(fname, "%s/%s/mri/%s", subjects_dir, subject_name, seg_dir) ;
+      int req = snprintf(fname, STRLEN, "%s/%s/mri/%s", subjects_dir, subject_name, seg_dir) ; 
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
         fprintf(stderr, "Reading segmentation from %s...\n", fname) ;
       mri_seg = MRIread(fname) ;
@@ -290,8 +293,11 @@ main(int argc, char *argv[])
       if (wmsa_fname)
       {
         MRI *mri_wmsa ;
-        sprintf(fname, "%s/%s/mri/%s",
-                subjects_dir, subject_name, wmsa_fname) ;
+        int req = snprintf(fname, STRLEN, "%s/%s/mri/%s",
+			   subjects_dir, subject_name, wmsa_fname) ;  
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         printf("reading WMSA labels from %s...\n", fname) ;
         mri_wmsa = MRIread(fname) ;
         if (mri_wmsa == NULL)
@@ -302,8 +308,11 @@ main(int argc, char *argv[])
         if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON )
         {
           char s[STRLEN] ;
-          sprintf(s, "%s/%s/mri/seg_%s",
-                  subjects_dir, subject_name, wmsa_fname) ;
+          int req = snprintf(s, STRLEN, "%s/%s/mri/seg_%s",
+			     subjects_dir, subject_name, wmsa_fname) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           MRIwrite(mri_seg, s) ;
         }
       }
@@ -322,8 +331,11 @@ main(int argc, char *argv[])
       {
         MRI *mri_insert ;
 
-        sprintf(fname, "%s/%s/mri/%s",
-                subjects_dir, subject_name, insert_fname) ;
+        int req = snprintf(fname, STRLEN, "%s/%s/mri/%s",
+			   subjects_dir, subject_name, insert_fname) ;  
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         mri_insert = MRIread(fname) ;
         if (mri_insert == NULL)
           ErrorExit(ERROR_NOFILE,
@@ -343,13 +355,17 @@ main(int argc, char *argv[])
                       reorder it to be in the same order as 1st */
       {
         // initialize the flag array
-        for (input =0; input < ninputs; input++)
+        for (input =0; input < ninputs; input++) {
           used[input] = 0;
+	}
 
         for (input = 0 ; input < ninputs ; input++)
         {
-          sprintf(fname, "%s/%s/mri/%s",
-                  subjects_dir, subject_name, input_names[input]);
+          int req = snprintf(fname, STRLEN, "%s/%s/mri/%s",
+			     subjects_dir, subject_name, input_names[input]);    
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           mri_tmp = MRIreadInfo(fname) ;
           if (!mri_tmp)
             ErrorExit(ERROR_NOFILE,
@@ -435,8 +451,11 @@ main(int argc, char *argv[])
         // thus we cannot allow flash data training.
         ////////////////////////////////////////////////////////////
 
-        sprintf(fname, "%s/%s/mri/%s",
-                subjects_dir, subject_name,input_names[ordering[input]]);
+        int req = snprintf(fname, STRLEN, "%s/%s/mri/%s",
+			  subjects_dir, subject_name,input_names[ordering[input]]);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         if (DIAG_VERBOSE_ON)
           printf("reading co-registered input from %s...\n", fname) ;
         fprintf(stderr, "   reading input %d: %s\n", input, fname);
@@ -509,8 +528,12 @@ main(int argc, char *argv[])
         {
           MRI *mri_mask ;
 
-          sprintf(fname, "%s/%s/mri/%s",
-                  subjects_dir, subject_name, mask_fname);
+          int req = snprintf(fname, STRLEN, "%s/%s/mri/%s",
+			     subjects_dir, subject_name, mask_fname); 
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
+
           printf("reading volume %s for masking...\n", fname) ;
           mri_mask = MRIread(fname) ;
           if (!mri_mask)
@@ -543,8 +566,11 @@ main(int argc, char *argv[])
       if (xform_name)
       {
         // we read talairach.xfm which is a RAS-to-RAS
-        sprintf(fname, "%s/%s/mri/transforms/%s",
-                subjects_dir, subject_name, xform_name) ;
+        int req = snprintf(fname, STRLEN, "%s/%s/mri/transforms/%s",
+			   subjects_dir, subject_name, xform_name) ; 
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
           printf("INFO: reading transform file %s...\n", fname);
         if (!FileExists(fname))
@@ -718,7 +744,10 @@ main(int argc, char *argv[])
       printf("computing covariances for subject %s, %d of %d...\n",
              subject_name,i+1-nargs,
              nsubjects);
-      sprintf(fname, "%s/%s/mri/%s", subjects_dir, subject_name, seg_dir) ;
+      int req = snprintf(fname, STRLEN, "%s/%s/mri/%s", subjects_dir, subject_name, seg_dir) ;  
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (DIAG_VERBOSE_ON)
         printf("reading segmentation from %s...\n", fname) ;
       // seg volume
@@ -730,8 +759,11 @@ main(int argc, char *argv[])
       if (wmsa_fname)
       {
         MRI *mri_wmsa ;
-        sprintf(fname, "%s/%s/mri/%s",
-                subjects_dir, subject_name, wmsa_fname) ;
+        int req = snprintf(fname, STRLEN, "%s/%s/mri/%s",
+			   subjects_dir, subject_name, wmsa_fname) ; 
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         printf("reading WMSA labels from %s...\n", fname) ;
         mri_wmsa = MRIread(fname) ;
         if (mri_wmsa == NULL)
@@ -742,8 +774,11 @@ main(int argc, char *argv[])
         if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON )
         {
           char s[STRLEN] ;
-          sprintf(s, "%s/%s/mri/seg_%s",
-                  subjects_dir, subject_name, wmsa_fname) ;
+          int req = snprintf(s, STRLEN, "%s/%s/mri/seg_%s",
+			     subjects_dir, subject_name, wmsa_fname) ; 
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           MRIwrite(mri_seg, s) ;
         }
       }
@@ -751,8 +786,11 @@ main(int argc, char *argv[])
       {
         MRI *mri_insert ;
 
-        sprintf(fname, "%s/%s/mri/%s",
-                subjects_dir, subject_name, insert_fname) ;
+        int req = snprintf(fname, STRLEN, "%s/%s/mri/%s",
+			   subjects_dir, subject_name, insert_fname) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         mri_insert = MRIread(fname) ;
         if (mri_insert == NULL)
           ErrorExit
@@ -773,8 +811,11 @@ main(int argc, char *argv[])
       // inputs are T1, PD, .... per subject
       for (input = 0 ; input < ninputs ; input++)
       {
-        sprintf(fname, "%s/%s/mri/%s",
-                subjects_dir, subject_name,input_names[ordering[input]]);
+        int req = snprintf(fname, STRLEN, "%s/%s/mri/%s",
+			   subjects_dir, subject_name,input_names[ordering[input]]);  
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         if (DIAG_VERBOSE_ON)
           printf("reading co-registered input from %s...\n", fname) ;
         mri_tmp = MRIread(fname) ;
@@ -825,8 +866,11 @@ main(int argc, char *argv[])
         {
           MRI *mri_mask ;
 
-          sprintf(fname, "%s/%s/mri/%s",
-                  subjects_dir, subject_name, mask_fname);
+          int req = snprintf(fname, STRLEN, "%s/%s/mri/%s",
+			     subjects_dir, subject_name, mask_fname);  
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           printf("reading volume %s for masking...\n", fname) ;
           mri_mask = MRIread(fname) ;
           if (!mri_mask)
@@ -848,8 +892,11 @@ main(int argc, char *argv[])
       ///////////////////////////////////////////////////////////
       if (xform_name)
       {
-        sprintf(fname, "%s/%s/mri/transforms/%s",
-                subjects_dir, subject_name, xform_name) ;
+        int req = snprintf(fname, STRLEN, "%s/%s/mri/transforms/%s",
+			   subjects_dir, subject_name, xform_name) ; 
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
           printf("reading transform from %s...\n", fname) ;
         transform = TransformRead(fname) ;
@@ -1661,6 +1708,10 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
               errors++;
             }
             // no break (check xt)
+#if __GNUC__  >= 8
+	    [[gnu::fallthrough]];
+#endif
+
 
           case Left_Caudate:
           case Left_Amygdala:
@@ -1697,6 +1748,10 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
               errors++;
             }
             // no break (check xt)
+#if __GNUC__  >= 8
+	    [[gnu::fallthrough]];
+#endif
+
 
           case Right_Caudate:
           case Right_Amygdala:
@@ -1796,7 +1851,10 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
   if ( do_fix_badsubjs && errors)
   {
     char fname[STRLEN];
-    sprintf(fname, "%s/%s/mri/seg_fixed.mgz", subjects_dir, subject_name);
+    int req = snprintf(fname, STRLEN, "%s/%s/mri/seg_fixed.mgz", subjects_dir, subject_name);  
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("Writing corrected volume to %s\n",fname);
     MRIwrite(mri_fixed,fname);
     MRIfree(&mri_fixed);

--- a/mri_cc/mri_cc.cpp
+++ b/mri_cc/mri_cc.cpp
@@ -211,7 +211,10 @@ main(int argc, char *argv[])
 
   if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON)
   {
-    sprintf(ifname,"%s/%s/mri/cc_volume_%d.txt",data_dir,argv[1], dxi) ;
+    int req = snprintf(ifname,STRLEN,"%s/%s/mri/cc_volume_%d.txt",data_dir,argv[1], dxi) ; 
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if ((fp = fopen(ifname, "a")) == NULL)
     {
       ErrorReturn
@@ -227,7 +230,11 @@ main(int argc, char *argv[])
   {
     MRI *mri_norm ;
 
-    sprintf(ifname,"%s/%s/mri/%s",data_dir,argv[1], aseg_fname) ;
+    int req = snprintf(ifname,STRLEN, "%s/%s/mri/%s",data_dir,argv[1], aseg_fname) ;  
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+
     printf("reading aseg from %s\n", ifname);
     mri_aseg = MRIread(ifname) ;
     if (mri_aseg == NULL)
@@ -235,7 +242,10 @@ main(int argc, char *argv[])
                 Progname, ifname) ;
     if (lh_only || rh_only)
     {
-      sprintf(ofname,"%s/%s/mri/%s",data_dir,argv[1], output_fname) ;
+      int req = snprintf(ofname,STRLEN,"%s/%s/mri/%s",data_dir,argv[1], output_fname) ; 
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       fprintf(stdout, "copying aseg WITHOUT callosum to %s...\n", ofname) ;
       MRIwrite(mri_aseg, ofname) ;
       exit(0) ;
@@ -255,7 +265,10 @@ main(int argc, char *argv[])
       // need to replace the cc labels with either lh or rh wm here...
     }
 
-    sprintf(ifname,"%s/%s/mri/%s",data_dir,argv[1],norm_fname) ;
+    req = snprintf(ifname,STRLEN,"%s/%s/mri/%s",data_dir,argv[1],norm_fname) ;  
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("reading norm from %s\n", ifname);
     mri_norm = MRIread(ifname) ;
     if (mri_norm == NULL)
@@ -270,11 +283,17 @@ main(int argc, char *argv[])
   }
   else
   {
-    sprintf(ifname,"%s/%s/%s",data_dir,argv[1],wmvolume) ;
+    int req = snprintf(ifname, STRLEN, "%s/%s/%s",data_dir,argv[1],wmvolume) ;   
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("reading white matter volume from %s\n", ifname);
     mri_wm = MRIread(ifname) ;
 
-    sprintf(ifname,"%s/%s/mri/transforms/talairach.xfm",data_dir,argv[1]) ;
+    req = snprintf(ifname,STRLEN, "%s/%s/mri/transforms/talairach.xfm",data_dir,argv[1]) ;  
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     lta = LTAreadEx(ifname);
     if (lta==0)
     {
@@ -313,7 +332,10 @@ main(int argc, char *argv[])
 
     if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON)
     {
-      sprintf(ofname,"%s/%s/mri/wm_tal.mgz",data_dir,argv[1]) ;
+      int req = snprintf(ofname,STRLEN,"%s/%s/mri/wm_tal.mgz",data_dir,argv[1]) ; 
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       fprintf(stdout,
               "writing talairach transformed white matter volume to %s...\n",
               ofname) ;
@@ -325,7 +347,10 @@ main(int argc, char *argv[])
     mrot = MatrixAlloc(4, 4, MATRIX_REAL) ;
 
     //try method 2 to get the rotation matrix
-    sprintf(ifname,"%s/%s/mri/transforms/talairach.xfm",data_dir,argv[1]) ;
+    req = snprintf(ifname,STRLEN,"%s/%s/mri/transforms/talairach.xfm",data_dir,argv[1]) ; 
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     lta2 = LTAreadEx(ifname);
     mtrans=lta2->xforms[0].m_L;
     Trns_ExtractRotationMatrix (mtrans,mrot);
@@ -350,7 +375,11 @@ main(int argc, char *argv[])
 
     if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON)
     {
-      sprintf(ofname,"%s/%s/mri/wm.mgz",data_dir,argv[1]) ;
+      int req = snprintf(ofname,STRLEN,"%s/%s/mri/wm.mgz",data_dir,argv[1]) ; 
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+
       fprintf(stdout,
               "writing rotated white matter volume to %s...\n", ofname) ;
       MRIwrite(mri_cc, ofname) ;
@@ -367,7 +396,10 @@ main(int argc, char *argv[])
                          lta, mri_cc_tal);
     if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON)
     {
-      sprintf(ofname,"%s/%s/mri/cc_tal.mgz",data_dir,argv[1]) ;
+      int req = snprintf(ofname,STRLEN,"%s/%s/mri/cc_tal.mgz",data_dir,argv[1]) ;   
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       fprintf(stdout, "writing output to %s...\n", ofname) ;
       MRIwrite(mri_cc_tal, ofname) ;
     }
@@ -378,7 +410,10 @@ main(int argc, char *argv[])
     MRIfromTalairachEx(mri_cc_tal, mri_wm, lta);
     // binalize the rotated cc volume (mri_wm)
     MRIbinarize(mri_wm, mri_wm, CC_VAL/2-1, 0, 100) ;
-    sprintf(ofname,"%s/%s/mri/cc_org.mgz",data_dir,argv[1]) ;
+    req = snprintf(ofname,STRLEN,"%s/%s/mri/cc_org.mgz",data_dir,argv[1]) ;  
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stdout,
             "writing corpus callosum in original space to %s...\n",
             ofname) ;
@@ -628,7 +663,10 @@ main(int argc, char *argv[])
       }
     }
 
-    sprintf(ofname,"%s/%s/mri/%s",data_dir,argv[1], output_fname) ;
+    int req = snprintf(ofname,STRLEN,"%s/%s/mri/%s",data_dir,argv[1], output_fname) ;    
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stdout, "writing aseg with callosum to %s...\n", ofname) ;
     MRIwrite(mri_aseg, ofname) ;
   }
@@ -653,14 +691,20 @@ main(int argc, char *argv[])
 
   if (write_cc)
   {
-    sprintf(ofname,"%s/%s/mri/cc_new.mgz",data_dir,argv[1]) ;
+    int req = snprintf(ofname,STRLEN,"%s/%s/mri/cc_new.mgz",data_dir,argv[1]) ; 
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stdout, "writing corpus callosum output to %s...\n", ofname) ;
     MRIwrite(mri_cc, ofname) ;
   }
 
   if (mri_fornix && fornix)
   {
-    sprintf(ofname,"%s/%s/mri/fornix.mgz",data_dir,argv[1]) ;
+    int req = snprintf(ofname,STRLEN,"%s/%s/mri/fornix.mgz",data_dir,argv[1]) ; 
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stdout, "writing fornix to to %s...\n", ofname) ;
     MRIwrite(mri_fornix, ofname) ;
   }

--- a/mri_compile_edits/mri_compile_edits.cpp
+++ b/mri_compile_edits/mri_compile_edits.cpp
@@ -106,12 +106,19 @@ main(int argc, char *argv[])
   printf("Compiling volume edits for subject %s...\n", subject) ;
   fflush(stdout);
 
-  sprintf(mdir, "%s/%s/mri", sdir, subject) ;
+  int req = snprintf(mdir, STRLEN, "%s/%s/mri", sdir, subject) ;  
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
 
   /*
    * brain.mgz
    */
-  sprintf(fname, "%s/brain.mgz", mdir) ;
+  req = snprintf(fname, STRLEN, "%s/brain.mgz", mdir) ; 
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+  
   mri = MRIread(fname) ;
   if (mri)
   {
@@ -135,7 +142,10 @@ main(int argc, char *argv[])
   /*
    * wm.mgz
    */
-  sprintf(fname, "%s/wm.mgz", mdir) ;
+  req = snprintf(fname, STRLEN, "%s/wm.mgz", mdir) ;  
+  if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mri = MRIread(fname) ;
   if (mri)
   {
@@ -158,12 +168,19 @@ main(int argc, char *argv[])
   /*
    * brainmask.mgz
    */
-  sprintf(fname, "%s/brainmask.mgz", mdir) ;
+  req = snprintf(fname, STRLEN, "%s/brainmask.mgz", mdir) ; 
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mri = MRIread(fname) ;
   if (mri)
   {
     if(NULL == mri_edits) mri_edits = MRIclone(mri, NULL) ;
-    sprintf(fname, "%s/brainmask.auto.mgz", mdir) ;
+    int req = snprintf(fname, STRLEN, "%s/brainmask.auto.mgz", mdir) ;  
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+
     mri_bm_auto = MRIread(fname) ;
     if (mri_bm_auto)
     {
@@ -182,7 +199,10 @@ main(int argc, char *argv[])
   /*
    * brain.finalsurfs.mgz
    */
-  sprintf(fname, "%s/brain.finalsurfs.mgz", mdir) ;
+  req = snprintf(fname, STRLEN, "%s/brain.finalsurfs.mgz", mdir) ;   
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mri = MRIread(fname) ;
   if (mri)
   {
@@ -206,12 +226,18 @@ main(int argc, char *argv[])
   /*
    * aseg.mgz
    */
-  sprintf(fname, "%s/aseg.mgz", mdir) ;
+  req = snprintf(fname, STRLEN, "%s/aseg.mgz", mdir) ;  
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mri = MRIread(fname) ;
   if (mri)
   {
     if(NULL == mri_edits) mri_edits = MRIclone(mri, NULL) ;
-    sprintf(fname, "%s/aseg.auto.mgz", mdir) ;
+    int req = snprintf(fname, STRLEN, "%s/aseg.auto.mgz", mdir) ;   
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     mri_aseg_auto = MRIread(fname) ;
     if (mri_aseg_auto)
     {
@@ -318,7 +344,10 @@ main(int argc, char *argv[])
     MRIwrite(mri_edits, out_fname);
     if (mri_edits->ct)
     {
-      sprintf(fname, "%s/mri_compile_edits_LUT", mdir) ;
+      int req = snprintf(fname, STRLEN, "%s/mri_compile_edits_LUT", mdir) ; 
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("Colortable saved to %s :\n",fname);
       CTABprintASCII(mri_edits->ct,stdout);
       ctfp = fopen(fname,"w");

--- a/mri_segstats/mri_segstats.cpp
+++ b/mri_segstats/mri_segstats.cpp
@@ -261,24 +261,32 @@ int main(int argc, char **argv)
     if (talxfmfile)
     {
       // path to talairach.xfm file spec'd on the command line
-      sprintf(tmpstr,"%s",talxfmfile);
+      int req = snprintf(tmpstr,STRLEN,"%s",talxfmfile); 
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+
     }
     else
     {
-      sprintf
-      (tmpstr,
-       "%s/%s/mri/transforms/talairach.xfm",
-       SUBJECTS_DIR,
-       subject);
+      int req = snprintf(tmpstr,STRLEN,
+			 "%s/%s/mri/transforms/talairach.xfm",
+			 SUBJECTS_DIR,
+			 subject);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
     if (DoOldETIVonly)
     {
       // back-door way to get the old way of calculating etiv, for debug
-      sprintf
-      (tmpstr,
-       "%s/%s/mri/transforms/talairach_with_skull.lta",
-       SUBJECTS_DIR,
-       subject);
+      int req = snprintf(tmpstr,STRLEN,
+			 "%s/%s/mri/transforms/talairach_with_skull.lta",
+			 SUBJECTS_DIR,
+			 subject);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       etiv_scale_factor = 2150;
     }
     double determinant = 0;
@@ -316,12 +324,18 @@ int main(int argc, char **argv)
   }
 
   if(DoEuler){
-    sprintf(tmpstr,"%s/%s/surf/lh.orig.nofix",SUBJECTS_DIR,subject);
+    int req = snprintf(tmpstr,STRLEN,"%s/%s/surf/lh.orig.nofix",SUBJECTS_DIR,subject); 
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if(!fio_FileExistsReadable(tmpstr)){
       printf("Warning: cannot find %s, not computing euler number\n",tmpstr);
       DoEuler = 0;
     }
-    sprintf(tmpstr,"%s/%s/surf/rh.orig.nofix",SUBJECTS_DIR,subject);
+    req = snprintf(tmpstr,STRLEN,"%s/%s/surf/rh.orig.nofix",SUBJECTS_DIR,subject); 
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if(!fio_FileExistsReadable(tmpstr)){
       printf("Warning: cannot find %s, not computing euler number\n",tmpstr);
       DoEuler = 0;
@@ -329,7 +343,10 @@ int main(int argc, char **argv)
   }
   if(DoEuler){
     int nvertices, nfaces, nedges;
-    sprintf(tmpstr,"%s/%s/surf/lh.orig.nofix",SUBJECTS_DIR,subject);
+    int req = snprintf(tmpstr,STRLEN,"%s/%s/surf/lh.orig.nofix",SUBJECTS_DIR,subject);  
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("Computing euler number\n");
     mris = MRISread(tmpstr);
     if(mris==NULL) exit(1);
@@ -2278,14 +2295,20 @@ int CountEdits(char *subject, char *outfile)
   SUBJECTS_DIR = getenv("SUBJECTS_DIR");
   sprintf(sd,"%s/%s",SUBJECTS_DIR,subject);
 
-  sprintf(tmpstr,"%s/tmp/control.dat",sd);
+  int req = snprintf(tmpstr,STRLEN,"%s/tmp/control.dat",sd);  
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   count = 0;
   if(fio_FileExistsReadable(tmpstr)){
     pArray = MRIreadControlPoints(tmpstr, &count, &useRealRAS);
     free(pArray);
   }
 
-  sprintf(tmpstr,"%s/mri/wm.mgz",sd);
+  req = snprintf(tmpstr,STRLEN,"%s/mri/wm.mgz",sd);  
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mri = MRIread(tmpstr);
   if(mri == NULL) return(1);
   nWMErase = 0;
@@ -2301,10 +2324,16 @@ int CountEdits(char *subject, char *outfile)
   }
   MRIfree(&mri);
 
-  sprintf(tmpstr,"%s/mri/brainmask.mgz",sd);
+  req = snprintf(tmpstr,STRLEN,"%s/mri/brainmask.mgz",sd);  
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mri = MRIread(tmpstr);
   if(mri == NULL) return(1);
-  sprintf(tmpstr,"%s/mri/brainmask.auto.mgz",sd);
+  req = snprintf(tmpstr,STRLEN,"%s/mri/brainmask.auto.mgz",sd);  
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mri2 = MRIread(tmpstr);
   if(mri2 == NULL) return(1);
   nBMErase = 0;
@@ -2323,10 +2352,16 @@ int CountEdits(char *subject, char *outfile)
   MRIfree(&mri);
   MRIfree(&mri2);
 
-  sprintf(tmpstr,"%s/mri/aseg.mgz",sd);
+  req = snprintf(tmpstr,STRLEN,"%s/mri/aseg.mgz",sd);  
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mri = MRIread(tmpstr);
   if(mri == NULL) return(1);
-  sprintf(tmpstr,"%s/mri/aseg.auto.mgz",sd);
+  req = snprintf(tmpstr,STRLEN,"%s/mri/aseg.auto.mgz",sd);   
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mri2 = MRIread(tmpstr);
   if(mri2 == NULL) return(1);
   nASegChanges = 0;

--- a/mri_segstats/mri_segstats.cpp
+++ b/mri_segstats/mri_segstats.cpp
@@ -261,30 +261,30 @@ int main(int argc, char **argv)
     if (talxfmfile)
     {
       // path to talairach.xfm file spec'd on the command line
-      int req = snprintf(tmpstr,STRLEN,"%s",talxfmfile); 
-      if( req >= STRLEN ) {
+      int req = snprintf(tmpstr,1000,"%s",talxfmfile); 
+      if( req >= 1000 ) {
 	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
       }
 
     }
     else
     {
-      int req = snprintf(tmpstr,STRLEN,
+      int req = snprintf(tmpstr,1000,
 			 "%s/%s/mri/transforms/talairach.xfm",
 			 SUBJECTS_DIR,
 			 subject);
-      if( req >= STRLEN ) {
+      if( req >= 1000 ) {
 	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
       }
     }
     if (DoOldETIVonly)
     {
       // back-door way to get the old way of calculating etiv, for debug
-      int req = snprintf(tmpstr,STRLEN,
+      int req = snprintf(tmpstr,1000,
 			 "%s/%s/mri/transforms/talairach_with_skull.lta",
 			 SUBJECTS_DIR,
 			 subject);
-      if( req >= STRLEN ) {
+      if( req >= 1000 ) {
 	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
       }
       etiv_scale_factor = 2150;
@@ -324,16 +324,16 @@ int main(int argc, char **argv)
   }
 
   if(DoEuler){
-    int req = snprintf(tmpstr,STRLEN,"%s/%s/surf/lh.orig.nofix",SUBJECTS_DIR,subject); 
-    if( req >= STRLEN ) {
+    int req = snprintf(tmpstr,1000,"%s/%s/surf/lh.orig.nofix",SUBJECTS_DIR,subject); 
+    if( req >= 1000 ) {
       std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
     }
     if(!fio_FileExistsReadable(tmpstr)){
       printf("Warning: cannot find %s, not computing euler number\n",tmpstr);
       DoEuler = 0;
     }
-    req = snprintf(tmpstr,STRLEN,"%s/%s/surf/rh.orig.nofix",SUBJECTS_DIR,subject); 
-    if( req >= STRLEN ) {
+    req = snprintf(tmpstr,1000,"%s/%s/surf/rh.orig.nofix",SUBJECTS_DIR,subject); 
+    if( req >= 1000 ) {
       std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
     }
     if(!fio_FileExistsReadable(tmpstr)){
@@ -343,8 +343,8 @@ int main(int argc, char **argv)
   }
   if(DoEuler){
     int nvertices, nfaces, nedges;
-    int req = snprintf(tmpstr,STRLEN,"%s/%s/surf/lh.orig.nofix",SUBJECTS_DIR,subject);  
-    if( req >= STRLEN ) {
+    int req = snprintf(tmpstr,1000,"%s/%s/surf/lh.orig.nofix",SUBJECTS_DIR,subject);  
+    if( req >= 1000 ) {
       std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
     }
     printf("Computing euler number\n");

--- a/mris_annot_to_segmentation/mris_annot_to_segmentation.cpp
+++ b/mris_annot_to_segmentation/mris_annot_to_segmentation.cpp
@@ -89,8 +89,8 @@ main(int argc, char *argv[]) {
   if (!cp)
     ErrorExit(ERROR_BADPARM, "no subjects directory in environment.\n") ;
   strcpy (subjects_dir, cp) ;
-  int req = snprintf(surf_name,STRLEN,"%s/%s/surf/%s.%s",subjects_dir,subject_name,hemi,surface);
-  if( req >= STRLEN ) {
+  int req = snprintf(surf_name,NAME_LEN,"%s/%s/surf/%s.%s",subjects_dir,subject_name,hemi,surface);
+  if( req >= NAME_LEN ) {
     std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
   }
   fprintf (stderr, "reading %s...\n", surf_name) ;
@@ -121,8 +121,8 @@ main(int argc, char *argv[]) {
   /* Read in the T1 for this subject and change its name to the one
      they passed in. Set all values to 0. We'll use this as the
      segmentation volume. */
-  req = snprintf (mri_name,STRLEN, "%s/%s/mri/T1",subjects_dir,subject_name);
-  if( req >= STRLEN ) {
+  req = snprintf (mri_name,NAME_LEN, "%s/%s/mri/T1",subjects_dir,subject_name);
+  if( req >= NAME_LEN ) {
     std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
   }
 

--- a/mris_annot_to_segmentation/mris_annot_to_segmentation.cpp
+++ b/mris_annot_to_segmentation/mris_annot_to_segmentation.cpp
@@ -89,7 +89,10 @@ main(int argc, char *argv[]) {
   if (!cp)
     ErrorExit(ERROR_BADPARM, "no subjects directory in environment.\n") ;
   strcpy (subjects_dir, cp) ;
-  sprintf(surf_name,"%s/%s/surf/%s.%s",subjects_dir,subject_name,hemi,surface);
+  int req = snprintf(surf_name,STRLEN,"%s/%s/surf/%s.%s",subjects_dir,subject_name,hemi,surface);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fprintf (stderr, "reading %s...\n", surf_name) ;
   mris = MRISread (surf_name) ;
   if (!mris)
@@ -118,7 +121,11 @@ main(int argc, char *argv[]) {
   /* Read in the T1 for this subject and change its name to the one
      they passed in. Set all values to 0. We'll use this as the
      segmentation volume. */
-  sprintf (mri_name,"%s/%s/mri/T1",subjects_dir,subject_name);
+  req = snprintf (mri_name,STRLEN, "%s/%s/mri/T1",subjects_dir,subject_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   mri = MRIread (mri_name);
   if (!mri)
     ErrorExit(ERROR_NOFILE, "%s: could not read T1 for template volume");

--- a/mris_average_curvature/mris_average_curvature.cpp
+++ b/mris_average_curvature/mris_average_curvature.cpp
@@ -106,7 +106,10 @@ main(int argc, char *argv[]) {
   skipped = 0 ;
   for (i = 4 ; i < argc-1 ; i++) {
     fprintf(stderr, "processing subject %s...\n", argv[i]) ;
-    sprintf(fname, "%s/%s/surf/%s.%s", sdir, argv[i], hemi, surf_name) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, argv[i], hemi, surf_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     mris = MRISread(fname) ;
     if (!mris) {
       ErrorPrintf(ERROR_NOFILE, "%s: could not read surface file %s",
@@ -144,7 +147,10 @@ main(int argc, char *argv[]) {
   }
 
   if (output_surf_name) {
-    sprintf(fname, "%s/%s/surf/%s.%s", sdir,output_surf_name,ohemi,osurf);
+    int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir,output_surf_name,ohemi,osurf);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stderr, "reading output surface %s...\n", fname) ;
     if (mris)
       MRISfree(&mris) ;

--- a/mris_ca_label/mris_ca_label.cpp
+++ b/mris_ca_label/mris_ca_label.cpp
@@ -148,7 +148,10 @@ main(int argc, char *argv[])
     ErrorExit(ERROR_NOFILE, "%s: could not read classifier from %s",
               Progname, argv[4]) ;
 
-  sprintf(fname, "%s/%s/%s/%s.%s", subjects_dir,subject_name,surf_dir,hemi,orig_name);
+  int req = snprintf(fname, STRLEN, "%s/%s/%s/%s.%s", subjects_dir,subject_name,surf_dir,hemi,orig_name); 
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   if (DIAG_VERBOSE_ON)
   {
     printf("reading surface from %s...\n", fname) ;

--- a/mris_ca_train/mris_ca_train.cpp
+++ b/mris_ca_train/mris_ca_train.cpp
@@ -220,8 +220,11 @@ main(int argc, char *argv[])
       subject_name = argv[i+4] ;
       printf("processing subject %s, %d of %d...\n", subject_name,i+1,
              nsubjects);
-      sprintf(fname, "%s/%s/surf/%s.%s", subjects_dir, subject_name,
-              hemi, orig_name) ;
+      int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", subjects_dir, subject_name,
+			 hemi, orig_name) ;    
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (DIAG_VERBOSE_ON)
         printf("reading surface from %s...\n", fname) ;
       mris = MRISread(fname) ;
@@ -238,8 +241,12 @@ main(int argc, char *argv[])
         int   i ;
         VERTEX *v ;
 
-        sprintf(fname, "%s/%s/label/%s.%s", 
-                subjects_dir, subject_name, hemi, annot_name) ;
+        int req = snprintf(fname, STRLEN, "%s/%s/label/%s.%s", 
+			   subjects_dir, subject_name, hemi, annot_name) ; 
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+	
         area = LabelRead(subject_name, fname) ;
         if (area == NULL)
           ErrorExit

--- a/mris_convert/mris_convert.cpp
+++ b/mris_convert/mris_convert.cpp
@@ -259,7 +259,10 @@ main(int argc, char *argv[])
       strcpy(hemi, "lh") ;
     }
 
-    sprintf(fname, "%s/%s.orig", path, hemi) ;
+    int req = snprintf(fname, STRLEN, "%s/%s.orig", path, hemi) ;    
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     mris = MRISread(fname) ;
     if (!mris)
       ErrorExit(ERROR_NOFILE, "%s: could not read surface file %s",

--- a/mris_inflate/mris_inflate.cpp
+++ b/mris_inflate/mris_inflate.cpp
@@ -235,7 +235,11 @@ main(int argc, char *argv[])
   {
     // disable this for now
     // if (compute_sulc_mm) mrisComputeSulcInMM(mris);
-    sprintf(fname, "%s/%s.%s", path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", sulc_name) ;
+    int req = snprintf(fname, STRLEN, "%s/%s.%s",
+		       path, mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", sulc_name) ;   
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stderr, "writing sulcal depths to %s\n", fname) ;
     MRISwriteCurvature(mris, fname) ;
   }

--- a/mris_label2annot/mris_label2annot.cpp
+++ b/mris_label2annot/mris_label2annot.cpp
@@ -648,7 +648,10 @@ static void check_options(void) {
     for (n=0; n<ctab->nentries; n++) {
       if(ctab->entries[n] == NULL) continue;
       if (strlen(ctab->entries[n]->name) == 0) continue;
-      sprintf(tmpstr,"%s/%s.%s.label",labeldir,hemi,ctab->entries[n]->name);
+      int req = snprintf(tmpstr,STRLEN,"%s/%s.%s.label",labeldir,hemi,ctab->entries[n]->name); 
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if(!fio_FileExistsReadable(tmpstr)) continue;
       printf("%2d %s\n",n,tmpstr);
       LabelFiles[nlabels] = strcpyalloc(tmpstr);

--- a/mris_label2annot/mris_label2annot.cpp
+++ b/mris_label2annot/mris_label2annot.cpp
@@ -648,8 +648,8 @@ static void check_options(void) {
     for (n=0; n<ctab->nentries; n++) {
       if(ctab->entries[n] == NULL) continue;
       if (strlen(ctab->entries[n]->name) == 0) continue;
-      int req = snprintf(tmpstr,STRLEN,"%s/%s.%s.label",labeldir,hemi,ctab->entries[n]->name); 
-      if( req >= STRLEN ) {
+      int req = snprintf(tmpstr,1000,"%s/%s.%s.label",labeldir,hemi,ctab->entries[n]->name); 
+      if( req >= 1000 ) {
 	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
       }
       if(!fio_FileExistsReadable(tmpstr)) continue;

--- a/mris_make_face_parcellation/mris_make_face_parcellation.cpp
+++ b/mris_make_face_parcellation/mris_make_face_parcellation.cpp
@@ -347,8 +347,12 @@ main(int argc, char *argv[]) {
   }
   printf("parcellating hemisphere into %d units\n", mris->ct->nentries);
   strcpy (mris->ct->fname, ico_fname);
-  for (vno = 0 ; vno < mris_ico->nvertices ; vno++)
-    sprintf (mris->ct->entries[vno]->name, "%s_vertex_%d", ico_name, vno);
+  for (vno = 0 ; vno < mris_ico->nvertices ; vno++) {
+    int req = snprintf (mris->ct->entries[vno]->name, STRLEN, "%s_vertex_%d", ico_name, vno);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+  }
   // Note: there was logic here that attempted to assure that nearby patches did not 
   // have similar color, but it caused some patches to have the same color, and so
   // resolve to the same ROI. Now just uses random ctab
@@ -1030,7 +1034,11 @@ write_snapshot(MRI_SURFACE *mris, PARMS *parms, int n, MRI *mri_cmatrix)
   int         vno, parcel, frame, nframes, min_vno ;
   double      val ;
 
-  sprintf(fname, "%s.%3.3d.annot", parms->base_name, n) ;
+  int req = snprintf(fname, STRLEN, "%s.%3.3d.annot", parms->base_name, n) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   printf("writing snapshot to %s\n", fname) ;
   MRISwriteAnnotation(mris, fname) ;
 
@@ -1049,7 +1057,10 @@ write_snapshot(MRI_SURFACE *mris, PARMS *parms, int n, MRI *mri_cmatrix)
         MRIsetVoxVal(mri_timecourses, frame, 0, 0, vno, val) ;
       }
     }
-    sprintf(fname, "%s.%3.3d.mgz", parms->base_name, n) ;
+    int req = snprintf(fname, STRLEN, "%s.%3.3d.mgz", parms->base_name, n) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     MRIwrite(mri_timecourses, fname) ;
   }
   return(NO_ERROR) ;

--- a/mris_make_surfaces/mris_make_surfaces.cpp
+++ b/mris_make_surfaces/mris_make_surfaces.cpp
@@ -344,7 +344,6 @@ int main(int argc, char *argv[])
   ErrorInit(NULL, NULL, NULL) ;
   DiagInit(NULL, NULL, NULL) ;
 
-  memset(&parms, 0, sizeof(parms)) ;
   // don't let gradient use exterior information (slows things down)
   parms.fill_interior = 0 ;
   parms.projection = NO_PROJECTION ;
@@ -419,9 +418,16 @@ int main(int argc, char *argv[])
   printf("\n");
 
   fflush(stdout);
-  sprintf(fname, "%s/%s/surf/mris_make_surfaces.%s.mrisurf.c.version", sdir, sname, hemi) ;
+  int req = snprintf(fname, STRLEN, "%s/%s/surf/mris_make_surfaces.%s.mrisurf.c.version", 
+		     sdir, sname, hemi) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
 
-  sprintf(fname, "%s/%s/mri/%s", sdir, sname, filled_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, sname, filled_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   if (MGZ)
   {
     strcat(fname, ".mgz");
@@ -434,7 +440,10 @@ int main(int argc, char *argv[])
   ////////////////////////////// we can handle only conformed volumes
 //  setMRIforSurface(mri_filled);
 
-  sprintf(fname, "%s/%s/mri/%s", sdir, sname, T1_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, sname, T1_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   if (MGZ)
   {
     strcat(fname, ".mgz");
@@ -459,7 +468,10 @@ int main(int argc, char *argv[])
   }
   if (white_fname != NULL)
   {
-    sprintf(fname, "%s/%s/mri/%s", sdir, sname, white_fname) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, sname, white_fname) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (MGZ) strcat(fname, ".mgz");
     fprintf(stdout, "reading volume %s...\n", fname) ;
     mri_T1_white = MRIread(fname) ;
@@ -485,14 +497,21 @@ int main(int argc, char *argv[])
     char fname[STRLEN], ventricle_fname[STRLEN] ;
     MRI  *mri_lv, *mri_inv_lv ;
 
-    sprintf(fname, "%s/%s/mri/transforms/%s", sdir, sname,xform_fname) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/mri/transforms/%s", 
+		       sdir, sname,xform_fname) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stdout, "reading transform %s...\n", fname) ;
     m3d = MRI3DreadSmall(fname) ;
     if (!m3d)
       ErrorExit(ERROR_NOFILE, "%s: could not open transform file %s\n",
                 Progname, fname) ;
-    sprintf(ventricle_fname, "%s/average/%s_ventricle.mgz#0@mgh",
-            mdir, !stricmp(hemi, "lh") ? "left" : "right") ;
+    req = snprintf(ventricle_fname, STRLEN, "%s/average/%s_ventricle.mgz#0@mgh",
+		   mdir, !stricmp(hemi, "lh") ? "left" : "right") ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stdout,"reading ventricle representation %s...\n",
             ventricle_fname);
     mri_lv = MRIread(ventricle_fname) ;
@@ -511,14 +530,20 @@ int main(int argc, char *argv[])
     MRIfree(&mri_lv) ;
     if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON)
     {
-      sprintf(fname, "%s/%s/mri/T1_filled", sdir, sname) ;
+      int req = snprintf(fname, STRLEN, "%s/%s/mri/T1_filled", sdir, sname) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       MRIwrite(mri_T1, fname) ;
     }
   }
   if (aseg_name)
   {
     char fname[STRLEN] ;
-    sprintf(fname, "%s/%s/mri/%s", sdir, sname, aseg_name) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, sname, aseg_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (MGZ)
     {
       strcat(fname, ".mgz");
@@ -593,7 +618,10 @@ int main(int argc, char *argv[])
   }
 
   // Load in wm.mgz (or equivalent)
-  sprintf(fname, "%s/%s/mri/%s", sdir, sname, wm_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, sname, wm_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   if (MGZ) strcat(fname, ".mgz");
   fprintf(stdout, "reading volume %s...\n", fname) ;
   mri_wm = MRIread(fname) ;
@@ -636,11 +664,17 @@ int main(int argc, char *argv[])
     MRImask(mri_T1, mri_wm, mri_T1,
             WM_EDITED_ON_VAL, DEFAULT_DESIRED_WHITE_MATTER_VALUE);
     MRIsmoothMasking(mri_T1, mri_wm, mri_T1, WM_EDITED_ON_VAL, 15) ;
-    sprintf(fname, "%s/%s/mri/T1_overlay", sdir, sname) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/mri/T1_overlay", sdir, sname) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     MRIwrite(mri_T1, fname) ;
   }
 
-  sprintf(fname, "%s/%s/surf/%s.%s%s", sdir, sname, hemi, orig_name, suffix) ;
+  req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s%s", sdir, sname, hemi, orig_name, suffix) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("reading original surface position from %s...\n", fname) ;
   if(orig_white) printf("  .. but with overwrite the positions with %s...\n",orig_white) ;
   mris = MRISreadOverAlloc(fname, 1.1) ;
@@ -648,7 +682,11 @@ int main(int argc, char *argv[])
     ErrorExit(ERROR_NOFILE, "%s: could not read surface file %s", Progname, fname) ;
 
   if(AutoDetSurfName){
-    sprintf(fname, "%s/%s/surf/%s.%s%s", sdir, sname, hemi, AutoDetSurfName, suffix) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s%s", 
+		       sdir, sname, hemi, AutoDetSurfName, suffix) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("reading surface for AutoDet from %s...\n", fname) ;
     mrisAutoDet = MRISreadOverAlloc(fname, 1.1) ;
     if (!mrisAutoDet)
@@ -1197,9 +1235,17 @@ int main(int argc, char *argv[])
       MRIcopyMRIS(ValResid, mris, 1, "valbak"); // value sampled at vertex
       MRIcopyMRIS(ValResid, mris, 0, "val2bak"); // residual = sample-target
       if (getenv("FS_POSIX")) {
-        sprintf(fname,"./%s.%s.res%s%s.mgz", hemi, white_matter_name, output_suffix, suffix);
+        int req = snprintf(fname,STRLEN,"./%s.%s.res%s%s.mgz", 
+			   hemi, white_matter_name, output_suffix, suffix);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       } else {
-        sprintf(fname,"%s/%s/surf/%s.%s.res%s%s.mgz", sdir, sname, hemi, white_matter_name, output_suffix, suffix);
+        int req = snprintf(fname,STRLEN,"%s/%s/surf/%s.%s.res%s%s.mgz", 
+			   sdir, sname, hemi, white_matter_name, output_suffix, suffix);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
       printf("Saving white value residual to %s\n",fname);
       MRIwrite(ValResid,fname);
@@ -1213,9 +1259,17 @@ int main(int argc, char *argv[])
     }
     if(SaveTarget) {
       if (getenv("FS_POSIX")) {
-        sprintf(fname, "./%s.%s.target%s%s", hemi, white_matter_name, output_suffix, suffix);
+        int req = snprintf(fname, STRLEN, "./%s.%s.target%s%s",
+			   hemi, white_matter_name, output_suffix, suffix);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       } else {
-        sprintf(fname, "%s/%s/surf/%s.%s.target%s%s", sdir, sname, hemi, white_matter_name, output_suffix, suffix);
+        int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s.target%s%s",
+			   sdir, sname, hemi, white_matter_name, output_suffix, suffix);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
       printf("writing white target surface to %s...\n", fname) ;
       MRISwrite(mristarget, fname) ;
@@ -1227,9 +1281,16 @@ int main(int argc, char *argv[])
       MRISaverageVertexPositions(mris, smoothwm); // "smoothwm" is a bad name
     }
     if (getenv("FS_POSIX")) {
-      sprintf(fname,"./%s.%s%s%s", hemi, white_matter_name, output_suffix, suffix);
+      int req = snprintf(fname,STRLEN,"./%s.%s%s%s", hemi, white_matter_name, output_suffix, suffix);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     } else {
-      sprintf(fname,"%s/%s/surf/%s.%s%s%s", sdir, sname, hemi, white_matter_name, output_suffix, suffix);
+      int req = snprintf(fname,STRLEN,"%s/%s/surf/%s.%s%s%s",
+			 sdir, sname, hemi, white_matter_name, output_suffix, suffix);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
     printf("writing white surface to %s...\n", fname) ;
     MRISwrite(mris, fname) ;
@@ -1241,9 +1302,17 @@ int main(int argc, char *argv[])
       // Label cortex based on aseg (4=ndilate,4=nerode)
       LABEL *lcortex = MRIScortexLabelDECC(mris, mri_aseg, 4, 4, -1, 0) ;
       if (getenv("FS_POSIX")) {
-        sprintf(fname,"./%s.%s%s%s.label", hemi, "cortex", output_suffix, suffix);
+        int req = snprintf(fname,STRLEN,"./%s.%s%s%s.label",
+			   hemi, "cortex", output_suffix, suffix);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       } else {
-        sprintf(fname,"%s/%s/label/%s.%s%s%s.label", sdir, sname, hemi, "cortex", output_suffix, suffix);
+        int req = snprintf(fname,STRLEN,"%s/%s/label/%s.%s%s%s.label",
+			   sdir, sname, hemi, "cortex", output_suffix, suffix);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
       printf("Writing cortical label to %s\n",fname);
       LabelWrite(lcortex, fname) ;
@@ -1258,14 +1327,20 @@ int main(int argc, char *argv[])
       MRIScomputeSecondFundamentalForm(mris) ;
       MRISuseMeanCurvature(mris) ;
       MRISaverageCurvatures(mris, curvature_avgs) ;
-      sprintf(fname, "%s.curv%s%s",
-              mris->hemisphere == LEFT_HEMISPHERE?"lh":"rh", output_suffix,
-              suffix);
+      int req = snprintf(fname, STRLEN, "%s.curv%s%s",
+			 mris->hemisphere == LEFT_HEMISPHERE?"lh":"rh", output_suffix,
+			 suffix);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       fprintf(stdout, "writing smoothed curvature to %s\n", fname) ;
       MRISwriteCurvature(mris, fname) ;
-      sprintf(fname, "%s.area%s%s",
-              mris->hemisphere == LEFT_HEMISPHERE?"lh":"rh", output_suffix,
-              suffix);
+      req = snprintf(fname, STRLEN, "%s.area%s%s",
+		     mris->hemisphere == LEFT_HEMISPHERE?"lh":"rh", output_suffix,
+		     suffix);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       fprintf(stdout, "writing smoothed area to %s\n", fname) ;
       MRISwriteArea(mris, fname) ;
       MRISprintTessellationStats(mris, stderr) ;
@@ -1385,8 +1460,14 @@ int main(int argc, char *argv[])
         mri_echos[e] = NULL ;
         continue ;
       }
-      sprintf(fmt, "%s/%s/mri/%s", sdir, sname, dura_echo_name) ;
-      sprintf(fname, fmt, e) ;
+      int req = snprintf(fmt, STRLEN, "%s/%s/mri/%s", sdir, sname, dura_echo_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+      req = snprintf(fname, STRLEN, fmt, e) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       mri_echos[e] = MRIread(fname) ;
       if (mri_echos[e] == NULL)
         ErrorExit
@@ -1418,7 +1499,10 @@ int main(int argc, char *argv[])
     if (Gdiag & DIAG_WRITE)
     {
       char fname[STRLEN] ;
-      sprintf(fname, "%s_ratio.mgz", parms.base_name) ;
+      int req = snprintf(fname, STRLEN, "%s_ratio.mgz", parms.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("writing dura ratio image to %s...\n", fname) ;
       MRIwrite(mri_ratio, fname) ;
     }
@@ -1554,7 +1638,11 @@ int main(int argc, char *argv[])
 	if ( followGradients)
 	{
 		std::cout << "T2/FLAIR compute target based on gradients "<< std::endl;
-		sprintf(fname, "%s/%s/surf/%s.%s%s", sdir, sname, hemi, orig_sphere, suffix) ;
+		int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s%s",
+				   sdir, sname, hemi, orig_sphere, suffix) ;
+		if( req >= STRLEN ) {
+		  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+		}
 		printf("reading sphere position from %s...\n", fname) ;
 		//MRIS* sph = MRISread(fname);
 		//MRIStoParameterization(sph,NULL, 1,0);
@@ -1600,7 +1688,10 @@ int main(int argc, char *argv[])
 	  static int n = 0 ;
           MRISsaveVertexPositions(mris, TMP_VERTICES) ;
           MRISrestoreVertexPositions(mris, TARGET_VERTICES) ;
-          sprintf(fname, "%s.flair.target.%3.3d", parms.base_name, n++) ;
+          int req = snprintf(fname, STRLEN, "%s.flair.target.%3.3d", parms.base_name, n++) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           printf("writing surface targets to %s\n", fname) ;
           MRISwrite(mris, fname) ;
           MRISrestoreVertexPositions(mris, TMP_VERTICES) ;
@@ -1634,7 +1725,10 @@ int main(int argc, char *argv[])
           char marked_fname[STRLEN] ;
 
           MRISreadVertexPositions(mris, read_pinch_fname) ;
-          sprintf(marked_fname, "%s.marked.mgz", read_pinch_fname) ;
+          int req = snprintf(marked_fname, STRLEN, "%s.marked.mgz", read_pinch_fname) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           MRISreadMarked(mris, marked_fname) ;
           MRISsegmentMarked(mris, &labels, &nlabels, 1) ;
         }
@@ -1698,7 +1792,10 @@ int main(int argc, char *argv[])
           char fname[STRLEN] ;
           MRISsaveVertexPositions(mris, TMP_VERTICES) ;
           MRISrestoreVertexPositions(mris, TARGET_VERTICES) ;
-          sprintf(fname, "%s.T2.target.%3.3d", parms.base_name, n++) ;
+          int req = snprintf(fname, STRLEN, "%s.T2.target.%3.3d", parms.base_name, n++) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           printf("writing surface targets to %s\n", fname) ;
           MRISwrite(mris, fname) ;
           MRISrestoreVertexPositions(mris, TMP_VERTICES) ;
@@ -1826,7 +1923,10 @@ int main(int argc, char *argv[])
       }
 
       if (write_vals) {
-        sprintf(fname, "./%s-gray%2.2f.mgz", hemi, current_sigma) ;
+        int req = snprintf(fname, STRLEN, "./%s-gray%2.2f.mgz", hemi, current_sigma) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         MRISwriteValues(mris, fname) ;
       }
 
@@ -1942,9 +2042,16 @@ int main(int argc, char *argv[])
 
   MRISremoveIntersections(mris) ;
   if (getenv("FS_POSIX")) {
-    sprintf(fname, "./%s.%s%s%s", hemi, pial_name, output_suffix, suffix);
+    int req = snprintf(fname, STRLEN, "./%s.%s%s%s", hemi, pial_name, output_suffix, suffix);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
   } else {
-    sprintf(fname, "%s/%s/surf/%s.%s%s%s", sdir, sname, hemi, pial_name, output_suffix, suffix);
+    int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s%s%s", 
+		       sdir, sname, hemi, pial_name, output_suffix, suffix);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
   }
   fprintf(stdout, "writing pial surface to %s...\n", fname) ;
   MRISwrite(mris, fname) ;
@@ -1962,14 +2069,20 @@ int main(int argc, char *argv[])
     MRIScomputeSecondFundamentalForm(mris) ;
     MRISuseMeanCurvature(mris) ;
     MRISaverageCurvatures(mris, curvature_avgs) ;
-    sprintf(fname, "%s.curv.pial%s%s",
-            mris->hemisphere == LEFT_HEMISPHERE?"lh":"rh", output_suffix,
-            suffix);
+    int req = snprintf(fname, STRLEN, "%s.curv.pial%s%s",
+		       mris->hemisphere == LEFT_HEMISPHERE?"lh":"rh", output_suffix,
+		       suffix);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stdout, "writing smoothed curvature to %s\n", fname) ;
     MRISwriteCurvature(mris, fname) ;
-    sprintf(fname, "%s.area.pial%s%s",
-            mris->hemisphere == LEFT_HEMISPHERE?"lh":"rh", output_suffix,
-            suffix);
+    req = snprintf(fname, STRLEN, "%s.area.pial%s%s",
+		   mris->hemisphere == LEFT_HEMISPHERE?"lh":"rh", output_suffix,
+		   suffix);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stdout, "writing smoothed area to %s\n", fname) ;
     MRISwriteArea(mris, fname) ;
     MRISprintTessellationStats(mris, stdout) ;
@@ -1985,9 +2098,17 @@ int main(int argc, char *argv[])
     MRIcopyMRIS(ValResid, mris, 1, "valbak"); // value sampled at vertex
     MRIcopyMRIS(ValResid, mris, 0, "val2bak"); // residual = sample-target
     if (getenv("FS_POSIX")) {
-      sprintf(fname, "./%s.%s.res%s%s.mgz", hemi, pial_name, output_suffix, suffix);
+      int req = snprintf(fname, STRLEN, "./%s.%s.res%s%s.mgz",
+			 hemi, pial_name, output_suffix, suffix);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     } else {
-      sprintf(fname, "%s/%s/surf/%s.%s.res%s%s.mgz", sdir, sname, hemi, pial_name, output_suffix, suffix);
+      int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s.res%s%s.mgz",
+			 sdir, sname, hemi, pial_name, output_suffix, suffix);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
     printf("Saving pial value residual to %s\n",fname);
     MRIwrite(ValResid,fname);
@@ -1996,9 +2117,17 @@ int main(int argc, char *argv[])
 
   if(SaveTarget){
     if (getenv("FS_POSIX")) {
-      sprintf(fname, "./%s.%s.target%s%s", hemi, pial_name, output_suffix, suffix);
+      int req = snprintf(fname, STRLEN, "./%s.%s.target%s%s",
+			 hemi, pial_name, output_suffix, suffix);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     } else {
-      sprintf(fname, "%s/%s/surf/%s.%s.target%s%s", sdir, sname, hemi, pial_name,output_suffix, suffix) ;
+      int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s.target%s%s",
+			 sdir, sname, hemi, pial_name,output_suffix, suffix) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
     printf("writing pial target surface to %s...\n", fname) ;
     MRISwrite(mristarget, fname) ;
@@ -2006,8 +2135,11 @@ int main(int argc, char *argv[])
 
   if (in_out_in_flag)// off by default
   {
-    sprintf(parms.base_name, "%s%s%s",
-            white_matter_name, output_suffix, suffix) ;
+    int req = snprintf(parms.base_name, STRLEN, "%s%s%s",
+		       white_matter_name, output_suffix, suffix) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     MRIScomputeMetricProperties(mris) ;    /* recompute surface normals */
     MRISstoreMetricProperties(mris) ;
     MRISsaveVertexPositions(mris, TMP_VERTICES) ;
@@ -2113,8 +2245,12 @@ int main(int argc, char *argv[])
     MRISsaveVertexPositions(mris, ORIGINAL_VERTICES) ; /* gray/white surface */
     MRISrestoreVertexPositions(mris, TMP_VERTICES) ;  /* pial surface */
     MRISremoveIntersections(mris) ;
-    sprintf(fname, "%s/%s/surf/%s.%s2%s", sdir, sname,hemi,white_matter_name,
-            suffix);
+    req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s2%s", 
+		   sdir, sname,hemi,white_matter_name,
+		   suffix);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stdout, "writing gray/white surface to %s...\n", fname) ;
     MRISwrite(mris, fname) ;
   } // end if(in_and_out)
@@ -2130,7 +2266,10 @@ int main(int argc, char *argv[])
 
     if(create){
       printf("writing cortical thickness estimate to 'thickness' file.\n") ;
-      sprintf(fname, "thickness%s%s", output_suffix, suffix) ;
+      int req = snprintf(fname, STRLEN, "thickness%s%s", output_suffix, suffix) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       MRISwriteCurvature(mris, fname) ;
     }
 
@@ -2142,8 +2281,12 @@ int main(int argc, char *argv[])
     {
       MRISsaveVertexPositions(mris, TMP_VERTICES) ;
       mrisFindMiddleOfGray(mris) ;
-      sprintf(fname, "%s/%s/surf/%s.%s%s", sdir, sname, hemi, GRAYMID_NAME,
-              suffix) ;
+      int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s%s",
+			 sdir, sname, hemi, GRAYMID_NAME,
+			 suffix) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       fprintf(stdout, "writing layer IV surface to %s...\n", fname) ;
       MRISwrite(mris, fname) ;
       MRISrestoreVertexPositions(mris, TMP_VERTICES) ;

--- a/mris_make_template/mris_make_template.cpp
+++ b/mris_make_template/mris_make_template.cpp
@@ -99,7 +99,6 @@ main(int argc, char *argv[])
     exit (0);
   argc -= nargs;
 
-  memset(&parms, 0, sizeof(parms)) ;
   Progname = argv[0] ;
   ErrorInit(NULL, NULL, NULL) ;
   DiagInit(NULL, NULL, NULL) ;
@@ -172,8 +171,11 @@ main(int argc, char *argv[])
     subject = argv[ino] ;
     fprintf(stderr, "\nprocessing subject %s (%d of %d)\n", subject,
             ino+1, argc-1) ;
-    sprintf(surf_fname, "%s/%s/%s/%s.%s",
-            subjects_dir, subject, surf_dir, hemi, sphere_name) ;
+    int req = snprintf(surf_fname, STRLEN, "%s/%s/%s/%s.%s",
+		       subjects_dir, subject, surf_dir, hemi, sphere_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stderr, "reading spherical surface %s...\n", surf_fname) ;
     mris = MRISread(surf_fname) ;
     if (!mris)
@@ -212,7 +214,10 @@ main(int argc, char *argv[])
       }
       else
         strcpy(parms.base_name, "template") ;
-      sprintf(fname, "%s.%s.out", hemi, parms.base_name);
+      int req = snprintf(fname, STRLEN, "%s.%s.out", hemi, parms.base_name);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       INTEGRATION_PARMS_openFp(&parms, fname, "w") ;
       printf("writing output to '%s'\n", fname) ;
     }
@@ -240,8 +245,11 @@ main(int argc, char *argv[])
       {
         if (parms.fields[n].name != NULL)
         {
-          sprintf(surf_fname, "%s/%s/%s/%s.%s", subjects_dir,
-                  subject, overlay_dir, hemi, parms.fields[n].name) ;
+          int req = snprintf(surf_fname, STRLEN, "%s/%s/%s/%s.%s", subjects_dir,
+			     subject, overlay_dir, hemi, parms.fields[n].name) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           printf("reading overlay file %s...\n", surf_fname) ;
           if (MRISreadValues(mris, surf_fname) != NO_ERROR)
             ErrorExit(ERROR_BADPARM, "%s: could not read overlay file %s",
@@ -251,8 +259,11 @@ main(int argc, char *argv[])
         else if (ReturnFieldName(parms.fields[n].field))
         {
           /* read in precomputed curvature file */
-          sprintf(surf_fname, "%s/%s/%s/%s.%s", subjects_dir,
-                  subject, surf_dir, hemi, ReturnFieldName(parms.fields[n].field)) ;
+          int req = snprintf(surf_fname, STRLEN, "%s/%s/%s/%s.%s", subjects_dir,
+			     subject, surf_dir, hemi, ReturnFieldName(parms.fields[n].field)) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           // fprintf(stderr,"\nreading field %d from %s(type=%d,frame=%d)\n",parms.fields[n].field,surf_fname,parms.fields[n].type,parms.fields[n].frame);
           if (MRISreadCurvatureFile(mris, surf_fname) != NO_ERROR)
           {
@@ -265,8 +276,11 @@ main(int argc, char *argv[])
         }
         else
         {                       /* compute curvature of surface */
-          sprintf(surf_fname, "%s/%s/%s/%s.%s", subjects_dir,
-                  subject, surf_dir, hemi, surface_names[parms.fields[n].field]) ;
+          int req = snprintf(surf_fname, STRLEN, "%s/%s/%s/%s.%s", subjects_dir,
+			     subject, surf_dir, hemi, surface_names[parms.fields[n].field]) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           /*if(parms.fields[n].field==0)
            sprintf(fname, "inflated") ;
            else
@@ -337,8 +351,11 @@ main(int argc, char *argv[])
     };
     if ((!multiframes) && (!no_rot) && ino > 0)
     { /* rigid body alignment */
-      sprintf(surf_fname, "%s/%s/%s/%s.%s",
-              subjects_dir, subject, surf_dir, hemi, "sulc") ;
+      int req = snprintf(surf_fname, STRLEN, "%s/%s/%s/%s.%s",
+			 subjects_dir, subject, surf_dir, hemi, "sulc") ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (MRISreadCurvatureFile(mris, surf_fname) != NO_ERROR)
       {
         ErrorPrintf(Gerror, "%s: could not read curvature file '%s'\n",
@@ -392,8 +409,11 @@ main(int argc, char *argv[])
       {
         if (curvature_names[sno])  /* read in precomputed curvature file */
         {
-          sprintf(surf_fname, "%s/%s/%s/%s.%s",
-                  subjects_dir, subject, surf_dir, hemi, curvature_names[sno]) ;
+          int req = snprintf(surf_fname, STRLEN, "%s/%s/%s/%s.%s",
+			     subjects_dir, subject, surf_dir, hemi, curvature_names[sno]) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           if (MRISreadCurvatureFile(mris, surf_fname) != NO_ERROR)
           {
             nbad++ ;
@@ -407,8 +427,11 @@ main(int argc, char *argv[])
           MRISnormalizeCurvature(mris, which_norm) ;
         } else                       /* compute curvature of surface */
         {
-          sprintf(surf_fname, "%s/%s/%s/%s.%s",
-                  subjects_dir, subject, surf_dir, hemi, surface_names[sno]) ;
+          int req = snprintf(surf_fname, STRLEN, "%s/%s/%s/%s.%s",
+			     subjects_dir, subject, surf_dir, hemi, surface_names[sno]) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           if (MRISreadVertexPositions(mris, surf_fname) != NO_ERROR)
           {
             ErrorPrintf(ERROR_NOFILE, "%s: could not read surface file %s",

--- a/mris_map_cuts/mris_map_cuts.cpp
+++ b/mris_map_cuts/mris_map_cuts.cpp
@@ -87,7 +87,10 @@ main(int argc, char *argv[]) {
   }
   else
     strcpy(hemi, "lh") ;
-  sprintf(in_surf_fname, "%s/%s.%s", path, hemi, orig_surf_name) ;
+  int req = snprintf(in_surf_fname, STRLEN, "%s/%s.%s", path, hemi, orig_surf_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
 
   FileNamePath(out_patch_fname, path) ;
   cp = strrchr(out_patch_fname, '/') ;
@@ -101,7 +104,10 @@ main(int argc, char *argv[]) {
   }
   else
     strcpy(hemi, "lh") ;
-  sprintf(out_surf_fname, "%s/%s.%s", path, hemi, orig_surf_name) ;
+  req = snprintf(out_surf_fname, STRLEN, "%s/%s.%s", path, hemi, orig_surf_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
 
   mris_in = MRISread(in_surf_fname) ;
   mris_out = MRISread(out_surf_fname) ;

--- a/mris_merge_parcellations/mris_merge_parcellations.cpp
+++ b/mris_merge_parcellations/mris_merge_parcellations.cpp
@@ -88,7 +88,10 @@ main(int argc, char *argv[])
       ErrorExit(ERROR_BADPARM, "FRESURFER_HOME must be defined in the environment") ;
     strcpy(fsdir, cp) ;
   }
-  sprintf(fname, "%s/FreeSurferColorLUT.txt", fsdir) ;
+  int req = snprintf(fname, STRLEN, "%s/FreeSurferColorLUT.txt", fsdir) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   ct = CTABreadASCII(fname) ;
   if (ct == NULL)
     ErrorExit(ERROR_NOFILE, "%s: could not read color table from %s", Progname, fname) ;
@@ -102,7 +105,10 @@ main(int argc, char *argv[])
   if (cp == NULL)
     ErrorExit(ERROR_UNSUPPORTED, "%s: could not scan hemisphere from fname %s", Progname, fname) ;
   strncpy(hemi, cp-1, 2) ; hemi[2] = 0 ;
-  sprintf(surf_name, "%s/../surf/%s.orig", path, hemi) ;
+  req = snprintf(surf_name, STRLEN, "%s/../surf/%s.orig", path, hemi) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mris1 = MRISread(surf_name) ;
   if (mris1 == NULL)
     ErrorExit(ERROR_NOFILE, "%s: could not read surface %s", Progname, surf_name) ;

--- a/mris_ms_refine/mris_ms_refine.cpp
+++ b/mris_ms_refine/mris_ms_refine.cpp
@@ -328,7 +328,6 @@ main(int argc, char *argv[]) {
   ErrorInit(NULL, NULL, NULL) ;
   DiagInit(NULL, NULL, NULL) ;
 
-  memset(&parms, 0, sizeof(parms)) ;
   parms.projection = NO_PROJECTION ;
   parms.tol = 1e-3 ;
   parms.dt = 0.5f ;
@@ -385,7 +384,10 @@ main(int argc, char *argv[]) {
   }
 
   xform_fname = argv[3] ;
-  sprintf(fname, "%s/%s/mri/flash/%s/%s", sdir, sname, map_dir, xform_fname) ;
+  int req = snprintf(fname, STRLEN, "%s/%s/mri/flash/%s/%s", sdir, sname, map_dir, xform_fname) ; 
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   lta = LTAread(fname) ;
   if (!lta)
     ErrorExit(ERROR_NOFILE, "%s: could not read FLASH transform from %s...\n",
@@ -405,7 +407,10 @@ main(int argc, char *argv[]) {
     MRI *mri ;
 
     index = i-FLASH_START ;
-    sprintf(fname, "%s/%s/mri/flash/%s/%s", sdir, sname, map_dir, argv[i]) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/mri/flash/%s/%s", sdir, sname, map_dir, argv[i]) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("reading FLASH volume %s...\n", fname) ;
     mri = mri_flash[index] = MRIread(fname) ;
     if (!mri_flash[index])
@@ -464,7 +469,10 @@ main(int argc, char *argv[]) {
   }
   MRIfree(&mri_template) ;
 
-  sprintf(fname, "%s/%s/mri/filled", sdir, sname) ;
+  req = snprintf(fname, STRLEN, "%s/%s/mri/filled", sdir, sname) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fprintf(stderr, "reading volume %s...\n", fname) ;
   mri_filled = MRIread(fname) ;
   if (!mri_filled)
@@ -492,15 +500,25 @@ main(int argc, char *argv[]) {
   MRIfree(&mri_filled) ;
 
   if (orig_flag) {
-    sprintf(fname, "%s/%s/surf/%s.%s%s", sdir, sname, hemi, orig_name, suffix) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s%s", sdir, sname, hemi, orig_name, suffix) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("reading orig surface position from %s...\n", fname) ;
   } else {
-    if (start_pial_name)
-      sprintf(fname, "%s/%s/surf/%s.%s%s", sdir, sname, hemi,
-              start_pial_name, suffix) ;
-    else
-      sprintf(fname, "%s/%s/surf/%s.%s%s", sdir, sname, hemi, pial_name,
-              suffix) ;
+    if (start_pial_name) {
+      int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s%s", sdir, sname, hemi,
+			 start_pial_name, suffix) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    } else {
+      int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s%s", sdir, sname, hemi, pial_name,
+			 suffix) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
   }
 
   if (add)
@@ -685,20 +703,15 @@ main(int argc, char *argv[]) {
     ep.max_outward_dist = MAX_PIAL_DIST ;
   }
 
-  sprintf(fname, "%s/%s/surf/%s.%s%s%s", sdir, sname,hemi,white_matter_name,
-          output_suffix,suffix);
+  req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s%s%s",
+		 sdir, sname,hemi,white_matter_name,
+		 output_suffix,suffix);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing white matter surface to %s...\n", fname) ;
   MRISaverageVertexPositions(mris, smoothwm) ;
   MRISwrite(mris, fname) ;
-#if 0
-  if (smoothwm > 0) {
-    MRISaverageVertexPositions(mris, smoothwm) ;
-    sprintf(fname, "%s/%s/surf/%s.%s%s", sdir, sname,hemi,SMOOTH_NAME,
-            suffix);
-    fprintf(stderr,"writing smoothed white matter surface to %s...\n",fname);
-    MRISwrite(mris, fname) ;
-  }
-#endif
 
   if (create)   /* write out curvature and area files */
   {
@@ -706,17 +719,19 @@ main(int argc, char *argv[]) {
     MRIScomputeSecondFundamentalForm(mris) ;
     MRISuseMeanCurvature(mris) ;
     MRISaverageCurvatures(mris, curvature_avgs) ;
-    sprintf(fname, "%s.curv%s%s",
-            mris->hemisphere == LEFT_HEMISPHERE?"lh":"rh", output_suffix,
-            suffix);
+    int req = snprintf(fname, STRLEN, "%s.curv%s%s",
+		       mris->hemisphere == LEFT_HEMISPHERE?"lh":"rh", output_suffix,
+		       suffix);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing smoothed curvature to %s\n", fname) ;
     MRISwriteCurvature(mris, fname) ;
-    sprintf(fname, "%s.area%s",
-            mris->hemisphere == LEFT_HEMISPHERE?"lh":"rh", suffix);
-#if 0
-    printf("writing smoothed area to %s\n", fname) ;
-    MRISwriteArea(mris, fname) ;
-#endif
+    req = snprintf(fname, STRLEN, "%s.area%s",
+		   mris->hemisphere == LEFT_HEMISPHERE?"lh":"rh", suffix);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     MRISprintTessellationStats(mris, stderr) ;
   }
 
@@ -731,13 +746,19 @@ main(int argc, char *argv[]) {
   msec = then.milliseconds() ;
   fprintf(stderr,"positioning took %2.1f minutes\n", (float)msec/(60*1000.0f));
   MRISrestoreVertexPositions(mris, ORIGINAL_VERTICES) ;
-  sprintf(fname, "%s/%s/surf/%s.%s%s%s", sdir, sname, hemi,
-          white_matter_name, output_suffix, suffix) ;
+  req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s%s%s", sdir, sname, hemi,
+		 white_matter_name, output_suffix, suffix) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
   printf("writing final white matter position to %s...\n", fname) ;
   MRISwrite(mris, fname) ;
   MRISrestoreVertexPositions(mris, PIAL_VERTICES) ;
-  sprintf(fname, "%s/%s/surf/%s.%s%s%s", sdir, sname, hemi,
-          pial_name, output_suffix, suffix) ;
+  req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s%s%s", sdir, sname, hemi,
+		 pial_name, output_suffix, suffix) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing final pial surface position to %s...\n", fname) ;
   MRISwrite(mris, fname) ;
 
@@ -748,7 +769,10 @@ main(int argc, char *argv[]) {
     MRISmeasureCorticalThickness(mris, nbhd_size, max_thickness) ;
     printf(
       "writing cortical thickness estimate to 'thickness' file.\n") ;
-    sprintf(fname, "thickness%s%s", output_suffix, suffix) ;
+    int req = snprintf(fname, STRLEN, "thickness%s%s", output_suffix, suffix) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     MRISwriteCurvature(mris, fname) ;
 
     /* at this point, the v->curv slots contain the cortical surface. Now
@@ -758,8 +782,12 @@ main(int argc, char *argv[]) {
     if (graymid) {
       MRISsaveVertexPositions(mris, TMP_VERTICES) ;
       mrisFindMiddleOfGray(mris) ;
-      sprintf(fname, "%s/%s/surf/%s.%s%s", sdir, sname, hemi, GRAYMID_NAME,
-              suffix) ;
+      int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s%s",
+			 sdir, sname, hemi, GRAYMID_NAME,
+			 suffix) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("writing layer IV surface to %s...\n", fname) ;
       MRISwrite(mris, fname) ;
       MRISrestoreVertexPositions(mris, TMP_VERTICES) ;

--- a/mris_multiscale_stats/mris_multiscale_stats.cpp
+++ b/mris_multiscale_stats/mris_multiscale_stats.cpp
@@ -210,8 +210,12 @@ main(int argc, char *argv[]) {
   } while (argv[n][0] != ':') ;
 
   /* find  # of vertices in output subject surface */
-  sprintf(fname, "%s/%s/surf/%s.%s",
-          subjects_dir,output_subject,hemi,surf_name);
+  int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s",
+		     subjects_dir,output_subject,hemi,surf_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   mris = MRISread(fname) ;
   if (!mris)
     ErrorExit(ERROR_NOFILE, "%s: could not read surface file %s",
@@ -277,25 +281,36 @@ main(int argc, char *argv[]) {
     subject_name = n < num_class1 ? c1_subjects[n] : c2_subjects[n-num_class1];
     fprintf(stderr, "reading subject %d of %d: %s\n",
             n+1, num_class1+num_class2, subject_name) ;
-    sprintf(fname, "%s/%s/surf/%s.%s",
-            subjects_dir,subject_name,hemi,surf_name);
+    int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s",
+		       subjects_dir,subject_name,hemi,surf_name);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     mris = MRISread(fname) ;
     if (!mris)
       ErrorExit(ERROR_NOFILE, "%s: could not read surface file %s",
                 Progname, fname) ;
     MRISsaveVertexPositions(mris, CANONICAL_VERTICES) ;
-    if (strchr(curv_name, '/') != NULL)
+    if (strchr(curv_name, '/') != NULL) {
       strcpy(fname, curv_name) ;  /* full path specified */
-    else
-      sprintf(fname,"%s/%s/surf/%s.%s",
-              subjects_dir,subject_name,hemi,curv_name);
+    } else {
+      int req = snprintf(fname,STRLEN,"%s/%s/surf/%s.%s",
+			 subjects_dir,subject_name,hemi,curv_name);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
     if (MRISreadCurvatureFile(mris, fname) != NO_ERROR)
       ErrorExit(Gerror, "%s: could no read curvature file %s",Progname,fname) ;
     mrisp = MRIStoParameterization(mris, NULL, 1, 0) ;
     MRISfree(&mris) ;
 
-    sprintf(fname, "%s/%s/surf/%s.%s",
-            subjects_dir,output_subject,hemi,surf_name);
+    req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s",
+		   subjects_dir,output_subject,hemi,surf_name);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+
     mris = MRISread(fname) ;
     if (!mris)
       ErrorExit(ERROR_NOFILE, "%s: could not read surface file %s",
@@ -319,8 +334,12 @@ main(int argc, char *argv[]) {
   cvector_compute_variance(c1_var, c1_mean, num_class1, nvertices) ;
   cvector_compute_variance(c2_var, c2_mean, num_class2, nvertices) ;
 
-  sprintf(fname, "%s/%s/surf/%s.%s",
-          subjects_dir,output_subject,hemi,surf_name);
+  req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s",
+		 subjects_dir,output_subject,hemi,surf_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   fprintf(stderr, "reading output surface %s...\n", fname) ;
   mris = MRISread(fname) ;
   if (!mris)

--- a/mris_segment/mris_segment.cpp
+++ b/mris_segment/mris_segment.cpp
@@ -630,7 +630,10 @@ main(int argc, char *argv[])
   printf("processing %d subjects and writing output to %s\n",
          nsubjects,out_fname) ;
 
-  sprintf(fname, "%s/fsaverage%d/surf/%s.inflated", sdir, ico_no, hemi_name) ;
+  int req = snprintf(fname, STRLEN, "%s/fsaverage%d/surf/%s.inflated", sdir, ico_no, hemi_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mris = MRISread(fname) ;
   if (mris == NULL)
   {
@@ -641,7 +644,10 @@ main(int argc, char *argv[])
   {
     subject = argv[sno+1] ;
     printf("processing subject %s, %d of %d\n", subject, sno+1, nsubjects) ;
-    sprintf(fname, "%s/%s/%s/%s", sdir, subject, data_dir, data_name) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/%s/%s", sdir, subject, data_dir, data_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (prior_only <= 0)
     {
       mri_frame = MRIread(fname) ;
@@ -681,14 +687,21 @@ main(int argc, char *argv[])
     MRIcopyFrame(mri_frame, mri, 0, sno) ;
     MRIfree(&mri_frame) ;
 
-    sprintf(fname, "%s/%s/label/%s.%s", sdir, subject, hemi_name,label_name) ;
+    req = snprintf(fname, STRLEN, "%s/%s/label/%s.%s", sdir, subject, hemi_name,label_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     labels[sno] = LabelRead(NULL, fname) ;
     if (labels[sno] == NULL)
       ErrorExit(ERROR_NOFILE, "%s: could not load label from %s",
                 Progname,fname) ;
   }
-  sprintf(fname, "%s/fsaverage%d/label/%s.%s",
-          sdir, ico_no, hemi_name, prior_name) ;
+  req = snprintf(fname, STRLEN, "%s/fsaverage%d/label/%s.%s",
+		 sdir, ico_no, hemi_name, prior_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   mri_prior = MRIread(fname) ;
   if (mri_prior == NULL)
   {

--- a/stat_normalize/stat_normalize.cpp
+++ b/stat_normalize/stat_normalize.cpp
@@ -94,11 +94,6 @@ main(int argc, char *argv[]) {
 
   out_prefix = argv[argc-1] ;
 
-#if 0
-  if (StatVolumeExists(out_prefix))
-    sv_avg = StatReadVolume(out_prefix) ;
-#endif
-
   for (ino = 1 ; ino < argc-1 ; ino++) {
     /* for each path/prefix specified, go through all slices */
     in_prefix = argv[ino] ;
@@ -120,9 +115,9 @@ main(int argc, char *argv[]) {
       break ;
     case SPHERICAL_COORDS:
     case ELLIPSOID_COORDS:
-      int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.orig",
+      int req = snprintf(fname, 100, "%s/%s/surf/%s.orig",
 			 subjects_dir, sv->reg->name, hemi) ;   
-      if( req >= STRLEN ) {
+      if( req >= 100 ) {
 	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
       }
       fprintf(stderr, "reading surface %s\n", fname) ;

--- a/stat_normalize/stat_normalize.cpp
+++ b/stat_normalize/stat_normalize.cpp
@@ -120,8 +120,11 @@ main(int argc, char *argv[]) {
       break ;
     case SPHERICAL_COORDS:
     case ELLIPSOID_COORDS:
-      sprintf(fname, "%s/%s/surf/%s.orig",
-              subjects_dir, sv->reg->name, hemi) ;
+      int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.orig",
+			 subjects_dir, sv->reg->name, hemi) ;   
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       fprintf(stderr, "reading surface %s\n", fname) ;
       mris = MRISread(fname) ;
       if (!mris)
@@ -138,13 +141,6 @@ main(int argc, char *argv[]) {
       MRISfree(&mris) ;
       break ;
     }
-
-#if 0
-    if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON) {
-      sprintf(out_fname, "avg%d.mnc", ino-1) ;
-      MRIwrite(sv->mri_avgs[0], out_fname) ;
-    }
-#endif
 
     StatFree(&sv) ;
   }


### PR DESCRIPTION
Another round of updates for gcc8. Mainly `sprintf` to `snprintf` conversions, but a few changes to do with `switch` statements, or bad uses of `memset()` are also included.