### PR TITLE
Fixes for gcc8

### DIFF
--- a/mri_extract_fcd_features/mri_extract_fcd_features.cpp
+++ b/mri_extract_fcd_features/mri_extract_fcd_features.cpp
@@ -118,7 +118,10 @@ main(int argc, char *argv[])
     strcpy(sdir, cp) ;
   }
 
-  sprintf(fname, "%s/%s/surf/%s.%s", sdir, subject, hemi, white_name) ;
+  int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, subject, hemi, white_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("reading %s\n", fname) ;
   mris  = MRISread(fname) ;
   if (mris == NULL)
@@ -126,63 +129,97 @@ main(int argc, char *argv[])
   MRISsaveVertexPositions(mris, WHITE_VERTICES) ;
   
 
-  sprintf(fname, "%s/%s/surf/%s.%s", sdir, subject, ohemi, white_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, subject, ohemi, white_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("reading %s\n", fname) ;
   mris_contra  = MRISread(fname) ;
   if (mris_contra == NULL)
     ErrorExit(ERROR_NOFILE, "%s: could not read surface from %s\n", Progname, fname) ;
   MRISsaveVertexPositions(mris_contra, WHITE_VERTICES) ;
 
-  sprintf(fname, "%s/%s/mri/%s", sdir, subject, ribbon_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, subject, ribbon_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+
   printf("reading %s\n", fname) ;
   mri_ribbon  = MRIread(fname) ;
   if (mri_ribbon == NULL)
     ErrorExit(ERROR_NOFILE, "%s: could not read ribbon from %s\n", Progname, fname) ;
 
-  sprintf(fname, "%s/%s/mri/%s", sdir, subject, aparc_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, subject, aparc_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("reading %s\n", fname) ;
   mri_aparc  = MRIread(fname) ;
   if (mri_aparc == NULL)
     ErrorExit(ERROR_NOFILE, "%s: could not read ribbon from %s\n", Progname, fname) ;
 
-  sprintf(fname, "%s/%s/mri/%s", sdir, subject, aseg_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, subject, aseg_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("reading %s\n", fname) ;
   mri_aseg  = MRIread(fname) ;
   if (mri_aseg == NULL)
     ErrorExit(ERROR_NOFILE, "%s: could not read aseg from %s\n", Progname, fname) ;
 
-  sprintf(fname, "%s/%s/surf/%s.%s", sdir, subject, hemi, pial_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, subject, hemi, pial_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   if (MRISreadPialCoordinates(mris, fname) != NO_ERROR)
     ErrorExit(ERROR_NOFILE, "%s: could not read pial coordinates from %s\n", Progname, fname) ;
 
-  sprintf(fname, "%s/%s/surf/%s.%s", sdir, subject, hemi, sphere_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, subject, hemi, sphere_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   if (MRISreadCanonicalCoordinates(mris, fname) != NO_ERROR)
     ErrorExit(ERROR_NOFILE, "%s: could not read left/right spherical coordinates from %s\n", Progname, fname) ;
   
 
-  sprintf(fname, "%s/%s/surf/%s.%s", sdir, subject, ohemi, pial_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, subject, ohemi, pial_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   if (MRISreadPialCoordinates(mris_contra, fname) != NO_ERROR)
     ErrorExit(ERROR_NOFILE, "%s: could not read pial coordinates from %s\n", Progname, fname) ;
 
-  sprintf(fname, "%s/%s/label/%s.%s", sdir, subject, hemi, cortex_label) ;
+  req = snprintf(fname, STRLEN, "%s/%s/label/%s.%s", sdir, subject, hemi, cortex_label) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   cortex = LabelRead(NULL, fname) ;
   if (cortex == NULL)
     ErrorExit(ERROR_NOFILE, "%s: could not read cortical label from %s\n", Progname, fname) ;
   LabelRipRestOfSurface(cortex, mris) ;
   LabelFree(&cortex) ;
 
-  sprintf(fname, "%s/%s/surf/%s.%s", sdir, subject, ohemi, sphere_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, subject, ohemi, sphere_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   if (MRISreadCanonicalCoordinates(mris_contra, fname) != NO_ERROR)
     ErrorExit(ERROR_NOFILE, "%s: could not read left/right spherical coordinates from %s\n", Progname, fname) ;
   
 
-  sprintf(fname, "%s/%s/mri/%s", sdir, subject, vol_name) ; 
+  req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, subject, vol_name) ; 
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("reading %s\n", fname) ;
   mri  = MRIread(fname) ;
   if (mri == NULL)
     ErrorExit(ERROR_NOFILE, "%s: could not read volume from %s\n", Progname, fname) ;
 
-  sprintf(fname, "%s/%s/mri/%s", sdir, subject, flair_name) ; 
+  req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, subject, flair_name) ; 
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("reading %s\n", fname) ;
   mri_flair  = MRIread(fname) ;
   if (mri_flair == NULL)
@@ -208,7 +245,10 @@ main(int argc, char *argv[])
     strcpy(fname, out_fname) ;
     FileNameExtension(fname, ext) ;
     FileNameRemoveExtension(fname, fname_no_ext) ;
-    sprintf(fname, "%s.flair.%s", fname_no_ext, ext) ;
+    int req = snprintf(fname, STRLEN, "%s.flair.%s", fname_no_ext, ext) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (Gdiag_no >= 0)
       printf("feature(%d) = %f\n", Gdiag_no, MRIgetVoxVal(mri_flair_features, Gdiag_no, 0, 0, 0)) ;
     printf("DISABLED: writing output to %s\n", fname) ;

--- a/mri_fuse_intensity_images/mri_fuse_intensity_images.cpp
+++ b/mri_fuse_intensity_images/mri_fuse_intensity_images.cpp
@@ -141,9 +141,15 @@ main(int argc, char *argv[])
   printf("processing %d timepoints in SUBJECTS_DIR %s...\n", ninputs, sdir) ;
   for (input = 0 ; input < ninputs ; input++)
   {
-    sprintf(subject, "%s.long.%s", subjects[input], base_name) ;
+    int req = snprintf(subject, STRLEN, "%s.long.%s", subjects[input], base_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("reading subject %s - %d of %d\n", subject, input+1, ninputs) ;
-    sprintf(fname, "%s/%s/mri/%s", sdir, subject, in_fname) ;
+    req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, subject, in_fname) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     mri_tmp = MRIread(fname) ;
     if (!mri_tmp)
       ErrorExit(ERROR_NOFILE, "%s: could not read input MR volume from %s",
@@ -205,7 +211,10 @@ main(int argc, char *argv[])
 
   for (input = 0 ; input < ninputs ; input++)
   {
-    sprintf(fname, "%s/%s.long.%s/mri/%s", sdir, subjects[input], base_name, out_fname) ;
+    int req = snprintf(fname, STRLEN, "%s/%s.long.%s/mri/%s", sdir, subjects[input], base_name, out_fname) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing normalized volume to %s...\n", fname) ;
     if (MRIwriteFrame(mri_in, fname, input)  != NO_ERROR)
       ErrorExit(ERROR_BADFILE, "%s: could not write normalized volume to %s",Progname, fname);

--- a/mri_gtmpvc/mri_gtmpvc.cpp
+++ b/mri_gtmpvc/mri_gtmpvc.cpp
@@ -278,7 +278,8 @@ int main(int argc, char *argv[])
   fprintf(logfp,"Loading seg for gtm %s\n",SegVolFile);fflush(logfp);
   gtm->anatseg = MRIread(SegVolFile);
   if(gtm->anatseg==NULL) exit(1);
-  if(Gdiag_no > 0)printf("  done loading seg\n");fflush(stdout);
+  if(Gdiag_no > 0)printf("  done loading seg\n");
+  fflush(stdout);
   if(Gdiag_no > 0) PrintMemUsage(stdout);
 
   stem = IDstemFromName(SegVolFile);
@@ -288,7 +289,8 @@ int main(int argc, char *argv[])
     fprintf(logfp,"Loading ctab %s\n",tmpstr);fflush(logfp);
     gtm->ctGTMSeg = CTABreadASCII(tmpstr);
     if(gtm->ctGTMSeg == NULL) exit(1);
-    if(Gdiag_no > 0) printf("  done loading ctab\n");fflush(stdout);
+    if(Gdiag_no > 0) printf("  done loading ctab\n");
+    fflush(stdout);
   }
   if(MergeHypos && gtm->ctGTMSeg->entries[77] == NULL){
     gtm->ctGTMSeg->entries[77] = (CTE*) malloc(sizeof(CTE));
@@ -356,7 +358,8 @@ int main(int argc, char *argv[])
   if(gtm->nReplace > 0) {
     printf("Replacing %d\n",gtm->nReplace);fflush(stdout);
     mritmp = MRIreplaceList(gtm->anatseg, gtm->SrcReplace, gtm->TrgReplace, gtm->nReplace, NULL, NULL);
-    if(Gdiag_no > 0) printf("  done replacing\n");fflush(stdout);
+    if(Gdiag_no > 0) printf("  done replacing\n");
+    fflush(stdout);
     MRIfree(&gtm->anatseg);
     gtm->anatseg = mritmp;
     sprintf(tmpstr,"%s/seg.replace.list",AuxDir);
@@ -367,7 +370,8 @@ int main(int argc, char *argv[])
 
   printf("Pruning ctab\n"); fflush(stdout);
   gtm->ctGTMSeg = CTABpruneCTab(gtm->ctGTMSeg, gtm->anatseg);
-  if(Gdiag_no > 0) printf("  done pruning ctab\n"); fflush(stdout);
+  if(Gdiag_no > 0) printf("  done pruning ctab\n"); 
+  fflush(stdout);
 
   printf("tissue type schema %s\n",gtm->ctGTMSeg->TissueTypeSchema);
 
@@ -438,7 +442,8 @@ int main(int argc, char *argv[])
     if(Gdiag_no > 0) PrintMemUsage(stdout);
     PrintMemUsage(logfp);
     GTMautoMask(gtm);
-    if(Gdiag_no > 0) printf("  done auto mask \n");fflush(stdout);
+    if(Gdiag_no > 0) printf("  done auto mask \n");
+    fflush(stdout);
     if(Gdiag_no > 0) PrintMemUsage(stdout);
     PrintMemUsage(logfp);
   }

--- a/mri_hires_register/mri_hires_register.cpp
+++ b/mri_hires_register/mri_hires_register.cpp
@@ -308,9 +308,15 @@ main(int argc, char *argv[]) {
 
 
   if (Gdiag & DIAG_WRITE && parms.write_iterations > 0) {
-    sprintf(fname, "%s_target", parms.base_name) ;
+    int req = snprintf(fname, STRLEN, "%s_target", parms.base_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     MRIwriteImageViews(mri_lowres, fname, IMAGE_SIZE) ;
-    sprintf(fname, "intensity_%s_target", parms.base_name) ;
+    req = snprintf(fname, STRLEN, "intensity_%s_target", parms.base_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     MRIwriteImageViews(mri_intensity, fname, IMAGE_SIZE) ;
     MRIwrite(mri_intensity, "intensity_target.mgz") ;
     MRIwrite(mri_lowres, "aseg_target.mgz") ;
@@ -389,11 +395,17 @@ main(int argc, char *argv[]) {
         MRITransformedCenteredMatrix
         (mri_hires, mri_lowres, ((LTA *)(transform->xform))->xforms[0].m_L) ;
 #endif
-      sprintf(fname, "%sfinal.mgz", parms.base_name) ;
+      int req = snprintf(fname, STRLEN, "%sfinal.mgz", parms.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       MRIwrite(mri_aligned, fname) ;
 
       for (i = 1 ; i <= 10 ; i++) {
-        sprintf(fname, "%sfiltered%d.mgz", parms.base_name, i) ;
+        int req = snprintf(fname, STRLEN, "%sfiltered%d.mgz", parms.base_name, i) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         mri_filtered = MRImodeFilter(mri_aligned, NULL, i) ;
         printf("writing filtered image to %s\n", fname) ;
         MRIwrite(mri_filtered, fname) ;
@@ -1585,15 +1597,29 @@ write_snapshot(MRI *mri_lowres, MRI *mri_hires, MATRIX *m_vox_xform,
                   (mri_hires_intensity, mri_lowres, m_vox_xform) ;
 #endif
   }
-  if (in_fname)
-    sprintf(fname, "%s_%s", parms->base_name, in_fname) ;
-  else
-    sprintf(fname, "%s_%03d", parms->base_name, fno) ;
+  if (in_fname) {
+    int req = snprintf(fname, STRLEN, "%s_%s", parms->base_name, in_fname) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+  } else {
+    int req = snprintf(fname, STRLEN, "%s_%03d", parms->base_name, fno) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+  }
   MRIwriteImageViews(mri_aligned, fname, IMAGE_SIZE) ;
-  if (in_fname)
-    sprintf(fname, "%s_%s.mgz", parms->base_name, in_fname) ;
-  else
-    sprintf(fname, "%s_%03d.mgz", parms->base_name, fno) ;
+  if (in_fname) {
+    int req = snprintf(fname, STRLEN, "%s_%s.mgz", parms->base_name, in_fname) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+  } else {
+    int req = snprintf(fname, STRLEN, "%s_%03d.mgz", parms->base_name, fno) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+  }
   printf("writing snapshot to %s...\n", fname) ;
   MRIwrite(mri_aligned, fname) ;
   MRIfree(&mri_aligned) ;
@@ -1606,10 +1632,17 @@ write_snapshot(MRI *mri_lowres, MRI *mri_hires, MATRIX *m_vox_xform,
     mri_aligned = MRITransformedCenteredMatrix
                   (mri_hires, mri_lowres, m_vox_xform) ;
 #endif
-    if (in_fname)
-      sprintf(fname, "orig_%s_%s.mgz", parms->base_name, in_fname) ;
-    else
-      sprintf(fname, "orig_%s_%03d.mgz", parms->base_name, fno) ;
+    if (in_fname) {
+      int req = snprintf(fname, STRLEN, "orig_%s_%s.mgz", parms->base_name, in_fname) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    } else {
+      int req = snprintf(fname, STRLEN, "orig_%s_%03d.mgz", parms->base_name, fno) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
     printf("writing snapshot to %s...\n", fname) ;
     MRIwrite(mri_aligned, fname) ;
     MRIfree(&mri_aligned) ;
@@ -1623,15 +1656,29 @@ write_snapshot(MRI *mri_lowres, MRI *mri_hires, MATRIX *m_vox_xform,
     mri_aligned = MRITransformedCenteredMatrix
                   (mri_hires_intensity, mri_lowres, m_vox_xform) ;
 #endif
-    if (in_fname)
-      sprintf(fname, "intensity_%s_%s", parms->base_name, in_fname) ;
-    else
-      sprintf(fname, "intensity_%s_%03d", parms->base_name, fno) ;
+    if (in_fname) {
+      int req = snprintf(fname, STRLEN, "intensity_%s_%s", parms->base_name, in_fname) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    } else {
+      int req = snprintf(fname, STRLEN, "intensity_%s_%03d", parms->base_name, fno) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
     MRIwriteImageViews(mri_aligned, fname, IMAGE_SIZE) ;
-    if (in_fname)
-      sprintf(fname, "intensity_%s_%s.mgz", parms->base_name, in_fname) ;
-    else
-      sprintf(fname, "intensity_%s_%03d.mgz", parms->base_name, fno) ;
+    if (in_fname) {
+      int req = snprintf(fname, STRLEN, "intensity_%s_%s.mgz", parms->base_name, in_fname) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    } else {
+      int req = snprintf(fname, STRLEN, "intensity_%s_%03d.mgz", parms->base_name, fno) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
     printf("writing snapshot to %s...\n", fname) ;
     MRIwrite(mri_aligned, fname) ;
     MRIfree(&mri_aligned) ;

--- a/mri_hires_register/mri_nl_align.cpp
+++ b/mri_hires_register/mri_nl_align.cpp
@@ -290,7 +290,10 @@ main(int argc, char *argv[])
     char path[STRLEN], fname[STRLEN] ;
     LABEL *area ;
     FileNamePath(mri_target->fname, path) ;
-    sprintf(fname, "%s/%s", path, label_ignore_name) ;
+    int req = snprintf(fname, STRLEN, "%s/%s", path, label_ignore_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     area = LabelRead(NULL, fname) ;
     if (area == NULL)
     {
@@ -388,7 +391,10 @@ main(int argc, char *argv[])
       LABEL *area ;
 
       FileNamePath(mri_target->fname, path) ;
-      sprintf(fname, "%s/%s", path, label_dist_name) ;
+      int req = snprintf(fname, STRLEN, "%s/%s", path, label_dist_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       area = LabelRead(NULL, fname) ;
       if (area == NULL)
       {
@@ -446,7 +452,10 @@ main(int argc, char *argv[])
               label = Right_Cerebral_Cortex ;
               hemi = "rh" ;
             }
-            sprintf(fname, "%s/%s%s.white", path, hemi, str) ;
+            int req = snprintf(fname, STRLEN, "%s/%s%s.white", path, hemi, str) ;
+	    if( req >= STRLEN ) {
+	      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	    }
             mris_white = MRISread(fname) ;
             if (mris_white == NULL)
             {
@@ -454,7 +463,10 @@ main(int argc, char *argv[])
                         "%s: could not read surface %s", Progname, fname) ;
             }
             MRISsaveVertexPositions(mris_white, WHITE_VERTICES) ;
-            sprintf(fname, "%s/%s%s.pial", path, hemi, str) ;
+            req = snprintf(fname, STRLEN, "%s/%s%s.pial", path, hemi, str) ;
+	    if( req >= STRLEN ) {
+	      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	    }
             mris_pial = MRISread(fname) ;
             if (mris_pial == NULL)
             {
@@ -505,7 +517,10 @@ main(int argc, char *argv[])
       LABEL *area ;
 
       FileNamePath(mri_target->fname, path) ;
-      sprintf(fname, "%s/%s", path, label_dist_name) ;
+      int req = snprintf(fname, STRLEN, "%s/%s", path, label_dist_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       area = LabelRead(NULL, fname) ;
       if (area == NULL)
       {
@@ -554,17 +569,26 @@ main(int argc, char *argv[])
 
     if (getenv("DONT_COMPRESS"))
     {
-      sprintf(fname, "%s_target.mgh", mp.base_name) ;
+      int req = snprintf(fname, STRLEN, "%s_target.mgh", mp.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
     else
     {
-      sprintf(fname, "%s_target.mgz", mp.base_name) ;
+      int req = snprintf(fname, STRLEN, "%s_target.mgz", mp.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
     if (mp.diag_morph_from_atlas == 0)
     {
       printf("writing target volume to %s...\n", fname) ;
       MRIwrite(mri_target_diag, fname) ;
-      sprintf(fname, "%s_target", mp.base_name) ;
+      int req = snprintf(fname, STRLEN, "%s_target", mp.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       MRIwriteImageViews(mri_target_diag, fname, IMAGE_SIZE) ;
     }
     else
@@ -580,7 +604,10 @@ main(int argc, char *argv[])
       }
       printf("writing target volume to %s...\n", fname) ;
       MRIwrite(mri_gca, fname) ;
-      sprintf(fname, "%s_target", mp.base_name) ;
+      int req = snprintf(fname, STRLEN, "%s_target", mp.base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       MRIwriteImageViews(mri_gca, fname, IMAGE_SIZE) ;
       MRIfree(&mri_gca) ;
     }
@@ -1204,20 +1231,32 @@ write_snapshot(MRI *mri_target, MRI *mri_source, MATRIX *m_vox_xform,
   }
   if (in_fname)
   {
-    sprintf(fname, "%s_%s", parms->base_name, in_fname) ;
+    int req = snprintf(fname, STRLEN, "%s_%s", parms->base_name, in_fname) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
   }
   else
   {
-    sprintf(fname, "%s_%03d", parms->base_name, fno) ;
+    int req = snprintf(fname, STRLEN, "%s_%03d", parms->base_name, fno) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
   }
   MRIwriteImageViews(mri_aligned, fname, IMAGE_SIZE) ;
   if (in_fname)
   {
-    sprintf(fname, "%s_%s.mgz", parms->base_name, in_fname) ;
+    int req = snprintf(fname, STRLEN, "%s_%s.mgz", parms->base_name, in_fname) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
   }
   else
   {
-    sprintf(fname, "%s_%03d.mgz", parms->base_name, fno) ;
+    int req = snprintf(fname, STRLEN, "%s_%03d.mgz", parms->base_name, fno) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
   }
   printf("writing snapshot to %s...\n", fname) ;
   MRIwrite(mri_aligned, fname) ;
@@ -1236,11 +1275,17 @@ write_snapshot(MRI *mri_target, MRI *mri_source, MATRIX *m_vox_xform,
 #endif
     if (in_fname)
     {
-      sprintf(fname, "orig_%s_%s.mgz", parms->base_name, in_fname) ;
+      int req =snprintf(fname, STRLEN, "orig_%s_%s.mgz", parms->base_name, in_fname) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
     else
     {
-      sprintf(fname, "orig_%s_%03d.mgz", parms->base_name, fno) ;
+      int req = snprintf(fname, STRLEN, "orig_%s_%03d.mgz", parms->base_name, fno) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
     }
     printf("writing snapshot to %s...\n", fname) ;
     MRIwrite(mri_aligned, fname) ;

--- a/mri_hires_register/mri_nl_align_binary.cpp
+++ b/mri_hires_register/mri_nl_align_binary.cpp
@@ -389,11 +389,18 @@ main(int argc, char *argv[])
 	}
   if (Gdiag & DIAG_WRITE && mp.write_iterations > 0)
   {
-		sprintf(fname, "%s_target", mp.base_name) ;
+    int req = snprintf(fname, STRLEN, "%s_target", mp.base_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     MRIwriteImageViews(mri_orig_target, fname, IMAGE_SIZE) ;	
-		sprintf(fname, "%s_target.mgz", mp.base_name) ;
-		MRIwrite(mri_orig_target, fname) ;
-	}
+    req = snprintf(fname, STRLEN, "%s_target.mgz", mp.base_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+
+    MRIwrite(mri_orig_target, fname) ;
+  }
 	
 	mp.max_grad = 0.3*mri_source->xsize ;
 
@@ -484,7 +491,11 @@ main(int argc, char *argv[])
 		char fname[STRLEN] ;
 		MRI  *mri_gca ;
 
-		sprintf(fname, "%s_target.mgz", mp.base_name) ;
+		int req = snprintf(fname, STRLEN, "%s_target.mgz", mp.base_name) ;
+		if( req >= STRLEN ) {
+		  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+		}
+
 		if (mp.diag_morph_from_atlas == 0)
 		{
 			printf("writing target volume to %s...\n", fname) ;
@@ -509,8 +520,12 @@ main(int argc, char *argv[])
 		MRI *mri_morphed ;
 		char fname[STRLEN] ;
 
-    mri_morphed = GCAMmorphFieldFromAtlas(gcam, mp.mri_diag, mp.diag_volume,0, mp.diag_mode_filter) ;
-		sprintf(fname, "%s_orig.mgz", mp.base_name) ;
+		mri_morphed = GCAMmorphFieldFromAtlas(gcam, mp.mri_diag, mp.diag_volume, 0, 
+						      mp.diag_mode_filter) ;
+		int req = snprintf(fname, STRLEN, "%s_orig.mgz", mp.base_name) ;
+		if( req >= STRLEN ) {
+		  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+		}
 		MRIwrite(mri_morphed, fname) ;
 	}
 		
@@ -959,15 +974,29 @@ write_snapshot(MRI *mri_target, MRI *mri_source, MATRIX *m_vox_xform,
 	{
 		mri_aligned = MRITransformedCenteredMatrix(mri_source, mri_target, m_vox_xform) ;
 	}
-	if (in_fname)
-		sprintf(fname, "%s_%s", parms->base_name, in_fname) ;
-	else
-		sprintf(fname, "%s_%03d", parms->base_name, fno) ;
+	if (in_fname) {
+	  int req = snprintf(fname, STRLEN, "%s_%s", parms->base_name, in_fname) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
+	} else {
+	  int req = snprintf(fname, STRLEN, "%s_%03d", parms->base_name, fno) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
+	}
 	MRIwriteImageViews(mri_aligned, fname, IMAGE_SIZE) ;
-	if (in_fname)
-		sprintf(fname, "%s_%s.mgz", parms->base_name, in_fname) ;
-	else
-		sprintf(fname, "%s_%03d.mgz", parms->base_name, fno) ;
+	if (in_fname) {
+	  int req = snprintf(fname, STRLEN, "%s_%s.mgz", parms->base_name, in_fname) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
+	} else {
+	  int req = snprintf(fname, STRLEN, "%s_%03d.mgz", parms->base_name, fno) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
+	}
 	printf("writing snapshot to %s...\n", fname) ;
 	MRIwrite(mri_aligned, fname) ;
 	MRIfree(&mri_aligned) ;
@@ -979,10 +1008,17 @@ write_snapshot(MRI *mri_target, MRI *mri_source, MATRIX *m_vox_xform,
 #else
 		mri_aligned = MRITransformedCenteredMatrix(mri_source, mri_target, m_vox_xform) ;
 #endif
-		if (in_fname)
-			sprintf(fname, "orig_%s_%s.mgz", parms->base_name, in_fname) ;
-		else
-			sprintf(fname, "orig_%s_%03d.mgz", parms->base_name, fno) ;
+		if (in_fname) {
+		  int req = snprintf(fname, STRLEN, "orig_%s_%s.mgz", parms->base_name, in_fname) ;
+		  if( req >= STRLEN ) {
+		    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+		  }
+		} else {
+		  int req = snprintf(fname, STRLEN, "orig_%s_%03d.mgz", parms->base_name, fno) ;
+		  if( req >= STRLEN ) {
+		    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+		  }
+		}
 		printf("writing snapshot to %s...\n", fname) ;
 		MRIwrite(mri_aligned, fname) ;
 		MRIfree(&mri_aligned) ;
@@ -996,15 +1032,17 @@ write_snapshot(MRI *mri_target, MRI *mri_source, MATRIX *m_vox_xform,
 #else
 		mri_aligned = MRITransformedCenteredMatrix(mri_source_intensity, mri_target, m_vox_xform) ;
 #endif
-		if (in_fname)
-			sprintf(fname, "intensity_%s_%s", parms->base_name, in_fname) ;
-		else
-			sprintf(fname, "intensity_%s_%03d", parms->base_name, fno) ;
+		if (in_fname) {
+		  sprintf(fname, "intensity_%s_%s", parms->base_name, in_fname) ;
+		} else {
+		  sprintf(fname, "intensity_%s_%03d", parms->base_name, fno) ;
+		}
 		MRIwriteImageViews(mri_aligned, fname, IMAGE_SIZE) ;
-		if (in_fname)
-			sprintf(fname, "intensity_%s_%s.mgz", parms->base_name, in_fname) ;
-		else
-			sprintf(fname, "intensity_%s_%03d.mgz", parms->base_name, fno) ;
+		if (in_fname) {
+		  sprintf(fname, "intensity_%s_%s.mgz", parms->base_name, in_fname) ;
+		} else {
+		  sprintf(fname, "intensity_%s_%03d.mgz", parms->base_name, fno) ;
+		}
 		printf("writing snapshot to %s...\n", fname) ;
 		MRIwrite(mri_aligned, fname) ;
 		MRIfree(&mri_aligned) ;

--- a/mri_histo_eq/mri_histo_eq.cpp
+++ b/mri_histo_eq/mri_histo_eq.cpp
@@ -90,7 +90,10 @@ main(int argc, char *argv[]) {
     FileNameOnly(xform_fname, xform_fname) ;
 
     FileNamePath(argv[1], path) ;
-    sprintf(fname, "%s/%s", path, xform_fname) ;
+    int req = snprintf(fname, STRLEN, "%s/%s", path, xform_fname) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     lta_src = LTAread(fname) ;
     if (!lta_src)
       ErrorExit(ERROR_BADPARM, "%s: could not read xform from %s",
@@ -103,7 +106,10 @@ main(int argc, char *argv[]) {
                 Progname, fname) ;
 
     FileNamePath(argv[2], path) ;
-    sprintf(fname, "%s/%s", path, xform_fname) ;
+    req = snprintf(fname, STRLEN, "%s/%s", path, xform_fname) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     lta_template = LTAread(fname) ;
     if (!lta_template)
       ErrorExit(ERROR_BADPARM, "%s: could not read xform from %s",
@@ -168,6 +174,7 @@ get_option(int argc, char *argv[]) {
   case 'T':
     xform_fname = argv[2] ;
     nargs = 1 ;
+    break;
   case '?':
   case 'U':
     usage_exit(0) ;

--- a/mri_label_vals/mri_label_vals.cpp
+++ b/mri_label_vals/mri_label_vals.cpp
@@ -207,7 +207,11 @@ main(int argc, char *argv[]) {
               MRIsurfaceRASToVoxel(mri, xw, yw, zw, &xv, &yv, &zv);
             MRIsampleVolume(mri, xv, yv, zv, &val) ;
             annot_means[index] += val ;
-            sprintf(fname, "%s-%s-%s.dat", annot_prefix, hemi, mris->ct->entries[index]->name) ;
+            int req = snprintf(fname, STRLEN, "%s-%s-%s.dat",
+			       annot_prefix, hemi, mris->ct->entries[index]->name) ;
+	    if( req >= STRLEN ) {
+	      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	    }
             fp = fopen(fname, "a") ;
             fprintf(fp, "%f\n", val) ;
             fclose(fp) ;

--- a/mri_mark_temporal_lobe/mri_mark_temporal_lobe.cpp
+++ b/mri_mark_temporal_lobe/mri_mark_temporal_lobe.cpp
@@ -83,14 +83,20 @@ main(int argc, char *argv[]) {
   out_fname = argv[argc-1] ;
 
   subject_name = argv[1] ;
-  sprintf(fname, "%s/%s/mri/%s", subjects_dir, subject_name, seg_dir) ;
+  int req = snprintf(fname, STRLEN, "%s/%s/mri/%s", subjects_dir, subject_name, seg_dir) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mri_seg = MRIread(fname) ;
   if (!mri_seg)
     ErrorExit(ERROR_NOFILE, "%s: could not read segmentation file %s",
               Progname, fname) ;
   mri_dst = MRImarkTemporalWM(mri_seg, NULL) ;
 
-  sprintf(fname, "%s/%s/mri/%s", subjects_dir, subject_name, out_fname) ;
+  req = snprintf(fname, STRLEN, "%s/%s/mri/%s", subjects_dir, subject_name, out_fname) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing labeled temporal lobe to %s...\n", fname) ;
   MRIwrite(mri_dst, fname) ;
   MRIfree(&mri_dst) ;

--- a/mri_mcsim/mri_mcsim.cpp
+++ b/mri_mcsim/mri_mcsim.cpp
@@ -214,10 +214,16 @@ int main(int argc, char *argv[]) {
 	if(SignList[nthSign] ==  0) signstr = "abs"; 
 	if(SignList[nthSign] == +1) signstr = "pos"; 
 	if(SignList[nthSign] == -1) signstr = "neg"; 
-	sprintf(tmpstr,"%s/fwhm%02d/%s/th%02d",
-		OutTop,(int)round(FWHMList[nthFWHM]),
-		signstr,(int)round(10*ThreshList[nthThresh]));
-	sprintf(fname,"%s/%s.csd",tmpstr,csdbase);
+	int req = snprintf(tmpstr,STRLEN,"%s/fwhm%02d/%s/th%02d",
+			   OutTop,(int)round(FWHMList[nthFWHM]),
+			   signstr,(int)round(10*ThreshList[nthThresh]));
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+	req = snprintf(fname,STRLEN,"%s/%s.csd",tmpstr,csdbase);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
 	if(fio_FileExistsReadable(fname)){
 	  printf("ERROR: output file %s exists\n",fname);
 	  if(fpLog) fprintf(fpLog,"ERROR: output file %s exists\n",fname);

--- a/mri_nlfilter/mri_nlfilter.cpp
+++ b/mri_nlfilter/mri_nlfilter.cpp
@@ -208,6 +208,7 @@ main(int argc, char *argv[]) {
     {
     default:
       ErrorExit(ERROR_UNSUPPORTED, "%s: unsupported no crop no offset filter %d\n", Progname, filter_type) ;
+      break;
     case FILTER_GAUSSIAN:
       mri_tmp = MRIconvolveGaussian(mri_full, NULL, mri_gaussian) ;
       if (!mri_tmp)

--- a/mri_rf_long_train/mri_rf_long_train.cpp
+++ b/mri_rf_long_train/mri_rf_long_train.cpp
@@ -247,7 +247,10 @@ main(int argc, char *argv[])
       sname = t == 0 ? s1_name : s2_name;
 
       // reading this subject segmentation
-      sprintf(fname, "%s/%s/mri/%s", subjects_dir, sname, seg_dir) ;
+      int req = snprintf(fname, STRLEN, "%s/%s/mri/%s", subjects_dir, sname, seg_dir) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
 	fprintf(stderr, "Reading segmentation from %s...\n", fname) ;
       mri_seg = MRIread(fname) ;
@@ -266,7 +269,10 @@ main(int argc, char *argv[])
       if (wmsa_fname)
       {
 	MRI *mri_wmsa ;
-	sprintf(fname, "%s/%s/mri/%s", subjects_dir, sname, wmsa_fname) ;
+	int req = snprintf(fname, STRLEN, "%s/%s/mri/%s", subjects_dir, sname, wmsa_fname) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
 	printf("reading WMSA labels from %s...\n", fname) ;
 	mri_wmsa = MRIread(fname) ;
 	if (mri_wmsa == NULL)
@@ -277,8 +283,11 @@ main(int argc, char *argv[])
 	if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON )
 	{
 	  char s[STRLEN] ;
-	  sprintf(s, "%s/%s/mri/seg_%s",
-		  subjects_dir, subject_name, wmsa_fname) ;
+	  int req = snprintf(s, STRLEN, "%s/%s/mri/seg_%s",
+			     subjects_dir, subject_name, wmsa_fname) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
 	  MRIwrite(mri_seg, s) ;
 	}
       }
@@ -297,8 +306,11 @@ main(int argc, char *argv[])
       {
 	MRI *mri_insert ;
 	
-	sprintf(fname, "%s/%s/mri/%s",
-		subjects_dir, subject_name, insert_fname) ;
+	int req = snprintf(fname, STRLEN, "%s/%s/mri/%s",
+			   subjects_dir, subject_name, insert_fname) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
 	mri_insert = MRIread(fname) ;
 	if (mri_insert == NULL)
 	  ErrorExit(ERROR_NOFILE,
@@ -329,7 +341,11 @@ main(int argc, char *argv[])
 	// thus we cannot allow flash data training.
 	////////////////////////////////////////////////////////////
 	
-	sprintf(fname, "%s/%s/mri/%s", subjects_dir, sname,input_names[input]);
+	int req = snprintf(fname, STRLEN, "%s/%s/mri/%s",
+			   subjects_dir, sname,input_names[input]);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
 	if (DIAG_VERBOSE_ON)
 	  printf("reading co-registered input from %s...\n", fname) ;
 	fprintf(stderr, "   reading input %d: %s\n", input, fname);
@@ -395,8 +411,11 @@ main(int argc, char *argv[])
 	{
 	  MRI *mri_mask ;
 	  
-	  sprintf(fname, "%s/%s/mri/%s",
-		  subjects_dir, subject_name, mask_fname);
+	  int req = snprintf(fname, STRLEN, "%s/%s/mri/%s",
+			     subjects_dir, subject_name, mask_fname);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
 	  printf("reading volume %s for masking...\n", fname) ;
 	  mri_mask = MRIread(fname) ;
 	  if (!mri_mask)
@@ -418,7 +437,11 @@ main(int argc, char *argv[])
       if (xform_name)
       {
 	// we read talairach.xfm which is a RAS-to-RAS
-	sprintf(fname, "%s/%s/mri/transforms/%s", subjects_dir, sname, xform_name) ;
+	int req = snprintf(fname, STRLEN, "%s/%s/mri/transforms/%s", 
+			   subjects_dir, sname, xform_name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
 	if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
 	  printf("INFO: reading transform file %s...\n", fname);
 	if (!FileExists(fname))
@@ -1121,6 +1144,10 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
               fflush(stdout) ;
               errors++;
             }
+#if __GNUC__  >= 8
+	    [[gnu::fallthrough]];
+#endif
+      
             // no break (check xt)
 
           case Left_Caudate:
@@ -1157,6 +1184,10 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
               fflush(stdout) ;
               errors++;
             }
+#if __GNUC__  >= 8
+	    [[gnu::fallthrough]];
+#endif
+
             // no break (check xt)
 
           case Right_Caudate:
@@ -1257,7 +1288,10 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
   if ( do_fix_badsubjs && errors)
   {
     char fname[STRLEN];
-    sprintf(fname, "%s/%s/mri/seg_fixed.mgz", subjects_dir, subject_name);
+    int req = snprintf(fname, STRLEN, "%s/%s/mri/seg_fixed.mgz", subjects_dir, subject_name);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("Writing corrected volume to %s\n",fname);
     MRIwrite(mri_fixed,fname);
     MRIfree(&mri_fixed);

--- a/mri_rf_train/mri_rf_train.cpp
+++ b/mri_rf_train/mri_rf_train.cpp
@@ -228,7 +228,11 @@ main(int argc, char *argv[])
 	   nsubjects);
     
     // reading this subject segmentation
-    sprintf(fname, "%s/%s/mri/%s", subjects_dir, subject_name, seg_dir) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/mri/%s", 
+		       subjects_dir, subject_name, seg_dir) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
       fprintf(stderr, "Reading segmentation from %s...\n", fname) ;
     mri_seg = MRIread(fname) ;
@@ -256,8 +260,11 @@ main(int argc, char *argv[])
     if (wmsa_fname)
     {
       MRI *mri_wmsa ;
-      sprintf(fname, "%s/%s/mri/%s",
-	      subjects_dir, subject_name, wmsa_fname) ;
+      int req = snprintf(fname, STRLEN, "%s/%s/mri/%s",
+			 subjects_dir, subject_name, wmsa_fname) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("reading WMSA labels from %s...\n", fname) ;
       mri_wmsa = MRIread(fname) ;
       if (mri_wmsa == NULL)
@@ -268,8 +275,11 @@ main(int argc, char *argv[])
       if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON )
       {
 	char s[STRLEN] ;
-	sprintf(s, "%s/%s/mri/seg_%s",
-		subjects_dir, subject_name, wmsa_fname) ;
+	int req = snprintf(s, STRLEN, "%s/%s/mri/seg_%s",
+			   subjects_dir, subject_name, wmsa_fname) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
 	MRIwrite(mri_seg, s) ;
       }
     }
@@ -288,8 +298,11 @@ main(int argc, char *argv[])
     {
       MRI *mri_insert ;
       
-      sprintf(fname, "%s/%s/mri/%s",
-	      subjects_dir, subject_name, insert_fname) ;
+      int req = snprintf(fname, STRLEN, "%s/%s/mri/%s",
+			 subjects_dir, subject_name, insert_fname) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       mri_insert = MRIread(fname) ;
       if (mri_insert == NULL)
 	ErrorExit(ERROR_NOFILE,
@@ -314,8 +327,11 @@ main(int argc, char *argv[])
       
       for (input = 0 ; input < ninputs ; input++)
       {
-	sprintf(fname, "%s/%s/mri/%s",
-		subjects_dir, subject_name, input_names[input]);
+	int req = snprintf(fname, STRLEN, "%s/%s/mri/%s",
+			   subjects_dir, subject_name, input_names[input]);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
 	mri_tmp = MRIreadInfo(fname) ;
 	if (!mri_tmp)
 	  ErrorExit
@@ -383,8 +399,11 @@ main(int argc, char *argv[])
       // thus we cannot allow flash data training.
       ////////////////////////////////////////////////////////////
       
-      sprintf(fname, "%s/%s/mri/%s",
-	      subjects_dir, subject_name,input_names[ordering[input]]);
+      int req = snprintf(fname, STRLEN, "%s/%s/mri/%s",
+			 subjects_dir, subject_name,input_names[ordering[input]]);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (DIAG_VERBOSE_ON)
 	printf("reading co-registered input from %s...\n", fname) ;
       fprintf(stderr, "   reading input %d: %s\n", input, fname);
@@ -451,8 +470,11 @@ main(int argc, char *argv[])
       {
 	MRI *mri_mask ;
 	
-	sprintf(fname, "%s/%s/mri/%s",
-		subjects_dir, subject_name, mask_fname);
+	int req = snprintf(fname, STRLEN, "%s/%s/mri/%s",
+			   subjects_dir, subject_name, mask_fname);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
 	printf("reading volume %s for masking...\n", fname) ;
 	mri_mask = MRIread(fname) ;
 	if (!mri_mask)
@@ -474,8 +496,11 @@ main(int argc, char *argv[])
     if (xform_name)
     {
       // we read talairach.xfm which is a RAS-to-RAS
-      sprintf(fname, "%s/%s/mri/transforms/%s",
-	      subjects_dir, subject_name, xform_name) ;
+      int req= snprintf(fname, STRLEN, "%s/%s/mri/transforms/%s",
+			subjects_dir, subject_name, xform_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON)
 	printf("INFO: reading transform file %s...\n", fname);
       if (!FileExists(fname))
@@ -1218,6 +1243,10 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
               fflush(stdout) ;
               errors++;
             }
+#if __GNUC__  >= 8
+	    [[gnu::fallthrough]];
+#endif
+
             // no break (check xt)
 
           case Left_Caudate:
@@ -1254,6 +1283,9 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
               fflush(stdout) ;
               errors++;
             }
+#if __GNUC__  >= 8
+	    [[gnu::fallthrough]];
+#endif
             // no break (check xt)
 
           case Right_Caudate:
@@ -1354,7 +1386,10 @@ static int check(MRI *mri_seg, char *subjects_dir, char *subject_name)
   if ( do_fix_badsubjs && errors)
   {
     char fname[STRLEN];
-    sprintf(fname, "%s/%s/mri/seg_fixed.mgz", subjects_dir, subject_name);
+    int req = snprintf(fname, STRLEN, "%s/%s/mri/seg_fixed.mgz", subjects_dir, subject_name);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("Writing corrected volume to %s\n",fname);
     MRIwrite(mri_fixed,fname);
     MRIfree(&mri_fixed);

--- a/mri_train/mri_train.cpp
+++ b/mri_train/mri_train.cpp
@@ -465,7 +465,11 @@ make_mask_from_segmentation(const char *sdir, const char *subject, char **long_n
 
   for (l = 0 ; l < nlong ; l++)
   {
-    sprintf(fname, "%s/%s%s.%s_base/mri/%s", sdir, subject, long_names[l], subject, seg_name) ;
+    int req = snprintf(fname, STRLEN, "%s/%s%s.%s_base/mri/%s",
+		       sdir, subject, long_names[l], subject, seg_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     mri_long_seg[l] = MRIread(fname) ;
     if (mri_long_seg[l] == NULL)
       ErrorExit(ERROR_NOFILE, "%s: could not load segmentation from %s",

--- a/mri_transform/mri_transform.cpp
+++ b/mri_transform/mri_transform.cpp
@@ -513,6 +513,7 @@ get_option(int argc, char *argv[]) {
       nargs = 1 ;
       fprintf(stderr, "computing average distance traversed by label %d\n", labels[nlabels]) ;
       nlabels++ ;
+      break;
     case 'V':
       Gdiag_no = atoi(argv[2]) ;
       nargs = 1 ;

--- a/mri_twoclass/mri_twoclass.cpp
+++ b/mri_twoclass/mri_twoclass.cpp
@@ -235,7 +235,10 @@ main(int argc, char *argv[]) {
       subject_name = n < num_class1 ? c1_subjects[n]:c2_subjects[n-num_class1];
       fprintf(stderr, "reading subject %d of %d: %s\n",
               n+1, num_class1+num_class2, subject_name) ;
-      sprintf(fname, "%s/%s/mri/%s", subjects_dir,subject_name,aseg_name);
+      int req = snprintf(fname, STRLEN, "%s/%s/mri/%s", subjects_dir,subject_name,aseg_name);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       mri = MRIread(fname) ;
       if (!mri)
         ErrorExit(ERROR_NOFILE, "%s: could not read segmentation %s",
@@ -250,7 +253,10 @@ main(int argc, char *argv[]) {
       if (mask_fname) {
         MRI *mri_mask ;
 
-        sprintf(fname, "%s/%s/mri/%s", subjects_dir,subject_name,mask_fname);
+        int req = snprintf(fname, STRLEN, "%s/%s/mri/%s", subjects_dir,subject_name,mask_fname);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         mri_mask = MRIread(fname) ;
         if (!mri_mask)
           ErrorExit(ERROR_NOFILE, "%s: could not open mask volume %s.\n",
@@ -259,8 +265,11 @@ main(int argc, char *argv[]) {
         MRImask(mri, mri_mask, mri, 0, 0) ;
         MRIfree(&mri_mask) ;
       }
-      sprintf(fname, "%s/%s/mri/transforms/%s", subjects_dir,subject_name,
-              xform_fname);
+      req = snprintf(fname, STRLEN, "%s/%s/mri/transforms/%s", 
+		     subjects_dir,subject_name, xform_fname);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (wm_flag) {
         MRIthresholdRangeInto(mri, mri, WM_MIN_VAL, WM_MAX_VAL) ;
         MRIbinarize(mri, mri, WM_MIN_VAL, 0, 64) ;
@@ -356,7 +365,10 @@ main(int argc, char *argv[]) {
       compute_voxel_statistics(voxel_labels_class1, voxel_labels_class2,
                                awidth, aheight, adepth, resolution,
                                num_class1, num_class2, NULL) ;
-  sprintf(fname, "%s/%s/mri/%s", subjects_dir,output_subject,out_fname);
+  int req = snprintf(fname, STRLEN, "%s/%s/mri/%s", subjects_dir,output_subject,out_fname);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing stats to %s...\n", fname) ;
 
   if (!output_bfloats)

--- a/mris_compute_acorr/mris_compute_acorr.cpp
+++ b/mris_compute_acorr/mris_compute_acorr.cpp
@@ -171,8 +171,11 @@ main(int argc, char *argv[]) {
   } while (argv[n][0] != ':') ;
 
   /* find  # of vertices in output subject surface */
-  sprintf(fname, "%s/%s/surf/%s.%s",
-          subjects_dir,output_subject,hemi,surf_name);
+  int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s",
+		     subjects_dir,output_subject,hemi,surf_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mris = MRISread(fname) ;
   if (!mris)
     ErrorExit(ERROR_NOFILE, "%s: could not read surface file %s",
@@ -267,26 +270,36 @@ main(int argc, char *argv[]) {
     subject_name = n < num_class1 ? c1_subjects[n] : c2_subjects[n-num_class1];
     fprintf(stderr, "reading subject %d of %d: %s\n",
             n+1, num_class1+num_class2, subject_name) ;
-    sprintf(fname, "%s/%s/surf/%s.%s",
-            subjects_dir,subject_name,hemi,surf_name);
+    int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s",
+		       subjects_dir,subject_name,hemi,surf_name);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     mris = MRISread(fname) ;
     if (!mris)
       ErrorExit(ERROR_NOFILE, "%s: could not read surface file %s",
                 Progname, fname) ;
     MRISsaveVertexPositions(mris, CANONICAL_VERTICES) ;
-    if (strchr(curv_name, '/') != NULL)
+    if (strchr(curv_name, '/') != NULL) {
       strcpy(fname, curv_name) ;  /* full path specified */
-    else
-      sprintf(fname,"%s/%s/surf/%s.%s",
-              subjects_dir,subject_name,hemi,curv_name);
+    } else {
+      int req = snprintf(fname,STRLEN,"%s/%s/surf/%s.%s",
+			 subjects_dir,subject_name,hemi,curv_name);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
     if (MRISreadCurvatureFile(mris, fname) != NO_ERROR)
       ErrorExit(Gerror, "%s: could no read curvature file %s",Progname,fname) ;
     MRISaverageCurvatures(mris, navgs) ;
     mrisp = MRIStoParameterization(mris, NULL, 1, 0) ;
     MRISfree(&mris) ;
 
-    sprintf(fname, "%s/%s/surf/%s.%s",
-            subjects_dir,output_subject,hemi,surf_name);
+    req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s",
+		   subjects_dir,output_subject,hemi,surf_name);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     mris = MRISread(fname) ;
     if (!mris)
       ErrorExit(ERROR_NOFILE, "%s: could not read surface file %s",
@@ -314,8 +327,11 @@ main(int argc, char *argv[]) {
   cvector_compute_t_test(c1_mean, c1_var, c2_mean, c2_var,
                          num_class1, num_class2, pvals, nvertices) ;
 
-  sprintf(fname, "%s/%s/surf/%s.%s",
-          subjects_dir,output_subject,hemi,surf_name);
+  req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s",
+		 subjects_dir,output_subject,hemi,surf_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fprintf(stderr, "reading output surface %s...\n", fname) ;
   mris = MRISread(fname) ;
   if (!mris)

--- a/mris_congeal/mris_congeal.cpp
+++ b/mris_congeal/mris_congeal.cpp
@@ -150,7 +150,7 @@ main(int argc, char *argv[])
   ErrorInit(NULL, NULL, NULL) ;
   DiagInit(NULL, NULL, NULL) ;
 
-  memset(&parms, 0, sizeof(parms)) ;
+  // memset(&parms, 0, sizeof(parms)) ; Have proper constructor now
   parms.projection = PROJECT_SPHERE ;
   parms.flags |= IP_USE_CURVATURE ;
   parms.tol = 0.5 ;    // was 1e-0*2.5
@@ -229,7 +229,10 @@ main(int argc, char *argv[])
 
   for (i = 0 ; i < nsubjects ; i++)
   {
-    sprintf(fname, "%s/%s/surf/%s.%s", sdir, argv[i+3], hemi, surf_name) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, argv[i+3], hemi, surf_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stderr, "reading surface from %s...\n", fname) ;
     mris_array[i] = MRISread(fname) ;
     if (!mris_array[i])
@@ -1048,7 +1051,10 @@ MRIScongeal(MRI_SURFACE *mris_ico, MRI_SURFACE **mris_array, int nsubjects,
   if (Gdiag & DIAG_WRITE)
   {
     char fname[STRLEN] ;
-    sprintf(fname, "%s.log", parms->base_name) ;
+    int req = snprintf(fname, STRLEN, "%s.log", parms->base_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     INTEGRATION_PARMS_openFp(parms, fname, "a") ;
   }
 
@@ -1100,7 +1106,10 @@ MRIScongeal(MRI_SURFACE *mris_ico, MRI_SURFACE **mris_array, int nsubjects,
       if (Gdiag & DIAG_WRITE && parms->write_iterations > 0)
       {
         char fname[STRLEN] ;
-        sprintf(fname, "%s.template.sno%d.iter%d", parms->base_name, sno, iter) ;
+        int req = snprintf(fname, STRLEN, "%s.template.sno%d.iter%d", parms->base_name, sno, iter) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         MRISwriteCurvature(mris_ico, fname) ;
       }
       MRIScongealUpdateRigidRegistration(mris_ico, mris_array, mht_array, mht_ico, nsubjects, angle, parms) ;
@@ -1114,7 +1123,10 @@ MRIScongeal(MRI_SURFACE *mris_ico, MRI_SURFACE **mris_array, int nsubjects,
     if (Gdiag & DIAG_WRITE && parms->write_iterations > 0)
     {
       char fname[STRLEN] ;
-      sprintf(fname, "%s.template.sno%d.iter%d", parms->base_name, sno, iter) ;
+      int req = snprintf(fname, STRLEN, "%s.template.sno%d.iter%d", parms->base_name, sno, iter) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       MRISwriteCurvature(mris_ico, fname) ;
     }
     do
@@ -1400,16 +1412,25 @@ mrisWriteSnapshot(MRI_SURFACE *mris, INTEGRATION_PARMS *parms, int t)
   char fname[STRLEN], path[STRLEN], base_name[STRLEN], *cp ;
 
   FileNamePath(mris->fname, path) ;
-  sprintf(base_name, "%s/%s.%s.sno%d.iter%d", path,
-          mris->hemisphere == LEFT_HEMISPHERE ? "lh":"rh", parms->base_name, Gsno, Giter);
+  int req = snprintf(base_name, STRLEN, "%s/%s.%s.sno%d.iter%d", path,
+		     mris->hemisphere == LEFT_HEMISPHERE ? "lh":"rh", parms->base_name, Gsno, Giter);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   if ((cp = strstr(base_name, ".geo")) != NULL)
   {
     *cp = 0;
-    sprintf(fname, "%s%4.4d.geo", base_name, t) ;
+    int req=snprintf(fname, STRLEN, "%s%4.4d.geo", base_name, t) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     *cp = '.' ;
+  } else {
+    int req = snprintf(fname, STRLEN, "%s.%4.4d", base_name, t) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
   }
-  else
-    sprintf(fname, "%s.%4.4d", base_name, t) ;
 #if 1
   if (Gdiag & DIAG_SHOW)
     fprintf(stdout, "writing %s...", fname) ;
@@ -1429,7 +1450,10 @@ mrisWriteSnapshot(MRI_SURFACE *mris, INTEGRATION_PARMS *parms, int t)
   {
     MRI_SP *mrisp = (MRI_SP *)mris->vp ;
 
-    sprintf(fname, "%s%4.4d.hipl", parms->base_name, t) ;
+    int req = snprintf(fname, STRLEN, "%s%4.4d.hipl", parms->base_name, t) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (Gdiag & DIAG_SHOW)
       fprintf(stdout, "writing %s\n", fname) ;
     MRIStoParameterization(mris, mrisp, 1, 0) ;

--- a/mris_deform/mris_ca_deform.cpp
+++ b/mris_deform/mris_ca_deform.cpp
@@ -113,7 +113,7 @@ main(int argc, char *argv[]) {
   TRANSFORM   *transform ;
   GCA         *gca ;
 
-  memset(&parms, 0, sizeof(parms)) ;
+  // memset(&parms, 0, sizeof(parms)) ; Now have proper constructor
   parms.integration_type = INTEGRATE_MOMENTUM ;
 
   // parms.l_nspring = .5; parms.l_tspring = 1; parms.l_curv = 1.0 ;

--- a/mris_deform/mris_deform.cpp
+++ b/mris_deform/mris_deform.cpp
@@ -415,19 +415,28 @@ main(int argc, char *argv[]) {
     else
       v1_prior = NULL;
 
-    sprintf(fname, "%s.white", read_name) ;
+    int req = snprintf(fname, STRLEN, "%s.white", read_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (MRISreadWhiteCoordinates(mris, fname) != NO_ERROR)
       ErrorExit(ERROR_NOFILE, "%s: could not read white coords from %s",
                 Progname, fname) ;
     vp_copy_from_surface(mris, WHITE_VERTICES, WHITE_VERTICES);
 
-    sprintf(fname, "%s.layerIV", read_name) ;
+    req = snprintf(fname, STRLEN, "%s.layerIV", read_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (MRISreadWhiteCoordinates(mris, fname) != NO_ERROR)
       ErrorExit(ERROR_NOFILE, "%s: could not read layer IV coords from %s",
                 Progname, fname) ;
     vp_copy_from_surface(mris, WHITE_VERTICES, LAYERIV_VERTICES);
 
-    sprintf(fname, "%s.pial", read_name) ;
+    req = snprintf(fname, STRLEN, "%s.pial", read_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (MRISreadWhiteCoordinates(mris, fname) != NO_ERROR)
       ErrorExit(ERROR_NOFILE, "%s: could not read pial coords from %s",
                 Progname, fname) ;
@@ -439,7 +448,10 @@ main(int argc, char *argv[]) {
     if (label_only)
     {
       v1 = label_v1(mris, mri, &dp) ;
-      sprintf(fname, "%s.%s.V1.label", hemi, parms.base_name);
+      int req = snprintf(fname, STRLEN, "%s.%s.V1.label", hemi, parms.base_name);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("writing v1 estimated position to %s\n", fname) ;
       if (v1)
       {
@@ -449,7 +461,10 @@ main(int argc, char *argv[]) {
       vp_copy_to_surface_vals(mris, DEEP_RATIO, &dp) ;
       //      MRISsoapBubbleVals(mris, 100) ; 
       MRISaverageVals(mris, vavgs) ;
-      sprintf(fname, "%s.%s.deep_ratio.mgz", hemi, parms.base_name);
+      req = snprintf(fname, STRLEN, "%s.%s.deep_ratio.mgz", hemi, parms.base_name);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("writing ratio of deep IG to layer IV to %s\n", fname) ;
       MRISwriteValues(mris, fname) ;
 
@@ -469,13 +484,19 @@ main(int argc, char *argv[]) {
         label_v1(mris, mri, &dp) ;
         vp_copy_to_surface_vals(mris, DEEP_RATIO, &dp) ;
         MRISaverageVals(mris, vavgs) ;
-        sprintf(fname, "%s.%s.mid.deep_ratio.mgz", hemi, parms.base_name);
+        int req = snprintf(fname, STRLEN, "%s.%s.mid.deep_ratio.mgz", hemi, parms.base_name);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         printf("writing ratio of deep middle surface to superficial to %s\n", fname) ;
         MRISwriteValues(mris, fname) ;
       }
       exit(0) ;
     }
-    sprintf(fname, "%s.%s.marked", hemi, base_read_name);
+    req = snprintf(fname, STRLEN, "%s.%s.marked", hemi, base_read_name);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (MRISreadMarked(mris, fname)!= NO_ERROR)
       ErrorPrintf(Gerror, "could not read marked from %s", fname) ;
     MRISaverageVals(mris, vavgs) ;
@@ -483,19 +504,28 @@ main(int argc, char *argv[]) {
 
     if (dp.use_intensity) // use precomputed intensity info instead of optimizing it
     {
-      sprintf(fname, "%s.%s.ig_intensity.mgz", hemi, base_read_name);
+      int req = snprintf(fname, STRLEN, "%s.%s.ig_intensity.mgz", hemi, base_read_name);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (MRISreadValues(mris, fname)!= NO_ERROR)
         ErrorExit(Gerror, "") ;
       MRISaverageVals(mris, vavgs) ;
       vp_copy_from_surface_vals(mris, IG_INTENSITY, &dp) ;
 
-      sprintf(fname, "%s.%s.wm_intensity.mgz", hemi, base_read_name);
+      req = snprintf(fname, STRLEN, "%s.%s.wm_intensity.mgz", hemi, base_read_name);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (MRISreadValues(mris, fname)!= NO_ERROR)
         ErrorExit(Gerror, "") ;
       MRISaverageVals(mris, vavgs) ;
       vp_copy_from_surface_vals(mris, WM_INTENSITY, &dp) ;
 
-      sprintf(fname, "%s.%s.sg_intensity.mgz", hemi, base_read_name);
+      req = snprintf(fname, STRLEN, "%s.%s.sg_intensity.mgz", hemi, base_read_name);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (MRISreadValues(mris, fname)!= NO_ERROR)
         ErrorExit(Gerror, "") ;
       MRISaverageVals(mris, vavgs) ;
@@ -506,7 +536,7 @@ main(int argc, char *argv[]) {
   {
     INTEGRATION_PARMS eparms ;
 
-    memset(&eparms, 0, sizeof(eparms)) ;
+    // memset(&eparms, 0, sizeof(eparms)) ; Have proper constructor now
     eparms.l_spring = .1;
     eparms.l_location = 1 ;
     // eparms.l_curv = 1.0 ;
@@ -524,7 +554,11 @@ main(int argc, char *argv[]) {
     if (Gdiag & DIAG_WRITE)
     {
       char fname[STRLEN] ;
-      sprintf(fname, "%s.%s.expanded", mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", parms.base_name);
+      int req = snprintf(fname, STRLEN, "%s.%s.expanded",
+			 mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", parms.base_name);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("writing expanded 'pial' surface to %s\n", fname) ;
       MRISwrite(mris, fname) ;
     }
@@ -587,7 +621,11 @@ main(int argc, char *argv[]) {
   {
     char fname[STRLEN] ;
     MRISstoreRipFlags(mris) ; MRISunrip(mris) ;
-    sprintf(fname, "%s.%s.wnormals.mgz", mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", parms.base_name);
+    int req = snprintf(fname, STRLEN, "%s.%s.wnormals.mgz",
+		       mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", parms.base_name);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing surface normals to %s\n", fname) ;
     MRISwriteNormals(mris, fname) ;
     MRISrestoreRipFlags(mris) ;
@@ -649,7 +687,10 @@ main(int argc, char *argv[]) {
           
           if (v1)
           {
-            sprintf(fname, "%s.%s.V1.%d.label", hemi, base_name,ino);
+            int req = snprintf(fname, STRLEN, "%s.%s.V1.%d.label", hemi, base_name,ino);
+	    if( req >= STRLEN ) {
+	      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	    }
             printf("writing v1 estimated position to %s\n", fname) ;
             LabelWrite(v1, fname) ;
             LabelFree(&v1) ;
@@ -657,38 +698,62 @@ main(int argc, char *argv[]) {
         }
 
         vp_copy_dist_to_surface_vals(mris, LAYERIV_VERTICES) ;
-        sprintf(fname, "%s.%s.layerIV.height.%d.mgz", hemi, base_name,ino);
+        int req = snprintf(fname, STRLEN, "%s.%s.layerIV.height.%d.mgz", hemi, base_name,ino);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         MRISwriteValues(mris, fname) ;
 
         vp_copy_to_surface_vals(mris, WM_INTENSITY, &dp) ;
-        sprintf(fname, "%s.%s.wtargets.%d.mgz", hemi, base_name,ino);
+        req = snprintf(fname, STRLEN, "%s.%s.wtargets.%d.mgz", hemi, base_name,ino);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         MRISwriteValues(mris, fname) ;
 
         vp_copy_to_surface_vals(mris, RMS, &dp) ;
-        sprintf(fname, "%s.%s.rms.%d.mgz", hemi, base_name,ino);
+        req = snprintf(fname, STRLEN, "%s.%s.rms.%d.mgz", hemi, base_name,ino);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         MRISwriteValues(mris, fname) ;
 
         vp_copy_to_surface_vals(mris, SG_INTENSITY, &dp) ;
-        sprintf(fname, "%s.%s.ptargets.%d.mgz", hemi, base_name,ino);
+        req = snprintf(fname, STRLEN, "%s.%s.ptargets.%d.mgz", hemi, base_name,ino);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         MRISwriteValues(mris, fname) ;
         vp_copy_to_surface_vals(mris, IG_INTENSITY, &dp) ;
-        sprintf(fname, "%s.%s.l4targets.%d.mgz", hemi, base_name,ino);
+        req = snprintf(fname, STRLEN, "%s.%s.l4targets.%d.mgz", hemi, base_name,ino);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         MRISwriteValues(mris, fname) ;
 
         MRISstoreRipFlags(mris) ; MRISunrip(mris) ;
 
         vp_copy_to_surface(mris, WHITE_TARGETS, CURRENT_VERTICES) ;
-        sprintf(fname, "%s.%s.wtarget.%d", hemi, base_name, ino);
+        req = snprintf(fname, STRLEN, "%s.%s.wtarget.%d", hemi, base_name, ino);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         printf("writing white target locations to %s\n", fname) ;
         MRISwrite(mris, fname) ;
 
         vp_copy_to_surface(mris, PIAL_TARGETS, CURRENT_VERTICES) ;
-        sprintf(fname, "%s.%s.ptarget.%d", hemi, base_name, ino);
+        req = snprintf(fname, STRLEN, "%s.%s.ptarget.%d", hemi, base_name, ino);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         printf("writing pial target locations to %s\n", fname) ;
         MRISwrite(mris, fname) ;
 
         vp_copy_to_surface(mris, LAYERIV_TARGETS, CURRENT_VERTICES) ;
-        sprintf(fname, "%s.%s.l4target.%d", hemi, base_name, ino);
+        req = snprintf(fname, STRLEN, "%s.%s.l4target.%d", hemi, base_name, ino);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         printf("writing layer IV target locations to %s\n", fname) ;
         MRISwrite(mris, fname) ;
 
@@ -710,8 +775,14 @@ main(int argc, char *argv[]) {
       }
 
       // do white matter surface
-      sprintf(parms.base_name, "%s.white", base_name) ;
-      sprintf(dp.base_name, "%s.white", base_name) ;
+      int req = snprintf(parms.base_name, STRLEN, "%s.white", base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+      req = snprintf(dp.base_name, STRLEN, "%s.white", base_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       vp_copy_to_surface(mris, WHITE_VERTICES, CURRENT_VERTICES) ;
       vp_copy_to_surface(mris, WHITE_TARGETS, TARGET_VERTICES) ;
       parms.l_surf_repulse = 0 ;
@@ -737,8 +808,14 @@ main(int argc, char *argv[]) {
       if (white_only == 0)
       {
         // do pial surface
-        sprintf(parms.base_name, "%s.pial", base_name) ;
-        sprintf(dp.base_name, "%s.pial", base_name) ;
+        int req = snprintf(parms.base_name, STRLEN, "%s.pial", base_name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+        req = snprintf(dp.base_name, STRLEN, "%s.pial", base_name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         vp_copy_to_surface(mris, PIAL_VERTICES, CURRENT_VERTICES) ;
         vp_copy_to_surface(mris, PIAL_TARGETS, TARGET_VERTICES) ;
         vp_copy_to_surface(mris, LAYERIV_VERTICES, ORIGINAL_VERTICES) ; // for surf repulse
@@ -754,8 +831,14 @@ main(int argc, char *argv[]) {
         MRISsaveVertexPositions(mris, PIAL_VERTICES) ;
         
         // do layer IV surface
-        sprintf(parms.base_name, "%s.layerIV", base_name) ;
-        sprintf(dp.base_name, "%s.layerIV", base_name) ;
+        req = snprintf(parms.base_name, STRLEN, "%s.layerIV", base_name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
+        req = snprintf(dp.base_name, STRLEN, "%s.layerIV", base_name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         vp_copy_to_surface(mris, LAYERIV_VERTICES, CURRENT_VERTICES) ;
         vp_copy_to_surface(mris, LAYERIV_TARGETS, TARGET_VERTICES) ;
         vp_copy_to_surface(mris, WHITE_VERTICES, ORIGINAL_VERTICES) ; // for surf repulse
@@ -794,59 +877,89 @@ main(int argc, char *argv[]) {
   minutes = seconds / 60 ;
   seconds = seconds % 60 ;
   MRISunrip(mris) ;
-  sprintf(fname, "%s.white", argv[4]) ;
+  int req = snprintf(fname, STRLEN, "%s.white", argv[4]) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   vp_copy_to_surface(mris, WHITE_VERTICES, CURRENT_VERTICES) ;
   printf("writing white final surface position to %s\n", fname) ;
   MRISwrite(mris, fname) ;
 
   vp_copy_dist_to_surface_vals(mris, LAYERIV_VERTICES) ;
   //  MRISsoapBubbleVals(mris, 100) ; 
-  sprintf(fname, "%s.%s.layerIV.height.mgz", hemi, base_name);
+  req = snprintf(fname, STRLEN, "%s.%s.layerIV.height.mgz", hemi, base_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing layer IV height to %s\n", fname) ;
   MRISwriteValues(mris, fname) ;
 
   vp_copy_to_surface_vals(mris, SG_INTENSITY, &dp) ;
   //  MRISsoapBubbleVals(mris, 100) ; 
-  sprintf(fname, "%s.%s.sg_intensity.mgz", hemi, base_name);
+  req = snprintf(fname, STRLEN, "%s.%s.sg_intensity.mgz", hemi, base_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing SG intensity to %s\n", fname) ;
   MRISwriteValues(mris, fname) ;
 
   vp_copy_to_surface_vals(mris, WM_INTENSITY, &dp) ;
   //  MRISsoapBubbleVals(mris, 100) ; 
-  sprintf(fname, "%s.%s.wm_intensity.mgz", hemi, base_name);
+  req = snprintf(fname, STRLEN, "%s.%s.wm_intensity.mgz", hemi, base_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing WM intensity to %s\n", fname) ;
   MRISwriteValues(mris, fname) ;
 
   vp_copy_to_surface_vals(mris, IG_INTENSITY, &dp) ;
   //  MRISsoapBubbleVals(mris, 100) ; 
-  sprintf(fname, "%s.%s.ig_intensity.mgz", hemi, base_name);
+  req = snprintf(fname, STRLEN, "%s.%s.ig_intensity.mgz", hemi, base_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing infragranular intensity to %s\n", fname) ;
   MRISwriteValues(mris, fname) ;
 
   vp_copy_to_surface_vals(mris, IG_WM_RATIO, &dp) ;
   //  MRISsoapBubbleVals(mris, 100) ; 
-  sprintf(fname, "%s.%s.ig_wm_ratio.mgz", hemi, base_name);
+  req = snprintf(fname, STRLEN, "%s.%s.ig_wm_ratio.mgz", hemi, base_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing infragranular/wm ratio to %s\n", fname) ;
   MRISwriteValues(mris, fname) ;
 
   vp_copy_to_surface_vals(mris, SG_WM_RATIO, &dp) ;
   //  MRISsoapBubbleVals(mris, 100) ; 
-  sprintf(fname, "%s.%s.sg_wm_ratio.mgz", hemi, base_name);
+  req = snprintf(fname, STRLEN, "%s.%s.sg_wm_ratio.mgz", hemi, base_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing supragranular/wm intensity ratio to %s\n", fname) ;
   MRISwriteValues(mris, fname) ;
 
   vp_copy_to_surface_vals(mris, SG_IG_RATIO, &dp) ;
   //  MRISsoapBubbleVals(mris, 100) ; 
-  sprintf(fname, "%s.%s.sg_ig_ratio.mgz", hemi, base_name);
+  req = snprintf(fname, STRLEN, "%s.%s.sg_ig_ratio.mgz", hemi, base_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing supragranular/infrgranular intensity ratio to %s\n", fname) ;
   MRISwriteValues(mris, fname) ;
 
-  sprintf(fname, "%s.pial", argv[4]) ;
+  req = snprintf(fname, STRLEN, "%s.pial", argv[4]) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   vp_copy_to_surface(mris, PIAL_VERTICES, CURRENT_VERTICES) ;
   printf("writing pial final surface position to %s\n", fname) ;
   MRISwrite(mris, fname) ;
 
-  sprintf(fname, "%s.layerIV", argv[4]) ;
+  req = snprintf(fname, STRLEN, "%s.layerIV", argv[4]) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   vp_copy_to_surface(mris, LAYERIV_VERTICES, CURRENT_VERTICES) ;
   printf("writing pial final surface position to %s\n", fname) ;
   MRISwrite(mris, fname) ;
@@ -854,11 +967,17 @@ main(int argc, char *argv[]) {
   vp_copy_to_surface_vals(mris, DEEP_RATIO, &dp) ;
   //      MRISsoapBubbleVals(mris, 100) ; 
   MRISaverageVals(mris, vavgs) ;
-  sprintf(fname, "%s.%s.deep_ratio.mgz", hemi, parms.base_name);
+  req = snprintf(fname, STRLEN, "%s.%s.deep_ratio.mgz", hemi, parms.base_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing ratio of deep IG to layer IV to %s\n", fname) ;
   MRISwriteValues(mris, fname) ;
 
-  sprintf(fname, "%s.marked", argv[4]) ;
+  req = snprintf(fname, STRLEN, "%s.marked", argv[4]) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing vertex marks to %s\n", fname) ;
   MRISwriteMarked(mris, fname) ;
 
@@ -1065,6 +1184,7 @@ get_option(int argc, char *argv[]) {
   case 'I':
     invert = 1 ;
     printf("inverting xform before applying\n") ;
+    break;
   case '?':
   case 'U':
     usage_exit(0) ;
@@ -1193,7 +1313,11 @@ compute_targets(MRI_SURFACE *mris, MRI *mri, double sigma, DP *dp, int skip)
   {
     char fname[STRLEN] ;
     MRISstoreRipFlags(mris) ; MRISunrip(mris) ;
-    sprintf(fname, "%s.%s.normals.%d.init.mgz", mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", parms.base_name, i);
+    int req = snprintf(fname, STRLEN, "%s.%s.normals.%d.init.mgz",
+		       mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", parms.base_name, i);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing surface normals to %s\n", fname) ;
     MRIScomputeNormals(mris) ;
     MRISwriteNormals(mris, fname) ;
@@ -1204,7 +1328,11 @@ compute_targets(MRI_SURFACE *mris, MRI *mri, double sigma, DP *dp, int skip)
   {
     char fname[STRLEN] ;
     MRISstoreRipFlags(mris) ; MRISunrip(mris) ;
-    sprintf(fname, "%s.%s.normals.%d.final.mgz", mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", parms.base_name,i);
+    int req = snprintf(fname, STRLEN, "%s.%s.normals.%d.final.mgz",
+		       mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", parms.base_name,i);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing surface normals to %s\n", fname) ;
     vp_copy_to_surface(mris, SURFACE_NORMALS, SURFACE_NORMALS) ;
     MRISwriteNormals(mris, fname) ;
@@ -1217,7 +1345,11 @@ compute_targets(MRI_SURFACE *mris, MRI *mri, double sigma, DP *dp, int skip)
     char fname[STRLEN] ;
     if (i == 0)
     {
-      sprintf(fname, "%s.%s.normals.mgz", mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", parms.base_name);
+      int req = snprintf(fname, STRLEN, "%s.%s.normals.mgz",
+			 mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", parms.base_name);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("reading surface normals from %s\n", fname) ;
       MRISreadNormals(mris, fname) ;
       vp_copy_from_surface(mris, SURFACE_NORMALS, SURFACE_NORMALS) ;
@@ -1812,13 +1944,19 @@ compute_targets(MRI_SURFACE *mris, MRI *mri, double sigma, DP *dp, int skip)
   {
     char fname[STRLEN] ;
     static int i = 0 ;
-    sprintf(fname, "%s.%s.wtvals.%3.3d.mgz",
-            mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", dp->base_name,i) ;
+    int req = snprintf(fname, STRLEN, "%s.%s.wtvals.%3.3d.mgz",
+		       mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", dp->base_name,i) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing white target vals to %s\n", fname) ;
     MRIwrite(mri_white, fname) ;
 
-    sprintf(fname, "%s.%s.ptvals.%3.3d.mgz",
-            mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", dp->base_name,i) ;
+    req = snprintf(fname, STRLEN, "%s.%s.ptvals.%3.3d.mgz",
+		   mris->hemisphere == LEFT_HEMISPHERE ? "lh" : "rh", dp->base_name,i) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing pial target vals to %s\n", fname) ;
     MRIwrite(mri_pial, fname) ;
 
@@ -3890,6 +4028,7 @@ vp_copy_to_surface_vals(MRI_SURFACE *mris, int which, DP *dp)
       break ;
     case SG_WM_RATIO:         
       val = (vp->sg_intensity_offset+dp->supra_granular_val) / (vp->wm_intensity_offset+dp->wm_val) ; 
+      break;
     case SG_IG_RATIO:         
       val = (vp->sg_intensity_offset+dp->supra_granular_val) / (vp->ig_intensity_offset+dp->infra_granular_val) ; 
       break ;
@@ -3930,7 +4069,7 @@ vp_copy_from_surface_vals(MRI_SURFACE *mris, int which, DP *dp)
     case IG_INTENSITY:        vp->ig_intensity_offset = v->val-dp->infra_granular_val ; break ;
     case SG_INTENSITY:        vp->sg_intensity_offset= v->val-dp->supra_granular_val ; break ;
     case WM_INTENSITY:        vp->wm_intensity_offset = v->val - dp->wm_val ; break ;
-    case DEEP_RATIO:          vp->deep_ratio = v->val ;
+    case DEEP_RATIO:          vp->deep_ratio = v->val ; break;
     default:
     case IG_WM_RATIO:         
     case SG_WM_RATIO:         
@@ -4585,7 +4724,7 @@ compute_normals(MRI_SURFACE *mris, VERTEX_PARMS *vp)
   //  return(NO_ERROR) ;
 
   MRISsaveVertexPositions(mris, ORIGINAL_VERTICES) ;
-  memset(&thick_parms, 0, sizeof(thick_parms)) ; 
+  // memset(&thick_parms, 0, sizeof(thick_parms)) ; Have proper constructor now
   if (cno++ > 0)
     thick_parms.dt = 0.01 ; 
   else

--- a/mris_distance_to_label/mris_distance_to_label.cpp
+++ b/mris_distance_to_label/mris_distance_to_label.cpp
@@ -260,14 +260,26 @@ int main(int argc, char *argv[]) {
 
     fprintf(stderr,"\n\nPROCESSING SUBJECT '%s' \n",subject_fname);
 
-    sprintf(fname,"%s/%s/surf/%s.white", subjects_dir,subject_fname,hemi);
+    int req = snprintf(fname,STRLEN,"%s/%s/surf/%s.white", subjects_dir,subject_fname,hemi);
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fprintf(stderr, "reading surface from %s...\n", fname) ;
     mris=MRISread(fname);
 
-    if (aseg_fname)
-      sprintf(fname,"%s/%s/mri/%s", subjects_dir,subject_fname,aseg_fname);
-    else
-      sprintf(fname,"%s/%s/mri/aseg.mgz", subjects_dir,subject_fname);
+    if (aseg_fname) {
+      int req = snprintf(fname,STRLEN,"%s/%s/mri/%s",
+			 subjects_dir,subject_fname,aseg_fname);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    } else {
+      int req = snprintf(fname,STRLEN,"%s/%s/mri/aseg.mgz", 
+			 subjects_dir,subject_fname);
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
 
     fprintf(stderr, "reading mri segmentation from %s...\n", fname) ;
     mri=MRIread(fname);
@@ -288,13 +300,20 @@ int main(int argc, char *argv[]) {
         mrisProcessDistanceValues(mris);
 
         surface_reference=findSurfaceReference(labels[n]);
-        if (surface_reference>=3 and surface_reference<=14)
-          sprintf(fname,"%s/%s/surf/%s.%s",
-                  subjects_dir,subject_fname,hemi,
-                  FRAME_FIELD_NAMES[surface_reference]);
-        else
-          sprintf(fname,"%s/%s/surf/%s.dist_%d",
-                  subjects_dir,subject_fname,hemi,labels[n]);
+        if (surface_reference>=3 and surface_reference<=14) {
+          int req = snprintf(fname,STRLEN, "%s/%s/surf/%s.%s",
+			     subjects_dir,subject_fname,hemi,
+			     FRAME_FIELD_NAMES[surface_reference]);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
+        } else {
+          int req = snprintf(fname,STRLEN,"%s/%s/surf/%s.dist_%d",
+			     subjects_dir,subject_fname,hemi,labels[n]);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
+	}
 
         fprintf(stderr,
                 "writing out surface distance file for label %d in %s...\n",
@@ -302,21 +321,30 @@ int main(int argc, char *argv[]) {
         MRISaverageCurvatures(mris,navgs);
         MRISwriteCurvature(mris,fname);
       } else { /* extract layer IV */
-        sprintf(fname,"%s/%s/surf/%s.thickness",
-                subjects_dir,subject_fname,hemi);
+        int req = snprintf(fname,STRLEN,"%s/%s/surf/%s.thickness",
+			   subjects_dir,subject_fname,hemi);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         fprintf(stderr, "reading curvature from %s...\n", fname) ;
         MRISreadCurvature(mris,fname);
 
-        sprintf(fname,"%s/%s/mri/T1.mgz", subjects_dir,subject_fname);
+        req = snprintf(fname,STRLEN,"%s/%s/mri/T1.mgz", subjects_dir,subject_fname);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         fprintf(stderr, "reading orig mri segmentation from %s...\n", fname) ;
         mri_orig=MRIread(fname);
         mrisExtractMidGrayValues(mris,mri_orig);
         MRIfree(&mri_orig);
 
         surface_reference=3;
-        sprintf(fname,"%s/%s/surf/%s.%s",
-                subjects_dir,subject_fname,hemi,
-                FRAME_FIELD_NAMES[surface_reference]);
+        req = snprintf(fname,STRLEN,"%s/%s/surf/%s.%s",
+		       subjects_dir,subject_fname,hemi,
+		       FRAME_FIELD_NAMES[surface_reference]);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         fprintf(stderr,
                 "writing out surface distance file for label %d in %s...\n",
                 labels[n],fname) ;

--- a/mris_distance_transform/mris_distance_transform.cpp
+++ b/mris_distance_transform/mris_distance_transform.cpp
@@ -220,12 +220,18 @@ main(int argc, char *argv[])
 	       i, area_division->n_points) ;
 	if (output_label)
 	{
-	  sprintf(fname, "%s%d.label", base_name, i) ;
+	  int req = snprintf(fname, STRLEN, "%s%d.label", base_name, i) ;
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
 	  printf("writing %dth subdivision to %s\n", i, fname) ;
 	  LabelWrite(area_division, fname);
 	}
 	MRISdistanceTransform(mris, area_division, mode) ;
-	sprintf(fname, "%s%d.%s", base_name, i, ext) ;
+	int req = snprintf(fname, STRLEN, "%s%d.%s", base_name, i, ext) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
 	if (normalize > 0)
 	  MRISmulVal(mris, 1.0/normalize) ;
 	MRISwriteValues(mris, fname) ;

--- a/mris_entropy/mris_entropy.cpp
+++ b/mris_entropy/mris_entropy.cpp
@@ -84,7 +84,11 @@ main(int argc, char *argv[]) {
                 Progname) ;
     strcpy(sdir, cp) ;
   }
-  sprintf(fname, "%s/%s/surf/%s.%s", sdir, subject_name, hemi, ORIG_NAME) ;
+  int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", 
+		     sdir, subject_name, hemi, ORIG_NAME) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mris = MRISfastRead(fname) ;
   if (!mris)
     ErrorExit(ERROR_NOFILE, "%s: could not read surface file %s",

--- a/mris_errors/mris_errors.cpp
+++ b/mris_errors/mris_errors.cpp
@@ -92,7 +92,10 @@ main(int argc, char *argv[]) {
       hemi[2] = 0 ;
     } else
       strcpy(hemi, "lh") ;
-    sprintf(fname, "%s/%s.smoothwm", path, hemi) ;
+    int req = snprintf(fname, STRLEN, "%s/%s.smoothwm", path, hemi) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     mris = MRISread(fname) ;
     if (!mris)
       ErrorExit(ERROR_NOFILE, "%s: could not read surface file %s",

--- a/mris_errors/mris_errors.cpp
+++ b/mris_errors/mris_errors.cpp
@@ -52,7 +52,7 @@ static int max_nbrs = 12 ;
 
 int
 main(int argc, char *argv[]) {
-  char         *cp, **av, *in_fname, fname[100], path[100],
+  char         *cp, **av, *in_fname, fname[STRLEN], path[100],
   name[100], hemi[100] ;
   int          ac, nargs ;
 

--- a/mris_expand/mris_expand.cpp
+++ b/mris_expand/mris_expand.cpp
@@ -107,7 +107,10 @@ main(int argc, char *argv[])
   if (Gdiag & DIAG_WRITE)
   {
     char log_fname[STRLEN] ;
-    sprintf(log_fname, "%s.log", fname) ;
+    int req = snprintf(log_fname, STRLEN, "%s.log", fname) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     INTEGRATION_PARMS_openFp(&parms, log_fname, "w") ;
     if (parms.fp)
       printf("writing log results to %s\n", log_fname) ;

--- a/mris_extract_patches/mris_extract_patches.cpp
+++ b/mris_extract_patches/mris_extract_patches.cpp
@@ -104,12 +104,18 @@ main(int argc, char *argv[])
   out_dir = argv[2] ;
 
   printf("processing subject %s hemi %s, label %s and writing results to %s\n", subject, hemi_name, label_name, out_dir) ;
-  sprintf(fname, "%s/%s/surf/%s.%s", sdir, subject, hemi_name, surf_name) ;
+  int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, subject, hemi_name, surf_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mris = MRISread(fname) ;
   if (!mris)
     ErrorExit(ERROR_NOFILE, "%s: MRISread(%s) failed", Progname, fname);
 
-  sprintf(fname, "%s/%s/surf/%s.%s", sdir, subject, ohemi_name, surf_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, subject, ohemi_name, surf_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mris_ohemi = MRISread(fname) ;
   if (!mris_ohemi)
     ErrorExit(ERROR_NOFILE, "%s: MRISread(%s) failed", Progname, fname);
@@ -128,17 +134,27 @@ main(int argc, char *argv[])
   MRIScomputeSecondFundamentalForm(mris);
   MRIScomputeSecondFundamentalForm(mris_ohemi);
 
-  sprintf(fname, "%s/%s/mri/%s", sdir, subject, vol_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, subject, vol_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mri_norm = MRIread(fname) ;
   if (mri_norm == NULL)
     ErrorExit(ERROR_NOFILE, "%s: MRIread(%s) failed", Progname, fname);
 
-  sprintf(fname, "%s/%s/mri/%s", sdir, subject, ovol_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, subject, ovol_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mri_onorm = MRIread(fname) ;
   if (mri_onorm == NULL)
     ErrorExit(ERROR_NOFILE, "%s: MRIread(%s) failed", Progname, fname);
 
-  sprintf(fname, "%s/%s/label/%s.%s.label", sdir, subject, hemi_name, label_name);
+  req = snprintf(fname, STRLEN, "%s/%s/label/%s.%s.label",
+		 sdir, subject, hemi_name, label_name);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   area_tmp = LabelRead(subject, fname) ;
   if (area_tmp == NULL)
     ErrorExit(ERROR_NOFILE, "%s: LabelRead(%s) failed", Progname, fname) ;
@@ -227,10 +243,16 @@ main(int argc, char *argv[])
   }
 
   FileNameRemoveExtension(FileNameOnly(vol_name, fname_only), fname_only) ;
-  sprintf(fname, "%s/%s.patches.%s.mgz", out_dir, hemi_name, fname_only) ;
+  req = snprintf(fname, STRLEN, "%s/%s.patches.%s.mgz", out_dir, hemi_name, fname_only) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing output file %s\n", fname) ;
   MRIwrite(mri_patches, fname) ;
-  sprintf(fname, "%s/%s.labels.%s.mgz", out_dir, hemi_name, fname_only) ;
+  req = snprintf(fname, STRLEN, "%s/%s.labels.%s.mgz", out_dir, hemi_name, fname_only) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing output file %s\n", fname) ;
   MRIwrite(mri_labels, fname) ;
 
@@ -321,10 +343,16 @@ main(int argc, char *argv[])
   }
   
   FileNameRemoveExtension(FileNameOnly(ovol_name, fname_only), fname_only) ;
-  sprintf(fname, "%s/%s.patches.%s.mgz", out_dir, ohemi_name, fname_only) ;
+  req = snprintf(fname, STRLEN, "%s/%s.patches.%s.mgz", out_dir, ohemi_name, fname_only) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing output file with %d patches to %s\n", mri_patches->nframes,fname) ;
   MRIwrite(mri_patches, fname) ;
-  sprintf(fname, "%s/%s.labels.%s.mgz", out_dir, ohemi_name, fname_only) ;
+  req = snprintf(fname, STRLEN, "%s/%s.labels.%s.mgz", out_dir, ohemi_name, fname_only) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing output file %s\n", fname) ;
   MRIwrite(mri_labels, fname) ;
 

--- a/mris_flatten/mris_flatten.cpp
+++ b/mris_flatten/mris_flatten.cpp
@@ -269,7 +269,7 @@ main(int argc, char *argv[])
   ErrorInit(NULL, NULL, NULL) ;
   DiagInit(NULL, NULL, NULL) ;
   Gdiag |= (DIAG_SHOW | DIAG_WRITE) ;
-  memset(&parms, 0, sizeof(parms)) ;
+  // memset(&parms, 0, sizeof(parms)) ;
   parms.dt = .1 ;
   parms.projection = PROJECT_PLANE ;
   parms.tol = 0.2 ;
@@ -314,10 +314,17 @@ main(int argc, char *argv[])
   }
   else
     strcpy(hemi, "lh") ;
-  if (one_surf_flag)
-    sprintf(in_surf_fname, "%s", in_patch_fname) ;
-  else
-    sprintf(in_surf_fname, "%s/%s.%s", path, hemi, original_surf_name) ;
+  if (one_surf_flag) {
+    int req = snprintf(in_surf_fname, STRLEN, "%s", in_patch_fname) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+  } else {
+    int req = snprintf(in_surf_fname, STRLEN, "%s/%s.%s", path, hemi, original_surf_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+  }
 
   if (parms.base_name[0] == 0)
   {
@@ -446,7 +453,10 @@ main(int argc, char *argv[])
     if (!FZERO(parms.l_unfold) || !FZERO(parms.l_expand))
     {
       static INTEGRATION_PARMS p2 ;
-      sprintf(in_surf_fname, "%s/%s.%s", path, hemi, original_surf_name) ;
+      int req = snprintf(in_surf_fname, STRLEN, "%s/%s.%s", path, hemi, original_surf_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (stricmp(original_unfold_surf_name,"none") == 0)
       {
         printf("using current position of patch as initial position\n") ;
@@ -491,7 +501,10 @@ main(int argc, char *argv[])
       MRIfree(&parms.mri_dist) ;
     }
 
-    sprintf(in_surf_fname, "%s/%s.%s", path, hemi, original_surf_name) ;
+    int req = snprintf(in_surf_fname, STRLEN, "%s/%s.%s", path, hemi, original_surf_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (!sphere_flag && !one_surf_flag)
       MRISreadOriginalProperties(mris, original_surf_name) ;
     if (randomly_flatten)
@@ -593,12 +606,18 @@ main(int argc, char *argv[])
       MRIsetValues(mri_overlay, 0) ;
       FileNameOnly(synth_name, fname_no_path) ;
       FileNamePath(synth_name, path) ;
-      sprintf(fname, "%s/lh.%s", path, fname_no_path) ;
+      int req = snprintf(fname, STRLEN, "%s/lh.%s", path, fname_no_path) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       area_lh = LabelRead(NULL, fname) ;
       if (area_lh == NULL)
         ErrorExit(ERROR_NOFILE, "%s: could not read label from %s",
                   Progname,fname) ;
-      sprintf(fname, "%s/rh.%s", path, fname_no_path) ;
+      req = snprintf(fname, STRLEN, "%s/rh.%s", path, fname_no_path) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       area_rh = LabelRead(NULL, fname) ;
       if (area_rh == NULL)
         ErrorExit(ERROR_NOFILE, "%s: could not read label from %s",

--- a/mris_init_global_tractography/mris_init_global_tractography.cpp
+++ b/mris_init_global_tractography/mris_init_global_tractography.cpp
@@ -164,7 +164,10 @@ main(int argc, char *argv[]) {
   }
   subject = argv[1] ;
   
-  sprintf(fname, "%s/%s/mri/%s.mgz", sdir, subject, argv[2]) ;
+  int req = snprintf(fname, STRLEN, "%s/%s/mri/%s.mgz", sdir, subject, argv[2]) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mri_aseg = MRIread(fname) ;
   if (mri_aseg == NULL)
     ErrorExit(ERROR_NOFILE, "%s: could not load aparc+aseg from %s", Progname, fname) ;

--- a/mris_label_area/mris_label_area.cpp
+++ b/mris_label_area/mris_label_area.cpp
@@ -86,7 +86,10 @@ main(int argc, char *argv[]) {
       ErrorExit(ERROR_BADPARM, "%s: SUBJECTS_DIR not defined in env or cmd line",Progname) ;
     strcpy(sdir, cp) ;
   }
-  sprintf(fname, "%s/%s/surf/%s.%s", sdir, subject_name, hemi, surf_name) ;
+  int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, subject_name, hemi, surf_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mris = MRISread(fname) ;
   if (!mris)
     ErrorExit(ERROR_NOFILE, "%s: could not read surface from %s",Progname,

--- a/mris_niters2fwhm/mris_niters2fwhm.cpp
+++ b/mris_niters2fwhm/mris_niters2fwhm.cpp
@@ -404,8 +404,13 @@ MRI *MRISgaussianSmooth2(MRIS *Surf, MRI *Src, double GStd, MRI *Targ,
   }
 
   /* These are needed by MRISextendedNeighbors()*/
-  XNbrVtxNo   = (int *) calloc(Surf->nvertices,sizeof(int));
-  XNbrDotProd = (double *) calloc(Surf->nvertices,sizeof(double));
+  if( Surf->nvertices >= 0 ) {
+    XNbrVtxNo   = (int *) calloc(Surf->nvertices,sizeof(int));
+    XNbrDotProd = (double *) calloc(Surf->nvertices,sizeof(double));
+  } else {
+    printf("ERROR: MRISgaussianSmooth: Surf->nvertices<0 \n");
+    return(NULL);
+  }
 
   if (0) {
     // This will mess up future searches because it sets

--- a/mris_register_label_map/mris_register_label_map.cpp
+++ b/mris_register_label_map/mris_register_label_map.cpp
@@ -224,7 +224,10 @@ int main(int argc, char *argv[])
       {
 	MRI *mri_tmp ;
 	sprintf(name, fmri_surf, hemi, run+1) ;
-	sprintf(fname, "%s/%s/surf/%s", SUBJECTS_DIR, subject, name) ;
+	int req = snprintf(fname, STRLEN, "%s/%s/surf/%s", SUBJECTS_DIR, subject, name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
 	mri_fsurf[n][run] = MRIread(fname) ;
 	if (mri_fsurf[n][run] == NULL)
 	  ErrorExit(ERROR_NOFILE, "%s: could not load surface time series from %s", Progname, fname) ;
@@ -238,14 +241,21 @@ int main(int argc, char *argv[])
 	}
 
 	sprintf(name, fmri_vol, run+1) ;
-	sprintf(fname, "%s/%s/mri/%s", SUBJECTS_DIR, subject, name) ;
+	req = snprintf(fname, STRLEN, "%s/%s/mri/%s", SUBJECTS_DIR, subject, name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
 	mri_fvol[n][run] = MRIread(fname) ;
 	if (mri_fvol[n][run] == NULL)
 	  ErrorExit(ERROR_NOFILE, "%s: could not load volume time series from %s", Progname, fname) ;
       }
       if (label_name)
       {
-        sprintf(fname, "%s/%s/label/%s.%s", SUBJECTS_DIR, subject, hemi, label_name) ;
+        int req = snprintf(fname, STRLEN, "%s/%s/label/%s.%s",
+			   SUBJECTS_DIR, subject, hemi, label_name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         labels[n] = LabelRead("", fname) ;
         if (!labels[n])
 	  ErrorExit(ERROR_NOFILE, "%s: could not read label from %s", Progname, fname) ;
@@ -261,12 +271,18 @@ int main(int argc, char *argv[])
     }
     else   // using surface-based correlation to drive warp
     {
-      sprintf(fname, "%s/%s/surf/%s", SUBJECTS_DIR, subject, cmat_name) ;
+      int req = snprintf(fname, STRLEN, "%s/%s/surf/%s", SUBJECTS_DIR, subject, cmat_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       mri_cmat = MRIread(fname) ;
       if (!mri_cmat)
 	ErrorExit(ERROR_NOFILE, "%s: could not read cmat from %s", Progname, fname) ;
       
-      sprintf(fname, "%s/%s/label/%s.%s", SUBJECTS_DIR, subject, hemi, label_name) ;
+      req = snprintf(fname, STRLEN, "%s/%s/label/%s.%s", SUBJECTS_DIR, subject, hemi, label_name) ;
+      if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       labels[n] = LabelRead("", fname) ;
       if (!labels[n])
 	ErrorExit(ERROR_NOFILE, "%s: could not read label from %s", Progname, fname) ;
@@ -277,7 +293,10 @@ int main(int argc, char *argv[])
 
       if (write_diags)
       {
-	sprintf(fname, "%s.%s.%s.label_avg.mgz", hemi, subject, output_name) ;
+	int req = snprintf(fname, STRLEN, "%s.%s.%s.label_avg.mgz", hemi, subject, output_name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
 	mri_label_avg[n]->width /= 2 ;
 	MRIwrite(mri_label_avg[n], fname) ;
 	mri_label_avg[n]->width *= 2 ;
@@ -289,7 +308,10 @@ int main(int argc, char *argv[])
     mri_stats = compute_mean_and_variance_across_frames(mri_label_avg, nsubjects) ;
     if (write_diags)
     {
-      sprintf(fname, "%s.%s.label_avg.mgz", hemi, output_name) ;
+      int req = snprintf(fname, STRLEN, "%s.%s.label_avg.mgz", hemi, output_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       mri_stats->width /= 2 ;
       MRIwriteFrame(mri_stats, fname, 0) ;
       mri_stats->width *= 2 ;
@@ -333,7 +355,10 @@ int main(int argc, char *argv[])
       {
 	MRI *mri_tmp ;
 	sprintf(name, fmri_surf, hemi, run+1) ;
-	sprintf(fname, "%s/%s/surf/%s", SUBJECTS_DIR, trgsubject, name) ;
+	int req = snprintf(fname, STRLEN, "%s/%s/surf/%s", SUBJECTS_DIR, trgsubject, name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
 	mri_fsurf[nsubjects][run] = MRIread(fname) ;
 	if (mri_fsurf[nsubjects][run] == NULL)
 	  ErrorExit(ERROR_NOFILE, "%s: could not load surface time series from %s", Progname, fname) ;
@@ -347,14 +372,21 @@ int main(int argc, char *argv[])
 	}
       
 	sprintf(name, fmri_vol, run+1) ;
-	sprintf(fname, "%s/%s/mri/%s", SUBJECTS_DIR, trgsubject, name) ;
+	req = snprintf(fname, STRLEN, "%s/%s/mri/%s", SUBJECTS_DIR, trgsubject, name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
 	mri_fvol[nsubjects][run] = MRIread(fname) ;
 	if (mri_fvol[nsubjects][run] == NULL)
 	  ErrorExit(ERROR_NOFILE, "%s: could not load volume time series from %s", Progname, fname) ;
       }
       if (label_name)
       {
-        sprintf(fname, "%s/%s/label/%s.%s", SUBJECTS_DIR, trgsubject, hemi, label_name) ;
+        int req = snprintf(fname, STRLEN, "%s/%s/label/%s.%s", 
+			   SUBJECTS_DIR, trgsubject, hemi, label_name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         labels[nsubjects] = LabelRead("", fname) ;
         if (!labels[nsubjects])
 	  ErrorExit(ERROR_NOFILE, "%s: could not read label from %s", Progname, fname) ;
@@ -367,7 +399,10 @@ int main(int argc, char *argv[])
       mri_stats = compute_mean_and_variance(mri_label_avg, nsubjects) ;
     if (write_diags)
     {
-      sprintf(fname, "%s.%s.label_avg.mgz", hemi, output_name) ;
+      int req = snprintf(fname, STRLEN, "%s.%s.label_avg.mgz", hemi, output_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("writing mean and variance volume to %s\n", fname) ;
       MRIwrite(mri_stats, fname) ;
     }
@@ -377,7 +412,10 @@ int main(int argc, char *argv[])
     {
       MRI *mri_tmp ;
       sprintf(name, fmri_surf, hemi, run+1) ;
-      sprintf(fname, "%s/%s/surf/%s", SUBJECTS_DIR, trgsubject, name) ;
+      int req = snprintf(fname, STRLEN, "%s/%s/surf/%s", SUBJECTS_DIR, trgsubject, name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       mri_fsurf[n][run] = MRIread(fname) ;
       if (mri_fsurf[n][run] == NULL)
 	ErrorExit(ERROR_NOFILE, "%s: could not load surface time series from %s", Progname, fname) ;
@@ -391,7 +429,10 @@ int main(int argc, char *argv[])
       }
       
       sprintf(name, fmri_vol, run+1) ;
-      sprintf(fname, "%s/%s/mri/%s", SUBJECTS_DIR, trgsubject, name) ;
+      req = snprintf(fname, STRLEN, "%s/%s/mri/%s", SUBJECTS_DIR, trgsubject, name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       mri_fvol[n][run] = MRIread(fname) ;
       if (mri_fvol[n][run] == NULL)
 	ErrorExit(ERROR_NOFILE, "%s: could not load volume time series from %s", Progname, fname) ;

--- a/mris_register_to_volume/mris_register_to_label.cpp
+++ b/mris_register_to_volume/mris_register_to_label.cpp
@@ -250,7 +250,10 @@ main(int argc, char **argv)
   MRIabs(mri_dist, mri_dist) ;
   if (write_diags)
   {
-    sprintf(fname, "%s.dist.mgz", base_name) ;
+    int req = snprintf(fname, STRLEN, "%s.dist.mgz", base_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing distance transform to %s\n", fname) ;
     MRIwrite(mri_dist, fname) ;
   }
@@ -804,18 +807,32 @@ find_optimal_linear_xform(MRI *mri_dist, MRI *mri_src, LABEL *area,
     mri_tmp = MRIcopy(mri_src, NULL) ;
     MRIsetVoxelToRasXform(mri_tmp, OCT_voxel_to_xformed_RAS)  ;
 
-    if (debug)
-      sprintf(fname, "%s.opt.%4.4d.label", "debug",nfound) ;
-    else
-      sprintf(fname, "%s.opt.%4.4d.label", base_name,nfound) ;
+    if (debug) {
+      int req = snprintf(fname, STRLEN, "%s.opt.%4.4d.label", "debug",nfound) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    } else {
+      int req = snprintf(fname, STRLEN, "%s.opt.%4.4d.label", base_name,nfound) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
     printf("writing new optimal label to %s, v(0): RAS=%2.1f %2.1f %2.1f, VOX=(%d %d %d)\n", 
 	   fname, l->lv[0].x, l->lv[0].y, l->lv[0].z,
 	   nint(lvol->lv[0].x), nint(lvol->lv[0].y), nint(lvol->lv[0].z)) ;
     LabelWrite(l, fname) ;
-    if (debug)
-      sprintf(fname, "%s.opt.%4.4d.mgz", "debug",nfound) ;
-    else
-      sprintf(fname, "%s.opt.%4.4d.mgz", base_name,nfound) ;
+    if (debug) {
+      int req = snprintf(fname, STRLEN, "%s.opt.%4.4d.mgz", "debug",nfound) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    } else {
+      int req = snprintf(fname, STRLEN, "%s.opt.%4.4d.mgz", base_name,nfound) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
     printf("saving %s\n", fname) ;
     MRIwrite(mri_tmp, fname) ;
     MRIfree(&mri_tmp) ; LabelFree(&l) ;
@@ -831,7 +848,10 @@ find_optimal_linear_xform(MRI *mri_dist, MRI *mri_src, LABEL *area,
       MRI_voxel_to_xformed_RAS = MatrixMultiply(R0, MRI_voxel_to_RAS, NULL) ;
       mri_tmp = MRIcopy(mri_targ_vol, NULL) ;
       MRIsetVoxelToRasXform(mri_tmp, MRI_voxel_to_xformed_RAS)  ;
-      sprintf(fname, "%s.targ.%4.4d.mgz", base_name,nfound) ;
+      int req = snprintf(fname, STRLEN, "%s.targ.%4.4d.mgz", base_name,nfound) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("writing reoriented target volume to %s\n", fname) ;
       MRIwrite(mri_tmp, fname) ;
       
@@ -840,7 +860,10 @@ find_optimal_linear_xform(MRI *mri_dist, MRI *mri_src, LABEL *area,
       
       FileNameExtension(outregfile, ext) ;
       FileNameRemoveExtension(outregfile, fname_only) ;
-      sprintf(fname, "%s.%4.4d.%s", fname_only, nfound, ext) ;
+      req = snprintf(fname, STRLEN, "%s.%4.4d.%s", fname_only, nfound, ext) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       printf("writing intermediate registration to %s\n", fname) ;
       
       if (TransformFileNameType(outregfile) == REGISTER_DAT)
@@ -961,18 +984,26 @@ find_optimal_linear_xform(MRI *mri_dist, MRI *mri_src, LABEL *area,
 			mri_tmp = MRIcopy(mri_src, NULL) ;
 			MRIsetVoxelToRasXform(mri_tmp, OCT_voxel_to_xformed_RAS)  ;
 			
-			if (debug)
+			if (debug) {
 			  sprintf(fname, "%s.opt.%4.4d.label", "debug",++nfound) ;
-			else
-			  sprintf(fname, "%s.opt.%4.4d.label", base_name,++nfound) ;
+			} else {
+			  int req = snprintf(fname, STRLEN, "%s.opt.%4.4d.label", base_name,++nfound) ;
+			  if( req >= STRLEN ) {
+			    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+			  }
+			}
 			printf("writing new optimal label to %s, v(0): RAS=%2.1f %2.1f %2.1f, VOX=(%d %d %d)\n", 
 			       fname, l->lv[0].x, l->lv[0].y, l->lv[0].z,
 			       nint(lvol->lv[0].x), nint(lvol->lv[0].y), nint(lvol->lv[0].z)) ;
 			LabelWrite(l, fname) ;
-			if (debug)
+			if (debug) {
 			  sprintf(fname, "%s.opt.%4.4d.mgz", "debug",nfound) ;
-			else
-			  sprintf(fname, "%s.opt.%4.4d.mgz", base_name,nfound) ;
+			} else {
+			  int req = snprintf(fname, STRLEN, "%s.opt.%4.4d.mgz", base_name,nfound) ;
+			  if( req >= STRLEN ) {
+			    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+			  }
+			}
 			printf("saving %s\n", fname) ;
 			MRIwrite(mri_tmp, fname) ;
 			if (debug || nfound == Gdiag_no)
@@ -990,7 +1021,10 @@ find_optimal_linear_xform(MRI *mri_dist, MRI *mri_src, LABEL *area,
 			  MRI_voxel_to_xformed_RAS = MatrixMultiply(m_L_tmp, MRI_voxel_to_RAS, NULL) ;
 			  mri_tmp = MRIcopy(mri_targ_vol, NULL) ;
 			  MRIsetVoxelToRasXform(mri_tmp, MRI_voxel_to_xformed_RAS)  ;
-			  sprintf(fname, "%s.targ.%4.4d.mgz", base_name,nfound) ;
+			  int req = snprintf(fname, STRLEN, "%s.targ.%4.4d.mgz", base_name,nfound) ;
+			  if( req >= STRLEN ) {
+			    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+			  }
 			  printf("writing reoriented target volume to %s\n", fname) ;
 			  MRIwrite(mri_tmp, fname) ;
 			  
@@ -999,7 +1033,10 @@ find_optimal_linear_xform(MRI *mri_dist, MRI *mri_src, LABEL *area,
 			  
 			  FileNameExtension(outregfile, ext) ;
 			  FileNameRemoveExtension(outregfile, fname_only) ;
-			  sprintf(fname, "%s.%4.4d.%s", fname_only, nfound, ext) ;
+			  req = snprintf(fname, STRLEN, "%s.%4.4d.%s", fname_only, nfound, ext) ;
+			  if( req >= STRLEN ) {
+			    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+			  }
 			  printf("writing intermediate registration to %s\n", fname) ;
 			  
 			  if (TransformFileNameType(outregfile) == REGISTER_DAT)

--- a/mris_register_to_volume/mris_register_to_volume.cpp
+++ b/mris_register_to_volume/mris_register_to_volume.cpp
@@ -408,8 +408,14 @@ main(int argc, char **argv)
         fflush(logfp) ;
       }
       FileNameRemoveExtension(vol_fname, fname_only) ;
-      sprintf(fname_grad, "%s.grad.sigma%2.3f.mgz", fname_only, sigma) ;
-      sprintf(fname_mag, "%s.mag.sigma%2.3f.mgz", fname_only, sigma) ;
+      int req = snprintf(fname_grad, STRLEN, "%s.grad.sigma%2.3f.mgz", fname_only, sigma) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+      req = snprintf(fname_mag, STRLEN, "%s.mag.sigma%2.3f.mgz", fname_only, sigma) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (read_grad == 0)  // compute gradient of smoothed image
       {
         mri_kernel = MRIgaussian1d(sigma/mri_reg->xsize, -1) ;
@@ -1322,7 +1328,10 @@ mrisRegistrationCNRSimilarity(MRI_SURFACE *mris, MRI *mri_reg, MRI *mri_mask, MA
           MRIsetVoxVal(mri, xv, yv, zv, 0, -.01) ;
       }
 
-      sprintf(fname, "%s_hvol%03d.mgz", name, ncalls) ;
+      int req = snprintf(fname, STRLEN, "%s_hvol%03d.mgz", name, ncalls) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON)
       {
         printf("writing hit vol to %s\n", fname) ;
@@ -1569,7 +1578,10 @@ mrisRegistrationGradientNormalSimilarity(MRI_SURFACE *mris, MRI *mri_reg, MRI *m
       }
       if (Gdiag & DIAG_WRITE && DIAG_VERBOSE_ON)
       {
-        sprintf(fname, "%s_hvol%03d.mgz", name, ncalls) ;
+        int req = snprintf(fname, STRLEN, "%s_hvol%03d.mgz", name, ncalls) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         printf("writing hit vol to %s\n", fname) ;
         MRIwrite(mri, fname) ;
       }
@@ -1918,15 +1930,24 @@ write_snapshot(MRI_SURFACE *mris, MATRIX *m, char *name, int n)
     MRISsetXYZ(mris,vno, V3_X(v2),V3_Y(v2),V3_Z(v2)) ;
   }
 
-  sprintf(fname, "%s%03d.dat", fname_only,n) ;
+  int req = snprintf(fname, STRLEN, "%s%03d.dat", fname_only,n) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   regio_write_surfacexform_to_register_dat(m, fname, mris, mri_reg, subject,
                                            FLT2INT_ROUND) ;
   write_lta(m, fname, mris, mri_reg) ;
-  sprintf(fname, "%s%03d", fname_only,n) ;
+  req = snprintf(fname, STRLEN, "%s%03d", fname_only,n) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing snapshot to %s\n", fname) ;
   MRISwrite(mris, fname) ;
   MRISrestoreRipFlags(mris);
-  sprintf(fname, "%s%03d.patch", fname_only,n) ;
+  req = snprintf(fname, STRLEN, "%s%03d.patch", fname_only,n) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   MRISwritePatch(mris, fname) ;
   MRISunrip(mris) ;
   
@@ -1942,10 +1963,16 @@ write_snapshot(MRI_SURFACE *mris, MATRIX *m, char *name, int n)
       MRISsetXYZ(mris,vno, V3_X(v2),V3_Y(v2),V3_Z(v2)) ;
     }
     
-    sprintf(fname, "%s_pial%03d", fname_only,n) ;
+    int req = snprintf(fname, STRLEN, "%s_pial%03d", fname_only,n) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing snapshot to %s\n", fname) ;
     MRISwrite(mris, fname) ;
-    sprintf(fname, "%s%03d.patch", fname_only,n) ;
+    req = snprintf(fname, STRLEN, "%s%03d.patch", fname_only,n) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     MRISwritePatch(mris, fname) ;
   }
 

--- a/mris_reverse/mris_reverse.cpp
+++ b/mris_reverse/mris_reverse.cpp
@@ -82,7 +82,10 @@ main(int argc, char *argv[]) {
     else
       ErrorExit(ERROR_BADPARM, "%s: could not scan hemisphere from %s\n",
                 in_fname) ;
-    sprintf(fname, "%s/%s.%s", path, hemi, ORIG_NAME) ;
+    int req = snprintf(fname, STRLEN, "%s/%s.%s", path, hemi, ORIG_NAME) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     mris = MRISread(fname) ;
     if (!mris)
       ErrorExit(ERROR_NOFILE, "%s: could not read surface file %s",

--- a/mris_rf_label/mris_rf_label.cpp
+++ b/mris_rf_label/mris_rf_label.cpp
@@ -106,19 +106,28 @@ main(int argc, char *argv[]) {
   rf = RFread(argv[2]) ;
   noverlays = rf->nfeatures ;
 
-  sprintf(fname, "%s/%s/surf/%s.%s", sdir, subject, hemi, surf_name) ;
+  int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, subject, hemi, surf_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mris = MRISread(fname) ;
   if (!mris)
     ErrorExit(ERROR_NOFILE, "%s: could not read surface from %s",Progname, fname) ;
     
   MRIScomputeMetricProperties(mris) ;
-  sprintf(fname, "%s/%s/label/%s.%s", sdir, subject, hemi, cortex_label_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/label/%s.%s", sdir, subject, hemi, cortex_label_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   cortex_label = LabelRead(NULL, fname) ;
   if (cortex_label == NULL)
     ErrorExit(ERROR_NOFILE, "%s: could not read cortex label %s\n", Progname, fname) ;
   LabelRipRestOfSurface(cortex_label, mris) ;
 
-  sprintf(fname, "%s/%s/label/%s.%s", sdir, subject, hemi, label_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/label/%s.%s", sdir, subject, hemi, label_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   if (FileExists(fname))
   {
     training_label = LabelRead(NULL, fname) ;
@@ -135,7 +144,10 @@ main(int argc, char *argv[]) {
 
   for (i = 0 ; i < noverlays ; i++)
   {
-    sprintf(fname, "%s/%s/surf/%s.%s", sdir, subject, hemi, rf->feature_names[i]) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, subject, hemi, rf->feature_names[i]) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     mri_overlays[i] = MRIread(fname) ;
     if (mri_overlays[i] == NULL)
       ErrorExit(ERROR_NOFILE, "%s: could not read overlay %s (%d)\n", Progname, fname, i) ;

--- a/mris_rf_train/mris_rf_train.cpp
+++ b/mris_rf_train/mris_rf_train.cpp
@@ -136,10 +136,16 @@ main(int argc, char *argv[]) {
     printf("processing subject %s: %d of %d\n", subject, sno+1, nsubjects) ;
 
 
-    sprintf(fname, "%s/%s/label/lh.%s.label", sdir, subject, label_name) ;
+    int req =snprintf(fname, STRLEN, "%s/%s/label/lh.%s.label", sdir, subject, label_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (FileExists(fname) == 0)
     {
-      sprintf(fname, "%s/%s/label/rh.%s.label", sdir, subject, label_name) ;
+      int req = snprintf(fname, STRLEN, "%s/%s/label/rh.%s.label", sdir, subject, label_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (FileExists(fname) == 0)
 	ErrorExit(ERROR_NOFILE, "%s: subject %s has no training label (%s) for either hemisphere", Progname, subject,fname) ;
       hemi = "rh" ;
@@ -151,7 +157,10 @@ main(int argc, char *argv[]) {
     if (training_label == NULL)
       ErrorExit(ERROR_NOFILE, "%s: could not read training label %s\n", Progname, fname) ;
 
-    sprintf(fname, "%s/%s/surf/%s.%s", sdir, subject, hemi, surf_name) ;
+    req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, subject, hemi, surf_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     mris[sno] = MRISread(fname) ;
     if (!mris[sno])
       ErrorExit(ERROR_NOFILE, "%s: could not read surface from %s",Progname, fname) ;
@@ -159,7 +168,10 @@ main(int argc, char *argv[]) {
     MRIScomputeMetricProperties(mris[sno]) ;
     if (nbhd_size > mris[sno]->nsize)
       MRISsetNeighborhoodSizeAndDist(mris[sno], nbhd_size) ;
-    sprintf(fname, "%s/%s/label/%s.%s", sdir, subject, hemi, cortex_label_name) ;
+    req = snprintf(fname, STRLEN, "%s/%s/label/%s.%s", sdir, subject, hemi, cortex_label_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     cortex_label = LabelRead(NULL, fname) ;
     if (cortex_label == NULL)
       ErrorExit(ERROR_NOFILE, "%s: could not read cortex label %s\n", Progname, fname) ;
@@ -180,7 +192,10 @@ main(int argc, char *argv[]) {
 
     for (i = 0 ; i < noverlays ; i++)
     {
-      sprintf(fname, "%s/%s/surf/%s.%s", sdir, subject, hemi, overlay_names[i]) ;
+      int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, subject, hemi, overlay_names[i]) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       mri_overlays[sno][i] = MRIread(fname) ;
       if (mri_overlays[sno][i] == NULL)
 	ErrorExit(ERROR_NOFILE, "%s: could not read overlay %s (%d)\n", Progname, fname, i) ;

--- a/mris_sample_parc/mris_sample_parc.cpp
+++ b/mris_sample_parc/mris_sample_parc.cpp
@@ -127,10 +127,14 @@ main(int argc, char *argv[]) {
     strcpy(sdir, cp) ;
   }
 
-  if (parc_name[0] == '/')  // full path specified
+  if (parc_name[0] == '/')  { // full path specified
     strcpy(fname, parc_name) ;
-  else
-    sprintf(fname, "%s/%s/mri/%s", sdir, subject_name, parc_name) ;
+  } else {
+    int req =snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, subject_name, parc_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
+  }
   printf("reading parcellation volume from %s...\n", fname) ;
   mri_parc = MRIread(fname) ;
   if (!mri_parc)
@@ -162,7 +166,10 @@ main(int argc, char *argv[]) {
   for (i = 0 ; i < ntrans ; i++) {
     MRIreplaceValues(mri_parc, mri_parc, trans_in[i], trans_out[i]) ;
   }
-  sprintf(fname, "%s/%s/surf/%s.%s", sdir, subject_name, hemi, surf_name) ;
+  int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, subject_name, hemi, surf_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("reading input surface %s...\n", fname) ;
   mris = MRISread(fname) ;
   if (!mris)

--- a/mris_segmentation_stats/mris_segmentation_stats.cpp
+++ b/mris_segmentation_stats/mris_segmentation_stats.cpp
@@ -102,25 +102,37 @@ main(int argc, char *argv[]) {
   for (i = 0 ; i < nsubjects ; i++)
   {
     subject = argv[i+3] ;
-    sprintf(fname, "%s/%s/label/lh.%s.label", sdir, subject, true_label_name) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/label/lh.%s.label", sdir, subject, true_label_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (FileExists(fname) == 0)
     {
-      sprintf(fname, "%s/%s/label/rh.%s.label", sdir, subject, true_label_name) ;
-    if (FileExists(fname) == 0)
-      ErrorExit(ERROR_NOFILE, "%s: subject %s has no training label for either hemisphere", Progname, subject) ;
+      int req = snprintf(fname, STRLEN, "%s/%s/label/rh.%s.label", sdir, subject, true_label_name) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+      if (FileExists(fname) == 0)
+	ErrorExit(ERROR_NOFILE, "%s: subject %s has no training label for either hemisphere", Progname, subject) ;
       hemi = "rh" ;
-    }
-    else
+    } else {
       hemi = "lh" ;
+    }
     printf("processing subject %s, hemi %s: %d of %d\n", subject, hemi,i+1, nsubjects) ;
     labels[i] = LabelRead(NULL, fname) ;
     if (labels[i] == NULL)
       ErrorExit(ERROR_NOFILE, "%s: could not load label from %s", Progname, fname) ;
-    sprintf(fname, "%s/%s/surf/%s.white", sdir, subject, hemi) ;
+    req = snprintf(fname, STRLEN, "%s/%s/surf/%s.white", sdir, subject, hemi) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     mris[i] = MRISread(fname) ;
     if (mris[i] == NULL)
       ErrorExit(ERROR_NOFILE, "%s: could not load surface from %s", Progname, fname) ;
-    sprintf(fname, "%s/%s/surf/%s.%s", sdir, subject, hemi, segmentation_name) ;
+    req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, subject, hemi, segmentation_name) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     mri_overlays[i] = MRIread(fname) ;
     if (mri_overlays[i] == NULL)
       ErrorExit(ERROR_NOFILE, "%s: could not load overlay from %s", Progname, fname) ;

--- a/mris_shrinkwrap/mris_AA_shrinkwrap.cpp
+++ b/mris_shrinkwrap/mris_AA_shrinkwrap.cpp
@@ -120,7 +120,7 @@ main(int argc, char *argv[]) {
   ErrorInit(NULL, NULL, NULL) ;
   DiagInit(NULL, NULL, NULL) ;
 
-  memset(&parms, 0, sizeof(parms)) ;
+  // memset(&parms, 0, sizeof(parms)) ; Have proper constructor now
 
   parms.projection = NO_PROJECTION ;
   parms.tol = 0.05 ;

--- a/mris_shrinkwrap/mris_shrinkwrap.cpp
+++ b/mris_shrinkwrap/mris_shrinkwrap.cpp
@@ -112,7 +112,7 @@ main(int argc, char *argv[])
   ErrorInit(NULL, NULL, NULL) ;
   DiagInit(NULL, NULL, NULL) ;
 
-  memset(&parms, 0, sizeof(parms)) ;
+  // memset(&parms, 0, sizeof(parms)) ; Have proper constructor now
   parms.projection = NO_PROJECTION ;
   parms.tol = 0.05 ;
   parms.dt = 0.5f ;

--- a/mris_simulate_atrophy/mris_simulate_atrophy.cpp
+++ b/mris_simulate_atrophy/mris_simulate_atrophy.cpp
@@ -265,13 +265,22 @@ main(int argc, char *argv[])
     mri_norm_atrophy =  MRISsimulateAtrophy(mri_norm, mri_unpv_intensities, mri_wm, mri_subcort_gm, mri_cortex, mri_csf,
 					    area, atrophy_frac, NULL, &mri_cortex_atrophy, &mri_csf_atrophy) ;
     
-    sprintf(fname, "%s.gm.atrophy%2.1f.%s", out_fname, atrophy_frac, extension) ;
+    int req = snprintf(fname, STRLEN, "%s.gm.atrophy%2.1f.%s", out_fname, atrophy_frac, extension) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing atrophic gm vfracs to %s\n", fname) ;
     MRIwrite(mri_cortex_atrophy, fname) ;
-    sprintf(fname, "%s.csf.atrophy%2.1f.%s", out_fname, atrophy_frac, extension) ;
+    req = snprintf(fname, STRLEN, "%s.csf.atrophy%2.1f.%s", out_fname, atrophy_frac, extension) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing atrophic csf vfracs to %s\n", fname) ;
     MRIwrite(mri_csf_atrophy, fname) ;
-    sprintf(fname, "%s.atrophy.0.0.noise.0.0.%s", out_fname, extension) ;
+    req = snprintf(fname, STRLEN, "%s.atrophy.0.0.noise.0.0.%s", out_fname, extension) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     printf("writing simulated atrophy with noise sigma = 0 image to %s\n", fname) ;
     MRIwrite(mri_norm_atrophy, fname) ;
 
@@ -282,8 +291,13 @@ main(int argc, char *argv[])
       mri_noisy_atrophy = MRIadd(mri_noise, mri_norm_atrophy, mri_noisy_atrophy) ;
       MRIfree(&mri_noise) ;
       
-      sprintf(fname, "%s.atrophy.%2.2f.noise.%2.1f.%s", out_fname, atrophy_frac, noise_sigma, extension) ;
-      printf("writing simulated atrophy (%2.2f) with noise sigma = %2.1f image to %s\n", atrophy_frac, noise_sigma, fname) ;
+      req = snprintf(fname, STRLEN, "%s.atrophy.%2.2f.noise.%2.1f.%s",
+		     out_fname, atrophy_frac, noise_sigma, extension) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
+      printf("writing simulated atrophy (%2.2f) with noise sigma = %2.1f image to %s\n",
+	     atrophy_frac, noise_sigma, fname) ;
       MRIwrite(mri_noisy_atrophy, fname) ;
     }
 #if 0
@@ -739,8 +753,9 @@ compute_unpartial_volumed_intensities(MRI *mri_src, MRI *mri_vfrac_wm, MRI *mri_
 	  }
 	  else   // only wm in this voxel
 	  {
-	    for (row = 1 ; row <= m_A3->rows ; row++)
+	    for (row = 1 ; row <= m_A3->rows ; row++) {
 	      *MATRIX_RELT(m_A1, row, 1) = *MATRIX_RELT(m_A3, row, 1) ;
+	    }
 
 	    v_s = v_s1 ;
 	    m_A = m_A1 ;
@@ -748,11 +763,12 @@ compute_unpartial_volumed_intensities(MRI *mri_src, MRI *mri_vfrac_wm, MRI *mri_
 	}
 	else  // only csf in this region
 	{
-	  for (row = 1 ; row <= m_A3->rows ; row++)
+	  for (row = 1 ; row <= m_A3->rows ; row++) {
 	    *MATRIX_RELT(m_A1, row, 1) = *MATRIX_RELT(m_A3, row, 3) ;
+	  }
 
-	    v_s = v_s1 ;
-	    m_A = m_A1 ;
+	  v_s = v_s1 ;
+	  m_A = m_A1 ;
 	}
 
 	m_A_pinv = MatrixPseudoInverse(m_A, NULL) ;

--- a/mris_smooth_intracortical/mris_smooth_intracortical.cpp
+++ b/mris_smooth_intracortical/mris_smooth_intracortical.cpp
@@ -138,11 +138,16 @@ int main(int argc, char *argv[]) {
 	// if no output dir/name given - set based on 1st overlay
 	if (strlen(out_dir) == 0) strcpy(out_dir, over_dir);
 	if (strlen(out_name) == 0) {
-		char *dot, *name;
-		name = basename(over_list.gl_pathv[0]);
-		dot = strrchr(name, '.') ;
-		strncpy(out_name, name, dot - name);
-		sprintf(out_name, "%s.nb%d_rad%d-%d.mgz", out_name, nb_rad, ic_start, (ic_start+ic_size-1));
+	  char *dot, *name;
+	  char tmp_out_name[STRLEN];
+	  name = basename(over_list.gl_pathv[0]);
+	  dot = strrchr(name, '.') ;
+	  strncpy(tmp_out_name, name, dot - name);
+	  int req = snprintf(out_name, STRLEN, "%s.nb%d_rad%d-%d.mgz", 
+			     tmp_out_name, nb_rad, ic_start, (ic_start+ic_size-1));
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
 	}
 
 	globfree(&surf_list);	globfree(&over_list);
@@ -200,7 +205,10 @@ int main(int argc, char *argv[]) {
 	}
 
 	// write an output overlay ///////////////////////////////////////////////////////////////////////////////////////
-	sprintf(out_path, "%s%s%s", out_dir, SEP, out_name);
+	int req = snprintf(out_path, STRLEN, "%s%s%s", out_dir, SEP, out_name);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
 	printf("Saving result: %s\n", out_path);
 	MRIwrite(output[0], out_path);
 

--- a/mris_spherical_average/mris_spherical_average.cpp
+++ b/mris_spherical_average/mris_spherical_average.cpp
@@ -269,7 +269,10 @@ main(int argc, char *argv[])
     case VERTEX_VALS:
     {
       char fname[STRLEN] ;
-      sprintf(fname,"%s/%s/%s/%s.%s", sdir, argv[i], dir, hemi, data_fname) ;
+      int req = snprintf(fname,STRLEN, "%s/%s/%s/%s.%s", sdir, argv[i], dir, hemi, data_fname) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
       if (MRISreadValues(mris, fname) != NO_ERROR)
       {
         ErrorExit(ERROR_BADFILE,
@@ -279,7 +282,11 @@ main(int argc, char *argv[])
       if (mask_name)
       {
 	LABEL *area ;
-	sprintf(fname,"%s/%s/label/%s.%s", sdir, argv[i], hemi, mask_name) ;
+	int req = snprintf(fname,STRLEN,"%s/%s/label/%s.%s",
+			   sdir, argv[i], hemi, mask_name) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
 	area = LabelRead(NULL, fname) ;
 	if (!area)
 	  ErrorPrintf(ERROR_BADFILE,"%s: could not read label file %s for %s (%s).\n",
@@ -316,7 +323,10 @@ main(int argc, char *argv[])
       }
       else
       {
-        sprintf(fname, "%s/%s/%s/%s", sdir, argv[i], dir, data_fname) ;
+        int req = snprintf(fname, STRLEN, "%s/%s/%s/%s", sdir, argv[i], dir, data_fname) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
       area = LabelRead(NULL, fname) ;
       if (!area)
@@ -362,7 +372,10 @@ main(int argc, char *argv[])
       }
       else
       {
-        sprintf(fname, "%s/%s/%s/%s", sdir, argv[i], dir, data_fname) ;
+        int req = snprintf(fname, STRLEN, "%s/%s/%s/%s", sdir, argv[i], dir, data_fname) ;
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
       }
       area = LabelRead(NULL, fname) ;
       if (!area)

--- a/mris_surface_to_vol_distances/mris_surface_to_vol_distances.cpp
+++ b/mris_surface_to_vol_distances/mris_surface_to_vol_distances.cpp
@@ -87,7 +87,10 @@ main(int argc, char *argv[]) {
   hemi = argv[2] ;
   nsubjects = argc-4 ;
   output_prefix = argv[argc-1] ;
-  sprintf(fname, "%s/%s/surf/%s.sphere", subjects_dir, avg_subject, hemi) ;
+  int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.sphere", subjects_dir, avg_subject, hemi) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mris_avg = MRISread(fname) ;
   if (mris_avg == NULL)
     ErrorExit(ERROR_NOFILE, "%s: could not read spherical surface from %s", Progname, fname) ;
@@ -112,14 +115,23 @@ main(int argc, char *argv[]) {
   for (i = 0 ; i < nsubjects ; i++) {
     subject = argv[i+3] ;
     printf("processing subject %s: %d of %d...\n", subject, i+1, nsubjects) ;
-    sprintf(fname, "%s/%s/surf/%s.sphere.reg", subjects_dir, subject, hemi) ;
+    int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.sphere.reg", subjects_dir, subject, hemi) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     mris = MRISread(fname) ;
     if (mris == NULL)
       ErrorExit(ERROR_NOFILE, "%s: could not read spherical surface from %s", Progname, fname) ;
-    sprintf(fname, "%s/%s/surf/%s.sphere", subjects_dir, subject, hemi) ;
+    req = snprintf(fname, STRLEN, "%s/%s/surf/%s.sphere", subjects_dir, subject, hemi) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (MRISreadCanonicalCoordinates(mris, fname) != NO_ERROR)
       ErrorExit(ERROR_NOFILE, "%s: could not read spherical surface from %s", Progname, fname) ;
-    sprintf(fname, "%s/%s/surf/%s.white", subjects_dir, subject, hemi) ;
+    req = snprintf(fname, STRLEN, "%s/%s/surf/%s.white", subjects_dir, subject, hemi) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     if (MRISreadOriginalProperties(mris, fname) != NO_ERROR)
       ErrorExit(ERROR_NOFILE, "%s: could not read white surface from %s", Progname, fname) ;
     if (MRISreadCurvatureFile(mris, "thickness") != NO_ERROR)
@@ -132,7 +144,10 @@ main(int argc, char *argv[]) {
   printf("writing log files with prefix %s...\n", output_prefix) ;
   for (vno = 0 ; vno < mris_avg->nvertices ; vno++) {
 
-    sprintf(fname, "%s%7.7d.histo", output_prefix, vno) ;
+    int req = snprintf(fname, STRLEN, "%s%7.7d.histo", output_prefix, vno) ;
+    if( req >= STRLEN ) {
+      std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+    }
     fp = fopen(fname, "w") ;
     for (i = 0 ; i < nbins ; i++) {
       for (j = 0 ; j < nbins*MAX_SURFACE_SCALE ; j++) {

--- a/mris_thickness_comparison/mris_thickness_comparison.cpp
+++ b/mris_thickness_comparison/mris_thickness_comparison.cpp
@@ -84,7 +84,10 @@ main(int argc, char *argv[]) {
     strcpy(subjects_dir, cp) ;
   }
 
-  sprintf(env_string, "SUBJECTS_DIR=%s", subjects_dir) ;
+  int req = snprintf(env_string, STRLEN, "SUBJECTS_DIR=%s", subjects_dir) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   putenv(env_string) ;
   cp = getenv("SUBJECTS_DIR") ;
   subject_name = argv[1] ;
@@ -92,7 +95,10 @@ main(int argc, char *argv[]) {
   thickness_name = argv[3] ;
   wfile_name = argv[4] ;
 
-  sprintf(fname, "%s/%s/surf/%s.%s", subjects_dir, subject_name, hemi, ORIG_NAME) ;
+  req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", subjects_dir, subject_name, hemi, ORIG_NAME) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mris = MRISread(fname) ;
   if (!mris)
     ErrorExit(ERROR_NOFILE, "%s: could not read surface file %s",

--- a/mris_translate_annotation/mris_translate_annotation.cpp
+++ b/mris_translate_annotation/mris_translate_annotation.cpp
@@ -83,7 +83,10 @@ main(int argc, char *argv[]) {
       ErrorExit(ERROR_BADPARM, "%s: SUBJECTS_DIR not defined in environment or cmd line", Progname) ;
     strcpy(subjects_dir, cp) ;
   }
-  sprintf(fname, "%s/%s/surf/%s.orig", subjects_dir, subject, hemi) ;
+  int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.orig", subjects_dir, subject, hemi) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fprintf(stderr, "reading surface from %s...\n", fname) ;
   mris = MRISread(fname) ;
   if (!mris)

--- a/mris_volume/mris_wm_volume.cpp
+++ b/mris_volume/mris_wm_volume.cpp
@@ -96,7 +96,10 @@ main(int argc, char *argv[])
   //  printf("command line parsing finished\n");
 
   /*** Read in the input surfaces ***/
-  sprintf(fname, "%s/%s/surf/%s.%s", sdir, subject, hemi, white_name) ;
+  int req = snprintf(fname, STRLEN, "%s/%s/surf/%s.%s", sdir, subject, hemi, white_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mris = MRISread(fname) ;
   if (mris == NULL)
     ErrorExit(ERROR_NOFILE, "%s: could not read surface %s", Progname, fname) ;
@@ -106,7 +109,10 @@ main(int argc, char *argv[])
     ErrorExit(ERROR_BADPARM, "%s: surface %s has an incorrect topology (eno=%d)",
               Progname, fname, eno) ;
   /*** Read in the aseg volume ***/
-  sprintf(fname, "%s/%s/mri/%s", sdir, subject, aseg_name) ;
+  req = snprintf(fname, STRLEN, "%s/%s/mri/%s", sdir, subject, aseg_name) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   mri_aseg = MRIread(fname) ;
   if (mri_aseg == NULL)
     ErrorExit(ERROR_NOFILE, 

--- a/mris_watershed/mris_watershed.cpp
+++ b/mris_watershed/mris_watershed.cpp
@@ -336,8 +336,13 @@ MRISfindMostSimilarBasin(MRI_SURFACE *mris, MRI *mri, int min_basin)
   int    best_basin, vno, n, basin, *nbr_vertices, nbr_basin, max_basin ;
   double *avg_grad, min_grad ;
 
-  nbr_vertices = (int *)calloc(mris->nvertices, sizeof(*nbr_vertices)) ;
-  avg_grad = (double *)calloc(mris->nvertices, sizeof(*avg_grad)) ;
+  if( mris->nvertices >= 0 ) {
+    nbr_vertices = (int *)calloc(mris->nvertices, sizeof(*nbr_vertices)) ;
+    avg_grad = (double *)calloc(mris->nvertices, sizeof(*avg_grad)) ;
+  } else {
+    ErrorExit(ERROR_BADPARM, "%s: mris->nvertices<0\n", Progname) ;
+    abort();
+  }
 
   max_basin = 0 ;
   for (vno = 0 ;  vno < mris->nvertices ; vno++)

--- a/oct_register_mosaic/oct_register_mosaic.cpp
+++ b/oct_register_mosaic/oct_register_mosaic.cpp
@@ -266,10 +266,13 @@ main(int argc, char *argv[]) {
     {
       FileNameExtension(out_fname, ext) ;
       FileNameRemoveExtension(out_fname, fname) ;
-    }
-    else
+    } else {
       sprintf(fname, "mosaic") ;
-      sprintf(orig_fname, "%s.orig.%s", fname, ext) ;
+      int req = snprintf(orig_fname, STRLEN, "%s.orig.%s", fname, ext) ;
+      if( req >= STRLEN ) {
+	std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+      }
+    }
     for (i = 0 ; i < nimages ; i++)
     {
       x0d[i] = x0[i] ;
@@ -1161,7 +1164,10 @@ powell_step_func(float *p, int nparms)
   double x0d[MAX_IMAGES], y0d[MAX_IMAGES] ;
 
   nimages = (nparms+2)/2 ;
-  sprintf(fname, "%s powell iter %d", Gout_name, step) ;
+  int req = snprintf(fname, STRLEN, "%s powell iter %d", Gout_name, step) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   dump_parms(p, nimages, fname) ;
   x0d[0] = Gx0 ; y0d[0] = Gy0 ;
   for (i = 1 ; i < Gnimages ; i++)
@@ -1170,7 +1176,10 @@ powell_step_func(float *p, int nparms)
     y0d[i] = p[Gnimages-1+i] ;
   }
   mri_mosaic = undistort_and_mosaic_images(Gmri, x0d, y0d, nimages, 0, 0, 0, 0, 0, 1, NULL) ;
-  sprintf(fname, "%s.powell.%2.2d.mgz", Gout_name, step) ;
+  req = snprintf(fname, STRLEN, "%s.powell.%2.2d.mgz", Gout_name, step) ;
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   printf("writing image after powell step %d to %s\n", step, fname) ;
   MRIwrite(mri_mosaic,fname) ;
 

--- a/qdecproject/QdecDataTable.cxx
+++ b/qdecproject/QdecDataTable.cxx
@@ -344,7 +344,7 @@ int QdecDataTable::Load (const char* isFileName,
     }
 
     char factor[2048];
-    strncpy( factor, token, sizeof(factor) );
+    strncpy( factor, token, sizeof(factor)-1 );
     //cout << "factor: " << factor << endl;
 
     // determine if this factor should be ignored (by comparing against

--- a/qdecproject/QdecGlmDesign.cxx
+++ b/qdecproject/QdecGlmDesign.cxx
@@ -1077,7 +1077,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1110,7 +1113,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1149,7 +1155,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1213,7 +1222,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1248,7 +1260,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1288,7 +1303,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1331,7 +1349,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1364,7 +1385,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1403,7 +1427,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1479,7 +1506,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1514,7 +1544,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1554,7 +1587,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1590,7 +1626,10 @@ int QdecGlmDesign::GenerateContrasts ( )
         question = strdup(tmpstr);
         if (nnf)
         {
-          sprintf(tmpstr, "%s\nNuisance factors:", question.c_str());
+          int req = snprintf(tmpstr, STRLEN, "%s\nNuisance factors:", question.c_str());
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
           char nfstr[2048];
           nfstr[0]=0;
@@ -1602,7 +1641,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          req = snprintf(tmpstr, 2048, "%s%s", question.c_str(), nfstr);
+	  if( req >= 2048 ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1610,23 +1652,33 @@ int QdecGlmDesign::GenerateContrasts ( )
       {
         QdecFactor* contFactor = this->mContinuousFactors[nthcf-1];
         string contFactorName = contFactor->GetFactorName();
-        sprintf(tmpstr,"%s-Diff-%s-%s-Cor-%s-%s",
-                this->msHemi.c_str(),
-                df1l1name,df1l2name,
-                this->msMeasure.c_str(),
-                contFactorName.c_str());
+        int req = snprintf(tmpstr,STRLEN,"%s-Diff-%s-%s-Cor-%s-%s",
+			   this->msHemi.c_str(),
+			   df1l1name,df1l2name,
+			   this->msMeasure.c_str(),
+			   contFactorName.c_str());
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         name = strdup(tmpstr);
-        sprintf(tmpstr,
-                "Does the %s--%s correlation, accounting for %s, "
-                "differ between %s and %s?",
-                this->msMeasure.c_str(),
-                contFactorName.c_str(),
-                df2Name.c_str(),
-                df1l1name,df1l2name);
+        req = snprintf(tmpstr,
+		       STRLEN, 
+		       "Does the %s--%s correlation, accounting for %s, "
+		       "differ between %s and %s?",
+		       this->msMeasure.c_str(),
+		       contFactorName.c_str(),
+		       df2Name.c_str(),
+		       df1l1name,df1l2name);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         question = strdup(tmpstr);
         if (nnf)
         {
-          sprintf(tmpstr, "%s\nNuisance factors:", question.c_str());
+          int req = snprintf(tmpstr, STRLEN, "%s\nNuisance factors:", question.c_str());
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
           char nfstr[2048];
           nfstr[0]=0;
@@ -1638,7 +1690,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          req = snprintf(tmpstr, 2048, "%s%s", question.c_str(), nfstr);
+	  if( req >= 2048 ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1650,24 +1705,34 @@ int QdecGlmDesign::GenerateContrasts ( )
         if (nthcf == 1) otherFactor = this->mContinuousFactors[nthcf];
         else otherFactor = this->mContinuousFactors[nthcf-2];
         string otherContFactorName = otherFactor->GetFactorName();
-        sprintf(tmpstr,"%s-Diff-%s-%s-Cor-%s-%s",
+        int req = snprintf(tmpstr,STRLEN,"%s-Diff-%s-%s-Cor-%s-%s",
                 this->msHemi.c_str(),
                 df1l1name,df1l2name,
                 this->msMeasure.c_str(),
                 contFactorName.c_str());
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         name = strdup(tmpstr);
-        sprintf(tmpstr,
-                "Does the %s--%s correlation, accounting for %s and %s, "
-                "differ between %s and %s?",
-                this->msMeasure.c_str(),
-                contFactorName.c_str(),
-                df2Name.c_str(),
-                otherContFactorName.c_str(),
-                df1l1name,df1l2name);
+        req = snprintf(tmpstr,
+		       STRLEN,
+		       "Does the %s--%s correlation, accounting for %s and %s, "
+		       "differ between %s and %s?",
+		       this->msMeasure.c_str(),
+		       contFactorName.c_str(),
+		       df2Name.c_str(),
+		       otherContFactorName.c_str(),
+		       df1l1name,df1l2name);
+	if( req >= STRLEN ) {
+	  std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	}
         question = strdup(tmpstr);
         if (nnf)
         {
-          sprintf(tmpstr, "%s\nNuisance factors:", question.c_str());
+          int req = snprintf(tmpstr, STRLEN, "%s\nNuisance factors:", question.c_str());
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
           char nfstr[2048];
           nfstr[0]=0;
@@ -1679,7 +1744,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          req = snprintf(tmpstr, 2048, "%s%s", question.c_str(), nfstr);
+	  if( req >= 2048 ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1727,7 +1795,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1763,7 +1834,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1804,7 +1878,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1849,7 +1926,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1884,7 +1964,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, 2048, "%s%s", question.c_str(), nfstr);
+	  if( req >= 2048 ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }
@@ -1925,7 +2008,10 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          sprintf(tmpstr, "%s%s", question.c_str(), nfstr);
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
+	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+	  }
           question = strdup(tmpstr);
         }
       }

--- a/qdecproject/QdecGlmDesign.cxx
+++ b/qdecproject/QdecGlmDesign.cxx
@@ -1641,8 +1641,8 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          req = snprintf(tmpstr, 2048, "%s%s", question.c_str(), nfstr);
-	  if( req >= 2048 ) {
+          req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
 	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
 	  }
           question = strdup(tmpstr);
@@ -1690,8 +1690,8 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          req = snprintf(tmpstr, 2048, "%s%s", question.c_str(), nfstr);
-	  if( req >= 2048 ) {
+          req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
 	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
 	  }
           question = strdup(tmpstr);
@@ -1744,8 +1744,8 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          req = snprintf(tmpstr, 2048, "%s%s", question.c_str(), nfstr);
-	  if( req >= 2048 ) {
+          req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
 	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
 	  }
           question = strdup(tmpstr);
@@ -1964,8 +1964,8 @@ int QdecGlmDesign::GenerateContrasts ( )
             strcat(nfstr,nuisanceFactorName.c_str());
             if (strlen(nfstr) > 2000) break;
           }
-          int req = snprintf(tmpstr, 2048, "%s%s", question.c_str(), nfstr);
-	  if( req >= 2048 ) {
+          int req = snprintf(tmpstr, STRLEN, "%s%s", question.c_str(), nfstr);
+	  if( req >= STRLEN ) {
 	    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
 	  }
           question = strdup(tmpstr);

--- a/trc/blood.cxx
+++ b/trc/blood.cxx
@@ -1308,9 +1308,10 @@ void Blood::MatchStreamlineEnds() {
         ivalid2++;
       }
 
-      if (!mMask.empty())
+      if (!mMask.empty()) {
         imask++;
-        iaseg++;
+      }
+      iaseg++;
     }
   }
   else {					// Have labeling ROIs

--- a/trc/coffin.cxx
+++ b/trc/coffin.cxx
@@ -2756,11 +2756,12 @@ bool Coffin::ProposePathFull() {
     if (!IsInMask(cpoint)) {
       *isrej = true;
 
-      if (mDebug)
+      if (mDebug) {
         mLog << "Reject due to control point " 
              << isrej - mRejectControl.begin() << " off mask at "
              << cpoint[0] << " " << cpoint[1] << " " << cpoint[2] << endl;
-        LogObjectiveNaN(0);
+      }
+      LogObjectiveNaN(0);
     }
 
     cpoint += 3;

--- a/tridec/tridec.cpp
+++ b/tridec/tridec.cpp
@@ -12,7 +12,7 @@
  *
  */
 
-
+#include <iostream>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -54,21 +54,33 @@ main(int argc,char *argv[]) {
   }
 
   sprintf(pname,"%s",argv[1]);
-  sprintf(fpref,"%s/%s",data_dir,pname);
+  int req = snprintf(fpref,STRLEN,"%s/%s",data_dir,pname);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
 
-  sprintf(fname,"%s/bem/%s",fpref,argv[2]);
+  req = snprintf(fname,STRLEN,"%s/bem/%s",fpref,argv[2]);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fp1 = fopen(fname,"r");
   if (fp1==NULL) {
     printf("File %s not found.\n",fname);
     exit(0);
   }
-  sprintf (fname,"%s/lib/bem/%s",mri_dir,argv[3]);
+  req = snprintf (fname,STRLEN,"%s/lib/bem/%s",mri_dir,argv[3]);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fp2 = fopen(fname,"r");
   if (fp2==NULL) {
     printf("File %s not found.\n",fname);
     exit(0);
   }
-  sprintf(fname,"%s/bem/%s",fpref,argv[4]);
+  req = snprintf(fname,STRLEN,"%s/bem/%s",fpref,argv[4]);
+  if( req >= STRLEN ) {
+    std::cerr << __FUNCTION__ << ": Truncation on line " << __LINE__ << std::endl;
+  }
   fp3 = fopen(fname,"w");
   if (fp3==NULL) {
     printf("can't write to file %s\n",fname);


### PR DESCRIPTION
Continuing fixes for gcc8; mainly `snprintf` conversions. Some sorting out of `break` statements in switches and other changes as well.

For complaints about indentation not matching the syntactic treatment (usually due to unbraced `if` and `for` statements), I have generally added braces to match the syntactic meaning, rather than the indentation.