### PR TITLE
FIX: Set LH/RHonly for -autorecon-hemi

### DIFF
--- a/scripts/recon-all
+++ b/scripts/recon-all
@@ -7140,6 +7140,8 @@ while( $#argv != 0 )
       set DoWMParc         = 0;
       set DoSegStats       = 0;
       set DoBaLabels       = 1;
+      if($hemilist == lh) set LHonly = 1 
+      if($hemilist == rh) set RHonly = 1 
       breaksw
 
 #-------------------------------------------------#


### PR DESCRIPTION
This section of `recon-all` will not attempt to run if I run `recon-all -autorecon2 -hemi lh` but will attempt to run if I use `-autorecon-hemi lh`:

https://github.com/freesurfer/freesurfer/blob/a391b2d733c01d8c39ed275e43e42773d3bb2ec3/scripts/recon-all#L4703-L4709