### PR TITLE
Update FSL configuration for FSL >= 6.0.6

### DIFF
--- a/distribution/FreeSurferEnv.csh
+++ b/distribution/FreeSurferEnv.csh
@@ -180,6 +180,8 @@ if(! $?FSL_DIR  || $FS_OVERRIDE) then
         setenv FSL_DIR /usr/pubsw/packages/fsl/current
     else if ( -e /usr/local/pubsw/packages/fsl/current) then
         setenv FSL_DIR /usr/local/pubsw/packages/fsl/current
+    else if ( -e $HOME/fsl); then
+        setenv FSL_DIR $HOME/fsl
     else if ( -e /usr/local/fsl) then
         setenv FSL_DIR /usr/local/fsl
     endif
@@ -430,7 +432,13 @@ endif
 ### ----------- FSL ------------ ####
 if ( $?FSL_DIR ) then
     setenv FSLDIR $FSL_DIR
-    setenv FSL_BIN $FSL_DIR/bin
+    # FSL >= 6.0.6
+    if ( -d $FSL_DIR/share/fsl/bin) then
+        setenv FSL_BIN $FSL_DIR/share/fsl/bin
+    # FSL <= 6.0.5.2
+    else
+        setenv FSL_BIN $FSL_DIR/bin
+    endif
     if(! -d $FSL_BIN) then
         if( $output ) then
             echo "WARNING: $FSL_BIN does not exist.";

--- a/distribution/FreeSurferEnv.sh
+++ b/distribution/FreeSurferEnv.sh
@@ -189,6 +189,8 @@ if [[ -z "$FSL_DIR" || $FS_OVERRIDE != 0 ]]; then
         export FSL_DIR=/usr/pubsw/packages/fsl/current
     elif [ -e /usr/local/pubsw/packages/fsl/current ]; then
         export FSL_DIR=/usr/local/pubsw/packages/fsl/current
+    elif [ -e $HOME/fsl ]; then
+        export FSL_DIR=$HOME/fsl
     elif [ -e /usr/local/fsl ]; then
         export FSL_DIR=/usr/local/fsl
     fi
@@ -437,7 +439,13 @@ fi
 ### ----------- FSL ------------ ####
 if [ -n "$FSL_DIR" ]; then
     export FSLDIR=$FSL_DIR
-    export FSL_BIN=$FSL_DIR/bin
+    # FSL >= 6.0.6
+    if [ -d $FSL_BIN/share/fsl/bin ]; then
+        export FSL_BIN=$FSL_DIR/share/fsl/bin
+    # FSL <= 6.0.5.2
+    else
+        export FSL_BIN=$FSL_DIR/bin
+    fi
     if [ ! -d $FSL_BIN ]; then
         if [[ $output == 1 ]]; then
             echo "WARNING: $FSL_BIN does not exist.";


### PR DESCRIPTION
(reported at #1071)

Howdy, this PR just updates the `$FSL_DIR` / `$FSL_BIN` configuration to work with newer (>= 6.0.6) FSL installations. For FSL >= 6.0.6:

* The default location for user installations is now `$HOME/fsl/` rather than `/usr/local/fsl/`
* FSL executables are now isolated to `$FSLDIR/share/fsl/bin/` - this is because `$FSLDIR` is now a conda environment, and so `$FSLDIR/bin/` contains unrelated executables (e.g. `python3`). `$FSLDIR/share/fsl/bin/` contains a set of "wrapper" scripts for all FSL executables, so can be added to the `$PATH` without it being polluted with non-FSL executables.

Thanks!