### PR TITLE
FIX: Set GeometricType to "Spherical" for sphere surfaces

### DIFF
--- a/utils/gifti.cpp
+++ b/utils/gifti.cpp
@@ -2499,10 +2499,10 @@ int MRISwriteGIFTISurface(MRIS *mris, gifti_image *image, const char *out_fname)
         geotype = "Inflated";
       }
       if (strstr(name, ".sphere")) {
-        geotype = "Sphere";
+        geotype = "Spherical";
       }
       if (strstr(name, ".qsphere")) {
-        geotype = "Sphere";
+        geotype = "Spherical";
       }
       if (strstr(name, "pial-outer")) {
         geotype = "Hull";


### PR DESCRIPTION
The GIFTI standard ([Section 3.5](https://www.nitrc.org/frs/download.php/2871/GIFTI_Surface_Format.pdf)) allows the GeometricType value "Spherical", but not "Sphere".