### PR TITLE
mris_gradient_unwarp changes

### DIFF
--- a/include/GradUnwarp.h
+++ b/include/GradUnwarp.h
@@ -11,37 +11,57 @@ typedef struct
   char xyz;
 } COEFF;
 
+class Siemens_B
+{
+public:
+  Siemens_B(int coeffDim0, int nmax0, float R0, double **normfact0, float X, float Y, float Z);
+  ~Siemens_B();
+
+  float siemens_B_x(float **Alpha_x, float **Beta_x);
+  float siemens_B_y(float **Alpha_y, float **Beta_y);
+  float siemens_B_z(float **Alpha_z, float **Beta_z);
+  float siemens_B(float **Alpha, float **Beta);
+  void  siemens_legendre(int n, double x);
+
+private:
+  int coeffDim;
+  int nmax;
+  float R0_mm;
+
+  double **normfact;
+
+  double **P;
+  float  *F;
+  double *cosPhi, *sinPhi;
+  float R, Theta, Phi;
+};
+
 class GradUnwarp
 {
 public:
   GradUnwarp();
   ~GradUnwarp();
 
-  void  setup();
-  void  list_coeff_files();
+  void  setup() {};
+  void  list_coeff_files() {};
 
   void  read_siemens_coeff(const char *gradfilename);
   void  printCoeff();
 
-  float siemens_B_x();
-  float siemens_B_y();
-  float siemens_B_z();
-  float siemens_B(float **Alpha, float **Beta, float **F2);
-  void  siemens_B0(float X, float Y, float Z);
-  void  siemens_legendre(int n, double x, double **P);
-
+  void initSiemensLegendreNormfact();
   void  spharm_evaluate(float X, float Y, float Z, float *Dx, float *Dy, float *Dz);
 
-  void  initSiemensLegendreNormfact();
-
-  void  unwarp();
-  void  unwap_volume();
-  void  unwarp_surface();
+  void  unwarp() {};
+  void  unwap_volume() {};
+  void  unwarp_surface() {};
   
 private:
   FILE *fgrad;
 
   COEFF coeff[100];
+
+  int nmax;
+  int mmax;
 
   int coeffCount;
   int coeffDim;
@@ -55,13 +75,6 @@ private:
   double *minusonepow;
   double *factorials;
   double **normfact;
-
-  // these are reset and re-calculated for each (x, y, z) in siemens_B0()  
-  double **P;
-  float **F2_x, **F2_y, **F2_z;
-  float  *F;
-  double *cosPhi, *sinPhi;
-  float R, Theta, Phi;
 
 private:
   void _skipCoeffComment();

--- a/mris_gradient_unwarp/mris_gradient_unwarp.cpp
+++ b/mris_gradient_unwarp/mris_gradient_unwarp.cpp
@@ -14,10 +14,10 @@
 #include "GradUnwarp.h"
 
 /* examples:
- * 1. mris_gradient_unwarp/mris_gradient_unwarp --gradcoeff $WKDIR/fs_test/gradunwarp/example/coeff_Sonata.grad --invol $WKDIR/fs_test/gradunwarp/example/orig.mgz --outvol unwarped.mgz
- * 2. mris_gradient_unwarp/mris_gradient_unwarp --gradcoeff $WKDIR/fs_test/gradunwarp/example/coeff_Sonata.grad --invol $WKDIR/fs_test/gradunwarp/example/orig.mgz --outvol orig.dup.mgz --dupinvol
- * 3. mris_gradient_unwarp/mris_gradient_unwarp --gradcoeff $WKDIR/fs_test/gradunwarp/example/coeff_Sonata.grad --invol $WKDIR/fs_test/gradunwarp/example/orig.mgz --ras 0.1,0.2,0.3
- * 4. mris_gradient_unwarp/mris_gradient_unwarp --gradcoeff $WKDIR/fs_test/gradunwarp/example/coeff_Sonata.grad --invol $WKDIR/fs_test/gradunwarp/example/orig.mgz  --crs 0,0,0
+ * 1. mris_gradient_unwarp/mris_gradient_unwarp --gradcoeff $FS_TEST/gradunwarp/example/coeff_Sonata.grad --invol $FS_TEST/gradunwarp/example/orig.mgz --outvol unwarped.mgz
+ * 2. mris_gradient_unwarp/mris_gradient_unwarp --gradcoeff $FS_TEST/gradunwarp/example/coeff_Sonata.grad --invol $FS_TEST/gradunwarp/example/orig.mgz --outvol orig.dup.mgz --dupinvol
+ * 3. mris_gradient_unwarp/mris_gradient_unwarp --gradcoeff $FS_TEST/gradunwarp/example/coeff_Sonata.grad --invol $FS_TEST/gradunwarp/example/orig.mgz --ras 0.1,0.2,0.3
+ * 4. mris_gradient_unwarp/mris_gradient_unwarp --gradcoeff $FS_TEST/gradunwarp/example/coeff_Sonata.grad --invol $FS_TEST/gradunwarp/example/orig.mgz  --crs 0,0,0
  */
 /****** BIG PICTURES ******/
 /*
@@ -62,8 +62,9 @@ int dupinvol = 0, inputras = 0, inputcrs = 0;
 double ras_x, ras_y, ras_z;
 int crs_c = 0, crs_r = 0, crs_s = 0;
 const char *interpmethod = "trilinear";
-int   interpcode = 0;
+int   interpcode = -1;
 int   sinchw = 0;
+int   nthreads = 1;
 
 int main(int argc, char *argv[])
 {
@@ -102,6 +103,8 @@ int main(int argc, char *argv[])
 
   GradUnwarp *gradUnwarp = new GradUnwarp();
   gradUnwarp->read_siemens_coeff(gradfile0.c_str());
+  //gradUnwarp->printCoeff();
+  //return 0;
   gradUnwarp->initSiemensLegendreNormfact();
 
   if (inputras) // for debugging only
@@ -164,14 +167,11 @@ static void unwarpVol(const char* origmgz, const char* unwarpedmgz, GradUnwarp* 
   if (interpcode == SAMPLE_CUBIC_BSPLINE)
     bspline = MRItoBSpline(origvol, NULL, 3);
 
-  int outofrangevoxels[_MAX_FS_THREADS];
+  int outofrange_total = 0;
+
 #ifdef HAVE_OPENMP
-  int tid;
-  for (tid = 0; tid < _MAX_FS_THREADS; tid++) {
-    outofrangevoxels[tid] = 0;
-  }
-#else
-  outofrangevoxels[0] = 0;
+  printf("\nSet OPEN MP NUM threads to %d\n", nthreads);
+  omp_set_num_threads(nthreads);
 #endif
 
   int c;
@@ -180,14 +180,24 @@ static void unwarpVol(const char* origmgz, const char* unwarpedmgz, GradUnwarp* 
 #endif
   for (c = 0; c < origvol->width; c++)
   {
-    int r = 0, s = 0, f = 0;
-
     // You could make a vector of CRS nthreads long
     MATRIX *CRS = MatrixAlloc(4, 1, MATRIX_REAL);
     MATRIX *RAS = MatrixAlloc(4, 1, MATRIX_REAL);;
     MATRIX *DeltaRAS = MatrixAlloc(4, 1, MATRIX_REAL);
     MATRIX *DistortedRAS = MatrixAlloc(4, 1, MATRIX_REAL);
     MATRIX *DistortedCRS = MatrixAlloc(4, 1, MATRIX_REAL);
+
+    int r = 0, s = 0;
+    int outofrange_local = 0;
+
+#if 0
+#ifdef HAVE_OPENMP
+    int tid = omp_get_thread_num();
+    printf("hello from thread #%d (%d, %d, %d) ...\n", tid, c, r, s);
+#else
+    printf("hello from process %d ...\n", getpid());
+#endif
+#endif
 
     for (r = 0; r < origvol->height; r++)
     {
@@ -196,7 +206,7 @@ static void unwarpVol(const char* origmgz, const char* unwarpedmgz, GradUnwarp* 
         if (!dupinvol)
         {
           // clear CRS, RAS, DeltaRAS, DistortedRAS, DistortedCRS
-	  MatrixClear(CRS);
+          MatrixClear(CRS);
           MatrixClear(RAS);
           MatrixClear(DeltaRAS);
           MatrixClear(DistortedRAS);
@@ -284,10 +294,9 @@ static void unwarpVol(const char* origmgz, const char* unwarpedmgz, GradUnwarp* 
               iss < 0 || iss >= origvol->depth)
           {
 #ifdef HAVE_OPENMP
-            int tid = omp_get_thread_num();
-            outofrangevoxels[tid]++;
+            outofrange_local++;
 #else
-            outofrangevoxels[0]++;
+            outofrange_total++;
 #endif
             continue;
           }
@@ -304,12 +313,15 @@ static void unwarpVol(const char* origmgz, const char* unwarpedmgz, GradUnwarp* 
           float *valvect = new float[origvol->nframes]; 
           MRIsampleSeqVolume(origvol, fcs, frs, fss, valvect, 0, origvol->nframes - 1);
           
+          int f;
           for (f = 0; f < origvol->nframes; f++) 
             MRIsetVoxVal2(unwarpedvol, c, r, s, f, valvect[f]);
 
           free(valvect);
 	} else {
           double rval = 0;
+
+          int f;
           for (f = 0; f < origvol->nframes; f++) {
             switch (interpcode) {
               case SAMPLE_NEAREST:
@@ -332,6 +344,12 @@ static void unwarpVol(const char* origmgz, const char* unwarpedmgz, GradUnwarp* 
       }   // s
     }     // r
 
+#ifdef HAVE_OPENMP
+#pragma omp critical 
+    outofrange_total += outofrange_local; 
+    //printf("update out of range voxel count: + %d = %d\n", outofrange_local, outofrange_total);
+#endif
+
     MatrixFree(&CRS);
     MatrixFree(&RAS);
     MatrixFree(&DeltaRAS);
@@ -343,16 +361,7 @@ static void unwarpVol(const char* origmgz, const char* unwarpedmgz, GradUnwarp* 
   int err = MRIwrite(unwarpedvol, unwarpedmgz);
   if(err) printf("something went wrong\n");
 
-  int totalCount = 0;
-#ifdef HAVE_OPENMP
-  for (tid = 0; tid < _MAX_FS_THREADS; tid++) {
-    totalCount += outofrangevoxels[tid];
-  }
-#else
-  totalCount = outofrangevoxels[0];
-#endif
-
-  printf("Total %d voxels are out of range\n", totalCount);
+  printf("Total %d voxels are out of range\n", outofrange_total);
 
   MatrixFree(&vox2ras_orig);
   MatrixFree(&inv_vox2ras_orig);
@@ -422,6 +431,10 @@ static int parse_commandline(int argc, char **argv) {
         printf("!!! <sinchw = %d> !!!\n", sinchw);
         nargsused ++;
       }
+    } else if(!strcasecmp(option, "--threads") || !strcasecmp(option, "--nthreads") ){
+      if(nargc < 1) CMDargNErr(option,1);
+      sscanf(pargv[0],"%d", &nthreads);
+      nargsused = 1;
     } else {
       fprintf(stderr,"ERROR: Option %s unknown\n",option);
       if (CMDsingleDash(option))
@@ -452,6 +465,8 @@ static void print_usage(void) {
   printf("   --crs       c,r,s\n");
   printf("\n"); 
   printf("   --interp    interptype nearest | trilinear | sinc | cubic\n");
+  printf("\n"); 
+  printf("   --nthreads  nthreads : Set OPEN MP threads\n");
   printf("\n"); 
   printf("   --debug     turn on debugging\n");
   printf("   --checkopts don't run anything, just check options and exit\n");

--- a/utils/GradUnwarp.cpp
+++ b/utils/GradUnwarp.cpp
@@ -7,9 +7,16 @@
 #include "GradUnwarp.h"
 #include "legendre.h"
 
+/*****************************************************************************/
+/******************** Implementation of GradUnwarp class *********************/
+/**********    3 environment variables to enable debug info:        **********/
+/********** COEFF_READ_DEBUG, LEGENDRE_NORMFACT_DEBUG, PRN_LEGENDRE **********/
 GradUnwarp::GradUnwarp()
 {
   fgrad = NULL;
+
+  nmax = 0;
+  mmax = 0;
 
   coeffCount = 0;
   coeffDim = 0;
@@ -17,14 +24,12 @@ GradUnwarp::GradUnwarp()
   R0 = 0;
   Alpha_x = NULL; Alpha_y = NULL; Alpha_z = NULL;
   Beta_x  = NULL; Beta_y  = NULL; Beta_z  = NULL;
-
-  P = NULL;
 }
 
 GradUnwarp::~GradUnwarp()
 {
-  int i = 0;
-  for (; i < coeffDim; i++)
+  int i;
+  for (i = 0; i < coeffDim; i++)
   {
     free(Alpha_x[i]);
     free(Alpha_y[i]);
@@ -43,26 +48,16 @@ GradUnwarp::~GradUnwarp()
 
   free(minusonepow);
   free(factorials);
+
   for (i = 0; i < coeffDim; i++)
-  {
     free(normfact[i]);
-    free(P[i]);
-  }
   free(normfact);
-  free(P);
-}
-
-void GradUnwarp::setup()
-{
-}
-
-void GradUnwarp::list_coeff_files()
-{
 }
 
 void GradUnwarp::read_siemens_coeff(const char *gradfilename)
 {
   // check if gradfile has extension .grad
+  // ...
 
   // open gradfilename
   fgrad = fopen(gradfilename, "r");
@@ -76,6 +71,9 @@ void GradUnwarp::read_siemens_coeff(const char *gradfilename)
 
   _skipCoeffComment();
 
+  // hard-coded limits:
+  // number of coeff entries - 100
+  // length of each entry    - 1024
   char coeffline[1024];
 
   // skip the next line. (It contains an information about the system type.)
@@ -115,10 +113,8 @@ void GradUnwarp::read_siemens_coeff(const char *gradfilename)
 
   /***********************************************************/
   /****** begin reading spherical harmonic coefficients ******/
-  while (!feof(fgrad))
+  while (fgets(coeffline, sizeof(coeffline), fgrad) != NULL)
   {
-    fgets(coeffline, sizeof(coeffline), fgrad);
-
     int len = strlen(coeffline);
     char* ptr = coeffline;
     char* endptr = ptr + len;
@@ -130,24 +126,30 @@ void GradUnwarp::read_siemens_coeff(const char *gradfilename)
     if (*ptr == '\0')
       continue;
 
+    // start filling coeff entries at index 1
+    coeffCount++;
+
+    if (getenv("COEFF_READ_DEBUG"))
+      printf("entry #%d: %s\n", coeffCount, coeffline);
+
     sscanf(ptr, "%d %c(%d, %d) %f %c", 
                       &coeff[coeffCount].num, &coeff[coeffCount].A_or_B, &coeff[coeffCount].n, &coeff[coeffCount].m, 
                       &coeff[coeffCount].value, &coeff[coeffCount].xyz);
-    int larger = (coeff[coeffCount].n > coeff[coeffCount].m) ? (coeff[coeffCount].n+1) : (coeff[coeffCount].m+1);
-    coeffDim = (coeffDim < larger) ? larger : coeffDim; 
+    nmax = (coeff[coeffCount].n > nmax) ? coeff[coeffCount].n : nmax;
+    mmax = (coeff[coeffCount].m > mmax) ? coeff[coeffCount].m : mmax;
     //printf("%d %c (%d, %d) %f %c\n", coeff[coeffCount].num, 
     //       coeff[coeffCount].A_or_B, coeff[coeffCount].n, coeff[coeffCount].m, coeff[coeffCount].value, coeff[coeffCount].xyz);
-    coeffCount++;
   }
 
   fclose(fgrad);    
 
+  coeffDim = (nmax > mmax) ? nmax+1 : mmax+1;
   _initCoeff();
 
   /**************************************************************************/
   /****** organize coefficient values ******/
-  int n = 0;
-  for (; n < coeffCount; n++)
+  int n;
+  for (n = 1; n <= coeffCount; n++)
   {
     float **arrPtr = NULL;
     if (coeff[n].A_or_B == 'A')
@@ -177,90 +179,8 @@ void GradUnwarp::read_siemens_coeff(const char *gradfilename)
 
     int row = coeff[n].n;
     int col = coeff[n].m; 
-    arrPtr[row][col] = coeff[n].value;
+    arrPtr[row+1][col+1] = coeff[n].value;
   }
-}
-
-float GradUnwarp::siemens_B_x()
-{
-  return GradUnwarp::siemens_B(Alpha_x, Beta_x, F2_x);
-}
-
-float GradUnwarp::siemens_B_y()
-{
-  return GradUnwarp::siemens_B(Alpha_y, Beta_y, F2_y);
-}
-
-float GradUnwarp::siemens_B_z()
-{
-  return GradUnwarp::siemens_B(Alpha_z, Beta_z, F2_z);
-}
-
-void GradUnwarp::siemens_B0(float X, float Y, float Z)
-{
-  int n;
-  for (n = 0; n < coeffDim; n++)
-  {
-    memset(P[n], 0, coeffDim*sizeof(double));
-    memset(F2_x[n], 0, coeffDim*sizeof(float));
-    memset(F2_y[n], 0, coeffDim*sizeof(float));
-    memset(F2_z[n], 0, coeffDim*sizeof(float));
-  }
-
-  memset(F, 0, coeffDim*sizeof(float));
-  memset(cosPhi, 0, coeffDim*sizeof(double));
-  memset(sinPhi, 0, coeffDim*sizeof(double));
-
-  // hack to avoid singularities at origin (R==0)
-  X = X+0.0001;
-
-  // convert to spherical coordinates
-  R = sqrt(X*X + Y*Y + Z*Z);
-  Theta = acos(Z/R);
-  Phi = atan2(Y/R, X/R);
-
-  // evaluate the Legendre polynomial (using Siemens's normalization)
-  int nmax = coeffDim - 1;
-
-  for (n = 0; n < nmax+1; n++)
-  {
-    siemens_legendre(n, cos(Theta), P);
-
-    F[n] = pow((R/R0), n);
-    cosPhi[n] = cos(n*Phi);
-    sinPhi[n] = sin(n*Phi);
-  }
-
-  for (n = 0; n < nmax+1; n++)
-  {
-    int m = 0;
-    for (; m < n+1; m++)
-    {
-      F2_x[n][m] = Alpha_x[n][m] * cosPhi[m] + Beta_x[n][m] * sinPhi[m];
-      F2_y[n][m] = Alpha_y[n][m] * cosPhi[m] + Beta_y[n][m] * sinPhi[m];
-      F2_z[n][m] = Alpha_z[n][m] * cosPhi[m] + Beta_z[n][m] * sinPhi[m];
-    }
-  }
-}
-
-float GradUnwarp::siemens_B(float **Alpha, float **Beta, float **F2)
-{
-  int nmax = coeffDim - 1;
-  float B = 0;
-  int n = 0;
-  for (; n < nmax+1; n++)
-  {
-    int m = 0;
-    for (; m < n+1; m++)
-    {
-      //float F2 = Alpha[n][m] * cos(m*Phi) + Beta[n][m] * sin(m*Phi);
-      //float F2 = Alpha[n][m] * cosPhi[m] + Beta[n][m] * sinPhi[m];
-      //B = B + F[n]*P[n][m]*F2;
-      B = B + F[n]*P[n][m]*F2[n][m];
-    }
-  }
-
-  return B;
 }
 
 void GradUnwarp::initSiemensLegendreNormfact()
@@ -270,119 +190,52 @@ void GradUnwarp::initSiemensLegendreNormfact()
   factorials  = new double[2*coeffDim];
   normfact = new double*[coeffDim];
 
-  P = new double*[coeffDim];
-  F2_x = new float*[coeffDim];
-  F2_y = new float*[coeffDim];
-  F2_z = new float*[coeffDim];
-
   int n;
   for (n = 0; n < coeffDim; n++)
-  {
     normfact[n] = new double[coeffDim];
-    P[n] = new double[coeffDim];
-
-    F2_x[n] = new float[coeffDim];
-    F2_y[n] = new float[coeffDim];
-    F2_z[n] = new float[coeffDim];
-  }
-
-  F = new float[coeffDim];
-  cosPhi = new double[coeffDim];
-  sinPhi = new double[coeffDim];
 
   // pre-calculate minusonepow, factorials, & normfact
-  for (n=0; n < coeffDim; n++)
-  {
+  for (n = 0; n < coeffDim; n++)
     minusonepow[n] = pow((-1), n);
-  }
 
-  for (n=0; n < 2*coeffDim; n++)
-  {
+  for (n = 0; n < 2*coeffDim; n++)
     factorials[n] = factorial(n);
-  }
 
-#if PRN_LEGENDRE
-  printf("\n");
-#endif
-  for (n=0; n < coeffDim; n++)
-  {
-    int m = 0;
-    for (; m < n; m++)
-    {
-      normfact[n][m] = minusonepow[m+1] * sqrt((2*n+1)*factorials[n-m-1]/(2*factorials[n+m+1]));
-   
-#if PRN_LEGENDRE
-      printf("normfact2[%2d][%2d] = %s%.6lf, pow((-1), %2d) * sqrt((%2d)*factorial(%2d)/(2*factorial(%2d)))\n",
-             n, m, (normfact[n][m] > 0) ? " " : "", normfact[n][m], m+1, 2*n+1, n-m-1, n+m+1);
-#endif
-    }
-#if PRN_LEGENDRE
+  if (getenv("LEGENDRE_NORMFACT_DEBUG"))
     printf("\n");
-#endif
+
+  for (n = 0; n < coeffDim; n++)
+  {
+    int m;
+    for (m = 1; m <= n; m++)
+    {
+      normfact[n][m] = minusonepow[m] * sqrt((2*n+1)*factorials[n-m]/(2*factorials[n+m]));
+   
+      if (getenv("LEGENDRE_NORMFACT_DEBUG"))
+        printf("normfact2[%2d][%2d] = %s%.6lf, pow((-1), %2d) * sqrt((%2d)*factorial(%2d)/(2*factorial(%2d)))\n",
+               n, m, (normfact[n][m] > 0) ? " " : "", normfact[n][m], m, 2*n+1, n-m, n+m);
+    }
+
+    if (getenv("LEGENDRE_NORMFACT_DEBUG"))
+      printf("\n");
   }
 }
 
-void GradUnwarp::siemens_legendre(int n, double x, double **P)
-{
-  int m = 0;
-  for (; m < n+1; m++)
-  {
-    P[n][m] = gsl_sf_legendre_Plm_e(n, m, x);
-  }
-
-#if PRN_LEGENDRE
-  printf("\nlegendre (n=%d) = \n", n);
-  for (m = 0; m < n+1; m++)
-  {
-    printf("\tP[%d][%d] = %lf\n", n, m, P[n][m]);
-  }
-#endif
-
-  m = 0;
-  for (; m < n; m++)
-  {
-    P[n][m+1] *= normfact[n][m];
-#if 0
-    double normfact = pow((-1), m+1) * sqrt((2*n+1)*factorial(n-m-1)/(2*factorial(n+m+1)));
-    P[m+1] *= normfact;
-
-    printf("normfact[%d][%d] = %lf, pow((-1), %d) * sqrt((%d)*factorial(%d)/(2*factorial(%d)))\n",
-           n, m, normfact, m+1, 2*n+1, n-m-1, n+m+1);
-#endif
-  }
-
-#if PRN_LEGENDRE
-  printf("\nsiemens_legendre (n=%d) = \n", n);
-  for (m = 0; m < n+1; m++)
-  {
-    printf("\tP[%d][%d] = %lf\n", n, m, P[n][m]);
-  }
-#endif
-}
- 
 void GradUnwarp::spharm_evaluate(float X, float Y, float Z, float *Dx, float *Dy, float *Dz)
 {
-  siemens_B0(X, Y, Z);
+  Siemens_B *siemens_B = new Siemens_B(coeffDim, nmax, R0, normfact, X, Y, Z);
 
-  float bx = siemens_B_x();
-  float by = siemens_B_y();
-  float bz = siemens_B_z();
+  float bx = siemens_B->siemens_B_x(Alpha_x, Beta_x);
+  float by = siemens_B->siemens_B_y(Alpha_y, Beta_y);
+  float bz = siemens_B->siemens_B_z(Alpha_z, Beta_z);
+
+  //printf("bx=%lf, by=%lf, bz=%lf\n", bx, by, bz);
 
   *Dx = bx * R0;
   *Dy = by * R0;
   *Dz = bz * R0;
-}
 
-void GradUnwarp::unwarp()
-{
-}
-
-void GradUnwarp::unwap_volume()
-{
-}
-
-void GradUnwarp::unwarp_surface()
-{
+  delete siemens_B;
 }
 
 void GradUnwarp::printCoeff()
@@ -456,37 +309,166 @@ void GradUnwarp::_skipCoeffComment()
 
 void GradUnwarp::_initCoeff()
 {
-
   printf("coeffDim = %d, coeffCount=%d\n", coeffDim, coeffCount);
 
   // allocate float *Alpha_x, *Alpha_y, *Alpha_z; float *Beta_x,  *Beta_y,  *Beta_z;
-  Alpha_x = new float*[coeffDim];
-  Alpha_y = new float*[coeffDim];
-  Alpha_z = new float*[coeffDim];
-  Beta_x  = new float*[coeffDim];
-  Beta_y  = new float*[coeffDim];
-  Beta_z  = new float*[coeffDim];
+  // first row and first col of Alpha_x, Alpha_y, Alpha_z, Beta_x, Beta_y, Beta_z are all zeros, they are not used.
+  // this is to align with MATLAB matrix which has index starting at 1.
+  int arrsize = coeffDim + 1;
+  Alpha_x = new float*[arrsize];
+  Alpha_y = new float*[arrsize];
+  Alpha_z = new float*[arrsize];
+  Beta_x  = new float*[arrsize];
+  Beta_y  = new float*[arrsize];
+  Beta_z  = new float*[arrsize];
 
-  int i = 0;
-  for (; i < coeffDim; i++)
+  // initialize coefficient arrays
+  int i;
+  for (i = 0; i <= coeffDim; i++)
   {
-    Alpha_x[i] = new float[coeffDim];
-    memset(Alpha_x[i], 0, sizeof(float)*coeffDim);
+    Alpha_x[i] = new float[arrsize];
+    memset(Alpha_x[i], 0, sizeof(float)*arrsize);
 
-    Alpha_y[i] = new float[coeffDim];
-    memset(Alpha_y[i], 0, sizeof(float)*coeffDim);
+    Alpha_y[i] = new float[arrsize];
+    memset(Alpha_y[i], 0, sizeof(float)*arrsize);
 
-    Alpha_z[i] = new float[coeffDim];
-    memset(Alpha_z[i], 0, sizeof(float)*coeffDim);
+    Alpha_z[i] = new float[arrsize];
+    memset(Alpha_z[i], 0, sizeof(float)*arrsize);
 
-    Beta_x[i]  = new float[coeffDim];
-    memset(Beta_x[i], 0, sizeof(float)*coeffDim);
+    Beta_x[i]  = new float[arrsize];
+    memset(Beta_x[i], 0, sizeof(float)*arrsize);
 
-    Beta_y[i]  = new float[coeffDim];
-    memset(Beta_y[i], 0, sizeof(float)*coeffDim);
+    Beta_y[i]  = new float[arrsize];
+    memset(Beta_y[i], 0, sizeof(float)*arrsize);
 
-    Beta_z[i]  = new float[coeffDim];
-    memset(Beta_z[i], 0, sizeof(float)*coeffDim);
+    Beta_z[i]  = new float[arrsize];
+    memset(Beta_z[i], 0, sizeof(float)*arrsize);
   }
 }
 
+
+/***********************************************************************************/
+/************************ Implementation of Siemens_B class ************************/
+Siemens_B::Siemens_B(int coeffDim0, int nmax0, float R0, double **normfact0, float X, float Y, float Z)
+{
+  coeffDim = coeffDim0;    // coeffDime = nmax + 1
+  nmax = nmax0;
+  R0_mm = R0;
+  normfact = normfact0;
+
+  P = new double*[coeffDim];
+
+  int n;
+  for (n = 0; n < coeffDim; n++)
+  {
+    // P[0][] is not used, MATLAB index starts at 1 
+    P[n] = new double[coeffDim+1];
+    memset(P[n], 0, (coeffDim+1)*sizeof(double));
+  }
+
+  F = new float[coeffDim];
+  cosPhi = new double[coeffDim];
+  sinPhi = new double[coeffDim];
+
+  memset(F, 0, coeffDim*sizeof(float));
+  memset(cosPhi, 0, coeffDim*sizeof(double));
+  memset(sinPhi, 0, coeffDim*sizeof(double));
+
+  // hack to avoid singularities at origin (R==0)
+  X = X+0.0001;
+
+  // convert to spherical coordinates
+  R = sqrt(X*X + Y*Y + Z*Z);
+  Theta = acos(Z/R);
+  Phi = atan2(Y/R, X/R);
+
+  // evaluate the Legendre polynomial (using Siemens's normalization)
+  for (n = 0; n <= nmax; n++)
+  {
+    siemens_legendre(n, cos(Theta));
+
+    F[n] = pow((R/R0_mm), n);
+    cosPhi[n] = cos(n*Phi);
+    sinPhi[n] = sin(n*Phi);
+  }
+}
+
+Siemens_B::~Siemens_B()
+{
+  int n;
+  for (n = 0; n < coeffDim; n++)
+    free(P[n]);
+
+  free(P);
+  free(F);
+  free(cosPhi);
+  free(sinPhi);
+}
+
+float Siemens_B::siemens_B_x(float **Alpha_x, float **Beta_x)
+{
+  return Siemens_B::siemens_B(Alpha_x, Beta_x);
+}
+
+float Siemens_B::siemens_B_y(float **Alpha_y, float **Beta_y)
+{
+  return Siemens_B::siemens_B(Alpha_y, Beta_y);
+}
+
+float Siemens_B::siemens_B_z(float **Alpha_z, float **Beta_z)
+{
+  return Siemens_B::siemens_B(Alpha_z, Beta_z);
+}
+
+float Siemens_B::siemens_B(float **Alpha, float **Beta)
+{
+  float B = 0;
+  int n;
+  for (n = 0; n <= nmax; n++)
+  {
+    int m;
+    for (m = 0; m <= n; m++)
+    {
+      float F2 = Alpha[n+1][m+1] * cosPhi[m] + Beta[n+1][m+1] * sinPhi[m];
+      B = B + F[n]*P[n][m+1]*F2;
+    }
+  }
+
+  return B;
+}
+
+void Siemens_B::siemens_legendre(int n, double x)
+{
+  int m;
+  for (m = 0; m <= n; m++)
+  {
+    P[n][m+1] = gsl_sf_legendre_Plm_e(n, m, x);
+  }
+
+  if (getenv("PRN_LEGENDRE"))
+  {
+    printf("\nlegendre (n=%d, x=%lf) = \n", n, x);
+    for (m = 0; m <= n+1; m++)
+      printf("\tP[%d][%d] = %lf\n", n, m, P[n][m]);
+  }
+
+  for (m = 1; m <= n; m++)
+  {
+    P[n][m+1] *= normfact[n][m];
+#if 0
+    double normfact = pow((-1), m+1) * sqrt((2*n+1)*factorial(n-m-1)/(2*factorial(n+m+1)));
+    P[m+1] *= normfact;
+
+    printf("normfact[%d][%d] = %lf, pow((-1), %d) * sqrt((%d)*factorial(%d)/(2*factorial(%d)))\n",
+           n, m, normfact, m+1, 2*n+1, n-m-1, n+m+1);
+#endif
+  }
+
+  if (getenv("PRN_LEGENDRE"))
+  {
+    printf("\nsiemens_legendre (n=%d, x=%lf) = \n", n, x);
+    for (m = 0; m <= n+1; m++)
+      printf("\tP[%d][%d] = %lf\n", n, m, P[n][m]);
+  }
+}
+ 


### PR DESCRIPTION
    1. add option '--nthreads' to mris_gradient_unwarp, set omp_set_num_threads(nthreads)
    2. separate GradUnwarp class into GradUnwarp and Siemens_B
    3. create new Siemens_B object for each GradUnwarp::spharm_evaluate() call to make it thread safe
    4. fix out of range voxel count in mris_gradient_unwarp (not sure why array indexed by thread id doesn't work)
