### PR TITLE
bf: FREESURFER -> FREESURFER_HOME

### DIFF
--- a/scripts/recon-all
+++ b/scripts/recon-all
@@ -3044,7 +3044,7 @@ if($DoFill) then
   set filledman = filled.mgz
   set filledauto = filled.auto.mgz
   if($FS_ALLOW_FILLED_EDIT) then
-    set cmd = ($cmd -ctab $FREESURFER/SubCorticalMassLUT.txt)
+    set cmd = ($cmd -ctab $FREESURFER_HOME/SubCorticalMassLUT.txt)
     if(-e $filledauto && -e $filledman) then
       set fillededits = ../tmp/filled.edits.txt
       set cmd = ($cmd -auto-man $filledauto $filledman $fillededits)


### PR DESCRIPTION
The use of `$FREESURFER` here appears to be accidental, `$FREESURFER_HOME` is used everywhere else for the same directory.

Closes #892 

Workaround for now: `export $FREESURFER=$FREESURFER_HOME`; a run that terminated because of this error can be resumed using the `autorecon2-fill` flag.