### PR TITLE
bf: resolve bashism with minimal impact

### DIFF
--- a/scripts/bedpostx_mgh
+++ b/scripts/bedpostx_mgh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # bedpostx_mgh
 # (This script was modified from FSL's bedpostx by Anastasia Yendiki)

--- a/scripts/map_to_base
+++ b/scripts/map_to_base
@@ -59,7 +59,7 @@ tp=$2
 input=$3
 rt=$4
 ldir=mri
-if [ "$rt" == "surface" ] ; then ldir=surf ; fi
+if [ "$rt" = "surface" ] ; then ldir=surf ; fi
 
 long=1
 tpid=$tp.long.$base

--- a/scripts/mri_motion_correct
+++ b/scripts/mri_motion_correct
@@ -62,7 +62,7 @@ get_size()
 
   tmpfile=$tmpdir_use/size_file
 
-  mri_convert --in_info --read_only $1 &> $transcript_file
+  mri_convert --in_info --read_only $1 > $transcript_file 2>&1
   ev=$?
   echo "--------" >> $transcript_file
   echo "command was: mri_convert --in_info --read_only $1" >> $transcript_file
@@ -212,14 +212,14 @@ fi
 
 # ----- check for "which" -----
 have_which=
-which which &> /dev/null
+which which > /dev/null 2>&1
 if [ $? -eq 0 ] ; then have_which=y ; fi
 
 # ----- get the base program name -----
 progname=
 if [ $have_which ]
 then
-  which basename &> /dev/null
+  which basename > /dev/null 2>&1
   if [ $? -eq 0 ] ; then progname=`basename $0` ; fi
 fi
 if [ ! $progname ] ; then progname=`echo $0 | awk -F'/' '{print $NF}'` ; fi
@@ -293,10 +293,10 @@ have_mri_convert=
 if [ $have_which ]
 then
   which mri_convert
-  which mri_convert &> /dev/null
+  which mri_convert > /dev/null 2>&1
   if [ $? -eq 0 ] ; then have_mri_convert=y ; fi
 else
-  mri_convert &> /dev/null
+  mri_convert > /dev/null 2>&1
   if [ $? -eq 0 -o $? -eq 1 ] ; then have_mri_convert=y ; fi
 fi
 
@@ -320,7 +320,7 @@ then
   for p in mincresample mincaverage minctracc
   do
     echo -n "checking for $p..."
-    $p &> $transcript_file
+    $p > $transcript_file 2>&1
     ev=$?
     echo "--------" >> $transcript_file
     echo "command was: $p" >> $transcript_file
@@ -344,7 +344,7 @@ if [ $c -eq 1 ]
 then
   echo "only one input file -- no motion correction needed"
   echo -n "converting $infile to $outfile..."
-  mri_convert $infile $outfile &> $transcript_file
+  mri_convert $infile $outfile > $transcript_file 2>&1
   ev=$?
   echo "--------" >> $transcript_file
   echo "command was: mri_convert $infile $outfile" >> $transcript_file
@@ -369,7 +369,7 @@ else
   do
 
     echo -n "converting $f to minc (volume $i)..."
-    mri_convert $f $tmpdir_use/$i.mnc &> $transcript_file
+    mri_convert $f $tmpdir_use/$i.mnc > $transcript_file 2>&1
     ev=$?
     echo "--------" >> $transcript_file
     echo "command was: mri_convert $f $tmpdir_use/$i.mnc" >> $transcript_file
@@ -389,7 +389,7 @@ else
     else
 
       echo -n "registering this volume ($i) to volume 0..."
-      minctracc -lsq6 $tmpdir_use/$i.mnc $tmpdir_use/0.mnc $tmpdir_use/${i}_to_0.xfm &> $transcript_file
+      minctracc -lsq6 $tmpdir_use/$i.mnc $tmpdir_use/0.mnc $tmpdir_use/${i}_to_0.xfm > $transcript_file 2>&1
       ev=$?
       echo "--------" >> $transcript_file
       echo "command was: minctracc -lsq6 $tmpdir_use/$i.mnc $tmpdir_use/0.mnc $tmpdir_use/${i}_to_0.xfm" >> $transcript_file
@@ -404,7 +404,7 @@ else
       echo " done"
 
       echo -n "reslicing registered volume..."
-      mincresample -transformation $tmpdir_use/${i}_to_0.xfm -like $tmpdir_use/0.mnc $tmpdir_use/${i}.mnc $tmpdir_use/${i}_to_0.mnc &> $transcript_file
+      mincresample -transformation $tmpdir_use/${i}_to_0.xfm -like $tmpdir_use/0.mnc $tmpdir_use/${i}.mnc $tmpdir_use/${i}_to_0.mnc > $transcript_file 2>&1
       ev=$?
       echo "--------" >> $transcript_file
       echo "command was: mincresample -transformation $tmpdir_use/${i}_to_0.xfm -like $tmpdir_use/0.mnc $tmpdir_use/${i}.mnc $tmpdir_use/${i}_to_0.mnc" >> $transcript_file
@@ -430,10 +430,10 @@ else
   done
 
   echo -n "averaging volumes..."
-  mincaverage $volumes_to_average $tmpdir_use/avg.mnc &> $transcript_file
+  mincaverage $volumes_to_average $tmpdir_use/avg.mnc > $transcript_file 2>&1
   ev=$?
   echo "--------" >> $transcript_file
-  echo "command was: mincaverage $volumes_to_average $tmpdir_use/avg.mnc &> $transcript_file" >> $transcript_file
+  echo "command was: mincaverage $volumes_to_average $tmpdir_use/avg.mnc > $transcript_file 2>&1" >> $transcript_file
   echo "exit value was: $ev" >> $transcript_file
   if [ $ev -ne 0 ]
   then
@@ -445,7 +445,7 @@ else
   echo "done"
 
   echo -n "creating output volume..."
-  mri_convert $tmpdir_use/avg.mnc $outfile &> $transcript_file
+  mri_convert $tmpdir_use/avg.mnc $outfile > $transcript_file 2>&1
   ev=$?
   echo "--------" >> $transcript_file
   echo "command was: mri_convert $tmpdir_use/avg.mnc $outfile" >> $transcript_file


### PR DESCRIPTION
We found a bashism in `bedpostx_mgh` when running `trac-all` and I used the tool checkbashisms in the debian devscripts package to 

#### identify more possible issues within the `scripts/` folder only:

```
for f in $(find . -type f) ; do head -n1 $f | grep -q '/bin/sh' && (checkbashisms $f || echo -e "\n\n$f\n\n") ; done
```


#### These are the results:

```
possible bashism in ./mri_motion_correct line 65 (should be >word 2>&1):
  mri_convert --in_info --read_only $1 &> $transcript_file
possible bashism in ./mri_motion_correct line 215 (should be >word 2>&1):
which which &> /dev/null
possible bashism in ./mri_motion_correct line 222 (should be >word 2>&1):
  which basename &> /dev/null
possible bashism in ./mri_motion_correct line 296 (should be >word 2>&1):
  which mri_convert &> /dev/null
possible bashism in ./mri_motion_correct line 299 (should be >word 2>&1):
  mri_convert &> /dev/null
possible bashism in ./mri_motion_correct line 323 (should be >word 2>&1):
    $p &> $transcript_file
possible bashism in ./mri_motion_correct line 347 (should be >word 2>&1):
  mri_convert $infile $outfile &> $transcript_file
possible bashism in ./mri_motion_correct line 372 (should be >word 2>&1):
    mri_convert $f $tmpdir_use/$i.mnc &> $transcript_file
possible bashism in ./mri_motion_correct line 392 (should be >word 2>&1):
      minctracc -lsq6 $tmpdir_use/$i.mnc $tmpdir_use/0.mnc $tmpdir_use/${i}_to_0.xfm &> $transcript_file
possible bashism in ./mri_motion_correct line 407 (should be >word 2>&1):
      mincresample -transformation $tmpdir_use/${i}_to_0.xfm -like $tmpdir_use/0.mnc $tmpdir_use/${i}.mnc $tmpdir_use/${i}_to_0.mnc &> $transcript_file
possible bashism in ./mri_motion_correct line 433 (should be >word 2>&1):
  mincaverage $volumes_to_average $tmpdir_use/avg.mnc &> $transcript_file
possible bashism in ./mri_motion_correct line 448 (should be >word 2>&1):
  mri_convert $tmpdir_use/avg.mnc $outfile &> $transcript_file


./mri_motion_correct


possible bashism in ./bedpostx_mgh line 129 (bash arrays, ${name[0|*|@]}):
if [ -z ${fslver[1]} ]; then fslver[1]=0; fi
possible bashism in ./bedpostx_mgh line 129 (bash arrays, H[0]):
if [ -z ${fslver[1]} ]; then fslver[1]=0; fi
possible bashism in ./bedpostx_mgh line 130 (bash arrays, ${name[0|*|@]}):
if [ -z ${fslver[2]} ]; then fslver[2]=0; fi
possible bashism in ./bedpostx_mgh line 130 (bash arrays, H[0]):
if [ -z ${fslver[2]} ]; then fslver[2]=0; fi
possible bashism in ./bedpostx_mgh line 131 (bash arrays, ${name[0|*|@]}):
if [ ${fslver[0]} -lt 6 ]; then
possible bashism in ./bedpostx_mgh line 132 (bash arrays, ${name[0|*|@]}):
    echo "Outdated FSL version (${fslver[0]}.${fslver[1]}.${fslver[2]})"


./bedpostx_mgh


possible bashism in ./map_to_base line 62 (should be 'b = a'):
if [ "$rt" == "surface" ] ; then ldir=surf ; fi


./map_to_base
```


The pull requests fixed the bashisms by translating the `==` comparison to `[`'s  `=` and the bash redirection shortcut `&> x` to `> x 2>&1` . The `bedpostx_mgh` script however relies on bash arrays and so I decided to switch to interpreter to bash.

No testing was done, but the changes are very trivial.