### PR TITLE
Buffer overflow fixes in `imageio.cpp`

### DIFF
--- a/utils/imageio.cpp
+++ b/utils/imageio.cpp
@@ -391,7 +391,7 @@ IMAGE *ImageFReadHeader(FILE *fp, const char *fname)
       break;
   }
 
-  free(buf)
+  free(buf);
   return (I);
 }
 /*-----------------------------------------------------


### PR DESCRIPTION
Fixes the [very serious](https://cwe.mitre.org/top25/archive/2019/2019_cwe_top25.html) buffer overflow issues described in #832.  (thanks @chrisadamsonmcri!)

The following functions in `imageio.cpp` are modifited:
  - `ImageFWrite()`
  - `ImageReadHeader()`
  - `ImageFReadHeader()`
  - `ImageRead()`
  - `ImageType()`
  - `ImageFrame()`
  - `ImageUnpackFileName()`
  - `ImageNumFrames()`
  - `ImageAppend()`*
