### PR TITLE
m3z support in GradUnwarp

### DIFF
--- a/include/GradUnwarp.h
+++ b/include/GradUnwarp.h
@@ -1,6 +1,9 @@
 #ifndef GRADUNWARP_H
 #define GRADUNWARP_H
 
+#include "gcamorph.h"
+#include "mri.h"
+
 typedef struct
 {
   int num;
@@ -39,23 +42,25 @@ private:
 class GradUnwarp
 {
 public:
-  GradUnwarp();
+  GradUnwarp(int nthreads = 1);
   ~GradUnwarp();
-
-  void  setup() {};
-  void  list_coeff_files() {};
 
   void  read_siemens_coeff(const char *gradfilename);
   void  printCoeff();
 
-  void initSiemensLegendreNormfact();
+  void  initSiemensLegendreNormfact();
   void  spharm_evaluate(float X, float Y, float Z, float *Dx, float *Dy, float *Dz);
 
-  void  unwarp() {};
-  void  unwap_volume() {};
-  void  unwarp_surface() {};
+  void  create_transtable(MRI *origvol, MRI *unwarpedvol, MATRIX *vox2ras, MATRIX *inv_vox2ras);
+  void  load_transtable(const char* morphfile);
+  void  save_transtable(const char* morphfile);
+
+  MRI*  unwarp_volume(MRI *origvol, MRI *unwarpedvol, int interpcode, int sinchw);
+  void  unwarp_surface();
   
 private:
+  int nthreads;
+
   FILE *fgrad;
 
   COEFF coeff[100];
@@ -65,6 +70,8 @@ private:
 
   int coeffCount;
   int coeffDim;
+
+  bool Alpha_Beta_initialized;
 
   float R0;
   float **Alpha_x, **Alpha_y, **Alpha_z;
@@ -76,9 +83,14 @@ private:
   double *factorials;
   double **normfact;
 
+  GCAM *gcam;
+
 private:
   void _skipCoeffComment();
   void _initCoeff();
+  void _update_GCAMnode(int c, int r, int s, float fcs, float frs, float fss);
+  void _assignUnWarpedVolumeValues(MRI* origvol, MRI* unwarpedvol, MRI_BSPLINE *bspline, int interpcode, int sinchw,
+                                   int c, int r, int s, float fcs, float frs, float fss);
 };
 
 #endif

--- a/utils/GradUnwarp.cpp
+++ b/utils/GradUnwarp.cpp
@@ -4,6 +4,9 @@
 #include <math.h>
 #include <ctype.h>
 
+#include "romp_support.h"
+#include "mriBSpline.h"
+
 #include "GradUnwarp.h"
 #include "legendre.h"
 
@@ -11,8 +14,9 @@
 /******************** Implementation of GradUnwarp class *********************/
 /***************     3 environment variables to enable debug info:        **************/
 /********** PRN_GRADCOEFF, PRN_LEGENDRE_NORMFACT, PRN_LEGENDRE, PRN_SIEMENS_B **********/
-GradUnwarp::GradUnwarp()
+GradUnwarp::GradUnwarp(int nthreads0)
 {
+  nthreads = nthreads0;
   fgrad = NULL;
 
   nmax = 0;
@@ -24,6 +28,10 @@ GradUnwarp::GradUnwarp()
   R0 = 0;
   Alpha_x = NULL; Alpha_y = NULL; Alpha_z = NULL;
   Beta_x  = NULL; Beta_y  = NULL; Beta_z  = NULL;
+
+  Alpha_Beta_initialized = false;
+
+  gcam = NULL;
 }
 
 GradUnwarp::~GradUnwarp()
@@ -181,6 +189,8 @@ void GradUnwarp::read_siemens_coeff(const char *gradfilename)
     int col = coeff[n].m; 
     arrPtr[row][col] = coeff[n].value;
   }
+
+  Alpha_Beta_initialized = true;
 }
 
 void GradUnwarp::initSiemensLegendreNormfact()
@@ -223,6 +233,9 @@ void GradUnwarp::initSiemensLegendreNormfact()
 
 void GradUnwarp::spharm_evaluate(float X, float Y, float Z, float *Dx, float *Dy, float *Dz)
 {
+  if (!Alpha_Beta_initialized)
+    return;
+
   Siemens_B *siemens_B = new Siemens_B(coeffDim, nmax, R0, normfact, X, Y, Z);
 
   float bx = siemens_B->siemens_B_x(Alpha_x, Beta_x);
@@ -287,6 +300,242 @@ void GradUnwarp::printCoeff()
       printf("\n");
     }
   }
+}
+
+void GradUnwarp::create_transtable(MRI *origvol, MRI *unwarpedvol, MATRIX *vox2ras, MATRIX *inv_vox2ras)
+{
+  printf("GradUnwarp::create_transtable() ...\n");
+  if (gcam != NULL)
+    GCAMfree(&gcam);
+
+  gcam = GCAMalloc(origvol->width, origvol->height, origvol->depth);
+
+  // save volgeom orig and target
+  if (origvol != NULL)
+  {
+    MRI *targvol = unwarpedvol;
+    targvol = (targvol == NULL) ? origvol : targvol;
+    GCAMinitVolGeom(gcam, origvol, targvol);
+  }
+
+#ifdef HAVE_OPENMP
+  printf("\nSet OPEN MP NUM threads to %d (create_transtable)\n", nthreads);
+  omp_set_num_threads(nthreads);
+#endif
+
+  int c; 
+#ifdef HAVE_OPENMP
+#pragma omp parallel for
+#endif
+  for (c = 0; c < origvol->width; c++)
+  {
+    // You could make a vector of CRS nthreads long
+    MATRIX *CRS = MatrixAlloc(4, 1, MATRIX_REAL);
+    MATRIX *RAS = MatrixAlloc(4, 1, MATRIX_REAL);;
+    MATRIX *DeltaRAS = MatrixAlloc(4, 1, MATRIX_REAL);
+    MATRIX *DistortedRAS = MatrixAlloc(4, 1, MATRIX_REAL);
+    MATRIX *DistortedCRS = MatrixAlloc(4, 1, MATRIX_REAL);
+
+    int r = 0, s = 0;
+    for (r = 0; r < origvol->height; r++)
+    {
+      for (s = 0; s < origvol->depth; s++)
+      {
+        // clear CRS, RAS, DeltaRAS, DistortedRAS, DistortedCRS
+        MatrixClear(CRS);
+        MatrixClear(RAS);
+        MatrixClear(DeltaRAS);
+        MatrixClear(DistortedRAS);
+        MatrixClear(DistortedCRS);
+
+        CRS->rptr[1][1] = c;
+        CRS->rptr[2][1] = r;
+        CRS->rptr[3][1] = s;
+        CRS->rptr[4][1] = 1;
+
+        // Convert the CRS to RAS
+        RAS->rptr[4][1] = 1;
+        RAS = MatrixMultiply(vox2ras, CRS, RAS);
+
+        double x = RAS->rptr[1][1];
+        double y = RAS->rptr[2][1];
+        double z = RAS->rptr[3][1];
+        float Dx = 0, Dy = 0, Dz = 0;
+        spharm_evaluate(x, y, z, &Dx, &Dy, &Dz);
+
+        DeltaRAS->rptr[1][1] = Dx;
+        DeltaRAS->rptr[2][1] = Dy;
+        DeltaRAS->rptr[3][1] = Dz;
+        DeltaRAS->rptr[4][1] = 1; 
+        
+        DistortedRAS = MatrixAdd(RAS, DeltaRAS, DistortedRAS);
+        DistortedRAS->rptr[4][1] = 1;
+        DistortedCRS = MatrixMultiply(inv_vox2ras, DistortedRAS, DistortedCRS);
+	   
+        float fcs = DistortedCRS->rptr[1][1];
+        float frs = DistortedCRS->rptr[2][1];
+        float fss = DistortedCRS->rptr[3][1];
+
+        // update GCAM nodes
+        _update_GCAMnode(c, r, s, fcs, frs, fss);
+      }   // s
+    }     // r
+
+    MatrixFree(&CRS);
+    MatrixFree(&RAS);
+    MatrixFree(&DeltaRAS);
+    MatrixFree(&DistortedRAS);
+    MatrixFree(&DistortedCRS);
+  }       // c
+}
+
+void GradUnwarp::_update_GCAMnode(int c, int r, int s, float fcs, float frs, float fss)
+{
+  GCA_MORPH_NODE *gcamn = &gcam->nodes[c][r][s];
+  gcamn->origx = c; gcamn->origy = r; gcamn->origz = s;
+  gcamn->x = fcs; gcamn->y = frs; gcamn->z = fss;
+}
+
+void GradUnwarp::load_transtable(const char* transfile)
+{
+  printf("GradUnwarp::load_transtable(%s) ...\n", transfile);
+  gcam = GCAMread(transfile);
+}
+
+void GradUnwarp::save_transtable(const char* transfile)
+{
+  printf("GradUnwarp::save_transtable(%s) ...\n", transfile);
+  GCAMwrite(gcam, transfile);
+}
+
+MRI *GradUnwarp::unwarp_volume(MRI *origvol, MRI *unwarpedvol, int interpcode, int sinchw)
+{
+  printf("GradUnwarp::unwarp_volume() ...\n");
+
+  int (*nintfunc)( double );
+  nintfunc = &nint;
+
+  if (unwarpedvol == NULL)
+  {
+    unwarpedvol = MRIallocSequence(origvol->width, origvol->height, origvol->depth, MRI_FLOAT, origvol->nframes);
+    MRIcopyHeader(origvol, unwarpedvol);
+    MRIcopyPulseParameters(origvol, unwarpedvol);
+  }
+
+  MRI_BSPLINE *bspline = NULL;
+  if (interpcode == SAMPLE_CUBIC_BSPLINE)
+    bspline = MRItoBSpline(origvol, NULL, 3);
+
+#ifdef HAVE_OPENMP
+  printf("\nSet OPEN MP NUM threads to %d (unwarp_volume)\n", nthreads);
+  omp_set_num_threads(nthreads);
+#endif
+
+  int c; 
+  int outofrange_total = 0;
+  int out_of_gcam;
+#ifdef HAVE_OPENMP
+#pragma omp parallel for reduction(+ : outofrange_total) 
+#endif
+  for (c = 0; c < origvol->width; c++)
+  {
+    int r = 0, s = 0;
+    //int outofrange_local = 0;
+    for (r = 0; r < origvol->height; r++)
+    {
+      for (s = 0; s < origvol->depth; s++)
+      {
+        float fcs = 0, frs = 0, fss = 0;
+        int ics = 0, irs = 0, iss = 0;
+
+        out_of_gcam = GCAMsampleMorph(gcam, (float)c, (float)r, (float)s, &fcs, &frs, &fss);
+
+        ics =  nintfunc(fcs);
+        irs =  nintfunc(frs);
+        iss =  nintfunc(fss);
+
+        if (ics < 0 || ics >= origvol->width  ||
+            irs < 0 || irs >= origvol->height || 
+            iss < 0 || iss >= origvol->depth)
+        {
+          outofrange_total++;
+#if 0
+#ifdef HAVE_OPENMP
+          outofrange_local++;
+#else
+          outofrange_total++;
+#endif
+#endif
+          continue;
+        }
+
+        _assignUnWarpedVolumeValues(origvol, unwarpedvol, bspline, interpcode, sinchw, c, r, s, fcs, frs, fss);
+      }   // s
+    }     // r
+
+#if 0
+#ifdef HAVE_OPENMP
+#pragma omp critical 
+    outofrange_total += outofrange_local; 
+    //printf("update out of range voxel count: + %d = %d\n", outofrange_local, outofrange_total);
+#endif
+#endif
+  }       // c
+
+  printf("Total %d voxels are out of range\n", outofrange_total);
+
+  if (bspline)
+    MRIfreeBSpline(&bspline);
+
+  return unwarpedvol;
+}
+
+void GradUnwarp::_assignUnWarpedVolumeValues(MRI* origvol, MRI* unwarpedvol, MRI_BSPLINE *bspline, int interpcode, int sinchw, 
+                                             int c, int r, int s, float fcs, float frs, float fss)
+{
+  int (*nintfunc)( double );
+  nintfunc = &nint;
+
+  int ics =  nintfunc(fcs);
+  int irs =  nintfunc(frs);
+  int iss =  nintfunc(fss);
+
+  if (interpcode == SAMPLE_TRILINEAR) {
+    float *valvect = new float[origvol->nframes];
+    MRIsampleSeqVolume(origvol, fcs, frs, fss, valvect, 0, origvol->nframes - 1);
+
+    int f;
+    for (f = 0; f < origvol->nframes; f++)
+      MRIsetVoxVal2(unwarpedvol, c, r, s, f, valvect[f]);
+
+    free(valvect);
+  } else {
+    double rval = 0;
+
+    int f;
+    for (f = 0; f < origvol->nframes; f++) {
+      switch (interpcode) {
+        case SAMPLE_NEAREST:
+          rval = MRIgetVoxVal2(origvol, ics, irs, iss, f);
+          break;
+        case SAMPLE_CUBIC_BSPLINE:
+          MRIsampleBSpline(bspline, fcs, frs, fss, f, &rval);
+          break;
+        case SAMPLE_SINC: /* no multi-frame */
+          MRIsincSampleVolume(origvol, fcs, frs, fss, sinchw, &rval);
+          break;
+        default:
+          printf("ERROR: MR: interpolation method '%i' unknown\n", interpcode);
+          exit(1);
+      } // switch
+
+      MRIsetVoxVal2(unwarpedvol, c, r, s, f, rval);
+    } // f
+  }
+}
+
+void GradUnwarp::unwarp_surface()
+{
 }
 
 void GradUnwarp::_skipCoeffComment()


### PR DESCRIPTION
1. transformation table (m3z) support in GradUnwarp - create, load, save the table
2. GradUnwarp method unwarp_volume() to apply the transformation to a MRI volume
3. adjust mris_gradient_unwarp.cpp accordingly