### PR TITLE
Additional argument for singularity command

### DIFF
--- a/mri_synthstrip/synthstrip-singularity
+++ b/mri_synthstrip/synthstrip-singularity
@@ -71,7 +71,7 @@ mounts = ' '.join(['-B %s:%s' % (p, p) for p in mounts])
 print('Running SynthStrip from Singularity')
 
 # Go ahead and run the entry point
-command = 'singularity run %s %s %s' % (mounts, image_path, args)
+command = 'singularity run -e --nv %s %s %s' % (mounts, image_path, args)
 proc = subprocess.Popen(command, shell=True)
 proc.communicate()
 if proc.returncode != 0:


### PR DESCRIPTION
I added "-e" to avoid errors when the user has freesurfer installed.
Also, the container couldn't use the gpu when "--gpu" flag was passed. So, "--nv" argument solved it.