### PR TITLE
Add --sobel to robust register

### DIFF
--- a/mri_robust_register/mri_robust_register.help.xml
+++ b/mri_robust_register/mri_robust_register.help.xml
@@ -118,6 +118,8 @@ Note: most cost functions require the image backgrounds to be black! Also, only 
       <explanation>with ROBENT: write movable entropy image.</explanation>
      <argument>--powelltol &lt;real&gt;</argument>
       <explanation>with MI,NMI etc: set Powell tolerance (default 0.00001 = 1e-5).</explanation>
+     <argument>--sobel</argument>
+      <explanation>register Sobel magnitude images (default no)</explanation>
       
 
       <argument>--nosym</argument>


### PR DESCRIPTION
This PR adds a flag --sobel to mri_robust_register. It will first convert inputs to Sobel magnitude images and run the registration on these. Output will be the mapped input. Sobel magnitude images are not written out, but only used internally. 