### PR TITLE
gradunwarp changes

### DIFF
--- a/include/GradUnwarp.h
+++ b/include/GradUnwarp.h
@@ -3,6 +3,7 @@
 
 #include "gcamorph.h"
 #include "mri.h"
+#include "vol_geom.h"
 
 typedef struct
 {
@@ -51,12 +52,13 @@ public:
   void  initSiemensLegendreNormfact();
   void  spharm_evaluate(float X, float Y, float Z, float *Dx, float *Dy, float *Dz);
 
-  void  create_transtable(MRI *origvol, MRI *unwarpedvol, MATRIX *vox2ras, MATRIX *inv_vox2ras);
+  void  create_transtable(VOL_GEOM *vg, MATRIX *vox2ras, MATRIX *inv_vox2ras);
   void  load_transtable(const char* morphfile);
   void  save_transtable(const char* morphfile);
 
   MRI*  unwarp_volume(MRI *origvol, MRI *unwarpedvol, int interpcode, int sinchw);
-  void  unwarp_surface();
+  MRIS* unwarp_surface_gradfile(MRIS *origsurf, MRIS *unwarpedsurf);
+  MRIS* unwarp_surface(MRIS *origsurf, MRIS *unwarpedsurf);
   
 private:
   int nthreads;

--- a/include/transform.h
+++ b/include/transform.h
@@ -24,8 +24,11 @@
 #include "const.h"
 #include "float.h"
 
+#include "vol_geom.h"
+
 typedef enum { MINC, TKREG, GENERIC, UNKNOWN=-1 } TransformType;
 
+#if 0
 typedef struct
 {
   int           valid;   /* whether this is a
@@ -43,6 +46,7 @@ typedef struct
   char          fname[STRLEN];  // volume filename
 }
 VOL_GEOM, VG;
+#endif
 
 typedef struct
 {

--- a/include/vol_geom.h
+++ b/include/vol_geom.h
@@ -1,0 +1,71 @@
+#ifndef VOL_GEOM_H
+#define VOL_GEOM_H
+
+//#include "gca.h"
+#include "mri.h"
+
+struct VOL_GEOM;
+
+struct VOL_GEOM
+{
+  int           valid;   /* whether this is a
+                                    valid info or not (1 valid, 0 not valid) */
+  int           width ;
+  int           height ;
+  int           depth ;
+  float         xsize ;
+  float         ysize ;
+  float         zsize ;
+  float         x_r, x_a, x_s;
+  float         y_r, y_a, y_s;
+  float         z_r, z_a, z_s;
+  float         c_r, c_a, c_s;
+  char          fname[STRLEN];  // volume filename
+
+  MATRIX *vox2ras;
+  MATRIX *ras2vox;
+  MATRIX *tkregvox2ras;
+  MATRIX *tkregras2vox;
+
+  VOL_GEOM(const char *srcVol = NULL);  // utils/transform.cpp:void initVolGeom(VOL_GEOM *vg)
+  ~VOL_GEOM();
+
+  void init();  // utils/transform.cpp:void initVolGeom(VOL_GEOM *vg)
+  void init_average_305();
+  void print();  // utils/transform.cpp:void vg_print(const VOL_GEOM *vg)
+  void copyFromMRI(const MRI *src); // utils/transform.cpp:void getVolGeom(const MRI *src, VOL_GEOM *dst)
+  void copyToMRI(MRI *dst);  // utils/transform.cpp:void useVolGeomToMRI(const VOL_GEOM *src, MRI *dst)
+  void write(FILE *fp);  // utils/transform.cpp:void writeVolGeom(FILE *fp, const VOL_GEOM *vg)
+  void read(FILE *fp);   // utils/transform.cpp:void readVolGeom(FILE *fp, VOL_GEOM *vg)
+  MATRIX *getVox2RAS(int base = 0);     // utils/transform.cpp:MATRIX *vg_i_to_r(const VOL_GEOM *vg)
+  MATRIX *getRAS2Vox(int base = 0);     // utils/transform.cpp:MATRIX *vg_r_to_i(const VOL_GEOM *vg)
+  MATRIX *getTkregVox2RAS(int base = 0);  // utils/transform.cpp:MATRIX *TkrVox2RASfromVolGeom(const VOL_GEOM *vg)
+  MATRIX *getTkregRAS2Vox(int base = 0);  // utils/transform.cpp:MATRIX *TkrRAS2VoxfromVolGeom(const VOL_GEOM *vg)
+  int isEqual(const VOL_GEOM* vg2); // utils/transform.cpp:int vg_isEqual(const VOL_GEOM *vg1, const VOL_GEOM *vg2)
+  int isNotEqualThresh(const VOL_GEOM *vg2, const double thresh);  // utils/transform.cpp:int vg_isNotEqualThresh(const VOL_GEOM *vg1, const VOL_GEOM *vg2, const double thresh)
+  //MATRIX *getVoxelToRasXform(int base = 0);  // utils/transform.cpp:MATRIX *VGgetVoxelToRasXform(VOL_GEOM *vg, MATRIX *m, int base)
+  //MATRIX *getRasToVoxelXform(int base = 0);  //utils/transform.cpp:MATRIX *VGgetRasToVoxelXform(VOL_GEOM *vg, MATRIX *m, int base)
+  MRI* allocMRI(int type, int nframes, int HeaderOnly);  // utils/transform.cpp:MRI *MRIallocFromVolGeom(VOL_GEOM *vg, int type, int nframes, int HeaderOnly)
+  void copy(VOL_GEOM *dst);  // utils/transform.cpp:void copyVolGeom(const VOL_GEOM *src, VOL_GEOM *dst)
+
+  // VOL_GEOM created with srcVol
+  // utils/transform.cpp:int mincFindVolume(const char *line, const char *line2, char **srcVol, char **dstVol)
+  // utils/transform.cpp:void mincGetVolumeInfo(const char *srcVol, VOL_GEOM *vgSrc)
+  // utils/transform.cpp:void mincGetVolInfo(const char *infoline, const char *infoline2, VOL_GEOM *vgSrc, VOL_GEOM *vgDst)
+
+  // utils/transform.cpp:static void LTAgetV2V(MATRIX *mod, VOL_GEOM *vgSrc, VOL_GEOM *vgDst)
+  // utils/transform.cpp:static void LTAgetR2R(MATRIX *mod, VOL_GEOM *vgSrc, VOL_GEOM *vgDst)
+  // utils/transform.cpp:int TransformGetSrcVolGeom(const TRANSFORM *transform, VOL_GEOM *vg)
+  // utils/transform.cpp:int TransformGetDstVolGeom(const TRANSFORM *transform, VOL_GEOM *vg)
+  // utils/transform.cpp:MRI *MRIallocFromVolGeom(VOL_GEOM *vg, int type, int nframes, int HeaderOnly)
+  // utils/transform.cpp:void copyVolGeom(const VOL_GEOM *src, VOL_GEOM *dst)
+
+  // utils/mri.cpp:int MRIcopyVolGeomToMRI(MRI *mri, const VOL_GEOM *vg)
+  // utils/mri.cpp:int MRIcopyVolGeomFromMRI(const MRI *mri, VOL_GEOM *vg)
+  //void setfrom(GCA *gca);  // utils/gca.cpp:void GCAsetVolGeom(GCA *gca, VOL_GEOM *vg)
+
+  // mri_modify/mri_modify.cpp:int get_option(int argc, char *argv[], VOL_GEOM &vg)
+};
+
+typedef VOL_GEOM VG;
+#endif

--- a/mris_gradient_unwarp/mris_gradient_unwarp.cpp
+++ b/mris_gradient_unwarp/mris_gradient_unwarp.cpp
@@ -13,38 +13,38 @@
 
 /* examples:
  *
- * unwarp at given crs
+ * unwarp at given crs (debugging)
  * 1. mris_gradient_unwarp/mris_gradient_unwarp 
  *    --gradcoeff $FS_TEST/gradunwarp/example/coeff_Sonata.grad 
- *    --invol $FS_TEST/gradunwarp/example/orig.mgz 
+ *    --i $FS_TEST/gradunwarp/example/orig.mgz 
  *    --crs 0,0,0
  *
- * unwarp for given ras
+ * unwarp for given ras (debugging)
  * 2. mris_gradient_unwarp/mris_gradient_unwarp 
  *    --gradcoeff $FS_TEST/gradunwarp/example/coeff_Sonata.grad 
- *    --invol $FS_TEST/gradunwarp/example/orig.mgz 
+ *    --i $FS_TEST/gradunwarp/example/orig.mgz 
  *    --ras 0.1,0.2,0.3
  *
- * save gradient unwarp transformation table
+ * create gradient unwarp transformation table
  * 3. mris_gradient_unwarp/mris_gradient_unwarp 
  *    --gradcoeff $FS_TEST/gradunwarp/example/coeff_Sonata.grad 
- *    --invol $FS_TEST/gradunwarp/example/orig.mgz 
+ *    --i $FS_TEST/gradunwarp/example/orig.mgz 
  *    --save_transtbl gradunwarp.m3z
  *    --nthreads 10
  *
  * transform given volume, save gradient unwarp transformation table
  * 4. mris_gradient_unwarp/mris_gradient_unwarp 
  *    --gradcoeff $FS_TEST/gradunwarp/example/coeff_Sonata.grad 
- *    --invol $FS_TEST/gradunwarp/example/orig.mgz 
- *    --outvol orig.unwarped.cubic.mgz --interp cubic 
+ *    --i $FS_TEST/gradunwarp/example/orig.mgz 
+ *    --o orig.unwarped.cubic.mgz --interp cubic --unwarpvol
  *    --save_transtbl gradunwarp.m3z
  *    --nthreads 10
  *
  * transform given volume using input gradient unwarp transformation table
  * 5. mris_gradient_unwarp/mris_gradient_unwarp 
  *    --load_transtbl $FS_TEST/gradunwarp/transtbl/savetbl/gradunwarp.m3z
- *    --invol $FS_TEST/gradunwarp/example/orig.mgz 
- *    --outvol orig.unwarped.cubic.mgz --interp cubic 
+ *    --i $FS_TEST/gradunwarp/example/orig.mgz 
+ *    --o orig.unwarped.cubic.mgz --interp cubic --unwarpvol
  *    --nthreads 10
  *
  */
@@ -75,10 +75,12 @@
  *     MATRIX *V = vg_getVoxelToRasXform(&surf->vg); // converts from voxel to RAS
  *     MATRIX *Q = MatrixMultiply(V,M,NULL); // convert from tkreg space to RAS
  *     DistortedRAS = MatrixMultiply(Q,tkRAS,DistortedCRS);
-       spharm_evaluate(Distx, Disty, Distz, &Dx, &Dy, &Dz);
-       v->x +/- Dx;
-       v->y +/- Dy;
-       v->z +/- Dz;
+ *     spharm_evaluate(Distx, Disty, Distz, &Dx, &Dy, &Dz);
+ *     v->x +/- Dx;
+ *     v->y +/- Dy;
+ *     v->z +/- Dz;
+ *
+ *  (include/transform.h:#define vg_getVoxelToRasXform vg_i_to_r)
  */
 
 static void dump_exit_codes(FILE *fp);
@@ -93,13 +95,14 @@ static void dump_options(FILE *fp);
 static int isflag(char *flag);
 static int nth_is_arg(int nargc, char **argv, int nth);
 
+static void printVolInfo(MRI *vol, MATRIX *vox2ras_orig, MATRIX *inv_vox2ras_orig);
 static void unwarpCRS(GradUnwarp *gradUnwarp, MATRIX *vox2ras, MATRIX *inv_vox2ras);
 
 int debug = 0, checkoptsonly = 0;
 const char *Progname = NULL;
-std::string gradfile_str, origmgz_str, unwarpedmgz_str, loadtrans_str, savetrans_str;
-const char *gradfile = NULL, *origmgz = NULL, *unwarpedmgz = NULL, *loadtrans = NULL, *savetrans = NULL;
-int inputras = 0, inputcrs = 0;
+std::string gradfile_str, inf_str, outf_str, loadtrans_str, savetrans_str;
+const char *gradfile = NULL, *invol = NULL, *insurf = NULL, *inf = NULL, *outf = NULL, *loadtrans = NULL, *savetrans = NULL;
+int inputras = 0, inputcrs = 0, unwarpvol = 0, unwarpsurf = 0;
 double ras_x, ras_y, ras_z;
 int crs_c = 0, crs_r = 0, crs_s = 0;
 const char *interpmethod = "trilinear";
@@ -142,58 +145,32 @@ int main(int argc, char *argv[])
 
   dump_options(stdout);
 
-  if (gradfile == NULL && loadtrans == NULL)
+  MRI *origvol = NULL;
+  MRIS *origsurf = NULL;
+  VOL_GEOM vg;
+  MATRIX *vox2ras_orig = NULL;
+  MATRIX *inv_vox2ras_orig = NULL;
+  if (invol != NULL)
   {
-    printf("Use --gradcoeff to specify gradient coeff file, \n");
-    printf(" or --load_transtbl to specify unwarp transformation table \n");
-    return 0; 
+    origvol = MRIread(invol);
+    if (origvol == NULL)
+      exit(1);
+
+    vox2ras_orig = extract_i_to_r(origvol);  //MRIxfmCRS2XYZ(origvol, 0);
+    inv_vox2ras_orig = MatrixInverse(vox2ras_orig, NULL);  //extract_r_to_i(origvol);
+
+    vg.copyFromMRI(origvol);
+
+    printVolInfo(origvol, vox2ras_orig, inv_vox2ras_orig);
   }
-
-  if (gradfile != NULL && loadtrans != NULL)
+  else if (insurf != NULL)
   {
-    printf("--gradcoeff and --load_transtbl are mutually excluded. \n");
-    printf("Use --gradcoeff to specify gradient coeff file, \n");
-    printf(" or --load_transtbl to specify unwarp transformation table \n");
-    return 0; 
-  }
+    origsurf = MRISread(insurf);
 
-  if (origmgz == NULL)
-  {
-    printf("Use --invol to specify input volumn\n");
-    return 0;
-  }
+    vox2ras_orig     = origsurf->vg.getVox2RAS();
+    inv_vox2ras_orig = origsurf->vg.getRAS2Vox();
 
-  MRI *origvol = MRIread(origmgz);
-
-  printf("\nVolume information for %s\n", origmgz);
-  if (origvol->nframes > 1)
-    printf("Dimensions: %d x %d x %d x %d\n", origvol->width, origvol->height, origvol->depth, origvol->nframes) ;
-  else
-    printf("Dimensions: %d x %d x %d\n", origvol->width, origvol->height, origvol->depth) ;
-  printf("Data Type: %s (%d)\n",
-         origvol->type == MRI_UCHAR   ? "UCHAR" :
-         origvol->type == MRI_SHORT   ? "SHORT" :
-	 origvol->type == MRI_USHRT   ? "USHRT" :
-         origvol->type == MRI_INT     ? "INT" :
-         origvol->type == MRI_LONG    ? "LONG" :
-         origvol->type == MRI_BITMAP  ? "BITMAP" :
-         origvol->type == MRI_TENSOR  ? "TENSOR" :
-         origvol->type == MRI_FLOAT   ? "FLOAT" : "UNKNOWN", origvol->type) ;
-
-  MATRIX *vox2ras_orig = extract_i_to_r(origvol);  //MRIxfmCRS2XYZ(origvol, 0);
-  printf("\nvoxel to ras transform:\n"); 
-  MatrixPrint(stdout, vox2ras_orig);
-
-  MATRIX *inv_vox2ras_orig = MatrixInverse(vox2ras_orig, NULL);  //extract_r_to_i(origvol);
-  printf("\nras to voxel transform:\n");
-  MatrixPrint(stdout, inv_vox2ras_orig);
-
-  MRI *unwarpedvol = NULL;
-  if (unwarpedmgz != NULL)
-  {
-    unwarpedvol = MRIallocSequence(origvol->width, origvol->height, origvol->depth, MRI_FLOAT, origvol->nframes);
-    MRIcopyHeader(origvol, unwarpedvol);
-    MRIcopyPulseParameters(origvol, unwarpedvol);
+    vg.copy(&origsurf->vg);
   }
 
   GradUnwarp *gradUnwarp = new GradUnwarp(nthreads);
@@ -227,34 +204,58 @@ int main(int argc, char *argv[])
       return 0;
     }
 
-    gradUnwarp->create_transtable(origvol, unwarpedvol, vox2ras_orig, inv_vox2ras_orig);
+    gradUnwarp->create_transtable(&vg, vox2ras_orig, inv_vox2ras_orig);
   }
   else
   {
     gradUnwarp->load_transtable(loadtrans);
   }
 
-  if (unwarpedvol != NULL)
+  if (unwarpvol)
   {
+    MRI *unwarpedvol = MRIallocSequence(origvol->width, origvol->height, origvol->depth, MRI_FLOAT, origvol->nframes);
+    MRIcopyHeader(origvol, unwarpedvol);
+    MRIcopyPulseParameters(origvol, unwarpedvol);
+
     gradUnwarp->unwarp_volume(origvol, unwarpedvol, interpcode, sinchw);
 
-    printf("Writing to %s\n", unwarpedmgz);
-    int err = MRIwrite(unwarpedvol, unwarpedmgz);
+    printf("Writing to %s\n", outf);
+    int err = MRIwrite(unwarpedvol, outf);
     if (err) 
       printf("something went wrong\n");
 
+    printf("unwarpvol done\n");
     MRIfree(&unwarpedvol);
+
+    printf("free vox2ras_orig ...\n");
+    MatrixFree(&vox2ras_orig);
+    printf("free inv_vox2ras_orig ...\n");
+    MatrixFree(&inv_vox2ras_orig);
+
+    MRIfree(&origvol);
+  }
+  else if (unwarpsurf)
+  {
+    if (getenv("USE_GRADFILE"))
+      gradUnwarp->unwarp_surface_gradfile(origsurf, origsurf);
+    else
+      gradUnwarp->unwarp_surface(origsurf, origsurf);
+
+    //origsurf->vg.copy(&unwarpedsurf->vg);
+
+    printf("Writing to %s\n", outf);
+    int err = MRISwrite(origsurf, outf);
+    if (err) 
+      printf("Erros outputing surface %s\n", outf);
+
+    MRISfree(&origsurf);
   }
 
   if (savetrans != NULL)
     gradUnwarp->save_transtable(savetrans);
 
+  printf("deleting graunwarp ...\n");
   delete gradUnwarp;
-
-  MatrixFree(&vox2ras_orig);
-  MatrixFree(&inv_vox2ras_orig);
-
-  MRIfree(&origvol);
 
   return 0;
 }
@@ -355,6 +356,7 @@ static int parse_commandline(int argc, char **argv) {
     else if (!strcasecmp(option, "--debug"))   debug = 1;
     else if (!strcasecmp(option, "--checkopts"))   checkoptsonly = 1;
     else if (!strcasecmp(option, "--nocheckopts")) checkoptsonly = 0;
+    /* these two options --ras, --crs are for debugging purposes only */
     else if (!strcmp(option, "--ras")) {
       inputras = 1;
       if (nargc < 1) CMDargNErr(option,1);
@@ -365,20 +367,25 @@ static int parse_commandline(int argc, char **argv) {
       if (nargc < 1) CMDargNErr(option,1);
       sscanf(pargv[0], "%d,%d,%d", &crs_c, &crs_r, &crs_s);
       nargsused = 1;
+    }
+    else if (!strcmp(option, "--unwarpvol")) {
+      unwarpvol = 1;
+    } else if (!strcmp(option, "--unwarpsurf")) {
+      unwarpsurf = 1;
     } else if (!strcmp(option, "--gradcoeff")) {
       if (nargc < 1) CMDargNErr(option,1);
       gradfile_str = fio_fullpath(pargv[0]);
       gradfile = gradfile_str.c_str();
       nargsused = 1;
-    } else if (!strcmp(option, "--invol")) {
+    } else if (!strcmp(option, "--i")) {
       if (nargc < 1) CMDargNErr(option,1);
-      origmgz_str = fio_fullpath(pargv[0]);
-      origmgz = origmgz_str.c_str();
+      inf_str = fio_fullpath(pargv[0]);
+      inf = inf_str.c_str();
       nargsused = 1;
-    } else if (!strcmp(option, "--outvol")) {
+    } else if (!strcmp(option, "--o")) {
       if (nargc < 1) CMDargNErr(option,1);
-      unwarpedmgz_str = fio_fullpath(pargv[0]);
-      unwarpedmgz = unwarpedmgz_str.c_str();
+      outf_str = fio_fullpath(pargv[0]);
+      outf = outf_str.c_str();
       nargsused = 1;
     } else if (!strcmp(option, "--load_transtbl")) {
       if (nargc < 1) CMDargNErr(option,1);
@@ -427,15 +434,15 @@ static void usage_exit(void) {
 static void print_usage(void) {
   printf("USAGE: %s \n",Progname) ;
   printf("\n");
-  printf("   --gradcoeff     gradient coeff input \n");
-  printf("   --load_transtbl load unwarp transform table in m3z format \n");
-  printf("   --invol         input volume \n");
-  printf("   --outvol        unwarped output volume \n");
+  printf("   --gradcoeff | --load_transtbl  gradient coeff input, or load unwarp transform table in m3z format \n");
+  printf("   --i                            input volume, or surface \n");
+  printf("   --o                            unwarped output volume, or surface \n");
+  printf("   --unwarpvol | --unwarpsurf     unwarp volume, or surface\n");
   printf("   --save_transtbl save unwarp transform table in m3z format \n");
   printf("\n");
-  printf("   --ras       x,y,z\n");
-  printf("   --crs       c,r,s\n");
-  printf("\n"); 
+  //printf("   --ras       x,y,z\n");
+  //printf("   --crs       c,r,s\n");
+  //printf("\n"); 
   printf("   --interp    interptype nearest | trilinear | sinc | cubic\n");
   printf("\n"); 
   printf("   --nthreads  nthreads : Set OPEN MP threads\n");
@@ -471,22 +478,66 @@ static void print_version(void) {
 }
 
 /* --------------------------------------------- */
-static void check_options(void) {
+static void check_options(void)
+{
+  if (gradfile == NULL && loadtrans == NULL)
+  {
+    printf("Use --gradcoeff to specify gradient coeff file, \n");
+    printf(" or --load_transtbl to specify unwarp transformation table \n");
+    exit(1); 
+  }
+
+  if (gradfile != NULL && loadtrans != NULL)
+  {
+    printf("--gradcoeff and --load_transtbl are mutually excluded. \n");
+    printf("Use --gradcoeff to specify gradient coeff file, \n");
+    printf(" or --load_transtbl to specify unwarp transformation table \n");
+    exit(1); 
+  }
+
+  if (unwarpvol && unwarpsurf)
+  {
+    printf("--unwarpvol and --unwarpsurf are mutually excluded.\n");
+    printf("Use --unwarpvol   to unwarp a volume \n");
+    printf(" or --unwarpsurf  to unwarp a surface\n");
+    exit(1); 
+  }
+
+  if (inf == NULL)
+  {
+    printf("Use --i to specify input volume or surface\n");
+    exit(1);
+  }
+
+  if ((inputcrs || inputras) && gradfile == NULL)
+  {
+    printf("Use --gradcoeff to specify gradient coeff file, \n");
+    exit(1);
+  }
+
+  if (unwarpvol || unwarpsurf)
+  {
+    if (outf == NULL)
+    {
+      printf("Use --o to specify output unwarped %s\n", (unwarpvol) ? "volume" : "surface");
+      exit(1);
+    }   
+  }
+
+  if (unwarpvol || inputcrs || gradfile != NULL)
+    invol = inf;
+
+  if (unwarpsurf)
+  {
+    insurf = inf;
+    invol = NULL;
+  }
+
   if (interpcode < 0) {
     printf("ERROR: interpolation method %s unrecognized\n",interpmethod);
     printf("       legal values are nearest, trilinear, sinc, and cubic\n");
     exit(1);
   }
-  /*if (vol1File.size() == 0) {
-    printf("ERROR: must specify a vol1 file\n");
-    exit(1);
-  }
-  if (vol2File.size() == 0) {
-    printf("ERROR: must specify a vol2 file\n");
-    exit(1);
-  }
-  return;
-  */
 }
 
 /* --------------------------------------------- */
@@ -531,4 +582,29 @@ static int nth_is_arg(int nargc, char **argv, int nth) {
   if (isflag(argv[nth])) return(0);
 
   return(1);
+}
+
+static void printVolInfo(MRI *vol, MATRIX *vox2ras_orig, MATRIX *inv_vox2ras_orig)
+{
+  printf("\nVolume information for %s\n", inf);
+  if (vol->nframes > 1)
+    printf("Dimensions: %d x %d x %d x %d\n", vol->width, vol->height, vol->depth, vol->nframes) ;
+  else
+    printf("Dimensions: %d x %d x %d\n", vol->width, vol->height, vol->depth) ;
+
+  printf("Data Type: %s (%d)\n",
+         vol->type == MRI_UCHAR   ? "UCHAR"  :
+         vol->type == MRI_SHORT   ? "SHORT"  :
+	 vol->type == MRI_USHRT   ? "USHRT"  :
+         vol->type == MRI_INT     ? "INT"    :
+         vol->type == MRI_LONG    ? "LONG"   :
+         vol->type == MRI_BITMAP  ? "BITMAP" :
+         vol->type == MRI_TENSOR  ? "TENSOR" :
+         vol->type == MRI_FLOAT   ? "FLOAT"  : "UNKNOWN", vol->type) ;
+
+  printf("\nvoxel to ras transform:\n"); 
+  MatrixPrint(stdout, vox2ras_orig);
+
+  printf("\nras to voxel transform:\n");
+  MatrixPrint(stdout, inv_vox2ras_orig);
 }

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -145,6 +145,7 @@ add_library(utils STATIC
   MRISrigidBodyAlignGlobal.cpp
   mris_sphshapepvf.cpp
   GradUnwarp.cpp
+  vol_geom.cpp
   mrisurf.cpp
   mrisurf_base.cpp
   mrisurf_compute_dxyz.cpp

--- a/utils/GradUnwarp.cpp
+++ b/utils/GradUnwarp.cpp
@@ -36,6 +36,14 @@ GradUnwarp::GradUnwarp(int nthreads0)
 
 GradUnwarp::~GradUnwarp()
 {
+  if (!Alpha_Beta_initialized)
+  {
+    if (gcam != NULL)
+      GCAMfree(&gcam);
+
+    return;
+  }
+
   int i;
   for (i = 0; i < coeffDim; i++)
   {
@@ -302,21 +310,16 @@ void GradUnwarp::printCoeff()
   }
 }
 
-void GradUnwarp::create_transtable(MRI *origvol, MRI *unwarpedvol, MATRIX *vox2ras, MATRIX *inv_vox2ras)
+void GradUnwarp::create_transtable(VOL_GEOM *vg, MATRIX *vox2ras, MATRIX *inv_vox2ras)
 {
   printf("GradUnwarp::create_transtable() ...\n");
   if (gcam != NULL)
     GCAMfree(&gcam);
 
-  gcam = GCAMalloc(origvol->width, origvol->height, origvol->depth);
+  gcam = GCAMalloc(vg->width, vg->height, vg->depth);
 
   // save volgeom orig and target
-  if (origvol != NULL)
-  {
-    MRI *targvol = unwarpedvol;
-    targvol = (targvol == NULL) ? origvol : targvol;
-    GCAMinitVolGeom(gcam, origvol, targvol);
-  }
+  //GCAMinitVolGeom(gcam, origvol, origvol);
 
 #ifdef HAVE_OPENMP
   printf("\nSet OPEN MP NUM threads to %d (create_transtable)\n", nthreads);
@@ -327,7 +330,7 @@ void GradUnwarp::create_transtable(MRI *origvol, MRI *unwarpedvol, MATRIX *vox2r
 #ifdef HAVE_OPENMP
 #pragma omp parallel for
 #endif
-  for (c = 0; c < origvol->width; c++)
+  for (c = 0; c < vg->width; c++)
   {
     // You could make a vector of CRS nthreads long
     MATRIX *CRS = MatrixAlloc(4, 1, MATRIX_REAL);
@@ -337,9 +340,9 @@ void GradUnwarp::create_transtable(MRI *origvol, MRI *unwarpedvol, MATRIX *vox2r
     MATRIX *DistortedCRS = MatrixAlloc(4, 1, MATRIX_REAL);
 
     int r = 0, s = 0;
-    for (r = 0; r < origvol->height; r++)
+    for (r = 0; r < vg->height; r++)
     {
-      for (s = 0; s < origvol->depth; s++)
+      for (s = 0; s < vg->depth; s++)
       {
         // clear CRS, RAS, DeltaRAS, DistortedRAS, DistortedCRS
         MatrixClear(CRS);
@@ -375,6 +378,8 @@ void GradUnwarp::create_transtable(MRI *origvol, MRI *unwarpedvol, MATRIX *vox2r
         float fcs = DistortedCRS->rptr[1][1];
         float frs = DistortedCRS->rptr[2][1];
         float fss = DistortedCRS->rptr[3][1];
+
+        //printf("%f => %f, %f => %f, %f => %f\n", (float)c, fcs, (float)r, frs, (float)s, fss);
 
         // update GCAM nodes
         _update_GCAMnode(c, r, s, fcs, frs, fss);
@@ -412,7 +417,7 @@ MRI *GradUnwarp::unwarp_volume(MRI *origvol, MRI *unwarpedvol, int interpcode, i
 {
   printf("GradUnwarp::unwarp_volume() ...\n");
 
-  int (*nintfunc)( double );
+   int (*nintfunc)( double );
   nintfunc = &nint;
 
   if (unwarpedvol == NULL)
@@ -469,6 +474,7 @@ MRI *GradUnwarp::unwarp_volume(MRI *origvol, MRI *unwarpedvol, int interpcode, i
           continue;
         }
 
+        //printf("%f => %f, %f => %f, %f => %f\n", (float)c, fcs, (float)r, frs, (float)s, fss);
         _assignUnWarpedVolumeValues(origvol, unwarpedvol, bspline, interpcode, sinchw, c, r, s, fcs, frs, fss);
       }   // s
     }     // r
@@ -534,8 +540,246 @@ void GradUnwarp::_assignUnWarpedVolumeValues(MRI* origvol, MRI* unwarpedvol, MRI
   }
 }
 
-void GradUnwarp::unwarp_surface()
+/*
+ * MRIS *surf = MRISread('lh.white');
+ * for n = 0:surf->nvertices-1
+ *  VERTEX *v = surf->vertices[n]
+ *     v->x, v->y, v->z // by default these are in the warped space
+ *     tkRAS->rptr[1][1] = v->x;
+ *     tkRAS->rptr[2][1] = v->y;
+ *     tkRAS->rptr[3][1] = v->z;
+ *     MATRIX *Tinv = TkrRAS2VoxfromVolGeom(&surf->vg); // convert from tkreg space to voxel
+ *     MATRIX *S = vg_i_to_r(&surf->vg); // converts from voxel to RAS
+ *     MATRIX *M = MatrixMultiply(S, Tinv, NULL); // convert from tkreg space to RAS
+ *     DistortedRAS = MatrixMultiply(M, tkRAS, DistortedCRS);
+ *     spharm_evaluate(Distx, Disty, Distz, &Dx, &Dy, &Dz);
+ *     v->x +/- Dx;
+ *     v->y +/- Dy;
+ *     v->z +/- Dz;
+ *
+ *  (include/transform.h:#define vg_getVoxelToRasXform vg_i_to_r)
+ */
+MRIS* GradUnwarp::unwarp_surface_gradfile(MRIS *origsurf, MRIS *unwarpedsurf)
 {
+  printf("GradUnwarp::unwarp_surface() ...\n");
+
+  if (unwarpedsurf == NULL)
+  {
+    unwarpedsurf = MRISalloc(origsurf->nvertices, 0);
+  }
+
+#ifdef HAVE_OPENMP
+  printf("\nSet OPEN MP NUM threads to %d (unwarp_surface)\n", nthreads);
+  omp_set_num_threads(nthreads);
+#endif
+
+  // to do: extract VOL_GEOM out of transform.h/transform.cpp
+  MATRIX *Tinv = origsurf->vg.getTkregRAS2Vox();       // tkreg space, RAS to VOX
+  MATRIX *S    = origsurf->vg.getVox2RAS();            // scanner space, VOX to RAS
+
+  //MATRIX *Tinv = TkrRAS2VoxfromVolGeom(&origsurf->vg); // tkreg space, RAS to VOX
+  //MATRIX *S    = vg_i_to_r(&origsurf->vg);             // scanner space, VOX to RAS
+  MATRIX *M    = MatrixMultiply(S, Tinv, NULL);        // RAS to RAS, tkreg space to scanner space
+    
+  MATRIX *Q    = origsurf->vg.getRAS2Vox();            // scanner space, RAS to VOX
+
+  int n; 
+#ifdef HAVE_OPENMP
+#pragma omp parallel for
+#endif
+  for (n = 0; n < origsurf->nvertices; n++)
+  {
+    VERTEX *v = &origsurf->vertices[n];
+
+    // v->x, v->y, v->z // by default these are in the warped space
+    MATRIX *tkregRAS = MatrixAlloc(4, 1, MATRIX_REAL);
+    tkregRAS->rptr[1][1] = v->x;
+    tkregRAS->rptr[2][1] = v->y;
+    tkregRAS->rptr[3][1] = v->z;
+    tkregRAS->rptr[4][1] = 1;
+
+    // Convert surface xyz coords from tkregister space to scanner space
+    MATRIX *warpedRAS = MatrixMultiply(M, tkregRAS, NULL);
+
+#if 0 // debug
+    // convert to surface xyz coords to CRS
+    //MATRIX *warpedCRS = MatrixMultiply(Tinv, tkregRAS, NULL);
+    MATRIX *warpedCRS = MatrixMultiply(Q, warpedRAS, NULL);
+#endif
+
+    // scanner space RAS
+    double Sx = warpedRAS->rptr[1][1];
+    double Sy = warpedRAS->rptr[2][1];
+    double Sz = warpedRAS->rptr[3][1];
+    
+    float  Dx = 0, Dy = 0, Dz = 0;
+    spharm_evaluate(Sx, Sy, Sz, &Dx, &Dy, &Dz);  // this will be replaced with m3z table lookup
+
+#if 0 // debug
+    MATRIX *DeltaRAS = MatrixAlloc(4, 1, MATRIX_REAL);
+    DeltaRAS->rptr[1][1] = Dx;
+    DeltaRAS->rptr[2][1] = Dy;
+    DeltaRAS->rptr[3][1] = Dz;
+    DeltaRAS->rptr[4][1] = 1; 
+    MATRIX *unwarpedRAS = MatrixAdd(warpedRAS, DeltaRAS, NULL);
+    MATRIX *unwarpedCRS = MatrixMultiply(Q, unwarpedRAS, NULL);
+
+    MATRIX *deltaCRS = MatrixAlloc(4, 1, MATRIX_REAL); 
+    deltaCRS = MatrixSubtract(unwarpedCRS, warpedCRS, NULL);
+    deltaCRS->rptr[4][1] = 1;
+
+    MATRIX *deltaRAS2 = MatrixMultiply(S, deltaCRS, NULL);
+#endif
+
+
+#if 0
+    printf("%d) (x=%f, y=%f, z=%f)\n", n, v->x, v->y, v->z);
+    printf("\t\t(Dc=%f (%f-%f), Dr=%f (%f-%f), Ds=%f (%f-%f))\n", 
+           deltaCRS->rptr[1][1], unwarpedCRS->rptr[1][1], warpedCRS->rptr[1][1], 
+           deltaCRS->rptr[2][1], unwarpedCRS->rptr[2][1], warpedCRS->rptr[2][1], 
+           deltaCRS->rptr[3][1], unwarpedCRS->rptr[3][1], warpedCRS->rptr[3][1]);
+    printf("\t\t(Dx =%f, Dy =%f, Dz =%f)\n", Dx, Dy, Dz);
+    printf("\t\t(Dx2=%f, Dy2=%f, Dz2=%f)\n", deltaRAS2->rptr[1][1], deltaRAS2->rptr[2][1], deltaRAS2->rptr[3][1]);
+
+    MatrixFree(&deltaRAS2);
+    MatrixFree(&deltaCRS);
+    MatrixFree(&unwarpedCRS);
+    MatrixFree(&unwarpedRAS);
+    MatrixFree(&DeltaRAS);
+    MatrixFree(&warpedCRS);
+#endif
+    
+    double x = v->x + Dx; // - Dx, warping
+    double y = v->y + Dy; // - Dy, warping
+    double z = v->z + Dz; // - Dz, warping
+
+    // set unwarped vertext xyz
+    MRISsetXYZ(unwarpedsurf, n, x, y, z);
+
+    MatrixFree(&warpedRAS);
+    MatrixFree(&tkregRAS);
+  }       // n
+
+  // Copy the volume geometry
+  //copyVolGeom(&(origsurf->vg), &(unwarpedsurf->vg));
+
+  MatrixFree(&Q);
+  MatrixFree(&M);
+  MatrixFree(&S);
+  MatrixFree(&Tinv);
+
+  return unwarpedsurf;
+}
+
+// using m3z transform table
+MRIS* GradUnwarp::unwarp_surface(MRIS *origsurf, MRIS *unwarpedsurf)
+{
+  int (*nintfunc)( double );
+  nintfunc = &nint;
+
+  printf("GradUnwarp::unwarp_surface2() ...\n");
+
+  if (unwarpedsurf == NULL)
+  {
+    unwarpedsurf = MRISalloc(origsurf->nvertices, 0);
+  }
+
+#ifdef HAVE_OPENMP
+  printf("\nSet OPEN MP NUM threads to %d (unwarp_surface)\n", nthreads);
+  omp_set_num_threads(nthreads);
+#endif
+
+  // to do: extract VOL_GEOM out of transform.h/transform.cpp
+  MATRIX *Tinv = origsurf->vg.getTkregRAS2Vox();       // tkreg space, RAS to VOX
+  MATRIX *S    = origsurf->vg.getVox2RAS();            // scanner space, VOX to RAS
+  MATRIX *M    = MatrixMultiply(S, Tinv, NULL);        // RAS to RAS, tkreg space to scanner space
+
+  int n; 
+  int outofrange_total = 0;
+#ifdef HAVE_OPENMP
+#pragma omp parallel for reduction(+ : outofrange_total) 
+#endif
+  for (n = 0; n < origsurf->nvertices; n++)
+  {
+    VERTEX *v = &origsurf->vertices[n];
+
+    // v->x, v->y, v->z // by default these are in the warped space
+    MATRIX *tkregRAS = MatrixAlloc(4, 1, MATRIX_REAL);;
+    tkregRAS->rptr[1][1] = v->x;
+    tkregRAS->rptr[2][1] = v->y;
+    tkregRAS->rptr[3][1] = v->z;
+    tkregRAS->rptr[4][1] = 1;
+
+    // Convert surface xyz coords from tkregister space to scanner space
+    MATRIX *warpedRAS = MatrixMultiply(M, tkregRAS, NULL);
+
+    // convert to surface xyz coords to CRS
+    MATRIX *warpedCRS = MatrixMultiply(Tinv, tkregRAS, NULL);
+
+    // warped CRS to unwarped CRS
+    float fcs = 0, frs = 0, fss = 0;
+    float c = warpedCRS->rptr[1][1];
+    float r = warpedCRS->rptr[2][1];
+    float s = warpedCRS->rptr[3][1];
+    GCAMsampleMorph(gcam, c, r, s, &fcs, &frs, &fss);
+
+    int ics =  nintfunc(fcs);
+    int irs =  nintfunc(frs);
+    int iss =  nintfunc(fss);
+
+    if (ics < 0 || ics >= origsurf->vg.width  ||
+        irs < 0 || irs >= origsurf->vg.height  || 
+        iss < 0 || iss >= origsurf->vg.depth)
+    {
+      outofrange_total++;
+      continue;
+    }
+
+    // convert delta CRS to delta RAS in scanner space
+    MATRIX *unwarpedCRS = MatrixAlloc(4, 1, MATRIX_REAL); 
+    unwarpedCRS->rptr[1][1] = fcs;
+    unwarpedCRS->rptr[2][1] = frs;
+    unwarpedCRS->rptr[3][1] = fss;
+    unwarpedCRS->rptr[4][1] = 1;
+
+    MATRIX *unwarpedRAS = MatrixMultiply(S, unwarpedCRS, NULL);
+
+    // scanner space RAS
+    MATRIX *deltaRAS = MatrixSubtract(unwarpedRAS, warpedRAS, NULL);
+
+    float Dx = deltaRAS->rptr[1][1];
+    float Dy = deltaRAS->rptr[2][1];
+    float Dz = deltaRAS->rptr[3][1];
+ 
+#if 0
+    printf("%d) (x=%f, y=%f, z=%f)\n", n, v->x, v->y, v->z);
+    printf("\t\t(Dc=(%f-%f), Dr=(%f-%f), Ds=(%f-%f))\n", 
+	   fcs, c, frs, r, fss, s);
+    printf("\t\t(Dx=%f, Dy=%f, Dz=%f)\n",  Dx, Dy, Dz);
+#endif
+    
+    double x = v->x + Dx; // - Dx, warping
+    double y = v->y + Dy; // - Dy, warping
+    double z = v->z + Dz; // - Dz, warping
+
+    // set unwarped vertext xyz
+    MRISsetXYZ(unwarpedsurf, n, x, y, z);
+
+    MatrixFree(&deltaRAS);
+    MatrixFree(&unwarpedRAS);
+    MatrixFree(&unwarpedCRS);
+    MatrixFree(&warpedRAS);
+    MatrixFree(&warpedCRS);
+    MatrixFree(&tkregRAS);
+  }       // n
+
+  // Copy the volume geometry
+  //copyVolGeom(&(origsurf->vg), &(unwarpedsurf->vg));
+
+  MatrixFree(&S);
+  MatrixFree(&Tinv);
+
+  return unwarpedsurf;
 }
 
 void GradUnwarp::_skipCoeffComment()

--- a/utils/vol_geom.cpp
+++ b/utils/vol_geom.cpp
@@ -1,0 +1,654 @@
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "log.h"
+#include "vol_geom.h"
+
+// utils/transform.cpp:void initVolGeom(VOL_GEOM *vg)
+VOL_GEOM::VOL_GEOM(const char *srcVol)
+{
+  vox2ras = NULL;
+  ras2vox = NULL;
+  tkregvox2ras = NULL;
+  tkregras2vox = NULL;
+
+  if (srcVol == NULL)
+  {
+    init();
+  }
+  else
+  {
+    struct stat stat_buf;
+
+    // check the existence of a file
+    int ret = stat(srcVol, &stat_buf);
+    if (ret != 0)
+    {
+      // srcVol doesn't exist
+      if (strstr(srcVol, "average_305"))
+      {
+        if (Gdiag & DIAG_SHOW && DIAG_VERBOSE_ON) printf("INFO: The transform was made with average_305.mnc.\n");
+
+        init_average_305();
+      }
+      else
+        init();
+    }
+    else  // srcVol exists
+    {
+      // note that both mri volume but also gca can be read
+      MRI *mri = MRIreadHeader((char *)srcVol, MRI_VOLUME_TYPE_UNKNOWN);
+      if (mri)  // find the MRI volume
+        copyFromMRI(mri);
+      else  // cound not find the volume
+        init();
+    }
+
+    // copy filename even if file does not exist to keep track
+    strcpy(fname, srcVol);
+  }
+}
+
+
+VOL_GEOM::~VOL_GEOM()
+{
+  if (vox2ras != NULL)
+    MatrixFree(&vox2ras);
+
+  if (ras2vox != NULL)
+    MatrixFree(&ras2vox);
+
+  if (tkregvox2ras != NULL)
+    MatrixFree(&tkregvox2ras);
+
+  if (tkregras2vox != NULL)
+    MatrixFree(&tkregras2vox);
+}
+
+// utils/transform.cpp:void initVolGeom(VOL_GEOM *vg)
+void VOL_GEOM::init()
+{
+  valid = 0;
+  width = 256;
+  height = 256;
+  depth = 256;
+  xsize = 1;
+  ysize = 1;
+  zsize = 1;
+  x_r = -1.;
+  x_a = 0.;
+  x_s = 0.;
+  y_r = 0.;
+  y_a = 0.;
+  y_s = -1.;
+  z_r = 0.;
+  z_a = 1.;
+  z_s = 0.;
+  c_r = 0.;
+  c_a = 0.;
+  c_s = 0.;
+  strcpy(fname, "unknown");  // initialized to be "unknown"
+}
+
+void VOL_GEOM::init_average_305()
+{
+  // average_305 value
+  width = 172;
+  height = 220;
+  depth = 156;
+  xsize = 1;
+  ysize = 1;
+  zsize = 1;
+  x_r = 1;
+  x_a = 0;
+  x_s = 0;
+  y_r = 0;
+  y_a = 1;
+  y_s = 0;
+  z_r = 0;
+  z_a = 0;
+  z_s = 1;
+  c_r = -0.0950;
+  c_a = -16.5100;
+  c_s = 9.7500;
+  valid = 1;
+}
+
+// utils/transform.cpp:void vg_print(const VOL_GEOM *vg)
+void VOL_GEOM::print()
+{
+  if (valid == 1) {
+    fprintf(stderr, "volume geometry:\n");
+    fprintf(stderr, "extent  : (%d, %d, %d)\n", width, height, depth);
+    fprintf(stderr, "voxel   : (%7.4f, %7.4f, %7.4f)\n", xsize, ysize, zsize);
+    fprintf(stderr, "x_(ras) : (%7.4f, %7.4f, %7.4f)\n", x_r, x_a, x_s);
+    fprintf(stderr, "y_(ras) : (%7.4f, %7.4f, %7.4f)\n", y_r, y_a, y_s);
+    fprintf(stderr, "z_(ras) : (%7.4f, %7.4f, %7.4f)\n", z_r, z_a, z_s);
+    fprintf(stderr, "c_(ras) : (%7.4f, %7.4f, %7.4f)\n", c_r, c_a, c_s);
+    fprintf(stderr, "file    : %s\n", fname);
+  }
+  else
+    fprintf(stderr,
+            "volume geometry info is either not contained "
+            "or not valid.\n");
+  fflush(stderr);
+}
+
+// utils/transform.cpp:void getVolGeom(const MRI *src, VOL_GEOM *dst)
+void VOL_GEOM::copyFromMRI(const MRI *src)
+{
+  if (!src) ErrorExit(ERROR_BADPARM, "must have a valid MRI (src)");
+
+  valid = 1;
+  width = src->width;
+  height = src->height;
+  depth = src->depth;
+  xsize = src->xsize;
+  ysize = src->ysize;
+  zsize = src->zsize;
+  x_r = src->x_r;
+  x_a = src->x_a;
+  x_s = src->x_s;
+  y_r = src->y_r;
+  y_a = src->y_a;
+  y_s = src->y_s;
+  z_r = src->z_r;
+  z_a = src->z_a;
+  z_s = src->z_s;
+  c_r = src->c_r;
+  c_a = src->c_a;
+  c_s = src->c_s;
+  strcpy(fname, src->fname);
+
+  vox2ras = NULL; ras2vox = NULL;
+  getVox2RAS();
+  getRAS2Vox();
+  
+}
+
+// utils/transform.cpp:void useVolGeomToMRI(const VOL_GEOM *src, MRI *dst)
+void VOL_GEOM::copyToMRI(MRI *dst)
+{
+  if (!dst) ErrorExit(ERROR_BADPARM, "must have a valid MRI (dst)");
+
+  dst->ras_good_flag = 1;
+  dst->width = width;
+  dst->height = height;
+  dst->depth = depth;
+  dst->xsize = xsize;
+  dst->ysize = ysize;
+  dst->zsize = zsize;
+  dst->x_r = x_r;
+  dst->x_a = x_a;
+  dst->x_s = x_s;
+  dst->y_r = y_r;
+  dst->y_a = y_a;
+  dst->y_s = y_s;
+  dst->z_r = z_r;
+  dst->z_a = z_a;
+  dst->z_s = z_s;
+  dst->c_r = c_r;
+  dst->c_a = c_a;
+  dst->c_s = c_s;
+  strcpy(dst->fname, fname);
+  // now we cache transform and thus we have to do the following whenever
+  // we change direction cosines
+  MRIreInitCache(dst);
+}
+
+// utils/transform.cpp:void writeVolGeom(FILE *fp, const VOL_GEOM *vg)
+void VOL_GEOM::write(FILE *fp)
+{
+  if (valid == 0)
+    fprintf(fp, "valid = %d  # volume info invalid\n", valid);
+  else
+    fprintf(fp, "valid = %d  # volume info valid\n", valid);
+  fprintf(fp, "filename = %s\n", fname);
+  fprintf(fp, "volume = %d %d %d\n", width, height, depth);
+  fprintf(fp, "voxelsize = %.15e %.15e %.15e\n", xsize, ysize, zsize);
+  fprintf(fp, "xras   = %.15e %.15e %.15e\n", x_r, x_a, x_s);
+  fprintf(fp, "yras   = %.15e %.15e %.15e\n", y_r, y_a, y_s);
+  fprintf(fp, "zras   = %.15e %.15e %.15e\n", z_r, z_a, z_s);
+  fprintf(fp, "cras   = %.15e %.15e %.15e\n", c_r, c_a, c_s);
+}
+
+// utils/transform.cpp:void readVolGeom(FILE *fp, VOL_GEOM *vg)
+void VOL_GEOM::read(FILE *fp)
+{
+  char line[STRLEN + 16];
+  char param[64];
+  char eq[2];
+  char buf[STRLEN];
+  int vgRead = 0;
+  char *p = 0;
+  int counter = 0;
+  long pos = 0;
+  int fail = 0;
+  while ((p = fgets(line, sizeof(line), fp)) && counter < 8) {
+    if (strlen(p) == 0) break;
+    sscanf(line, "%s %s %*s", param, eq);
+    if (!strcmp(param, "valid")) {
+      sscanf(line, "%s %s %d \n", param, eq, &valid);
+      vgRead = 1;
+      counter++;
+    }
+    else if (!strcmp(param, "filename")) {
+      // 1023 = STRLEN - 1
+      if (sscanf(line, "%s %s %1023s%*s\n", param, eq, buf) >= 3) {
+        strcpy(fname, buf);
+      }
+      counter++;
+    }
+    else if (!strcmp(param, "volume")) {
+      // rescan again
+      sscanf(line, "%s %s %d %d %d\n", param, eq, &width, &height, &depth);
+      counter++;
+    }
+    else if (!strcmp(param, "voxelsize")) {
+      // rescan again
+      sscanf(line, "%s %s %f %f %f\n", param, eq, &xsize, &ysize, &zsize);
+      counter++;
+    }
+    else if (!strcmp(param, "xras")) {
+      sscanf(line, "%s %s %f %f %f\n", param, eq, &x_r, &x_a, &x_s);
+      counter++;
+    }
+    else if (!strcmp(param, "yras")) {
+      sscanf(line, "%s %s %f %f %f\n", param, eq, &y_r, &y_a, &y_s);
+      counter++;
+    }
+    else if (!strcmp(param, "zras")) {
+      sscanf(line, "%s %s %f %f %f\n", param, eq, &z_r, &z_a, &z_s);
+      counter++;
+    }
+    else if (!strcmp(param, "cras")) {
+      sscanf(line, "%s %s %f %f %f\n", param, eq, &c_r, &c_a, &c_s);
+      counter++;
+    }
+    // remember the current position
+    pos = ftell(fp);  // if fail = 0, then ok
+  }
+  if (p)  // we read one more line
+  {
+    if (pos > 0)                        // if success in getting pos, then
+      fail = fseek(fp, pos, SEEK_SET);  // restore the position
+    // note that this won't allow compression using pipe
+  }
+  if (!vgRead) {
+    fprintf(stderr, "INFO: volume info was not present.\n");
+    init();
+  }
+}
+
+// utils/transform.cpp:MATRIX *vg_i_to_r(const VOL_GEOM *vg)
+// #define vg_getVoxelToRasXform vg_i_to_r
+// scanner space vox2ras from vol geom
+#if 0
+MATRIX* VOL_GEOM::getVox2RAS()
+{ 
+  MATRIX *mat = 0;
+  MRI *tmp = 0;
+  tmp = MRIallocHeader(width, height, depth, MRI_UCHAR, 1);
+  copyToMRI(tmp);
+  mat = extract_i_to_r(tmp);
+  MRIfree(&tmp);
+  return mat;
+}
+
+// utils/transform.cpp:MATRIX *vg_r_to_i(const VOL_GEOM *vg)
+// #define vg_getRasToVoxelXform vg_r_to_i
+MATRIX* VOL_GEOM::getRAS2Vox()
+{
+  MATRIX *mat = 0;
+  MRI *tmp = 0;
+  tmp = MRIallocHeader(width, height, depth, MRI_UCHAR, 1);
+  copyToMRI(tmp);
+  mat = extract_r_to_i(tmp);
+  MRIfree(&tmp);
+  return mat;
+}
+
+// utils/transform.cpp:MATRIX *TkrVox2RASfromVolGeom(const VOL_GEOM *vg)
+// tkregister space vox2ras from vol geom
+MATRIX* VOL_GEOM::getTkregVox2RAS()
+{
+  MATRIX *mat = NULL;
+  MRI *tmp = 0;
+  tmp = MRIallocHeader(width, height, depth, MRI_UCHAR, 1);
+  copyToMRI(tmp);
+  mat = MRIxfmCRS2XYZtkreg(tmp);
+  MRIfree(&tmp);
+  return (mat);
+}
+
+// utils/transform.cpp:MATRIX *TkrRAS2VoxfromVolGeom(const VOL_GEOM *vg)
+// tkregister space ras2vox from vol geom
+MATRIX* VOL_GEOM::getTkregRAS2Vox()
+{ 
+  MATRIX *mat = NULL;
+  mat = getTkrVox2RAS();
+  mat = MatrixInverse(mat, mat);
+  return (mat);                                                 
+}
+#endif
+
+// utils/transform.cpp:int vg_isEqual(const VOL_GEOM *vg1, const VOL_GEOM *vg2)
+int VOL_GEOM::isEqual(const VOL_GEOM* vg2)
+{
+  int rt;
+  extern double vg_isEqual_Threshold;
+  // rt = vg_isEqualThresh(vg1, vg2, FLT_EPSILON);
+  rt = isNotEqualThresh(vg2, vg_isEqual_Threshold);
+  if (rt == 0)
+    return (1);
+  else
+    return (0);
+}
+
+// utils/transform.cpp:int vg_isNotEqualThresh(const VOL_GEOM *vg1, const VOL_GEOM *vg2, const double thresh)
+int VOL_GEOM::isNotEqualThresh(const VOL_GEOM *vg2, const double thresh)
+{
+  if (valid != vg2->valid) return (1);
+  if (width != vg2->width) return (2);
+  if (height != vg2->height) return (3);
+  if (depth != vg2->depth) return (4);
+  if (!FZEROTHR(xsize - vg2->xsize, thresh)) return (5);
+  if (!FZEROTHR(ysize - vg2->ysize, thresh)) return (6);
+  if (!FZEROTHR(zsize - vg2->zsize, thresh)) return (7);
+  if (!FZEROTHR(x_r - vg2->x_r, thresh)) return (8);
+  if (!FZEROTHR(x_a - vg2->x_a, thresh)) return (9);
+  if (!FZEROTHR(x_s - vg2->x_s, thresh)) return (10);
+  if (!FZEROTHR(y_r - vg2->y_r, thresh)) return (11);
+  if (!FZEROTHR(y_a - vg2->y_a, thresh)) return (12);
+  if (!FZEROTHR(y_s - vg2->y_s, thresh)) return (13);
+  if (!FZEROTHR(z_r - vg2->z_r, thresh)) return (14);
+  if (!FZEROTHR(z_a - vg2->z_a, thresh)) return (15);
+  if (!FZEROTHR(z_s - vg2->z_s, thresh)) return (16);
+  if (!FZEROTHR(c_r - vg2->c_r, thresh)) return (17);
+  if (!FZEROTHR(c_a - vg2->c_a, thresh)) return (18);
+  if (!FZEROTHR(c_s - vg2->c_s, thresh)) return (19);
+  return (0);
+}
+
+// utils/transform.cpp:MATRIX *VGgetVoxelToRasXform(VOL_GEOM *vg, MATRIX *m, int base)
+/*----------------------------------------------------------
+  MRIxfmCRS2XYZ() - computes the matrix needed to compute the
+  XYZ of the center of a voxel at a given Col, Row, and Slice
+  from the native geometry of the volume (ie, native or scanner
+  Vox2RAS matrix).
+
+  x         col
+  y  = T *  row
+  z        slice
+  1          1
+
+  T = [Mdc*D Pxyz0]
+  [0 0 0   1  ]
+
+  Mdc = [Vcol Vrow Vslice]
+  V<dim> = the direction cosine pointing from the center of one voxel
+  to the center of an adjacent voxel in the next dim, where
+  dim is either colum, row, or slice. Vcol = [x_r x_a x_s],
+  Vrow = [y_r y_a y_s], Vslice = [z_r z_a z_s]. Vcol can also
+  be described as the vector normal to the plane formed by
+  the rows and slices of a given column (ie, the column normal).
+
+  D = diag([colres rowres sliceres])
+  dimres = the distance between adjacent dim, where colres = mri->xsize,
+  rowres = mri->ysize, and sliceres = mri->zsize.
+
+  Pxyz0 = the XYZ location at CRS=0. This number is not part of the
+  mri structure, so it is computed here according to the formula:
+  Pxyz0 = PxyzCenter - Mdc*D*PcrsCenter
+
+  PcrsCenter = the col, row, and slice at the center of the volume,
+  = [ ncols/2 nrows/2 nslices/2 ]
+
+  PxyzCenter = the X, Y, and Z at the center of the volume and does
+  exist in the header as mri->c_r, mri->c_a, and mri->c_s,
+  respectively.
+
+  Note: to compute the matrix with respect to the first voxel being
+  at CRS 1,1,1 instead of 0,0,0, then set base = 1. This is
+  necessary with SPM matrices.
+
+  See also: MRIxfmCRS2XYZtkreg, MRItkReg2Native, extract_i_to_r().
+  surfaceRASFromVoxel_(MRI *mri), voxelFromSurfaceRAS_().
+
+  Note: MRIgetVoxelToRasXform is #defined to be extract_i_to_r().
+  ----------------------------------------------------------------*/
+//MATRIX* VOL_GEOM::getVoxelToRasXform(int base)
+MATRIX* VOL_GEOM::getVox2RAS(int base)
+{
+  if (vox2ras != NULL)
+    return vox2ras;
+
+  MATRIX *PxyzOffset, *Pcrs;
+
+  vox2ras = MatrixAlloc(4, 4, MATRIX_REAL);
+
+  /* direction cosine between columns scaled by
+     distance between colums */
+  *MATRIX_RELT(vox2ras, 1, 1) = (double)x_r * xsize;
+  *MATRIX_RELT(vox2ras, 2, 1) = (double)x_a * xsize;
+  *MATRIX_RELT(vox2ras, 3, 1) = (double)x_s * xsize;
+
+  /* direction cosine between rows scaled by
+     distance between rows */
+  *MATRIX_RELT(vox2ras, 1, 2) = (double)y_r * ysize;
+  *MATRIX_RELT(vox2ras, 2, 2) = (double)y_a * ysize;
+  *MATRIX_RELT(vox2ras, 3, 2) = (double)y_s * ysize;
+
+  /* direction cosine between slices scaled by
+     distance between slices */
+  *MATRIX_RELT(vox2ras, 1, 3) = (double)z_r * zsize;
+  *MATRIX_RELT(vox2ras, 2, 3) = (double)z_a * zsize;
+  *MATRIX_RELT(vox2ras, 3, 3) = (double)z_s * zsize;
+
+  /* Preset the offsets to 0 */
+  *MATRIX_RELT(vox2ras, 1, 4) = 0.0;
+  *MATRIX_RELT(vox2ras, 2, 4) = 0.0;
+  *MATRIX_RELT(vox2ras, 3, 4) = 0.0;
+
+  /* Last row of matrix */
+  *MATRIX_RELT(vox2ras, 4, 1) = 0.0;
+  *MATRIX_RELT(vox2ras, 4, 2) = 0.0;
+  *MATRIX_RELT(vox2ras, 4, 3) = 0.0;
+  *MATRIX_RELT(vox2ras, 4, 4) = 1.0;
+
+  /* At this point, m = Mdc * D */
+
+  /* Col, Row, Slice at the Center of the Volume */
+  Pcrs = MatrixAlloc(4, 1, MATRIX_REAL);
+  *MATRIX_RELT(Pcrs, 1, 1) = (double)width / 2.0 + base;
+  *MATRIX_RELT(Pcrs, 2, 1) = (double)height / 2.0 + base;
+  *MATRIX_RELT(Pcrs, 3, 1) = (double)depth / 2.0 + base;
+  *MATRIX_RELT(Pcrs, 4, 1) = 1.0;
+
+  /* XYZ offset the first Col, Row, and Slice from Center */
+  /* PxyzOffset = Mdc*D*PcrsCenter */
+  PxyzOffset = MatrixMultiply(vox2ras, Pcrs, NULL);
+
+  /* XYZ at the Center of the Volume is c_r, c_a, c_s  */
+
+  /* The location of the center of the voxel at CRS = (0,0,0)*/
+  *MATRIX_RELT(vox2ras, 1, 4) = (double)c_r - PxyzOffset->rptr[1][1];
+  *MATRIX_RELT(vox2ras, 2, 4) = (double)c_a - PxyzOffset->rptr[2][1];
+  *MATRIX_RELT(vox2ras, 3, 4) = (double)c_s - PxyzOffset->rptr[3][1];
+
+  MatrixFree(&Pcrs);
+  MatrixFree(&PxyzOffset);
+
+  return (vox2ras);
+}
+
+//utils/transform.cpp:MATRIX *VGgetRasToVoxelXform(VOL_GEOM *vg, MATRIX *m, int base)
+//MATRIX* VOL_GEOM::getRasToVoxelXform(int base)
+MATRIX* VOL_GEOM::getRAS2Vox(int base)
+{
+  if (ras2vox != NULL)
+    return ras2vox;
+
+  if (vox2ras == NULL)
+    vox2ras = getVox2RAS(base);
+
+  ras2vox = MatrixInverse(vox2ras, ras2vox);
+
+  return (ras2vox);
+}
+
+MATRIX* VOL_GEOM::getTkregVox2RAS(int base)
+{
+  if (tkregvox2ras != NULL)
+    return tkregvox2ras;
+
+  
+  MATRIX *PxyzOffset, *Pcrs;
+
+  tkregvox2ras = MatrixAlloc(4, 4, MATRIX_REAL);
+
+  float x_r_tkreg = -1;
+  float y_r_tkreg = 0;
+  float z_r_tkreg = 0;
+  float c_r_tkreg = 0.0;
+  float x_a_tkreg = 0;
+  float y_a_tkreg = 0;
+  float z_a_tkreg = 1;
+  float c_a_tkreg = 0.0;
+  float x_s_tkreg = 0;
+  float y_s_tkreg = -1;
+  float z_s_tkreg = 0;
+  float c_s_tkreg = 0.0;
+
+  /* direction cosine between columns scaled by
+     distance between colums */
+  *MATRIX_RELT(tkregvox2ras, 1, 1) = (double)x_r_tkreg * xsize;
+  *MATRIX_RELT(tkregvox2ras, 2, 1) = (double)x_a_tkreg * xsize;
+  *MATRIX_RELT(tkregvox2ras, 3, 1) = (double)x_s_tkreg * xsize;
+
+  /* direction cosine between rows scaled by
+     distance between rows */
+  *MATRIX_RELT(tkregvox2ras, 1, 2) = (double)y_r_tkreg * ysize;
+  *MATRIX_RELT(tkregvox2ras, 2, 2) = (double)y_a_tkreg * ysize;
+  *MATRIX_RELT(tkregvox2ras, 3, 2) = (double)y_s_tkreg * ysize;
+
+  /* direction cosine between slices scaled by
+     distance between slices */
+  *MATRIX_RELT(tkregvox2ras, 1, 3) = (double)z_r_tkreg * zsize;
+  *MATRIX_RELT(tkregvox2ras, 2, 3) = (double)z_a_tkreg * zsize;
+  *MATRIX_RELT(tkregvox2ras, 3, 3) = (double)z_s_tkreg * zsize;
+
+  /* Preset the offsets to 0 */
+  *MATRIX_RELT(tkregvox2ras, 1, 4) = 0.0;
+  *MATRIX_RELT(tkregvox2ras, 2, 4) = 0.0;
+  *MATRIX_RELT(tkregvox2ras, 3, 4) = 0.0;
+
+  /* Last row of matrix */
+  *MATRIX_RELT(tkregvox2ras, 4, 1) = 0.0;
+  *MATRIX_RELT(tkregvox2ras, 4, 2) = 0.0;
+  *MATRIX_RELT(tkregvox2ras, 4, 3) = 0.0;
+  *MATRIX_RELT(tkregvox2ras, 4, 4) = 1.0;
+
+  /* At this point, m = Mdc * D */
+
+  /* Col, Row, Slice at the Center of the Volume */
+  Pcrs = MatrixAlloc(4, 1, MATRIX_REAL);
+  *MATRIX_RELT(Pcrs, 1, 1) = (double)width / 2.0 + base;
+  *MATRIX_RELT(Pcrs, 2, 1) = (double)height / 2.0 + base;
+  *MATRIX_RELT(Pcrs, 3, 1) = (double)depth / 2.0 + base;
+  *MATRIX_RELT(Pcrs, 4, 1) = 1.0;
+
+  /* XYZ offset the first Col, Row, and Slice from Center */
+  /* PxyzOffset = Mdc*D*PcrsCenter */
+  PxyzOffset = MatrixMultiply(tkregvox2ras, Pcrs, NULL);
+
+  /* XYZ at the Center of the Volume is c_r, c_a, c_s  */
+
+  /* The location of the center of the voxel at CRS = (0,0,0)*/
+  *MATRIX_RELT(tkregvox2ras, 1, 4) = (double)c_r_tkreg - PxyzOffset->rptr[1][1];
+  *MATRIX_RELT(tkregvox2ras, 2, 4) = (double)c_a_tkreg - PxyzOffset->rptr[2][1];
+  *MATRIX_RELT(tkregvox2ras, 3, 4) = (double)c_s_tkreg - PxyzOffset->rptr[3][1];
+
+  MatrixFree(&Pcrs);
+  MatrixFree(&PxyzOffset);
+
+  return (tkregvox2ras);
+}
+
+//utils/transform.cpp:MATRIX *VGgetRasToVoxelXform(VOL_GEOM *vg, MATRIX *m, int base)
+//MATRIX* VOL_GEOM::getRasToVoxelXform(int base)
+MATRIX* VOL_GEOM::getTkregRAS2Vox(int base)
+{
+  if (tkregras2vox != NULL)
+    return tkregras2vox;
+
+  if (tkregvox2ras == NULL)
+    tkregvox2ras = getTkregVox2RAS(base);
+
+  tkregras2vox = MatrixInverse(tkregvox2ras, tkregras2vox);
+
+  return tkregras2vox;
+}
+
+// utils/transform.cpp:MRI *MRIallocFromVolGeom(VOL_GEOM *vg, int type, int nframes, int HeaderOnly)
+// Creates an MRI from this VOL_GEOM, copying the geometry info
+MRI* VOL_GEOM::allocMRI(int type, int nframes, int HeaderOnly)
+{
+  MRI *mri;
+  if (HeaderOnly)
+    mri = MRIallocHeader(width, height, depth, type, nframes);
+  else
+    mri = MRIallocSequence(width, height, depth, type, nframes);
+  if (mri) copyToMRI(mri);
+  return (mri);
+}
+
+// utils/transform.cpp:void copyVolGeom(const VOL_GEOM *src, VOL_GEOM *dst)
+void  VOL_GEOM::copy(VOL_GEOM *dst)
+{
+  dst->valid = valid;
+  dst->width = width;
+  dst->height = height;
+  dst->depth = depth;
+  dst->xsize = xsize;
+  dst->ysize = ysize;
+  dst->zsize = zsize;
+  dst->x_r = x_r;
+  dst->x_a = x_a;
+  dst->x_s = x_s;
+  dst->y_r = y_r;
+  dst->y_a = y_a;
+  dst->y_s = y_s;
+  dst->z_r = z_r;
+  dst->z_a = z_a;
+  dst->z_s = z_s;
+  dst->c_r = c_r;
+  dst->c_a = c_a;
+  dst->c_s = c_s;
+  strcpy(dst->fname, fname);
+
+  // copy transform matrix too???
+  // ...
+}
+
+// VOL_GEOM created with srcVol
+// utils/transform.cpp:int mincFindVolume(const char *line, const char *line2, char **srcVol, char **dstVol)
+// utils/transform.cpp:void mincGetVolumeInfo(const char *srcVol, VOL_GEOM *vgSrc)
+// utils/transform.cpp:void mincGetVolInfo(const char *infoline, const char *infoline2, VOL_GEOM *vgSrc, VOL_GEOM *vgDst)
+
+// utils/transform.cpp:static void LTAgetV2V(MATRIX *mod, VOL_GEOM *vgSrc, VOL_GEOM *vgDst)
+// utils/transform.cpp:static void LTAgetR2R(MATRIX *mod, VOL_GEOM *vgSrc, VOL_GEOM *vgDst)
+
+
+
+// utils/transform.cpp:int TransformGetSrcVolGeom(const TRANSFORM *transform, VOL_GEOM *vg)
+// utils/transform.cpp:int TransformGetDstVolGeom(const TRANSFORM *transform, VOL_GEOM *vg)
+
+// utils/mri.cpp:int MRIcopyVolGeomToMRI(MRI *mri, const VOL_GEOM *vg)
+// utils/mri.cpp:int MRIcopyVolGeomFromMRI(const MRI *mri, VOL_GEOM *vg)
+
+
+// mri_modify/mri_modify.cpp:int get_option(int argc, char *argv[], VOL_GEOM &vg)
+
+// utils/gca.cpp:void GCAsetVolGeom(GCA *gca, VOL_GEOM *vg)


### PR DESCRIPTION
1. extract struct VOL_GEOM and related functions from transform.h/transform.cpp
   into vol_geom.h/vol_geom.cpp. Duplicated functions in transform.cpp will be
   removed after we move all applications to use vol_geom.h/vol_geom.cpp
2. implement unwarp_surface() and unwarp_surface_gradfile() in GradUnwarp class
3. implement --unwarpsurf option in mris_gradient_unwarp.cpp