### PR TITLE
More gcc8 updates

### DIFF
--- a/hiam_make_surfaces/hiam_make_surfaces.cpp
+++ b/hiam_make_surfaces/hiam_make_surfaces.cpp
@@ -151,7 +151,10 @@ main(int argc, char *argv[]) {
   strcpy(surftype, argv[2]);
 
   //***** Extract volume for each label  *****//
-  sprintf(labelfilename,"%s/%s/%s",data_dir,argv[1],labelvolume);
+  int req = snprintf(labelfilename,STRLEN,"%s/%s/%s",data_dir,argv[1],labelvolume);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fprintf(stderr, "reading segmentation volume from %s...\n", labelfilename) ;
   mri_orig = MRIread(labelfilename) ;
   extractlabelvolume(mri_label, mri_orig);
@@ -169,7 +172,10 @@ main(int argc, char *argv[]) {
   MRIfree(&mri_e);
   /******************************/
   //******** read original tesselation ********//
-  sprintf(ifname,"%s/%s/surf/%s.%s",data_dir,argv[1],argv[2],orig_name);
+  req = snprintf(ifname,STRLEN,"%s/%s/surf/%s.%s",data_dir,argv[1],argv[2],orig_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fprintf(stderr, "reading original surface position from %s...\n", ifname) ;
   mris = MRISread(ifname) ;
 
@@ -299,7 +305,12 @@ main(int argc, char *argv[]) {
 
       if (write_iterations > 0) {
         if (((++counter) % write_iterations) == 0) {
-          sprintf(ofname, "%s/%s/surf/movie/%s.firstrefined%3.3d", data_dir, argv[1], argv[2],counter/write_iterations);
+          int req = snprintf(ofname, STRLEN,
+			     "%s/%s/surf/movie/%s.firstrefined%3.3d",
+			     data_dir, argv[1], argv[2],counter/write_iterations);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           MRISwrite(mris, ofname) ;
         }
       }
@@ -330,7 +341,12 @@ main(int argc, char *argv[]) {
       spikes = FindSpikes(mris,i);
       if (write_iterations > 0) {
         if (((++counter) % write_iterations) == 0) {
-          sprintf(ofname, "%s/%s/surf/movie/%s.refined%3.3d", data_dir, argv[1], argv[2],counter/write_iterations);
+          int req = snprintf(ofname, STRLEN,
+			     "%s/%s/surf/movie/%s.refined%3.3d",
+			     data_dir, argv[1], argv[2],counter/write_iterations);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           fprintf(stderr, "writing out reconstructed surface after %d iteration to %3.3d \n", i, counter/write_iterations );
           MRISwrite(mris, ofname) ;
           //measure the volume this new surface encloses and compare with the original//
@@ -357,7 +373,12 @@ main(int argc, char *argv[]) {
       mrisClearGradient(mris);
       if (write_iterations > 0) {
         if (((++counter) % write_iterations) == 0) {
-          sprintf(ofname, "%s/%s/surf/movie/%s.refined%3.3d", data_dir, argv[1], argv[2],counter/write_iterations);
+          int req = snprintf(ofname, STRLEN, 
+			     "%s/%s/surf/movie/%s.refined%3.3d",
+			     data_dir, argv[1], argv[2],counter/write_iterations);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           MRISwrite(mris, ofname) ;
         }
       }
@@ -369,15 +390,26 @@ main(int argc, char *argv[]) {
   //write out final smoothing  result//
   if (write_iterations > 0) {
     counter = floor(counter/write_iterations)+1 ;
-    sprintf(ofname, "%s/%s/surf/movie/%s.refined%3.3d", data_dir, argv[1], argv[2],counter);
+    int req = snprintf(ofname, STRLEN,
+		       "%s/%s/surf/movie/%s.refined%3.3d", data_dir, argv[1], argv[2],counter);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     MRISwrite(mris, ofname) ;
   }
 
-  sprintf(ofname, "%s/%s/surf/%s.%s", data_dir, argv[1], argv[2],suffix) ;
+  req = snprintf(ofname, STRLEN,
+		 "%s/%s/surf/%s.%s", data_dir, argv[1], argv[2],suffix) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fprintf (stderr,"writing refined surface to %s\n", ofname);
   MRISwrite(mris, ofname) ;
   MRISuseMeanCurvature(mris);
-  sprintf(ofname, "%s/%s/surf/%s.%s.curv", data_dir, argv[1], argv[2],suffix) ;
+  req = snprintf(ofname, STRLEN, "%s/%s/surf/%s.%s.curv", data_dir, argv[1], argv[2],suffix) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   MRISwriteCurvature(mris, ofname) ;
   MRISfree(&mris);
   MRIfree(&mri_label[0]);
@@ -390,113 +422,7 @@ main(int argc, char *argv[]) {
   return(0) ;
 }
 
-#if 0
-static int
-extractlabelvolume(MRI *mri_label[5], MRI *mri_orig) {
-  int  xi, yi, zi;
 
-  mri_label[0] = MRIalloc(256, 256, 256, MRI_FLOAT) ;
-  mri_label[1] = MRIalloc(256, 256, 256, MRI_FLOAT) ;
-  mri_label[2] = MRIalloc(256, 256, 256, MRI_FLOAT) ;
-  mri_label[3] = MRIalloc(256, 256, 256, MRI_FLOAT) ;
-  mri_label[4] = MRIalloc(256, 256, 256, MRI_FLOAT) ;
-
-  for (xi=0; xi<mri_orig->depth; xi++)
-    for (yi=0; yi<mri_orig->height; yi++)
-      for (zi=0; zi<mri_orig->width; zi++) {
-        if ( MRIvox(mri_orig,zi,yi,xi) >=1 && MRIvox(mri_orig,zi,yi,xi) <=4 ) {
-          MRIFvox(mri_label[0],zi,yi,xi) = 1.0;
-          MRIFvox(mri_label[1],zi,yi,xi) = 0.0;
-          MRIFvox(mri_label[2],zi,yi,xi) = 0.0;
-          MRIFvox(mri_label[3],zi,yi,xi) = 0.0;
-          MRIFvox(mri_label[4],zi,yi,xi) = 0.0;
-        } else if ( MRIvox(mri_orig,zi,yi,xi) >=5 && MRIvox(mri_orig,zi,yi,xi) <=8 ) {
-          MRIFvox(mri_label[0],zi,yi,xi) = 0.0;
-          MRIFvox(mri_label[1],zi,yi,xi) = 1.0;
-          MRIFvox(mri_label[2],zi,yi,xi) = 0.0;
-          MRIFvox(mri_label[3],zi,yi,xi) = 0.0;
-          MRIFvox(mri_label[4],zi,yi,xi) = 0.0;
-        } else if ( MRIvox(mri_orig,zi,yi,xi) == 13 ) {
-          MRIFvox(mri_label[0],zi,yi,xi) = 0.0;
-          MRIFvox(mri_label[1],zi,yi,xi) = 0.0;
-          MRIFvox(mri_label[2],zi,yi,xi) = 1.0;
-          MRIFvox(mri_label[3],zi,yi,xi) = 0.0;
-          MRIFvox(mri_label[4],zi,yi,xi) = 0.0;
-        } else if ( MRIvox(mri_orig,zi,yi,xi) == 14 ) {
-          MRIFvox(mri_label[0],zi,yi,xi) = 0.0;
-          MRIFvox(mri_label[1],zi,yi,xi) = 0.0;
-          MRIFvox(mri_label[2],zi,yi,xi) = 0.0;
-          MRIFvox(mri_label[3],zi,yi,xi) = 1.0;
-          MRIFvox(mri_label[4],zi,yi,xi) = 0.0;
-        } else {
-          MRIFvox(mri_label[0],zi,yi,xi) = 0.0;
-          MRIFvox(mri_label[1],zi,yi,xi) = 0.0;
-          MRIFvox(mri_label[2],zi,yi,xi) = 0.0;
-          MRIFvox(mri_label[3],zi,yi,xi) = 0.0;
-          MRIFvox(mri_label[4],zi,yi,xi) = 1.0;
-        }
-      }
-  return(NO_ERROR);
-
-}
-
-static int
-mrisFindneighborlabel(MRI_SURFACE *mris, char surftype[10], MRI *mri_label[5], MRI *mri_orig) {
-  int           vno, type=0, tt;
-  VERTEX        *v;
-  float         x, y, z, step;
-  double        xw, yw, zw, val=0;
-
-  for (tt=0; tt<4; tt++) {
-    if ( !strcmp(surftype,surf[tt]) ) type = tt;
-  }
-
-  for ( vno=0; vno < mris->nvertices; vno++ ) {
-    v = &mris->vertices[vno] ;
-    x = v->x ;
-    y = v->y ;
-    z = v->z ;
-    step = 0.5;
-    table[0][vno] = type;
-
-    while ( table[0][vno] == type && step <= 2 ) {
-      MRIsurfaceRASToVoxel(mri_orig, v->x+step*v->nx, v->y+step*v->ny, v->z+step*v->nz, &xw, &yw, &zw) ;
-      MRIsampleVolumeType(mri_orig, xw, yw, zw, &val, SAMPLE_NEAREST);
-      if ( val >=1 && val <=4 )
-        table[0][vno] = 0;
-      else if ( val >=5 && val <=8 )
-        table[0][vno] = 1;
-      else if ( val == 13 )
-        table[0][vno] = 2;
-      else if ( val == 14 )
-        table[0][vno] = 3;
-      else
-        table[0][vno] = 4;
-      step +=0.25;
-    }
-
-#if 0
-    MRIsurfaceRASToVoxel(mri_orig, v->x-0.5*v->nx, v->y-0.5*v->ny, v->z-0.5*v->nz, &xw, &yw, &zw) ;
-    MRIsampleVolumeType(mri_orig, xw, yw, zw, &val, SAMPLE_NEAREST);
-    if ( val >=1 && val <=4 )
-      table[1][vno] = 0;
-    else if ( val >=5 && val <=8 )
-      table[1][vno] = 1;
-    else if ( val == 13 )
-      table[1][vno] = 2;
-    else if ( val == 14 )
-      table[1][vno] = 3;
-    else
-      table[1][vno] = 4;
-#else
-    table[1][vno] = type;
-#endif
-  }
-  return(NO_ERROR);
-}
-
-
-#else
 
 static int
 extractlabelvolume(MRI *mri_label[5], MRI *mri_orig) {
@@ -602,8 +528,6 @@ table[1][vno] = type;
   }
   return(NO_ERROR);
 }
-
-#endif
 
 
 

--- a/hiam_make_surfaces/hiam_make_surfaces.cpp
+++ b/hiam_make_surfaces/hiam_make_surfaces.cpp
@@ -115,7 +115,7 @@ int main(int argc, char *argv[]) ;
 
 int
 main(int argc, char *argv[]) {
-  char          data_dir[400], *cp, ifname[200], ofname[200], labelfilename[200], surftype[10];
+  char          data_dir[400], *cp, ifname[STRLEN], ofname[STRLEN], labelfilename[STRLEN], surftype[10];
   int           nargs, s, counter=0, i, spikes=1;
   float         ratio = 1, energy_new = 0, energy_old = 0 ;
   // float         weight_quadcur = 0.2, weight_label = 0.5, weight_repulse = 0.0,

--- a/hiam_make_template/hiam_make_template.cpp
+++ b/hiam_make_template/hiam_make_template.cpp
@@ -69,7 +69,7 @@ main(int argc, char *argv[]) {
   MRI_SP       *mrisp, *mrisp_aligned, *mrisp_template ;
   INTEGRATION_PARMS parms ;
 
-  memset(&parms, 0, sizeof(parms)) ;
+  // memset(&parms, 0, sizeof(parms)) ;
   Progname = argv[0] ;
   ErrorInit(NULL, NULL, NULL) ;
   DiagInit(NULL, NULL, NULL) ;
@@ -119,8 +119,12 @@ main(int argc, char *argv[]) {
   for (ino = 0 ; ino < argc-1 ; ino++) {
     subject = argv[ino] ;
     fprintf(stderr, "processing subject %s\n", subject) ;
-    sprintf(surf_fname, "%s/%s/surf/%s.%s",
-            subjects_dir, subject, hemi, sphere_name) ;
+    int req = snprintf(surf_fname, STRLEN,
+		       "%s/%s/surf/%s.%s",
+		       subjects_dir, subject, hemi, sphere_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stderr, "reading spherical surface %s...\n", surf_fname) ;
     mris = MRISread(surf_fname) ;
     if (!mris)
@@ -133,8 +137,12 @@ main(int argc, char *argv[]) {
     for (sno = 0; sno < SURFACES ; sno++) {
       if (curvature_names[sno])  /* read in precomputed curvature file */
       {
-        sprintf(surf_fname, "%s/%s/surf/%s.%s",
-                subjects_dir, subject, hemi, curvature_names[sno]) ;
+        int req = snprintf(surf_fname, STRLEN,
+			   "%s/%s/surf/%s.%s",
+			   subjects_dir, subject, hemi, curvature_names[sno]) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         if (MRISreadCurvatureFile(mris, surf_fname) != NO_ERROR)
           ErrorExit(Gerror, "%s: could not read curvature file '%s'\n",
                     Progname, surf_fname) ;
@@ -175,13 +183,19 @@ main(int argc, char *argv[]) {
       cp = strchr(fname, '.') ;
       if (cp) {
         cp1 = strrchr(fname, '.') ;
-        if (cp1 && cp1 != cp)
+        if (cp1 && cp1 != cp) {
           strncpy(parms.base_name, cp+1, cp1-cp-1) ;
-        else
+        } else {
           strcpy(parms.base_name, cp+1) ;
-      } else
+	}
+      } else {
         strcpy(parms.base_name, "template") ;
-      sprintf(fname, "%s.%s.out", hemi, parms.base_name);
+      }
+      int req = snprintf(fname, STRLEN,
+			 "%s.%s.out", hemi, parms.base_name);
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       INTEGRATION_PARMS_openFp(&parms, fname, "w") ;
       printf("writing output to '%s'\n", fname) ;
     }
@@ -190,8 +204,12 @@ main(int argc, char *argv[]) {
       if (Gdiag & DIAG_WRITE)
         fprintf(parms.fp, "processing subject %s\n", subject) ;
       fprintf(stderr, "processing subject %s\n", subject) ;
-      sprintf(surf_fname, "%s/%s/surf/%s.%s",
-              subjects_dir, subject, hemi, sphere_name) ;
+      int req = snprintf(surf_fname, STRLEN,
+			 "%s/%s/surf/%s.%s",
+			 subjects_dir, subject, hemi, sphere_name) ;
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       fprintf(stderr, "reading spherical surface %s...\n", surf_fname) ;
       mris = MRISread(surf_fname) ;
       if (!mris)
@@ -200,8 +218,12 @@ main(int argc, char *argv[]) {
       MRIScomputeMetricProperties(mris) ;
       MRISstoreMetricProperties(mris) ;
       MRISsaveVertexPositions(mris, ORIGINAL_VERTICES) ;
-      sprintf(surf_fname, "%s/%s/surf/%s.%s",
-              subjects_dir, subject, hemi, "hippocampus.curv") ;
+      req = snprintf(surf_fname, STRLEN,
+		     "%s/%s/surf/%s.%s",
+		     subjects_dir, subject, hemi, "hippocampus.curv") ;
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (MRISreadCurvatureFile(mris, surf_fname) != NO_ERROR)
         ErrorExit(Gerror, "%s: could not read curvature file '%s'\n",
                   Progname, surf_fname) ;
@@ -225,8 +247,12 @@ main(int argc, char *argv[]) {
       for (sno = 0; sno < SURFACES ; sno++) {
         if (curvature_names[sno])  /* read in precomputed curvature file */
         {
-          sprintf(surf_fname, "%s/%s/surf/%s.%s",
-                  subjects_dir, subject, hemi, curvature_names[sno]) ;
+          int req = snprintf(surf_fname, STRLEN,
+			     "%s/%s/surf/%s.%s",
+			     subjects_dir, subject, hemi, curvature_names[sno]) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           if (MRISreadCurvatureFile(mris, surf_fname) != NO_ERROR)
             ErrorExit(Gerror, "%s: could not read curvature file '%s'\n",
                       Progname, surf_fname) ;

--- a/hiam_register/hiam_register.cpp
+++ b/hiam_register/hiam_register.cpp
@@ -101,7 +101,7 @@ main(int argc, char *argv[]) {
   ErrorInit(NULL, NULL, NULL) ;
   DiagInit(NULL, NULL, NULL) ;
 
-  memset(&parms, 0, sizeof(parms)) ;
+  // memset(&parms, 0, sizeof(parms)) ;
   parms.projection = PROJECT_SPHERE ;
   parms.flags |= IP_USE_CURVATURE ;
   parms.tol = 1e-0*10 ;
@@ -349,7 +349,7 @@ get_option(int argc, char *argv[]) {
       fprintf(stderr, "momentum = %2.2f\n", (float)parms.momentum) ;
       break ;
     case 'C':
-      strncpy(const_cast<char*>(curvature_fname), argv[2], STRLEN) ; // Well... at least it's strncpy
+      strncpy(const_cast<char*>(curvature_fname), argv[2], STRLEN-1) ; // Well... at least it's strncpy
       nargs = 1 ;
       break ;
     case 'A':
@@ -462,13 +462,23 @@ mrisRegister(MRI_SURFACE *mris, MRI_SP *mrisp_template,
   Timer start;
   MRISsaveVertexPositions(mris, ORIGINAL_VERTICES) ;
   FileNamePath(mris->fname, path) ;
-  sprintf(base_name, "%s/%s.%s", path,
-          mris->hemisphere == LEFT_HEMISPHERE ? "lh":"rh", parms->base_name);
+  int req = snprintf(base_name, STRLEN,
+		     "%s/%s.%s",
+		     path,
+		     mris->hemisphere == LEFT_HEMISPHERE ? "lh":"rh", 
+		     parms->base_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
 
   base_dt = parms->dt ;
   if (Gdiag & DIAG_WRITE) {
-    sprintf(fname, "%s.%s.out",
-            mris->hemisphere == RIGHT_HEMISPHERE ? "rh":"lh",parms->base_name);
+    int req = snprintf(fname, STRLEN,
+		       "%s.%s.out",
+		       mris->hemisphere == RIGHT_HEMISPHERE ? "rh":"lh",parms->base_name);
+    if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (!parms->start_t) {
       INTEGRATION_PARMS_openFp(parms, fname, "w") ;
       if (!parms->fp)
@@ -556,7 +566,13 @@ mrisRegister(MRI_SURFACE *mris, MRI_SP *mrisp_template,
                 sigma) ;
       if (Gdiag & DIAG_WRITE && !i && !parms->start_t) {
         MRISfromParameterization(mrisp_template, mris, ino);
-        sprintf(fname, "%s/%s.target", path, mris->hemisphere == RIGHT_HEMISPHERE ? "rh":"lh") ;
+        int req = snprintf(fname, STRLEN,
+			   "%s/%s.target",
+			   path, mris->hemisphere == RIGHT_HEMISPHERE ? "rh":"lh") ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+
         if (Gdiag & DIAG_SHOW)
           fprintf(stdout, "writing curvature file %s...", fname) ;
         MRISwriteCurvature(mris, fname) ;
@@ -575,17 +591,15 @@ mrisRegister(MRI_SURFACE *mris, MRI_SP *mrisp_template,
       MRISnormalizeCurvature(mris,which_norm) ;
       MRIStoParameterization(mris, parms->mrisp_template, 1, ino) ;
 
-#if 0
-      /* normalize variances for both source and target */
-      MRISfromParameterization(parms->mrisp_template, mris, ino+1);
-      MRISnormalizeCurvature(mris, which_norm) ;
-      MRIStoParameterization(mris, parms->mrisp_template, 1, ino+1) ;
-#endif
 
       if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON) {
-        sprintf(fname, "%s/%s.%4.4dtarget%2.2f",
-                path, mris->hemisphere == RIGHT_HEMISPHERE ? "rh":"lh",
-                parms->start_t, sigma) ;
+        int req = snprintf(fname, STRLEN,
+			   "%s/%s.%4.4dtarget%2.2f",
+			   path, mris->hemisphere == RIGHT_HEMISPHERE ? "rh":"lh",
+			   parms->start_t, sigma) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         if (Gdiag & DIAG_SHOW)
           fprintf(stdout, "writing curvature file %s...", fname) ;
         MRISwriteCurvature(mris, fname) ;
@@ -605,15 +619,25 @@ mrisRegister(MRI_SURFACE *mris, MRI_SP *mrisp_template,
       mris->vp = (void *)parms->mrisp ;  /* hack to get it to projectSurface */
 
       if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON) {
-        sprintf(fname, "%s/%s.%4.4dblur%2.2f",
-                path, mris->hemisphere == RIGHT_HEMISPHERE ? "rh":"lh",
-                parms->start_t, sigma) ;
+        int req = snprintf(fname, STRLEN,
+			   "%s/%s.%4.4dblur%2.2f",
+			   path, mris->hemisphere == RIGHT_HEMISPHERE ? "rh":"lh",
+			   parms->start_t, sigma) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+
         if (Gdiag & DIAG_SHOW)
           fprintf(stdout, "writing curvature file %s...", fname) ;
         MRISwriteCurvature(mris, fname) ;
         if (Gdiag & DIAG_SHOW)
           fprintf(stdout, "done.\n") ;
-        sprintf(fname, "target.%s.%4.4d.hipl",parms->base_name,parms->start_t);
+        req = snprintf(fname, STRLEN,
+		       "target.%s.%4.4d.hipl",parms->base_name,parms->start_t);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+
         if (Gdiag & DIAG_SHOW)
           fprintf(stdout, "writing parameterization file %s...", fname) ;
         MRISPwrite(parms->mrisp_template, fname) ;
@@ -705,9 +729,14 @@ mrisIntegrationEpoch(MRI_SURFACE *mris, INTEGRATION_PARMS *parms,int base_averag
     if (Gdiag & DIAG_WRITE) {
       char fname[STRLEN] ;
       if (!parms->fp) {
-        sprintf(fname, "%s.%s.out",
-                mris->hemisphere == RIGHT_HEMISPHERE ? "rh":"lh",
-                parms->base_name);
+        int req= snprintf(fname, STRLEN,
+			  "%s.%s.out",
+			  mris->hemisphere == RIGHT_HEMISPHERE ? "rh":"lh",
+			  parms->base_name);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+
         if (!parms->start_t)
           INTEGRATION_PARMS_openFp(parms, fname, "w") ;
         else

--- a/histo_register_block/histo_register_block.cpp
+++ b/histo_register_block/histo_register_block.cpp
@@ -439,10 +439,15 @@ compute_optimal_xform(MRI *mri_src, MRI *mri_dst, MRI *mri_seg, DENSITY **pdfs, 
     mri_dst_pyramid[level] = MRIreduce2D(mri_dst_pyramid[level-1], NULL) ;
   }
 
-  sprintf(fname, "%s_target", base) ;
+  int req = snprintf(fname, STRLEN, "%s_target", base) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mriWriteImageView(mri_dst, fname, RGB_SIZE, MRI_CORONAL, 0, mri_dst) ;
   for (level = nlevels-1 ; level >= 0 ; level--) {
-    align_pyramid_level(mri_src_pyramid[level], mri_dst_pyramid[level], mri_seg_pyramid[level], xform, pdf, level, mri_src,
+    align_pyramid_level(mri_src_pyramid[level], 
+			mri_dst_pyramid[level], 
+			mri_seg_pyramid[level], xform, pdf, level, mri_src,
                         cost_type, skip);
   }
 
@@ -767,10 +772,16 @@ write_snapshot(MRI *mri, MRI *mri1, MRI *mri2, MATRIX *m, char *base, int n, int
   mri = MRIresampleFill(mri, mri2, SAMPLE_NEAREST, 255) ;
   mri_xformed = mri_apply_slice_xform(mri, NULL, m, 0) ;
 
-  sprintf(fname, "%s%3.3d", base, n) ;
+  int req = snprintf(fname, STRLEN, "%s%3.3d", base, n) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing snapshot to %s...\n", fname) ;
   mriWriteImageView(mri_xformed, fname, RGB_SIZE, MRI_CORONAL, -1, mri2) ;
-  sprintf(fname, "%s%3.3d.mgz", base, n) ;
+  req = snprintf(fname, STRLEN, "%s%3.3d.mgz", base, n) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   MRIwrite(mri_xformed, fname) ;
   MRIfree(&mri_xformed) ;
 
@@ -778,14 +789,20 @@ write_snapshot(MRI *mri, MRI *mri1, MRI *mri2, MATRIX *m, char *base, int n, int
     MATRIX *m_inv ;
 
     mri_ll = DensityLikelihoodImage(mri1, mri2, NULL, m, pdf, mri_seg, 0) ;
-    sprintf(fname, "%s_ll_%3.3d.mgz", base, n) ;
+    int req = snprintf(fname, STRLEN, "%s_ll_%3.3d.mgz", base, n) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing density map to %s...\n", fname) ;
     MRIwrite(mri_ll, fname) ;
     MRIfree(&mri_ll) ;
 
     m_inv = MatrixInverse(m, NULL) ;
     mri_ll = DensityLikelihoodImage(mri2, mri1, NULL, m_inv, pdf, mri_seg, 1) ;
-    sprintf(fname, "%s_ll_src_%3.3d.mgz", base, n) ;
+    req = snprintf(fname, STRLEN, "%s_ll_src_%3.3d.mgz", base, n) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing density map to %s...\n", fname) ;
     MRIwrite(mri_ll, fname) ;
     MRIfree(&mri_ll) ;

--- a/histo_synthesize/histo_synthesize.cpp
+++ b/histo_synthesize/histo_synthesize.cpp
@@ -513,7 +513,10 @@ HISTOsynthesize(MRI *mri, MRI *histo, int test_slice, int train_slice, MRI *hsyn
     if (x % 50 == 0)
     {
       char fname[STRLEN] ;
-      sprintf(fname, "%s.%03d.mgz", base_name, x) ;
+      int req = snprintf(fname, STRLEN, "%s.%03d.mgz", base_name, x) ;
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("writing snapshot to %s\n", fname) ;
       MRIwrite(hsynth, fname) ;
     }

--- a/label2flat/label2flat.cpp
+++ b/label2flat/label2flat.cpp
@@ -120,18 +120,27 @@ main(int argc, char *argv[]) {
     ErrorExit(ERROR_BADPARM, "no subjects directory in environment.\n") ;
   strcpy(subjects_dir, cp) ;
 
-  sprintf(label_fname, "%s/%s/label/%s.label",
-          subjects_dir, subject_name, label_name) ;
+  int req = snprintf(label_fname, STRLEN,
+		     "%s/%s/label/%s.label",
+		     subjects_dir, subject_name, label_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
 
   linear_transform = load_transform(subject_name, &transform) ;
 
   cp = strrchr(patch_name, '.') ;
-  if (!cp)
+  if (!cp) {
     strcpy(hemi, "lh") ;
-  else
+  } else {
     strncpy(hemi, cp-2, 2) ;
+  }
   hemi[2] = 0 ;
-  sprintf(surf_fname, "%s/%s/surf/%s.orig", subjects_dir, subject_name, hemi);
+  req = snprintf(surf_fname, STRLEN,
+		 "%s/%s/surf/%s.orig", subjects_dir, subject_name, hemi);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fprintf(stderr, "reading surface %s...\n", surf_fname) ;
   mris = MRISread(surf_fname) ;
   if (!mris)
@@ -144,12 +153,23 @@ main(int argc, char *argv[]) {
   if (canon_name)   /* put it onto a canonical surface */
   {
     cp = strrchr(canon_name, '.') ;
-    if (cp)   /* hemisphere specified explicitly */
-      sprintf(surf_fname, "%s/%s/surf/%s", subjects_dir, subject_name,
-              canon_name) ;
-    else
-      sprintf(surf_fname, "%s/%s/surf/%s.%s", subjects_dir, subject_name,
-              hemi, canon_name) ;
+    if (cp)  { /* hemisphere specified explicitly */
+      int req = snprintf(surf_fname, STRLEN,
+			 "%s/%s/surf/%s", 
+			 subjects_dir, subject_name,
+			 canon_name) ;
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    } else {
+      int req = snprintf(surf_fname, STRLEN,
+			 "%s/%s/surf/%s.%s", 
+			 subjects_dir, subject_name,
+			 hemi, canon_name) ;
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
     MRISreadCanonicalCoordinates(mris, surf_fname) ;
     LabelToCanonical(area, mris) ;
   }
@@ -160,7 +180,11 @@ main(int argc, char *argv[]) {
   if (output_subject)   /* write onto a different subject's flat map */
   {
     MRISfree(&mris) ;
-    sprintf(surf_fname, "%s/%s/surf/%s.orig", subjects_dir, subject_name,hemi);
+    int req = snprintf(surf_fname, STRLEN,
+		       "%s/%s/surf/%s.orig", subjects_dir, subject_name,hemi);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stderr, "reading surface %s...\n", surf_fname) ;
     mris = MRISread(surf_fname) ;
     if (!mris)
@@ -171,15 +195,27 @@ main(int argc, char *argv[]) {
     if (canon_name)   /* put it onto a canonical surface */
     {
       cp = strrchr(canon_name, '.') ;
-      if (cp)   /* hemisphere specified explicitly */
-        sprintf(surf_fname, "%s/%s/surf/%s", subjects_dir, subject_name,
-                canon_name) ;
-      else
-        sprintf(surf_fname, "%s/%s/surf/%s.%s", subjects_dir, subject_name,
-                hemi, canon_name) ;
+      if (cp)  { /* hemisphere specified explicitly */
+        int req = snprintf(surf_fname, STRLEN,
+			   "%s/%s/surf/%s",
+			   subjects_dir, subject_name,
+			   canon_name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+      } else {
+        int req = snprintf(surf_fname, STRLEN,
+			   "%s/%s/surf/%s.%s",
+			   subjects_dir, subject_name,
+			   hemi, canon_name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+      }
       MRISreadCanonicalCoordinates(mris, surf_fname) ;
-    } else
+    } else {
       MRISsaveVertexPositions(mris, CANONICAL_VERTICES) ;
+    }
 
     LabelFromCanonical(area, mris) ;
   }
@@ -262,8 +298,12 @@ static Transform *
 load_transform(char *subject_name, General_transform *transform) {
   char xform_fname[100] ;
 
-  sprintf(xform_fname, "%s/%s/mri/transforms/talairach.xfm",
-          subjects_dir, subject_name) ;
+  int req = snprintf(xform_fname, 100,
+		     "%s/%s/mri/transforms/talairach.xfm",
+		     subjects_dir, subject_name) ;
+  if( req >= 100 ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   if (input_transform_file(xform_fname, transform) != OK)
     ErrorExit(ERROR_NOFILE, "%s: could not load transform file '%s'",
               Progname, xform_fname) ;

--- a/label2flat/label2flat.cpp
+++ b/label2flat/label2flat.cpp
@@ -85,8 +85,8 @@ int
 main(int argc, char *argv[]) {
   char         **av ;
   int          ac, nargs ;
-  char         *cp, label_fname[100], *subject_name, *label_name,
-  *out_fname, *patch_name, surf_fname[100], hemi[10] ;
+  char         *cp, label_fname[STRLEN], *subject_name, *label_name,
+  *out_fname, *patch_name, surf_fname[STRLEN], hemi[10] ;
   LABEL        *area ;
   MRI_SURFACE  *mris ;
 

--- a/label2patch/label2patch.cpp
+++ b/label2patch/label2patch.cpp
@@ -56,7 +56,7 @@ static int writesurf = 0;
 int
 main(int argc, char *argv[]) {
   int          ac, nargs ;
-  char         **av, *cp, surf_name[100], *hemi, *subject_name, *label_name,
+  char         **av, *cp, surf_name[STRLEN], *hemi, *subject_name, *label_name,
                *out_fname ;
   MRI_SURFACE  *mris ;
   LABEL        *label ;

--- a/label2patch/label2patch.cpp
+++ b/label2patch/label2patch.cpp
@@ -95,7 +95,13 @@ main(int argc, char *argv[]) {
     strcpy(subjects_dir, cp) ;
   }
 
-  sprintf(surf_name,"%s/%s/surf/%s.%s",subjects_dir,subject_name,hemi,surface);
+  int req = snprintf(surf_name,STRLEN,
+		     "%s/%s/surf/%s.%s",
+		     subjects_dir,subject_name,hemi,surface);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   fprintf(stderr, "reading %s...\n", surf_name) ;
   mris = MRISread(surf_name) ;
   if (!mris)

--- a/mri_bias/mri_compute_bias.cpp
+++ b/mri_bias/mri_compute_bias.cpp
@@ -216,29 +216,32 @@ main(int argc, char *argv[])
   
   mri_bias = MRIalloc(256+2*pad, 256+2*pad, 256+2*pad, MRI_FLOAT) ;
   mri_counts = MRIalloc(256+2*pad, 256+2*pad, 256+2*pad, MRI_FLOAT) ;
-#if 0
-	mri_bias->c_r = (double)mri_bias->width/2.0 ;
-	mri_bias->c_a = (double)mri_bias->height/2.0 ;
-	mri_bias->c_s = (double)mri_bias->depth/2.0 ;
-	mri_counts->c_r = (double)mri_counts->width/2.0 ;
-	mri_counts->c_a = (double)mri_counts->height/2.0 ;
-	mri_counts->c_s = (double)mri_counts->depth/2.0 ;
-#endif
 
   for (i = 1 ; i < argc-1 ; i++)
 	{
 		subject = argv[i] ;
 		fprintf(stderr, "subject %s, %d of %d...\n", subject, i, argc-2) ;
 
-		sprintf(fname, "%s/%s/mri/orig.mgz", sdir, subject) ;
+		int req = snprintf(fname, STRLEN,
+				   "%s/%s/mri/orig.mgz", sdir, subject) ;
+		if( req >= STRLEN ) {
+		  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+		}
+
 		mri_orig = MRIread(fname) ;
 		if (!mri_orig)
 			ErrorExit(Gerror, "%s: could not read orig volume %s", Progname, fname) ;
-		sprintf(fname, "%s/%s/mri/T1.mgz", sdir, subject) ;
+		req = snprintf(fname, STRLEN, "%s/%s/mri/T1.mgz", sdir, subject) ;
+		if( req >= STRLEN ) {
+		  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+		}
 		mri_T1 = MRIread(fname) ;
 		if (!mri_T1)
 			ErrorExit(Gerror, "%s: could not read T1 volume %s", Progname, fname) ;
-		sprintf(fname, "%s/%s/mri/brainmask.mgz", sdir, subject) ;
+		req = snprintf(fname, STRLEN, "%s/%s/mri/brainmask.mgz", sdir, subject) ;
+		if( req >= STRLEN ) {
+		  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+		}
 		mri_brain = MRIread(fname) ;
 		if (!mri_T1)
 			ErrorExit(Gerror, "%s: could not read T1 volume %s", Progname, fname) ;
@@ -270,7 +273,11 @@ main(int argc, char *argv[])
     {
       TRANSFORM    *transform ;
       MRI          *mri ;
-      sprintf(fname, "%s/%s/mri/transforms/%s", sdir, subject, xform_name) ;
+      int req = snprintf(fname, STRLEN,
+			 "%s/%s/mri/transforms/%s", sdir, subject, xform_name) ;
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       transform = TransformRead(fname) ;
       if (transform == NULL)
         ErrorExit(ERROR_NOFILE, "%s: could not load transform from %s", Progname, fname) ;

--- a/mri_ca_tissue_parms/mri_ca_tissue_parms.cpp
+++ b/mri_ca_tissue_parms/mri_ca_tissue_parms.cpp
@@ -105,7 +105,11 @@ main(int argc, char *argv[]) {
     subject_name = argv[i+2] ;
     printf("processing subject %s, %d of %d...\n", subject_name,i+1,
            nsubjects);
-    sprintf(fname, "%s/%s/mri/%s", subjects_dir, subject_name, parc_dir) ;
+    int req = snprintf(fname, STRLEN,
+		       "%s/%s/mri/%s", subjects_dir, subject_name, parc_dir) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (DIAG_VERBOSE_ON)
       printf("reading parcellation from %s...\n", fname) ;
     mri_parc = MRIread(fname) ;
@@ -113,7 +117,11 @@ main(int argc, char *argv[]) {
       ErrorExit(ERROR_NOFILE, "%s: could not read parcellation file %s",
                 Progname, fname) ;
 
-    sprintf(fname, "%s/%s/mri/%s", subjects_dir, subject_name, T1_name) ;
+    req = snprintf(fname, STRLEN,
+		   "%s/%s/mri/%s", subjects_dir, subject_name, T1_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (DIAG_VERBOSE_ON)
       printf("reading co-registered T1 from %s...\n", fname) ;
     mri_T1 = MRIread(fname) ;
@@ -121,52 +129,42 @@ main(int argc, char *argv[]) {
       ErrorExit(ERROR_NOFILE, "%s: could not read T1 data from file %s",
                 Progname, fname) ;
 
-    sprintf(fname, "%s/%s/mri/%s", subjects_dir, subject_name, PD_name) ;
+    req = snprintf(fname, STRLEN,
+		   "%s/%s/mri/%s", subjects_dir, subject_name, PD_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (DIAG_VERBOSE_ON)
       printf("reading co-registered T1 from %s...\n", fname) ;
     mri_PD = MRIread(fname) ;
-    if (!mri_PD)
+    if (!mri_PD) {
       ErrorExit(ERROR_NOFILE, "%s: could not read PD data from file %s",
                 Progname, fname) ;
-
+    }
 
     if (xform_name) {
       /*      VECTOR *v_tmp, *v_tmp2 ;*/
 
-      sprintf(fname, "%s/%s/mri/%s", subjects_dir, subject_name, xform_name) ;
+      int req = snprintf(fname, STRLEN,
+			 "%s/%s/mri/%s", 
+			 subjects_dir, subject_name, xform_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("reading xform from %s...\n", fname) ;
       transform = TransformRead(fname) ;
       if (!transform)
         ErrorExit(ERROR_NOFILE, "%s: could not read xform from %s",
                   Progname, fname) ;
-#if 0
-      v_tmp = VectorAlloc(4,MATRIX_REAL) ;
-      *MATRIX_RELT(v_tmp,4,1)=1.0 ;
-      v_tmp2 = MatrixMultiply(lta->xforms[0].m_L, v_tmp, NULL) ;
-      printf("RAS (0,0,0) -->\n") ;
-      MatrixPrint(stdout, v_tmp2) ;
-#endif
 
       if (transform->type == LINEAR_RAS_TO_RAS) {
         MATRIX *m_L ;
         m_L = ((LTA *)transform->xform)->xforms[0].m_L ;
         MRIrasXformToVoxelXform(mri_parc, mri_T1, m_L,m_L) ;
-      }
-#if 0
-      v_tmp2 = MatrixMultiply(lta->xforms[0].m_L, v_tmp, v_tmp2) ;
-      printf("voxel (0,0,0) -->\n") ;
-      MatrixPrint(stdout, v_tmp2) ;
-      VectorFree(&v_tmp) ;
-      VectorFree(&v_tmp2) ;
-      test(mri_parc, mri_T1, mri_PD, lta->xforms[0].m_L) ;
-#endif
-    }
-    if (histo_parms)
+      }    }
+    if (histo_parms) {
       GCAhistogramTissueStatistics(gca,mri_T1,mri_PD,mri_parc,transform,histo_parms);
-#if 0
-    else
-      GCAaccumulateTissueStatistics(gca, mri_T1, mri_PD, mri_parc, transform) ;
-#endif
+    }
 
     MRIfree(&mri_parc) ;
     MRIfree(&mri_T1) ;
@@ -277,60 +275,3 @@ usage_exit(int code) {
   printf("\t-gradient - use intensity gradient as input to classifier.\n") ;
   exit(code) ;
 }
-#if 0
-static int
-test(MRI *mri1, MRI *mri2, MRI *mri3, MATRIX *m_vol1_to_vol2_ras) {
-  VECTOR *v_test, *v_vox ;
-  float  x_ras1, y_ras1, z_ras1, x_ras2, y_ras2, z_ras2, x_vox1, y_vox1,
-  z_vox1, x_vox2, y_vox2, z_vox2 ;
-  MATRIX  *m_vol2_vox2ras, *m_vol2_ras2vox, *m_vol1_ras2vox, *m_vol1_vox2ras,
-  *m_vol3_ras2vox, *m_vol3_vox2ras ;
-  int     val ;
-
-
-  v_test = VectorAlloc(4, MATRIX_REAL) ;
-  m_vol1_vox2ras = MRIgetVoxelToRasXform(mri1) ;
-  m_vol2_vox2ras = MRIgetVoxelToRasXform(mri2) ;
-  m_vol1_ras2vox = MRIgetRasToVoxelXform(mri1) ;
-  m_vol2_ras2vox = MRIgetRasToVoxelXform(mri2) ;
-  m_vol3_vox2ras = MRIgetVoxelToRasXform(mri3) ;
-  m_vol3_ras2vox = MRIgetRasToVoxelXform(mri3) ;
-
-  x_ras1 = 126.50 ;
-  y_ras1 = -125.500 ;
-  z_ras1 = 127.50 ;
-  V3_X(v_test) = x_ras1 ;
-  V3_Y(v_test) = y_ras1 ;
-  V3_Z(v_test) = z_ras1 ;
-  *MATRIX_RELT(v_test, 4, 1) = 1.0 ;
-  v_vox = MatrixMultiply(m_vol1_ras2vox, v_test, NULL) ;
-  x_vox1 = V3_X(v_vox) ;
-  y_vox1 = V3_Y(v_vox) ;
-  z_vox1 = V3_Z(v_vox) ;
-  val = MRISvox(mri1, nint(x_vox1), nint(y_vox1), nint(z_vox1)) ;
-  printf("VOL1: ras (%1.1f, %1.1f, %1.1f) --> VOX (%1.1f, %1.1f, %1.1f) = %d\n",
-         x_ras1, y_ras1, z_ras1, x_vox1, y_vox1, z_vox1, val) ;
-
-
-  x_ras2 = 76.5421 ;
-  y_ras2 = 138.5352 ;
-  z_ras2 = 96.0910 ;
-  V3_X(v_test) = x_ras2 ;
-  V3_Y(v_test) = y_ras2 ;
-  V3_Z(v_test) = z_ras2 ;
-  *MATRIX_RELT(v_test, 4, 1) = 1.0 ;
-  v_vox = MatrixMultiply(m_vol2_ras2vox, v_test, NULL) ;
-  x_vox2 = V3_X(v_vox) ;
-  y_vox2 = V3_Y(v_vox) ;
-  z_vox2 = V3_Z(v_vox) ;
-  val = MRISvox(mri2, nint(x_vox2), nint(y_vox2), nint(z_vox2)) ;
-  printf("VOL2: ras (%2.1f, %2.1f, %2.1f) --> VOX (%2.1f, %2.1f, %2.1f) = %d\n",
-         x_ras2, y_ras2, z_ras2, x_vox2, y_vox2, z_vox2, val) ;
-
-
-
-  MatrixFree(&v_test) ;
-  return(NO_ERROR) ;
-}
-
-#endif

--- a/mri_cal_renormalize_gca/mri_cal_renormalize_gca.cpp
+++ b/mri_cal_renormalize_gca/mri_cal_renormalize_gca.cpp
@@ -147,11 +147,21 @@ main(int argc, char *argv[])
   for (input = 0 ; input < ninputs ; input++)
   {
     printf("reading subject %d of %d: %s \n", input+1, ninputs, subjects[input]) ;
-    if (longinput)
-      sprintf(fname, "%s/%s.long.%s/mri/%s", sdir, subjects[input], base_name, in_fname) ;
-    else
-      sprintf(fname, "%s/%s/longtp/%s/%s", sdir, base_name, subjects[input], in_fname) ;
-
+    if (longinput) {
+      int req =snprintf(fname, STRLEN,
+			"%s/%s.long.%s/mri/%s",
+			sdir, subjects[input], base_name, in_fname) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    } else {
+      int req = snprintf(fname, STRLEN,
+			 "%s/%s/longtp/%s/%s",
+			 sdir, base_name, subjects[input], in_fname) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
     mri_tmp = MRIread(fname) ;
     if (!mri_tmp)
       ErrorExit(ERROR_NOFILE, "%s: could not read input MR volume from %s",

--- a/mri_compute_volume_fractions/mri_compute_layer_fractions.cpp
+++ b/mri_compute_volume_fractions/mri_compute_layer_fractions.cpp
@@ -171,45 +171,54 @@ main(int argc, char *argv[])
   if (FS_names && nlayers != 1)
     ErrorExit(ERROR_UNSUPPORTED, "%s: if specifying FS_names must use -nlayers 1", Progname) ;
   printf("reading laminar surfaces from %s.?\n", LAMINAR_NAME) ;
-  for (i = 0 ; i <= nlayers ; i++)
-  {
-    if (FS_names && nlayers == 1)
-    {
-      if (i == 0)
-	sprintf(fname, "%s/%s/surf/%s.white", sdir, subject,hemi) ;
-      else
-	sprintf(fname, "%s/%s/surf/%s.pial", sdir, subject,hemi) ;
-    }
-    else
-    {
-      sprintf(fname, "%s/%s/surf/%s.%s.%d", sdir, subject,hemi,LAMINAR_NAME,i) ;
-      if (FileExists(fname) == 0)
-	sprintf(fname, "%s/%s/surf/%s.%s%3.3d", sdir, subject,hemi,LAMINAR_NAME,i) ;
+  for (i = 0 ; i <= nlayers ; i++) {
+    if (FS_names && nlayers == 1) {
+      if (i == 0) {
+	int req = snprintf(fname, STRLEN,
+			   "%s/%s/surf/%s.white", sdir, subject,hemi) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+      } else {
+	int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.pial", sdir, subject,hemi) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+      }
+    } else {
+      int req = snprintf(fname, STRLEN,
+			 "%s/%s/surf/%s.%s.%d", sdir, subject,hemi,LAMINAR_NAME,i) ;
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+      if (FileExists(fname) == 0) {
+	int req = snprintf(fname, STRLEN,
+			   "%s/%s/surf/%s.%s%3.3d", sdir, subject,hemi,LAMINAR_NAME,i) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+      }
     }
     printf("reading surface %s\n", fname) ;
     mris = MRISread(fname) ;
     if (mris == NULL)
       ErrorExit(ERROR_NOFILE, "%s: could not load %s surface %d from %s", 
                 Progname,hemi, i, fname) ;
-
+    
     mri_interior_top = MRIclone(mri_layers, NULL) ;
     MRISfillInterior(mris, resolution, mri_interior_top) ;
-
-    if (Gdiag & DIAG_WRITE)
-    {
+    
+    if (Gdiag & DIAG_WRITE) {
       sprintf(fname, "top%d.mgz", i) ;
       printf("writing layer %d interior to %s\n", i, fname) ;
       MRIwrite(mri_interior_top, fname) ;
     }
-    if (i == 0)  // fill white matter
-    {
+    if (i == 0)  { // fill white matter
       mri_tmp = MRIclone(mri_interior_top, NULL) ;
       MRIreplaceValuesOnly(mri_interior_top, mri_tmp, 1, WM_VAL) ;
       MRIcopyLabel(mri_tmp, mri_layers, WM_VAL) ;
       MRIfree(&mri_tmp) ;
-    }
-    else  // fill cortical layer
-    {
+    } else  { // fill cortical layer
       mri_tmp = MRInot(mri_interior_bottom, NULL) ;
       MRIfree(&mri_interior_bottom) ;
       MRIand(mri_interior_top, mri_tmp, mri_tmp, 1) ;

--- a/mri_compute_volume_fractions/mri_compute_layer_fractions.cpp
+++ b/mri_compute_volume_fractions/mri_compute_layer_fractions.cpp
@@ -144,18 +144,6 @@ main(int argc, char *argv[])
     ErrorExit(ERROR_NOFILE, "%s: could not load aseg volume from %s", Progname,fname) ;
 
   nvox = (int)ceil(256/resolution);  
-#if 0
-  mri_layers = MRIalloc(nvox, nvox, nvox, MRI_UCHAR) ;
-  MRIsetResolution(mri_layers, resolution, resolution, resolution) ;
-  mri_layers->xstart = -resolution*mri_layers->width/2.0 ;
-  mri_layers->xend = resolution*mri_layers->width/2.0 ;
-  mri_layers->ystart = -resolution*mri_layers->height/2.0 ;
-  mri_layers->yend = resolution*mri_layers->height/2.0 ;
-  mri_layers->zstart = -resolution*mri_layers->depth/2.0 ;
-  mri_layers->zend = resolution*mri_layers->depth/2 ;
-  mri_layers->c_r = mri_aseg->c_r ; mri_layers->c_a = mri_aseg->c_a ; 
-  mri_layers->c_s = mri_aseg->c_s ;
-#else
   mri_in = MRIreadHeader(in_fname, MRI_VOLUME_TYPE_UNKNOWN) ;
   if (mri_in == NULL)
     ErrorExit(ERROR_NOFILE, "%s: could not load input volume from %s", Progname,in_fname) ;
@@ -172,7 +160,6 @@ main(int argc, char *argv[])
   mri_layers->z_r = mri_in->z_r ; mri_layers->z_a = mri_in->z_a ; mri_layers->z_s = mri_in->z_s ;
   mri_layers->c_r = mri_in->c_r ; mri_layers->c_a = mri_in->c_a ; mri_layers->c_s = mri_in->c_s ;
   MRIfree(&mri_in) ;
-#endif
 
   MRIreInitCache(mri_layers) ; 
 

--- a/mri_compute_volume_fractions/mri_compute_layer_fractions.cpp
+++ b/mri_compute_volume_fractions/mri_compute_layer_fractions.cpp
@@ -137,7 +137,12 @@ main(int argc, char *argv[])
 
   if (subject_name)
     subject = subject_name ;   // specified on command line
-  sprintf(fname, "%s/%s/mri/%s", sdir, subject, aseg_name) ;
+  int req = snprintf(fname, STRLEN,
+		     "%s/%s/mri/%s", sdir, subject, aseg_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   printf("reading volume %s\n", fname) ;
   mri_aseg = MRIread(fname) ;
   if (mri_aseg == NULL)

--- a/mri_compute_volume_fractions/mri_compute_volume_intensities.cpp
+++ b/mri_compute_volume_fractions/mri_compute_volume_intensities.cpp
@@ -337,8 +337,9 @@ compute_unpartial_volumed_intensities(MRI *mri_src, MRI *mri_vfrac_wm, MRI *mri_
 	  }
 	  else   // only wm in this voxel
 	  {
-	    for (row = 1 ; row <= m_A3->rows ; row++)
+	    for (row = 1 ; row <= m_A3->rows ; row++) {
 	      *MATRIX_RELT(m_A1, row, 1) = *MATRIX_RELT(m_A3, row, 1) ;
+	    }
 
 	    v_s = v_s1 ;
 	    m_A = m_A1 ;
@@ -346,11 +347,12 @@ compute_unpartial_volumed_intensities(MRI *mri_src, MRI *mri_vfrac_wm, MRI *mri_
 	}
 	else  // only csf in this region
 	{
-	  for (row = 1 ; row <= m_A3->rows ; row++)
+	  for (row = 1 ; row <= m_A3->rows ; row++) {
 	    *MATRIX_RELT(m_A1, row, 1) = *MATRIX_RELT(m_A3, row, 3) ;
+	  }
 
-	    v_s = v_s1 ;
-	    m_A = m_A1 ;
+	  v_s = v_s1 ;
+	  m_A = m_A1 ;
 	}
 
 	m_A_pinv = MatrixPseudoInverse(m_A, NULL) ;

--- a/mri_dct_align/mri_dct_align.cpp
+++ b/mri_dct_align/mri_dct_align.cpp
@@ -180,21 +180,29 @@ main(int argc, char *argv[])
 
   if (Gdiag & DIAG_WRITE && mp.write_iterations > 0)
   {
-		sprintf(fname, "%s_target", mp.base_name) ;
+    int req = snprintf(fname, STRLEN,
+		       "%s_target", mp.base_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     MRIwriteImageViews(mri_target, fname, IMAGE_SIZE) ;	
-		sprintf(fname, "%s_target.mgz", mp.base_name) ;
-		MRIwrite(mri_target, fname) ;
-	}
-	
-	if (transform == NULL)
-		transform = TransformAlloc(LINEAR_RAS_TO_RAS, NULL) ;
-
-
-	if (transform->type == MORPH_3D_TYPE)  // initializing m3d from a linear transform
-	{
-		printf("using previously create gcam...\n") ;
-    ErrorExit(ERROR_UNSUPPORTED, "%s: can't initialize DCT with GCAM", Progname) ;
+    
+    req = snprintf(fname, STRLEN, "%s_target.mgz", mp.base_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+    MRIwrite(mri_target, fname) ;
   }
+  
+  if (transform == NULL)
+    transform = TransformAlloc(LINEAR_RAS_TO_RAS, NULL) ;
+  
+  
+  if (transform->type == MORPH_3D_TYPE)  // initializing m3d from a linear transform
+    {
+      printf("using previously create gcam...\n") ;
+      ErrorExit(ERROR_UNSUPPORTED, "%s: can't initialize DCT with GCAM", Progname) ;
+    }
   
   new_transform = 1 ;
   lta = ((LTA *)(transform->xform)) ;

--- a/mri_dct_align/mri_dct_align_binary.cpp
+++ b/mri_dct_align/mri_dct_align_binary.cpp
@@ -325,13 +325,6 @@ main(int argc, char *argv[])
 	}
 	else if (which == HIPPO)
 	{
-#if 0
-		for (i = 0 ; i < NUM_NON_HIPPO_LABELS ; i++)
-		{
-			label = non_hippo_labels[i] ;
-			MRIreplaceValues(mri_source, mri_source, label, 0) ;
-		}
-#endif
 	}
 
 	if (which == WM)  // debugging
@@ -339,12 +332,18 @@ main(int argc, char *argv[])
 		mri_orig_target = mri_target ; mri_orig_source = mri_source ;
 		mp.target_label = target_label ;
 	}
-  if (Gdiag & DIAG_WRITE && mp.write_iterations > 0)
-  {
-		sprintf(fname, "%s_target", mp.base_name) ;
-    MRIwriteImageViews(mri_orig_target, fname, IMAGE_SIZE) ;	
-		sprintf(fname, "%s_target.mgz", mp.base_name) ;
-		MRIwrite(mri_orig_target, fname) ;
+	if (Gdiag & DIAG_WRITE && mp.write_iterations > 0)
+	  {
+	    int req = snprintf(fname, STRLEN, "%s_target", mp.base_name) ;
+	    if( req >= STRLEN ) {
+	      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	    }
+	    MRIwriteImageViews(mri_orig_target, fname, IMAGE_SIZE) ;	
+	    req = snprintf(fname, STRLEN, "%s_target.mgz", mp.base_name) ;
+	    if( req >= STRLEN ) {
+	      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	    }
+	    MRIwrite(mri_orig_target, fname) ;
 	}
 	
 	if (transform == NULL)
@@ -373,17 +372,22 @@ main(int argc, char *argv[])
 	{
 		char fname[STRLEN] ;
 
-		sprintf(fname, "%s_target.mgz", mp.base_name) ;
-    printf("writing target volume to %s...\n", fname) ;
-		if (mp.diag_morph_from_atlas)
-			MRIwrite(mri_orig_target, fname) ;
-		else
-		{
-      MRI    *mri_tmp ;
-      mri_tmp = MRITransformedCenteredMatrix(mri_source, mri_target, m_L) ;
-			MRIwrite(mri_tmp, fname) ;
-      MRIfree(&mri_tmp) ;
+		int req = snprintf(fname, STRLEN,
+				   "%s_target.mgz", mp.base_name) ;
+		if( req >= STRLEN ) {
+		  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
 		}
+		
+		printf("writing target volume to %s...\n", fname) ;
+		if (mp.diag_morph_from_atlas)
+		  MRIwrite(mri_orig_target, fname) ;
+		else
+		  {
+		    MRI    *mri_tmp ;
+		    mri_tmp = MRITransformedCenteredMatrix(mri_source, mri_target, m_L) ;
+		    MRIwrite(mri_tmp, fname) ;
+		    MRIfree(&mri_tmp) ;
+		  }
 	}
 
   for (i = 0 ; i < mp.npasses ; i++) 

--- a/mri_evaluate_morph/mri_evaluate_morph.cpp
+++ b/mri_evaluate_morph/mri_evaluate_morph.cpp
@@ -91,7 +91,11 @@ main(int argc, char *argv[]) {
 
   for (i = FIRST_SUBJECT ; i < argc-1 ; i++) {
     fprintf(stderr, "processing subject %s...\n", argv[i]) ;
-    sprintf(fname, "%s/%s/mri/%s", sdir, argv[i], seg_name) ;
+    int req =snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, argv[i], seg_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+    
     mri_seg[i-FIRST_SUBJECT] = MRIread(fname) ;
     if (!mri_seg[i-FIRST_SUBJECT])
       ErrorExit(ERROR_NOFILE, "%s: could not read segmentation %s",
@@ -108,12 +112,21 @@ main(int argc, char *argv[]) {
       s1 = argv[i+FIRST_SUBJECT] ;
       s2 = argv[j+FIRST_SUBJECT] ;
       printf("reading transforms for subjects %s and %s...\n", s1, s2) ;
-      sprintf(fname, "%s/%s/mri/transforms/%s", sdir, s1, xform_name) ;
+      int req = snprintf(fname, STRLEN,
+			 "%s/%s/mri/transforms/%s", sdir, s1, xform_name) ;
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+
       transform1 = TransformRead(fname) ;
       if (transform1 == NULL)
         ErrorExit(ERROR_NOFILE, "%s: could not read transform %s",
                   Progname, fname) ;
-      sprintf(fname, "%s/%s/mri/transforms/%s", sdir, s1, xform_name) ;
+      req = snprintf(fname, STRLEN,
+		     "%s/%s/mri/transforms/%s", sdir, s1, xform_name) ;
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       transform2 = TransformRead(fname) ;
       if (transform2 == NULL)
         ErrorExit(ERROR_NOFILE, "%s: could not read transform %s",

--- a/mri_robust_register/MultiRegistration.cpp
+++ b/mri_robust_register/MultiRegistration.cpp
@@ -519,7 +519,7 @@ bool MultiRegistration::computeTemplate(int itmax, double eps, int iterate,
     return true;
   }
 
-  strncpy(mri_mean->fname, (outdir + "template-it0.mgz").c_str(), STRLEN);
+  strncpy(mri_mean->fname, (outdir + "template-it0.mgz").c_str(), STRLEN-1);
   if (debug)
   {
     cout << "debug: saving template-it0.mgz" << endl;
@@ -1756,7 +1756,7 @@ bool MultiRegistration::writeMean(const std::string& mean)
     cout << " ERROR: No average exists! Skipping output." << endl;
     return false;
   }
-  strncpy(mri_mean->fname, mean.c_str(), STRLEN);
+  strncpy(mri_mean->fname, mean.c_str(), STRLEN-1);
   return (MRIwrite(mri_mean, mean.c_str()) == 0);
 }
 
@@ -1771,7 +1771,7 @@ bool MultiRegistration::writeConformMean(const std::string& mean)
   // create conform mean
   MRI * mri_cmean = averageConformSet(0);
 
-  strncpy(mri_cmean->fname, mean.c_str(), STRLEN);
+  strncpy(mri_cmean->fname, mean.c_str(), STRLEN-1);
   int ok = MRIwrite(mri_cmean, mean.c_str());
   return (ok == 0);
 }
@@ -1797,8 +1797,8 @@ bool MultiRegistration::writeLTAs(const std::vector<std::string> & nltas,
     {
       error += (LTAchangeType(ltas[i], LINEAR_RAS_TO_RAS) == NULL);
     }
-    strncpy(ltas[i]->xforms[0].dst.fname, mean.c_str(), STRLEN);
-    strncpy(ltas[i]->xforms[0].src.fname, mov[i].c_str(), STRLEN);
+    strncpy(ltas[i]->xforms[0].dst.fname, mean.c_str(), STRLEN-1);
+    strncpy(ltas[i]->xforms[0].src.fname, mov[i].c_str(), STRLEN-1);
     LTAwriteEx(ltas[i], nltas[i].c_str());
 
     vnl_matrix<double> fMv2v = MyMatrix::LTA2VOXmatrix(ltas[i]);

--- a/mris_curvature/mris_curvature.cpp
+++ b/mris_curvature/mris_curvature.cpp
@@ -588,7 +588,8 @@ print_version(void)
 int
 MRIScomputeNeighbors(MRI_SURFACE *mris, float max_mm)
 {
-  int    vno, n, vlist[MAX_NBHD_SIZE], nbrs, done, found, m, nbhd, first =1 ;
+  int    vno, n, vlist[MAX_NBHD_SIZE], done, found, m, nbhd, first =1 ;
+  size_t nbrs=0;
   float  dist, dx, dy, dz ;
 
 
@@ -643,7 +644,7 @@ MRIScomputeNeighbors(MRI_SURFACE *mris, float max_mm)
             {
               if (first)
               {
-                printf("max nbrs %d exceeded at vertex %d\n", nbrs, vno) ;
+                printf("max nbrs %zu exceeded at vertex %d\n", nbrs, vno) ;
               }
               first = 0 ;
               break ;
@@ -658,7 +659,7 @@ MRIScomputeNeighbors(MRI_SURFACE *mris, float max_mm)
     vt->v = (int *)calloc(nbrs, sizeof(int)) ;
     if (vt->v == NULL)
       ErrorExit(ERROR_NOMEMORY,
-                "%s: vno %d could not allocate %d vertex array",
+                "%s: vno %d could not allocate %zu vertex array",
                 Progname, vno, nbrs) ;
     memmove(vt->v, vlist, sizeof(vlist[0])*nbrs) ;
     vt->vtotal = nbrs ;

--- a/mris_left_right_register/mris_left_right_register.cpp
+++ b/mris_left_right_register/mris_left_right_register.cpp
@@ -775,7 +775,7 @@ get_option(int argc, char *argv[])
       printf("setting l_external = %2.1f\n", parms.l_external) ;
       break ;
     case 'C':
-      strncpy(curvature_fname, argv[2], STRLEN) ; // Convert to strncpy at least
+      strncpy(curvature_fname, argv[2], STRLEN-1) ; // Convert to strncpy at least
       nargs = 1 ;
       break ;
     case 'A':

--- a/mris_make_surfaces/mris_exvivo_surfaces.cpp
+++ b/mris_make_surfaces/mris_exvivo_surfaces.cpp
@@ -222,7 +222,7 @@ main(int argc, char *argv[]) {
   ErrorInit(NULL, NULL, NULL) ;
   DiagInit(NULL, NULL, NULL) ;
 
-  memset(&parms, 0, sizeof(parms)) ;
+  // memset(&parms, 0, sizeof(parms)) ;
   parms.projection = NO_PROJECTION ;
   parms.fill_interior = 0 ;  // don't let gradient use exterior information (slows things down)
   parms.tol = 5e-3 ;
@@ -280,7 +280,11 @@ main(int argc, char *argv[]) {
               "%s: FREESURFER_HOME not defined in environment.\n", Progname) ;
   strcpy(mdir, cp) ;
 
-  sprintf(fname, "%s/%s/mri/filled", sdir, sname) ;
+  int req = snprintf(fname, STRLEN, "%s/%s/mri/filled", sdir, sname) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   if (MGZ) strcat(fname, ".mgz");
   fprintf(stderr, "reading volume %s...\n", fname) ;
   mri_filled = MRIread(fname) ;
@@ -297,7 +301,10 @@ main(int argc, char *argv[]) {
     replace_val = lh_label ;
   }
 
-  sprintf(fname, "%s/%s/mri/%s", sdir, sname, T1_30_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, sname, T1_30_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   if (MGZ) strcat(fname, ".mgz");
   fprintf(stderr, "reading volume %s...\n", fname) ;
   mri_T1_30 = MRIread(fname) ;
@@ -306,7 +313,10 @@ main(int argc, char *argv[]) {
     ErrorExit(ERROR_NOFILE, "%s: could not read input volume %s",
               Progname, fname) ;
 
-  sprintf(fname, "%s/%s/mri/%s", sdir, sname, T1_5_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, sname, T1_5_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   if (MGZ) strcat(fname, ".mgz");
   fprintf(stderr, "reading volume %s...\n", fname) ;
   mri_T1_5 = MRIread(fname) ;
@@ -373,7 +383,10 @@ main(int argc, char *argv[]) {
                                 white_mean, white_std, gray_mean, gray_std) ;
   if (PD_name)
   {
-    sprintf(fname, "%s/%s/mri/%s", sdir, sname, PD_name) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, sname, PD_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (MGZ) strcat(fname, ".mgz");
     fprintf(stderr, "reading volume %s...\n", fname) ;
     mri_PD = MRIread(fname) ;
@@ -394,7 +407,10 @@ main(int argc, char *argv[]) {
 
     mri_wm_labeled = 
       MRIbinarize(mri_filled, NULL, MIN_WM_VAL, MRI_NOT_WHITE, MRI_WHITE) ;
-    sprintf(fname, "%s/%s/mri/%s", sdir, sname, T1_name) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, sname, T1_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (MGZ) strcat(fname, ".mgz");
     fprintf(stderr, "reading volume %s...\n", fname) ;
     mri_T1 = MRIread(fname) ;
@@ -418,7 +434,10 @@ main(int argc, char *argv[]) {
   printf("GM: mean = (%g, %g) std = (%g, %g)\n", 
          gray_mean[0], gray_mean[1], gray_std[0], gray_std[1]);
 
-  sprintf(fname, "%s/%s/surf/%s.%s%s", sdir, sname, hemi, orig_name, suffix) ;
+  req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s%s", sdir, sname, hemi, orig_name, suffix) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fprintf(stderr, "reading original surface position from %s...\n", fname) ;
   mris = MRISreadOverAlloc(fname, 1.1) ;
   if (!mris)
@@ -542,8 +561,12 @@ main(int argc, char *argv[]) {
   }
 
   if (!nowhite) {
-    sprintf(fname, "%s/%s/surf/%s.%s%s%s", sdir, sname,hemi,white_matter_name,
-            output_suffix,suffix);
+    int req = snprintf(fname, STRLEN,
+		       "%s/%s/surf/%s.%s%s%s",
+		       sdir, sname,hemi,white_matter_name, output_suffix,suffix);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stderr, "writing white matter surface to %s...\n", fname) ;
     MRISaverageVertexPositions(mris, smoothwm) ;
     MRISwrite(mris, fname) ;
@@ -717,8 +740,12 @@ main(int argc, char *argv[]) {
     }
   }
 
-  sprintf(fname, "%s/%s/surf/%s.%s%s%s", sdir, sname, hemi, pial_name,
-          output_suffix, suffix) ;
+  req = snprintf(fname, STRLEN,
+		 "%s/%s/surf/%s.%s%s%s",
+		 sdir, sname, hemi, pial_name, output_suffix, suffix) ; 
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fprintf(stderr, "writing pial surface to %s...\n", fname) ;
   MRISwrite(mris, fname) ;
 
@@ -744,8 +771,12 @@ main(int argc, char *argv[]) {
     if (graymid) {
       MRISsaveVertexPositions(mris, TMP_VERTICES) ;
       mrisFindMiddleOfGray(mris) ;
-      sprintf(fname, "%s/%s/surf/%s.%s%s", sdir, sname, hemi, GRAYMID_NAME,
-              suffix) ;
+      int req = snprintf(fname, STRLEN,
+			 "%s/%s/surf/%s.%s%s",
+			 sdir, sname, hemi, GRAYMID_NAME, suffix) ;
+      if( req >= STRLEN ) {
+        std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       fprintf(stderr, "writing layer IV surface to %s...\n", fname) ;
       MRISwrite(mris, fname) ;
       MRISrestoreVertexPositions(mris, TMP_VERTICES) ;


### PR DESCRIPTION
Further updates for gcc8

- Mainly conversions from `sprintf()` to `snprintf()`
- Tweak lengths on some `strncpy()` calls
- Some indentation fixes
- Don't need `memset` now that `INTEGRATION_PARMS` has a proper constructor

Also killed off some `#if 0` blocks.