### PR TITLE
[FIX] Adding surfa to infant python requirements

### DIFF
--- a/infant/docker/requirements.txt
+++ b/infant/docker/requirements.txt
@@ -31,6 +31,7 @@ scikit-learn==0.24.0
 scipy==1.5.3
 six==1.15.0
 sklearn==0.0
+surfa==0.3.7
 tables==3.6.1
 tensorflow==1.5.0
 tensorflow-tensorboard==1.5.1


### PR DESCRIPTION
Due to change in [`sscnn_skullstrip`](https://github.com/freesurfer/freesurfer/blob/1651213955e0a736be489c3b9cd6761ab680bf4f/sscnn_skullstripping/sscnn_skullstrip#L11)