### PR TITLE
use VOL_GEOM functions in transform.cpp

### DIFF
--- a/include/GradUnwarp.h
+++ b/include/GradUnwarp.h
@@ -3,7 +3,7 @@
 
 #include "gcamorph.h"
 #include "mri.h"
-#include "vol_geom.h"
+//#include "vol_geom.h"
 
 typedef struct
 {

--- a/include/transform.h
+++ b/include/transform.h
@@ -24,11 +24,8 @@
 #include "const.h"
 #include "float.h"
 
-#include "vol_geom.h"
-
 typedef enum { MINC, TKREG, GENERIC, UNKNOWN=-1 } TransformType;
 
-#if 0
 typedef struct
 {
   int           valid;   /* whether this is a
@@ -46,7 +43,6 @@ typedef struct
   char          fname[STRLEN];  // volume filename
 }
 VOL_GEOM, VG;
-#endif
 
 typedef struct
 {

--- a/include/vol_geom.h
+++ b/include/vol_geom.h
@@ -1,7 +1,6 @@
 #ifndef VOL_GEOM_H
 #define VOL_GEOM_H
 
-//#include "gca.h"
 #include "mri.h"
 
 struct VOL_GEOM;
@@ -68,4 +67,5 @@ struct VOL_GEOM
 };
 
 typedef VOL_GEOM VG;
+
 #endif

--- a/mris_gradient_unwarp/mris_gradient_unwarp.cpp
+++ b/mris_gradient_unwarp/mris_gradient_unwarp.cpp
@@ -159,7 +159,8 @@ int main(int argc, char *argv[])
     vox2ras_orig = extract_i_to_r(origvol);  //MRIxfmCRS2XYZ(origvol, 0);
     inv_vox2ras_orig = MatrixInverse(vox2ras_orig, NULL);  //extract_r_to_i(origvol);
 
-    vg.copyFromMRI(origvol);
+    //vg.copyFromMRI(origvol);  // vol_geom.cpp
+    getVolGeom(origvol, &vg);
 
     printVolInfo(origvol, vox2ras_orig, inv_vox2ras_orig);
   }
@@ -167,10 +168,13 @@ int main(int argc, char *argv[])
   {
     origsurf = MRISread(insurf);
 
-    vox2ras_orig     = origsurf->vg.getVox2RAS();
-    inv_vox2ras_orig = origsurf->vg.getRAS2Vox();
+    //vox2ras_orig     = origsurf->vg.getVox2RAS();
+    //inv_vox2ras_orig = origsurf->vg.getRAS2Vox();
+    //vg.copy(&origsurf->vg);  // vol_geom.cpp
 
-    vg.copy(&origsurf->vg);
+    vox2ras_orig     = vg_i_to_r(&origsurf->vg);
+    inv_vox2ras_orig = vg_r_to_i(&origsurf->vg);
+    copyVolGeom(&origsurf->vg, &vg);
   }
 
   GradUnwarp *gradUnwarp = new GradUnwarp(nthreads);

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -145,7 +145,7 @@ add_library(utils STATIC
   MRISrigidBodyAlignGlobal.cpp
   mris_sphshapepvf.cpp
   GradUnwarp.cpp
-  vol_geom.cpp
+  #vol_geom.cpp
   mrisurf.cpp
   mrisurf_base.cpp
   mrisurf_compute_dxyz.cpp

--- a/utils/GradUnwarp.cpp
+++ b/utils/GradUnwarp.cpp
@@ -574,14 +574,15 @@ MRIS* GradUnwarp::unwarp_surface_gradfile(MRIS *origsurf, MRIS *unwarpedsurf)
 #endif
 
   // to do: extract VOL_GEOM out of transform.h/transform.cpp
-  MATRIX *Tinv = origsurf->vg.getTkregRAS2Vox();       // tkreg space, RAS to VOX
-  MATRIX *S    = origsurf->vg.getVox2RAS();            // scanner space, VOX to RAS
+  //MATRIX *Tinv = origsurf->vg.getTkregRAS2Vox();       // tkreg space, RAS to VOX
+  //MATRIX *S    = origsurf->vg.getVox2RAS();            // scanner space, VOX to RAS
+  //MATRIX *Q    = origsurf->vg.getRAS2Vox();            // scanner space, RAS to VOX
 
-  //MATRIX *Tinv = TkrRAS2VoxfromVolGeom(&origsurf->vg); // tkreg space, RAS to VOX
-  //MATRIX *S    = vg_i_to_r(&origsurf->vg);             // scanner space, VOX to RAS
+  MATRIX *Tinv = TkrRAS2VoxfromVolGeom(&origsurf->vg); // tkreg space, RAS to VOX
+  MATRIX *S    = vg_i_to_r(&origsurf->vg);             // scanner space, VOX to RAS
   MATRIX *M    = MatrixMultiply(S, Tinv, NULL);        // RAS to RAS, tkreg space to scanner space
     
-  MATRIX *Q    = origsurf->vg.getRAS2Vox();            // scanner space, RAS to VOX
+  MATRIX *Q    = vg_r_to_i(&origsurf->vg);             // scanner space, RAS to VOX
 
   int n; 
 #ifdef HAVE_OPENMP
@@ -690,8 +691,12 @@ MRIS* GradUnwarp::unwarp_surface(MRIS *origsurf, MRIS *unwarpedsurf)
 #endif
 
   // to do: extract VOL_GEOM out of transform.h/transform.cpp
-  MATRIX *Tinv = origsurf->vg.getTkregRAS2Vox();       // tkreg space, RAS to VOX
-  MATRIX *S    = origsurf->vg.getVox2RAS();            // scanner space, VOX to RAS
+  //MATRIX *Tinv = origsurf->vg.getTkregRAS2Vox();       // tkreg space, RAS to VOX
+  //MATRIX *S    = origsurf->vg.getVox2RAS();            // scanner space, VOX to RAS
+
+  MATRIX *Tinv = TkrRAS2VoxfromVolGeom(&origsurf->vg); // tkreg space, RAS to VOX
+  MATRIX *S    = vg_i_to_r(&origsurf->vg);             // scanner space, VOX to RAS
+
   MATRIX *M    = MatrixMultiply(S, Tinv, NULL);        // RAS to RAS, tkreg space to scanner space
 
   int n; 

--- a/utils/vol_geom.cpp
+++ b/utils/vol_geom.cpp
@@ -498,16 +498,19 @@ MATRIX* VOL_GEOM::getRAS2Vox(int base)
   return (ras2vox);
 }
 
+
+// tkregister space vox2ras from vol geom
+// MATRIX *TkrVox2RASfromVolGeom(const VOL_GEOM *vg)
+// MATRIX *MRIxfmCRS2XYZtkreg(const MRI *mri)
 MATRIX* VOL_GEOM::getTkregVox2RAS(int base)
 {
   if (tkregvox2ras != NULL)
     return tkregvox2ras;
-
   
-  MATRIX *PxyzOffset, *Pcrs;
-
   tkregvox2ras = MatrixAlloc(4, 4, MATRIX_REAL);
 
+  /* Set tkregister defaults */
+  /* column         row           slice          center      */
   float x_r_tkreg = -1;
   float y_r_tkreg = 0;
   float z_r_tkreg = 0;
@@ -553,7 +556,7 @@ MATRIX* VOL_GEOM::getTkregVox2RAS(int base)
   /* At this point, m = Mdc * D */
 
   /* Col, Row, Slice at the Center of the Volume */
-  Pcrs = MatrixAlloc(4, 1, MATRIX_REAL);
+  MATRIX *Pcrs = MatrixAlloc(4, 1, MATRIX_REAL);
   *MATRIX_RELT(Pcrs, 1, 1) = (double)width / 2.0 + base;
   *MATRIX_RELT(Pcrs, 2, 1) = (double)height / 2.0 + base;
   *MATRIX_RELT(Pcrs, 3, 1) = (double)depth / 2.0 + base;
@@ -561,7 +564,7 @@ MATRIX* VOL_GEOM::getTkregVox2RAS(int base)
 
   /* XYZ offset the first Col, Row, and Slice from Center */
   /* PxyzOffset = Mdc*D*PcrsCenter */
-  PxyzOffset = MatrixMultiply(tkregvox2ras, Pcrs, NULL);
+  MATRIX *PxyzOffset = MatrixMultiply(tkregvox2ras, Pcrs, NULL);
 
   /* XYZ at the Center of the Volume is c_r, c_a, c_s  */
 


### PR DESCRIPTION
on centos8, utils/mrisurf_deform.cpp failed compiling 'memmove(&mris->vg, &mris1->vg, sizeof(mris1->vg));'