### PR TITLE
Update deprecated function on mri_3d_photo_recon

### DIFF
--- a/mri_3d_photo_recon/mri_3d_photo_recon
+++ b/mri_3d_photo_recon/mri_3d_photo_recon
@@ -978,7 +978,7 @@ def MRIread(filename, dtype=None, im_only=False):
         ('.nii', '.nii.gz', '.mgz')), 'Unknown data file: %s' % filename
 
     x = nib.load(filename)
-    volume = x.get_data()
+    volume = x.get_fdata()
     aff = x.affine
 
     if dtype is not None:


### PR DESCRIPTION
Changed get_data() function to get_fdata() since the former is deprecated and throws an exception. 