### PR TITLE
Nf SB-cost for cross modal symmetric registration

### DIFF
--- a/mri_robust_register/CostFunctions.cpp
+++ b/mri_robust_register/CostFunctions.cpp
@@ -1196,7 +1196,7 @@ double CostFunctions::SBCost(MRI * mriS, MRI * mriT,
   //cf = -max( (Ic(1:end-1).^2 + Jc(1:end-1).^2) ./ ((1:(N-1)).*((N-1):-1:1))');
 
   // assert same sizes
-  if (mriS->width != mriT->width || mriS->height != mriT>height || mriS->depth != mriT->depth)
+  if (mriS->width != mriT->width || mriS->height != mriT->height || mriS->depth != mriT->depth)
   {
     cerr << "CostFunctions::SBCost image dimensions differ!" << endl;
     exit(1);

--- a/mri_robust_register/CostFunctions.cpp
+++ b/mri_robust_register/CostFunctions.cpp
@@ -1290,7 +1290,7 @@ double CostFunctions::SBCost(MRI * mriS, MRI * mriT,
     f1 = (c1[i]*c1[i] + c2[i]*c2[i]) / ((i+1.0) * (n-1.0-i));
     if (f1 > mm) mm = f1;
   }
-  return -n*mm;
+  return -mm*n;
 }
 
 

--- a/mri_robust_register/CostFunctions.cpp
+++ b/mri_robust_register/CostFunctions.cpp
@@ -1223,6 +1223,8 @@ double CostFunctions::SBCost(MRI * i1, MRI * i2)
         norm2 += f2*f2;
         counter++;
       }
+  norm1 = sqrt(norm1);
+  norm2 = sqrt(norm2);
       
   // normalize and compute sign
   double prod = 0.0;

--- a/mri_robust_register/CostFunctions.cpp
+++ b/mri_robust_register/CostFunctions.cpp
@@ -1180,7 +1180,7 @@ double CostFunctions::normalizedCorrelation(MRI * i1, MRI * i2)
 }
 
 
-double CostFunctions::SBCost(MRI * mriS, MRI * mriT
+double CostFunctions::SBCost(MRI * mriS, MRI * mriT,
     const vnl_matrix_fixed<double, 4, 4>& Msi,
     const vnl_matrix_fixed<double, 4, 4>& Mti,
     int d1, int d2, int d3)

--- a/mri_robust_register/CostFunctions.cpp
+++ b/mri_robust_register/CostFunctions.cpp
@@ -1266,9 +1266,6 @@ double CostFunctions::SBCost(MRI * mriS, MRI * mriT,
   std::vector<size_t> idx(iv1.size());
   iota(idx.begin(), idx.end(), 0);
   // sort indexes based on comparing values in iv1
-  // using std::stable_sort to avoid index re-orderings
-  // when v contains elements of equal values 
-  // stable_sort(idx.begin(), idx.end(),
   sort(idx.begin(), idx.end(),
        [&iv1](size_t i1, size_t i2) {return iv1[i1] > iv1[i2];});
 

--- a/mri_robust_register/CostFunctions.cpp
+++ b/mri_robust_register/CostFunctions.cpp
@@ -1183,14 +1183,14 @@ double CostFunctions::normalizedCorrelation(MRI * i1, MRI * i2)
 double CostFunctions::SBCost(MRI * i1, MRI * i2)
 {
 
-// matlab:
-//N = length(vJ);
-//vI = vI - mean(vI); vI = vI / norm(vI);
-//vJ = vJ - mean(vJ); vJ = vJ / norm(vJ);
-//[~, ind] = sort(vI + sign(vI'*vJ)*vJ, 'descend');
-//Ic = cumsum(vI(ind));
-//Jc = cumsum(vJ(ind));
-//cf = -max( (Ic(1:end-1).^2 + Jc(1:end-1).^2) ./ ((1:(N-1)).*((N-1):-1:1))');
+  // matlab:
+  //N = length(vJ);
+  //vI = vI - mean(vI); vI = vI / norm(vI);
+  //vJ = vJ - mean(vJ); vJ = vJ / norm(vJ);
+  //[~, ind] = sort(vI + sign(vI'*vJ)*vJ, 'descend');
+  //Ic = cumsum(vI(ind));
+  //Jc = cumsum(vJ(ind));
+  //cf = -max( (Ic(1:end-1).^2 + Jc(1:end-1).^2) ./ ((1:(N-1)).*((N-1):-1:1))');
 
   // get total size
   unsigned int n  =  i1->width * i1->height * i1->depth;
@@ -1205,7 +1205,7 @@ double CostFunctions::SBCost(MRI * i1, MRI * i2)
   double m1 = mean(i1,0);
   double m2 = mean(i2,0);
   
-  // convert to stl float vector, de-mean and compute norm
+  // convert to stl vector, de-mean and compute norm
   unsigned int counter = 0;
   std::vector < double > iv1(n), iv2(n);
   double norm1 = 0.0;
@@ -1271,7 +1271,7 @@ double CostFunctions::SBCost(MRI * i1, MRI * i2)
     f1 = (c1[i]*c1[i] + c2[i]*c2[i]) / ((i+1.0) * (n-1.0-i));
     if (f1 > mm) mm = f1;
   }
-  return -mm;
+  return -10000*mm;
 }
 
 

--- a/mri_robust_register/CostFunctions.cpp
+++ b/mri_robust_register/CostFunctions.cpp
@@ -1226,9 +1226,9 @@ double CostFunctions::SBCost(MRI * mriS, MRI * mriT,
   double norm1 = 0.0;
   double norm2 = 0.0;
   double f1,f2 = 0;
-  for (int z = 0; z < i1->depth; z++)
-    for (int y = 0; y < i1->height; y++)
-      for (int x = 0; x < i1->width; x++)
+  for (int z = 0; z < nmriS->depth; z++)
+    for (int y = 0; y < nmriS->height; y++)
+      for (int x = 0; x < nmriS->width; x++)
       {
         f1 = MRIgetVoxVal(nmriS, x, y, z, 0)-m1;
         f2 = MRIgetVoxVal(nmriT, x, y, z, 0)-m2;

--- a/mri_robust_register/CostFunctions.cpp
+++ b/mri_robust_register/CostFunctions.cpp
@@ -1290,7 +1290,7 @@ double CostFunctions::SBCost(MRI * mriS, MRI * mriT,
     f1 = (c1[i]*c1[i] + c2[i]*c2[i]) / ((i+1.0) * (n-1.0-i));
     if (f1 > mm) mm = f1;
   }
-  return -10000*mm;
+  return -n*mm;
 }
 
 

--- a/mri_robust_register/CostFunctions.cpp
+++ b/mri_robust_register/CostFunctions.cpp
@@ -1180,7 +1180,7 @@ double CostFunctions::normalizedCorrelation(MRI * i1, MRI * i2)
 }
 
 
-double CostFunctions::RBCost(MRI * i1, MRI * i2)
+double CostFunctions::SBCost(MRI * i1, MRI * i2)
 {
 
 // matlab:

--- a/mri_robust_register/CostFunctions.cpp
+++ b/mri_robust_register/CostFunctions.cpp
@@ -230,7 +230,7 @@ double CostFunctions::var(MRI *i, int frame)
 }
 
 
-double CostFunction::norm(MRI *mri, int frame)
+double CostFunctions::norm(MRI *mri, int frame)
 {
   double d = 0.0;
   int z;
@@ -1180,7 +1180,7 @@ double CostFunctions::normalizedCorrelation(MRI * i1, MRI * i2)
 }
 
 
-double CostFunction::RBCost(MRI * i1, MRI * i2)
+double CostFunctions::RBCost(MRI * i1, MRI * i2)
 {
 
 // matlab:
@@ -1202,8 +1202,8 @@ double CostFunction::RBCost(MRI * i1, MRI * i2)
   }
   
   // get means
-  double m1 = mean(i1);
-  double m2 = mean(i2);
+  double m1 = mean(i1,0);
+  double m2 = mean(i2,0);
   
   // convert to stl float vector, de-mean and compute norm
   unsigned int counter = 0;
@@ -1232,7 +1232,7 @@ double CostFunction::RBCost(MRI * i1, MRI * i2)
     iv2[i] /= norm2;
     prod += iv1[i] * iv2[i];    
   }
-  int sign = std::copysign(1,prod)
+  int sign = std::copysign(1,prod);
 
   // compute sorting vector (into iv1 to save space)
   for (unsigned int i = 0; i<n; i++)

--- a/mri_robust_register/CostFunctions.cpp
+++ b/mri_robust_register/CostFunctions.cpp
@@ -1197,7 +1197,7 @@ double CostFunctions::SBCost(MRI * i1, MRI * i2)
   unsigned int n2 =  i2->width * i2->height * i2->depth;
   if (n != n2)
   {
-    cerr << "CostFunctions::RBCost image dimensions differ!" << endl;
+    cerr << "CostFunctions::SBCost image dimensions differ!" << endl;
     exit(1);
   }
   

--- a/mri_robust_register/CostFunctions.cpp
+++ b/mri_robust_register/CostFunctions.cpp
@@ -1268,7 +1268,8 @@ double CostFunctions::SBCost(MRI * mriS, MRI * mriT,
   // sort indexes based on comparing values in iv1
   // using std::stable_sort to avoid index re-orderings
   // when v contains elements of equal values 
-  stable_sort(idx.begin(), idx.end(),
+  // stable_sort(idx.begin(), idx.end(),
+  sort(idx.begin(), idx.end(),
        [&iv1](size_t i1, size_t i2) {return iv1[i1] > iv1[i2];});
 
   // cumsums

--- a/mri_robust_register/CostFunctions.h
+++ b/mri_robust_register/CostFunctions.h
@@ -67,6 +67,8 @@ public:
   {
     return sqrt(var(i,frame));
   }
+  //! Get 2-norm of intensity values
+  static double norm(MRI * mri, int frame);
 
   //! Get median of intensity values
   static float median(MRI *i);
@@ -150,6 +152,9 @@ public:
     H.smooth(fwhm);
     return -H.computeNCC();
   }
+  
+  //! Segmentation Based Registration (http://doi.org/10.1109/LSP.2017.2754263)
+  static double SBCost(MRI * i1, MRI * i2);
 
 
   //! not implemented and not sure where they are from? Flirt?

--- a/mri_robust_register/CostFunctions.h
+++ b/mri_robust_register/CostFunctions.h
@@ -154,7 +154,10 @@ public:
   }
   
   //! Segmentation Based Registration (http://doi.org/10.1109/LSP.2017.2754263)
-  static double SBCost(MRI * i1, MRI * i2);
+  static double SBCost(MRI * si, MRI * ti,
+    const vnl_matrix_fixed<double, 4, 4>& Msi,
+    const vnl_matrix_fixed<double, 4, 4>& Mti,
+    int d1, int d2, int d3);
 
 
   //! not implemented and not sure where they are from? Flirt?

--- a/mri_robust_register/RegPowell.cpp
+++ b/mri_robust_register/RegPowell.cpp
@@ -165,7 +165,7 @@ double RegPowell::costFunction(const vnl_vector<double>& p)
       case SAD:
         dd = CostFunctions::absDiff(scf,tcf,msi,mti,tocurrent->subsamp,tocurrent->subsamp, tocurrent->subsamp,si,sii);
       break;
-      case RB:
+      case SB:
         dd = CostFunctions::SBCost(scf,tcf); // subsample not yet implemented!
       default:
         cout << " RegPowell::costFunction ERROR cannot deal with cost function "

--- a/mri_robust_register/RegPowell.cpp
+++ b/mri_robust_register/RegPowell.cpp
@@ -165,6 +165,8 @@ double RegPowell::costFunction(const vnl_vector<double>& p)
       case SAD:
         dd = CostFunctions::absDiff(scf,tcf,msi,mti,tocurrent->subsamp,tocurrent->subsamp, tocurrent->subsamp,si,sii);
       break;
+      case RB:
+        dd = CostFunctions::SBCost(scf,tcf); // subsample not yet implemented!
       default:
         cout << " RegPowell::costFunction ERROR cannot deal with cost function "
              << tocurrent->costfun << " ! " << endl;

--- a/mri_robust_register/RegPowell.cpp
+++ b/mri_robust_register/RegPowell.cpp
@@ -132,7 +132,7 @@ double RegPowell::costFunction(const vnl_vector<double>& p)
 
   // special case for sum of squared differences:
   if (tocurrent->costfun == LS || tocurrent->costfun == TB || tocurrent->costfun==LNCC
-       || tocurrent->costfun==SAD || tocurrent->costfun==NCC )
+       || tocurrent->costfun==SAD || tocurrent->costfun==NCC || tocurrent->costfun==SB  )
   {
     // iscale should be taken care of here:
     double dd;

--- a/mri_robust_register/RegPowell.cpp
+++ b/mri_robust_register/RegPowell.cpp
@@ -167,6 +167,7 @@ double RegPowell::costFunction(const vnl_vector<double>& p)
       break;
       case SB:
         dd = CostFunctions::SBCost(scf,tcf); // subsample not yet implemented!
+      break;
       default:
         cout << " RegPowell::costFunction ERROR cannot deal with cost function "
              << tocurrent->costfun << " ! " << endl;

--- a/mri_robust_register/RegPowell.cpp
+++ b/mri_robust_register/RegPowell.cpp
@@ -166,7 +166,7 @@ double RegPowell::costFunction(const vnl_vector<double>& p)
         dd = CostFunctions::absDiff(scf,tcf,msi,mti,tocurrent->subsamp,tocurrent->subsamp, tocurrent->subsamp,si,sii);
       break;
       case SB:
-        dd = CostFunctions::SBCost(scf,tcf); // subsample not yet implemented!
+        dd = CostFunctions::SBCost(scf,tcf,msi,mti,tocurrent->subsamp,tocurrent->subsamp,tocurrent->subsamp);
       break;
       default:
         cout << " RegPowell::costFunction ERROR cannot deal with cost function "

--- a/mri_robust_register/Registration.h
+++ b/mri_robust_register/Registration.h
@@ -58,7 +58,7 @@ public:
 //! The different cost functions
   enum Cost
   {
-    LS = 0, ROB, MI, NMI, ECC, NCC, SCR, TB, LNCC, SAD
+    LS = 0, ROB, MI, NMI, ECC, NCC, SCR, TB, LNCC, SAD, SB
   };
 
   //! Default constructor

--- a/mri_robust_register/mri_robust_register.cpp
+++ b/mri_robust_register/mri_robust_register.cpp
@@ -1205,10 +1205,10 @@ int main(int argc, char *argv[])
     
     if (P.cost == Registration::SB) 
     {
-      cout << "And for the segmentation based cost function:" << endl;
-      cout << "Multimodal image registration through simultaneous segmentation," << endl;
-      cout << "I. Aganj and B. Fischl. IEEE Signal Processing Letters 24(11):1661-1665, 2017." << endl;
-      cout << "https://doi.org/10.1109/LSP.2017.2754263" << endl << endl;
+      cout << " And for the segmentation based cost function:" << endl;
+      cout << " Multimodal image registration through simultaneous segmentation," << endl;
+      cout << " I. Aganj and B. Fischl. IEEE Signal Processing Letters 24(11):1661-1665, 2017." << endl;
+      cout << " https://doi.org/10.1109/LSP.2017.2754263" << endl << endl;
     }
 
     //if (diag_fp) fclose(diag_fp) ;

--- a/mri_robust_register/mri_robust_register.cpp
+++ b/mri_robust_register/mri_robust_register.cpp
@@ -1930,7 +1930,7 @@ static int parseNextCommand(int argc, char *argv[], Parameters & P)
     else if (cost == "SAD")
       P.cost = Registration::SAD;
     else if (cost == "SB")
-      P.cost = Registration:SB;
+      P.cost = Registration::SB;
     else
     {
       cout << "ERROR: cost function " << cost << " unknown! " << endl;

--- a/mri_robust_register/mri_robust_register.cpp
+++ b/mri_robust_register/mri_robust_register.cpp
@@ -1202,7 +1202,14 @@ int main(int argc, char *argv[])
         << endl;
     cout << " http://dx.doi.org/10.1016/j.neuroimage.2010.07.020" << endl;
     cout << " http://reuter.mit.edu/papers/reuter-robreg10.pdf" << endl << endl;
-    ;
+    
+    if (P.cost == Registration::SB) 
+    {
+      cout << "And for the segmentation based cost function:" << endl;
+      cout << "Multimodal image registration through simultaneous segmentation," << endl;
+      cout << "I. Aganj and B. Fischl. IEEE Signal Processing Letters 24(11):1661-1665, 2017." << endl;
+      cout << "https://doi.org/10.1109/LSP.2017.2754263" << endl << endl;
+    }
 
     //if (diag_fp) fclose(diag_fp) ;
   } // for valgrind, so that everything is free

--- a/mri_robust_register/mri_robust_register.cpp
+++ b/mri_robust_register/mri_robust_register.cpp
@@ -1929,6 +1929,8 @@ static int parseNextCommand(int argc, char *argv[], Parameters & P)
       P.cost = Registration::LNCC;
     else if (cost == "SAD")
       P.cost = Registration::SAD;
+    else if (cost == "SB")
+      P.cost = Registration:SB;
     else
     {
       cout << "ERROR: cost function " << cost << " unknown! " << endl;

--- a/mri_robust_register/mri_robust_register.help.xml
+++ b/mri_robust_register/mri_robust_register.help.xml
@@ -97,11 +97,12 @@ Use --noinit if center of mass is meaningless, e.g. when registering different r
       ROBENT (robust entropy) experimental, 
              for robust cross modal registration, can be slow.
              Also see --entradius, --entball, --entcorrection.
-      MI     (mutual information),
-      NMI    (normalized mutual information),
+      MI     (mutual information) (not robust).
+      NMI    (normalized mutual information)
              MI, NMI are also good for x-modal (not robust).
-      ECC    (entropy correlation coefficient) experimental,
-      NCC    (normalized cross corrrelation) experimental,
+      SB     (segmentation-based) Aganj paper.
+      ECC    (entropy correlation coefficient) experimental.
+      NCC    (normalized cross corrrelation) experimental.
       SCR    (symetrized correlation ratio) experimental.
 Note: most cost functions require the image backgrounds to be black! Also, only ROB and ROBENT use gradient decend, the others use a Powell optimizer.
 </explanation>

--- a/mri_robust_register/mri_robust_register.help.xml
+++ b/mri_robust_register/mri_robust_register.help.xml
@@ -100,7 +100,7 @@ Use --noinit if center of mass is meaningless, e.g. when registering different r
       MI     (mutual information) (not robust).
       NMI    (normalized mutual information)
              MI, NMI are also good for x-modal (not robust).
-      SB     (segmentation-based) by Aganj, Fischl (IEEE SPL, 2017).
+      SB     (segmentation-based) Aganj,Fischl (IEEE SPL 2017).
       ECC    (entropy correlation coefficient) experimental.
       NCC    (normalized cross corrrelation) experimental.
       SCR    (symetrized correlation ratio) experimental.

--- a/mri_robust_register/mri_robust_register.help.xml
+++ b/mri_robust_register/mri_robust_register.help.xml
@@ -92,14 +92,14 @@ Use --noinit if center of mass is meaningless, e.g. when registering different r
       <explanation>output VOX2VOX lta file (default is RAS2RAS)</explanation>
       <argument>--cost &lt;str&gt;</argument>
       <explanation>Cost function:
-      ROB    robust &lt;- default,
+      ROB    robust &lt;- default, recommended
              for robust same modality registration.
       ROBENT robust entropy, experimental, 
              for robust cross modal registration, can be slow
              also see --entradius, --entball, --entcorrection
-      MI     mutual information, not robust
-      NMI    normalized mutual information (not robust)
-             recommended for x-modal registration
+      MI     mutual information 
+      NMI    normalized mutual information,
+             recommended for x-modal registration.
       SB     segmentation-based: Aganj, Fischl, IEEE SPL, 2017
       ECC    entropy correlation coefficient, experimental
       NCC    normalized cross corrrelation, experimental

--- a/mri_robust_register/mri_robust_register.help.xml
+++ b/mri_robust_register/mri_robust_register.help.xml
@@ -100,7 +100,7 @@ Use --noinit if center of mass is meaningless, e.g. when registering different r
       MI     (mutual information) (not robust).
       NMI    (normalized mutual information)
              MI, NMI are also good for x-modal (not robust).
-      SB     (segmentation-based) Aganj paper.
+      SB     (segmentation-based) by Aganj & Fischl (IEEE SPL, 2017).
       ECC    (entropy correlation coefficient) experimental.
       NCC    (normalized cross corrrelation) experimental.
       SCR    (symetrized correlation ratio) experimental.

--- a/mri_robust_register/mri_robust_register.help.xml
+++ b/mri_robust_register/mri_robust_register.help.xml
@@ -100,7 +100,7 @@ Use --noinit if center of mass is meaningless, e.g. when registering different r
       MI     (mutual information) (not robust).
       NMI    (normalized mutual information)
              MI, NMI are also good for x-modal (not robust).
-      SB     (segmentation-based) by Aganj & Fischl (IEEE SPL, 2017).
+      SB     (segmentation-based) by Aganj, Fischl (IEEE SPL, 2017).
       ECC    (entropy correlation coefficient) experimental.
       NCC    (normalized cross corrrelation) experimental.
       SCR    (symetrized correlation ratio) experimental.

--- a/mri_robust_register/mri_robust_register.help.xml
+++ b/mri_robust_register/mri_robust_register.help.xml
@@ -92,18 +92,18 @@ Use --noinit if center of mass is meaningless, e.g. when registering different r
       <explanation>output VOX2VOX lta file (default is RAS2RAS)</explanation>
       <argument>--cost &lt;str&gt;</argument>
       <explanation>Cost function:
-      ROB    (robust) &lt;- default,
+      ROB    robust &lt;- default,
              for robust same modality registration.
-      ROBENT (robust entropy) experimental, 
-             for robust cross modal registration, can be slow.
-             Also see --entradius, --entball, --entcorrection.
-      MI     (mutual information) (not robust).
-      NMI    (normalized mutual information)
-             MI, NMI are also good for x-modal (not robust).
-      SB     (segmentation-based) Aganj,Fischl (IEEE SPL 2017).
-      ECC    (entropy correlation coefficient) experimental.
-      NCC    (normalized cross corrrelation) experimental.
-      SCR    (symetrized correlation ratio) experimental.
+      ROBENT robust entropy, experimental, 
+             for robust cross modal registration, can be slow
+             also see --entradius, --entball, --entcorrection
+      MI     mutual information, not robust
+      NMI    normalized mutual information (not robust)
+             recommended for x-modal registration
+      SB     segmentation-based: Aganj, Fischl, IEEE SPL, 2017
+      ECC    entropy correlation coefficient, experimental
+      NCC    normalized cross corrrelation, experimental
+      SCR    symetrized correlation ratio, experimental
 Note: most cost functions require the image backgrounds to be black! Also, only ROB and ROBENT use gradient decend, the others use a Powell optimizer.
 </explanation>
      <argument>--entradius</argument>

--- a/mri_robust_register/mri_robust_register.help.xml
+++ b/mri_robust_register/mri_robust_register.help.xml
@@ -101,6 +101,8 @@ Use --noinit if center of mass is meaningless, e.g. when registering different r
       NMI    normalized mutual information,
              recommended for x-modal registration.
       SB     segmentation-based: Aganj, Fischl, IEEE SPL, 2017
+             for cross modal with large initial misalignment,
+             may need NMI to fine-tune, experimental
       ECC    entropy correlation coefficient, experimental
       NCC    normalized cross corrrelation, experimental
       SCR    symetrized correlation ratio, experimental


### PR DESCRIPTION
This PR adds the segmentation based cost function from the following paper to mri_robust_register for cross modal registration:

```
Multimodal image registration through simultaneous segmentation,
 I. Aganj and B. Fischl. IEEE Signal Processing Letters 24(11):1661-1665, 2017.
 https://doi.org/10.1109/LSP.2017.2754263
```

The function works well in cases with large initial misalignment, where NMI may fail. Sometimes the final registration is not as accurate as NMI, however, so this could be used to construct an initial alignment and then run a second time with `--ixform <lta> --cost NMI` to fine tune the registration using NMI. If only used for pre-alignment, you can speed it up using `--highit 0` to skip optimisation of the highest resolution in the first call. 

Commits can be squashed when merging. 