### PR TITLE
Update mri_mergelabels to fix typo (bf)

### DIFF
--- a/scripts/mri_mergelabels
+++ b/scripts/mri_mergelabels
@@ -121,7 +121,7 @@ while( $#argv != 0 )
       breaksw
 
     default:
-      echo "ERROR: $flag not regocnized"
+      echo "ERROR: $flag not recognized"
       exit 1;
       breaksw
   endsw


### PR DESCRIPTION
bf: Fixed typo in error message.