### PR TITLE
[FIX] wrap around martinos-specific niftireg install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ option(INSTALL_PYTHON_DEPENDENCIES "Install python package dependencies" ON)
 #  compiler errors with "-Werror" turned on.  The WARNING_AS_ERROR option allows temporarily
 #  disabling warnings as errors to allow a more gradual move to supporting new compilers.
 option(WARNING_AS_ERROR "Convert build warnings to errors" ON)
+option(INSTALL_NIFTIREG_MARTINOS "Installs niftireg on martinos network" ON)
 
 if(NOT APPLE)
   # linux-only build options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ option(INSTALL_PYTHON_DEPENDENCIES "Install python package dependencies" ON)
 #  compiler errors with "-Werror" turned on.  The WARNING_AS_ERROR option allows temporarily
 #  disabling warnings as errors to allow a more gradual move to supporting new compilers.
 option(WARNING_AS_ERROR "Convert build warnings to errors" ON)
-option(INSTALL_NIFTIREG_MARTINOS "Installs niftireg on martinos network" ON)
+option(MARTINOS_BUILD "Does the build have access to the martinos network" ON)
 
 if(NOT APPLE)
   # linux-only build options

--- a/infant/CMakeLists.txt
+++ b/infant/CMakeLists.txt
@@ -31,6 +31,7 @@ install_pyscript(mri_label_fusion)
 add_subdirectory(labelfusion)
 
 # install external niftyreg binaries
+if(INSTALL_NIFTIREG_MARTINOS)
 if(APPLE)
   set(NIFTY_REG_DIR "/autofs/cluster/freesurfer/build/misc/infant/niftyreg-mac")
 else()
@@ -39,6 +40,7 @@ endif()
 foreach(CMD reg_resample reg_f3d reg_aladin)
   install(PROGRAMS ${NIFTY_REG_DIR}/${CMD} DESTINATION bin)
 endforeach()
+endif()
 
 # install externally-stored skullstripping models
 foreach(MODEL ax_sscnn.h5 cor_sscnn.h5 sag_sscnn.h5)

--- a/infant/CMakeLists.txt
+++ b/infant/CMakeLists.txt
@@ -31,7 +31,7 @@ install_pyscript(mri_label_fusion)
 add_subdirectory(labelfusion)
 
 # install external niftyreg binaries
-if(INSTALL_NIFTIREG_MARTINOS)
+if(MARTINOS_BUILD)
 if(APPLE)
   set(NIFTY_REG_DIR "/autofs/cluster/freesurfer/build/misc/infant/niftyreg-mac")
 else()
@@ -40,12 +40,12 @@ endif()
 foreach(CMD reg_resample reg_f3d reg_aladin)
   install(PROGRAMS ${NIFTY_REG_DIR}/${CMD} DESTINATION bin)
 endforeach()
-endif()
 
 # install externally-stored skullstripping models
 foreach(MODEL ax_sscnn.h5 cor_sscnn.h5 sag_sscnn.h5)
   install(PROGRAMS /autofs/cluster/freesurfer/build/misc/infant/sscnn_skullstripping/${MODEL} DESTINATION average/sscnn_skullstripping)
 endforeach()
+endif()
 
 # install any package requirements
 if(INSTALL_PYTHON_DEPENDENCIES)


### PR DESCRIPTION
Creates a new cmake var: `MARTINOS_BUILD` (defaults to ON) 

This is to support external builds by wrapping around martinos-specific filepaths.