### PR TITLE
Add resampling and subject directory support to thalamus cnn

### DIFF
--- a/mri_segment_thalamic_nuclei_dti_cnn/CMakeLists.txt
+++ b/mri_segment_thalamic_nuclei_dti_cnn/CMakeLists.txt
@@ -3,6 +3,7 @@ project(mri_segment_thalamic_nuclei_dti_cnn)
 install_pyscript(mri_segment_thalamic_nuclei_dti_cnn)
 
 install_symlinks(TYPE files DESTINATION models thalseg_1.0.h5)
+install_symlinks(TYPE files DESTINATION models thalseg_1.1.h5)
 
 install(FILES thalseg_segmentation_labels_1.0.npy DESTINATION models)
 install(FILES thalseg_segmentation_names_1.0.npy DESTINATION models)

--- a/mri_segment_thalamic_nuclei_dti_cnn/mri_segment_thalamic_nuclei_dti_cnn
+++ b/mri_segment_thalamic_nuclei_dti_cnn/mri_segment_thalamic_nuclei_dti_cnn
@@ -48,6 +48,10 @@ def main():
                                      "headers, do NOT resample when registering; see instructions on FreeSurfer wiki)")
     parser.add_argument("--fa", help="FA image(s). Must be a folder if --t1 designates a folder. ")
     parser.add_argument("--v1", help="V1 image(s). Must be a folder if --t1 designates a folder. ")
+    parser.add_argument("--lta", default=None, help="Optional transform lta file(s) from T1 to FA. "
+                                                          "Must be a folder if --t1 designates a folder.")
+    parser.add_argument("--lta_inv", default=None, help="Optional transform lta file(s) from FA to T1. "
+                                                          "Must be a folder if --t1 designates a folder.")
     parser.add_argument("--o", help="Segmentation output(s). Must be a folder if --t1 designates a folder.")
     parser.add_argument("--vol", help="(optional) Output CSV file with volumes for all structures and subjects.")
     parser.add_argument("--post", help="(optional) Posteriors output(s). Must be a folder if --t1 designates a folder.")
@@ -109,7 +113,9 @@ def main():
         names_segmentation=names_segmentation_labels,
         path_posteriors=args.post,
         path_volumes=args.vol,
-        topology_classes=topology_classes
+        topology_classes=topology_classes,
+        path_xfrm=args.lta,
+        path_xfrm_inv=args.lta_inv
     )
 
 
@@ -129,14 +135,26 @@ def predict(path_t1,
             names_segmentation,
             path_posteriors,
             path_volumes,
-            topology_classes):
+            topology_classes,
+            path_xfrm=None,
+            path_xfrm_inv=None):
     '''
     Prediction pipeline.
     '''
+    invert_transform = False
+
+    if path_xfrm_inv is not None:
+        if path_xfrm is not None:
+            raise Exception('Can only supply forward or inverse lta transform.')
+        else :
+            path_xfrm = path_xfrm_inv
+            invert_transform = True
+
 
     # prepare input/output filepaths
     outputs = prepare_output_files(path_t1, path_aseg, path_fa, path_v1,
-                                   path_segmentations, path_posteriors, path_volumes)
+                                   path_segmentations, path_posteriors, path_volumes,
+                                   path_xfrm=path_xfrm)
     path_t1 = outputs[0]
     path_aseg = outputs[1]
     path_fa = outputs[2]
@@ -145,6 +163,8 @@ def predict(path_t1,
     path_posteriors = outputs[5]
     path_volumes = outputs[6]
     unique_vol_file = outputs[7]
+    if path_xfrm is not None:
+        path_xfrm = outputs[8]
 
     # get label lists
     labels_segmentation, _ = get_list_labels(label_list=labels_segmentation)
@@ -192,7 +212,10 @@ def predict(path_t1,
                                                                          path_fa=path_fa[i],
                                                                          path_v1=path_v1[i],
                                                                          crop=128,
-                                                                         min_pad=min_pad)
+                                                                         min_pad=min_pad,
+                                                                         xfrm_aff=path_xfrm[i],
+                                                                         path_output=path_segmentations[i],
+                                                                         invert_transform=invert_transform)
 
             # prediction
             shape_input = add_axis(np.array(image.shape[1:-1]))
@@ -265,11 +288,11 @@ def predict(path_t1,
             '\nDomain-agnostic segmentation of thalamic nuclei from joint structural and diffusion MRI')
         print('H.F.J. Tregidgo, S.Soskic, M.D. Olchanyi, J. Althonayan, B. Billot, C. Maffei, P. Golland,'
               '\n A. Yendiki, D.C. Alexander, M. Bocchetta, J.D. Rohrer, J.E. Iglesias')
-        print('arXiv preprint: https://arxiv.org/abs/2305.03413')
+        print('arXiv preprint: https://arxiv.org/abs/2305.03413 (Accepted to MICCAI 2023)')
 
 
 def prepare_output_files(path_t1, path_aseg, path_fa, path_v1, out_seg, out_posteriors,
-                         out_volumes):
+                         out_volumes, path_xfrm=None):
     '''
     Prepare output files.
     '''
@@ -325,6 +348,7 @@ def prepare_output_files(path_t1, path_aseg, path_fa, path_v1, out_seg, out_post
         path_aseg, _, _ = text_helper(path_aseg, 'path_aseg')
         path_fa, _, _ = text_helper(path_fa, 'path_fa')
         path_v1, _, _ = text_helper(path_v1, 'path_v1')
+        path_xfrm, _, _ = text_helper(path_xfrm, 'path_xfrm')
 
         # use helper on all outputs
         out_seg, recompute_seg, _ = text_helper(out_seg, 'path_segmentations')
@@ -370,6 +394,7 @@ def prepare_output_files(path_t1, path_aseg, path_fa, path_v1, out_seg, out_post
         path_aseg, _, _ = helper_dir(path_aseg, 'path_aseg', '', '')
         path_fa, _, _ = helper_dir(path_fa, 'path_fa', '', '')
         path_v1, _, _ = helper_dir(path_v1, 'path_v1', '', '')
+        path_xfrm, _, _ = helper_dir(path_xfrm, 'path_xfrm', '', '')
 
         # use helper on all outputs
         out_seg, recompute_seg, _ = helper_dir(out_seg, 'path_segmentations', '', 'synthseg')
@@ -415,6 +440,7 @@ def prepare_output_files(path_t1, path_aseg, path_fa, path_v1, out_seg, out_post
         path_aseg, _, _ = helper_im(path_aseg, 'path_aseg', '', '')
         path_fa, _, _ = helper_im(path_fa, 'path_fa', '', '')
         path_v1, _, _ = helper_im(path_v1, 'path_v1', '', '')
+        path_xfrm = [path_xfrm]
 
         # use helper on all outputs
         out_seg, recompute_seg, _ = helper_im(out_seg, 'path_segmentations', '', 'synthseg')
@@ -423,10 +449,18 @@ def prepare_output_files(path_t1, path_aseg, path_fa, path_v1, out_seg, out_post
 
 
     return path_t1, path_aseg, path_fa, path_v1, out_seg, out_posteriors, \
-           out_volumes, unique_volume_file
+           out_volumes, unique_volume_file, path_xfrm
 
 
-def preprocess(path_t1, path_aseg, path_fa, path_v1, n_levels=5, crop=None, min_pad=None, path_resample=None):
+def preprocess(path_t1, path_aseg, path_fa, path_v1, n_levels=5, crop=None, min_pad=None, path_resample=None,
+               xfrm_aff=None,path_output=None,invert_transform=False):
+
+    # set transform application behaviour
+    trans_flag = ' --lta '
+
+    if invert_transform :
+        trans_flag = ' --lta-inv '
+
     # read image and corresponding info
     im_fa, _, aff, n_dims, n_channels, h, im_res = get_volume_info(path_fa, True)
     if n_dims < 3:
@@ -455,11 +489,37 @@ def preprocess(path_t1, path_aseg, path_fa, path_v1, n_levels=5, crop=None, min_
     shape = list(im_fa.shape[:n_dims])
 
     # Read and resample ASEG
-    aseg, aff, _ = load_volume(path_aseg, im_only=False)
+    if xfrm_aff is not None:
+        temp_file = path_output +'.tmp.mgz'
+        temp_os = os.system('mri_vol2vol --mov ' +  path_aseg + ' --o ' + temp_file + trans_flag + xfrm_aff + ' --no-resample'
+                  + ' --targ ' + path_fa + ' > /dev/null')
+
+        if temp_os != 0 :
+            raise Exception('mri_vol2vol failed. Is FreeSurfer sourced?')
+
+        aseg, aff, _ = load_volume(temp_file, im_only=False)
+
+        os.system('rm -rf ' + temp_file)
+    else:
+        aseg, aff, _ = load_volume(path_aseg, im_only=False)
+
     aseg = resample_like(im_fa, aff2, aseg, aff, method='nearest')
 
     # Read and resample T1
-    im_t1, aff, _ = load_volume(path_t1, im_only=False)
+    if xfrm_aff is not None:
+        temp_file = path_output +'.tmp.mgz'
+        temp_os = os.system('mri_vol2vol --mov ' +  path_t1 + ' --o ' + temp_file + trans_flag + xfrm_aff + ' --no-resample'
+                  + ' --targ ' + path_fa  + ' > /dev/null')
+
+        if temp_os != 0 :
+            raise Exception('mri_vol2vol failed. Is FreeSurfer sourced?')
+
+        im_t1, aff, _ = load_volume(temp_file, im_only=False)
+
+        os.system('rm -rf ' + temp_file)
+    else:
+        im_t1, aff, _ = load_volume(path_t1, im_only=False)
+
     im_t1 = resample_like(im_fa, aff2, im_t1, aff)
 
     # Normalize the T1

--- a/mri_segment_thalamic_nuclei_dti_cnn/mri_segment_thalamic_nuclei_dti_cnn
+++ b/mri_segment_thalamic_nuclei_dti_cnn/mri_segment_thalamic_nuclei_dti_cnn
@@ -57,6 +57,7 @@ def main():
     parser.add_argument("--post", help="(optional) Posteriors output(s). Must be a folder if --t1 designates a folder.")
     parser.add_argument("--threads", type=int, default=1, help="(optional) Number of cores to be used. Default is 1.")
     parser.add_argument("--cpu", action="store_true", help="(optional) Enforce running with CPU rather than GPU.")
+    parser.add_argument("--version1", action="store_true", help="(optional) Use version 1.0 of the model (defaults to 1.1 updated 1st Jun 2023).")
     parser.add_argument("--model", default=None, help="(optional) Use a different model file.")
 
     # check for no arguments
@@ -87,11 +88,16 @@ def main():
 
     # path models
     if args.model is None:
-        path_model_segmentation = os.path.join(thalseg_home, 'models', 'thalseg_1.0.h5')
-
+        if args.version1:
+            path_model_segmentation = os.path.join(thalseg_home, 'models', 'thalseg_1.0.h5')
+            suffix_vrsn = 'thalseg.v1.0'
+        else:
+            path_model_segmentation = os.path.join(thalseg_home, 'models', 'thalseg_1.1.h5')
+            suffix_vrsn = 'thalseg.v1.1'
     else:
         print('Using user-specified model: ' + args.model)
         path_model_segmentation = args.model
+        suffix_vrsn = 'thalseg.user.specified'
 
 
     # path labels
@@ -115,7 +121,8 @@ def main():
         path_volumes=args.vol,
         topology_classes=topology_classes,
         path_xfrm=args.lta,
-        path_xfrm_inv=args.lta_inv
+        path_xfrm_inv=args.lta_inv,
+        suffix=suffix_vrsn
     )
 
 
@@ -137,7 +144,8 @@ def predict(path_t1,
             path_volumes,
             topology_classes,
             path_xfrm=None,
-            path_xfrm_inv=None):
+            path_xfrm_inv=None,
+            suffix=None):
     '''
     Prediction pipeline.
     '''
@@ -154,7 +162,7 @@ def predict(path_t1,
     # prepare input/output filepaths
     outputs = prepare_output_files(path_t1, path_aseg, path_fa, path_v1,
                                    path_segmentations, path_posteriors, path_volumes,
-                                   path_xfrm=path_xfrm)
+                                   path_xfrm=path_xfrm, vers_suffix=suffix)
     path_t1 = outputs[0]
     path_aseg = outputs[1]
     path_fa = outputs[2]
@@ -205,6 +213,10 @@ def predict(path_t1,
         loop_info.update(i)
 
         try:
+            if path_xfrm is not None:
+                xfrm_i = path_xfrm[i]
+            else:
+                xfrm_i = None
 
             # preprocessing
             image, aff, h, im_res, shape, pad_idx, crop_idx = preprocess(path_t1=path_t1[i],
@@ -213,7 +225,7 @@ def predict(path_t1,
                                                                          path_v1=path_v1[i],
                                                                          crop=128,
                                                                          min_pad=min_pad,
-                                                                         xfrm_aff=path_xfrm[i],
+                                                                         xfrm_aff=xfrm_i,
                                                                          path_output=path_segmentations[i],
                                                                          invert_transform=invert_transform)
 
@@ -282,7 +294,7 @@ def predict(path_t1,
         print('H.F.J. Tregidgo, S.Soskic, J. Althonayan, C. Maffei, K. Van Leemput, P. Golland, R. Insausti,'
               '\n G. Lerma-Usabiaga, C. Caballero-Gaudes, P.M. Paz-Alonso, A. Yendiki, D.C. Alexander, M. Bocchetta,'
               '\n J.D. Rohrer, J.E. Iglesias')
-        print('NeuroImage, accepted for publication.')
+        print('NeuroImage, 274 (2023): 120129.')
 
         print(
             '\nDomain-agnostic segmentation of thalamic nuclei from joint structural and diffusion MRI')
@@ -292,20 +304,20 @@ def predict(path_t1,
 
 
 def prepare_output_files(path_t1, path_aseg, path_fa, path_v1, out_seg, out_posteriors,
-                         out_volumes, path_xfrm=None):
+                         out_volumes, path_xfrm=None, vers_suffix='thalseg'):
     '''
     Prepare output files.
     '''
 
     # check inputs
     if path_t1 is None:
-        sf.system.fatal('please specify an input t1 file/folder (--i)')
+        sf.system.fatal('please specify an input t1 file/folder (--t1)')
     if path_aseg is None:
-        sf.system.fatal('please specify an input aseg file/folder (--i)')
+        sf.system.fatal('please specify an input aseg file/folder (--aseg)')
     if path_fa is None:
-        sf.system.fatal('please specify an input fa file/folder (--i)')
+        sf.system.fatal('please specify an input fa file/folder (--fa)')
     if path_v1 is None:
-        sf.system.fatal('please specify an input v1 file/folder (--i)')
+        sf.system.fatal('please specify an input v1 file/folder (--v1)')
     if out_seg is None:
         sf.system.fatal('please specify an output file/folder (--o)')
 
@@ -397,8 +409,8 @@ def prepare_output_files(path_t1, path_aseg, path_fa, path_v1, out_seg, out_post
         path_xfrm, _, _ = helper_dir(path_xfrm, 'path_xfrm', '', '')
 
         # use helper on all outputs
-        out_seg, recompute_seg, _ = helper_dir(out_seg, 'path_segmentations', '', 'synthseg')
-        out_posteriors, recompute_post, _ = helper_dir(out_posteriors, 'path_posteriors', '', 'posteriors')
+        out_seg, recompute_seg, _ = helper_dir(out_seg, 'path_segmentations', '', vers_suffix)
+        out_posteriors, recompute_post, _ = helper_dir(out_posteriors, 'path_posteriors', '', 'thalamusposteriors')
         out_volumes, recompute_volume, unique_volume_file = helper_dir(out_volumes, 'path_volumes', 'csv', '')
 
 
@@ -443,8 +455,8 @@ def prepare_output_files(path_t1, path_aseg, path_fa, path_v1, out_seg, out_post
         path_xfrm = [path_xfrm]
 
         # use helper on all outputs
-        out_seg, recompute_seg, _ = helper_im(out_seg, 'path_segmentations', '', 'synthseg')
-        out_posteriors, recompute_post, _ = helper_im(out_posteriors, 'path_posteriors', '', 'posteriors')
+        out_seg, recompute_seg, _ = helper_im(out_seg, 'path_segmentations', '', vers_suffix)
+        out_posteriors, recompute_post, _ = helper_im(out_posteriors, 'path_posteriors', '', 'thalamusposteriors')
         out_volumes, recompute_volume, unique_volume_file = helper_im(out_volumes, 'path_volumes', 'csv', '')
 
 

--- a/mri_segment_thalamic_nuclei_dti_cnn/mri_segment_thalamic_nuclei_dti_cnn
+++ b/mri_segment_thalamic_nuclei_dti_cnn/mri_segment_thalamic_nuclei_dti_cnn
@@ -48,6 +48,8 @@ def main():
                                      "headers, do NOT resample when registering; see instructions on FreeSurfer wiki)")
     parser.add_argument("--fa", help="FA image(s). Must be a folder if --t1 designates a folder. ")
     parser.add_argument("--v1", help="V1 image(s). Must be a folder if --t1 designates a folder. ")
+    parser.add_argument("--s", default=None, help="Subject in SUBJECT_DIR to be processed. Assumes the subject has "
+                                                  "been processed through the recon-all and trac-all -prep pipelines.")
     parser.add_argument("--lta", default=None, help="Optional transform lta file(s) from T1 to FA. "
                                                           "Must be a folder if --t1 designates a folder.")
     parser.add_argument("--lta_inv", default=None, help="Optional transform lta file(s) from FA to T1. "
@@ -90,10 +92,10 @@ def main():
     if args.model is None:
         if args.version1:
             path_model_segmentation = os.path.join(thalseg_home, 'models', 'thalseg_1.0.h5')
-            suffix_vrsn = 'thalseg.v1.0'
+            suffix_vrsn = 'thalseg_dti_cnn_v1.0'
         else:
             path_model_segmentation = os.path.join(thalseg_home, 'models', 'thalseg_1.1.h5')
-            suffix_vrsn = 'thalseg.v1.1'
+            suffix_vrsn = 'thalseg_dti_cnn_v1.1'
     else:
         print('Using user-specified model: ' + args.model)
         path_model_segmentation = args.model
@@ -105,6 +107,57 @@ def main():
     names_segmentation_labels = os.path.join(thalseg_home, 'models', 'thalseg_segmentation_names_1.0.npy')
     topology_classes = os.path.join(thalseg_home, 'models', 'thalseg_topological_classes_1.0.npy')
     n_neutral_labels = 1
+
+    # handle subject specification
+    if args.s:
+        if not os.environ.get('SUBJECTS_DIR'):
+            sf.system.fatal('SUBJECTS_DIR is not set. Please set to use subject id input.')
+        # get freesurfer subjects dir
+        subjects_dir_top = os.environ.get('SUBJECTS_DIR')
+
+        # check for conflicting inputs
+        if (args.t1!=None) | (args.aseg!=None) | (args.fa!=None) | (args.v1!=None) | (args.lta!=None) \
+                | (args.lta_inv!=None):
+            Exception("No other input flags may be specified alongside --s.")
+
+        subject_dir = os.path.join(subjects_dir_top,args.s)
+
+        if not os.path.isdir(subject_dir):
+            Exception("Subject specified by --s does not exist in SUBJECTS_DIR."
+                      "Please check subject ID.")
+
+        # set default inputs for subjects run through recon all and trac all
+        args.t1 = os.path.join(subject_dir,'mri','norm.mgz')
+        args.aseg = os.path.join(subject_dir,'mri','aseg.mgz')
+
+        if (not os.path.exists(args.t1)) | (not os.path.exists(args.aseg)):
+            Exception("norm.mgz/aseg.mgz do not exist in subject folder. "
+                      "Please run recon-all to use subject input (--s). ")
+
+        # set default DTI inputs
+        args.fa = os.path.join(subject_dir,'dmri','dtifit_FA.nii.gz')
+        args.v1 = os.path.join(subject_dir,'dmri','dtifit_V1.nii.gz')
+
+        if (not os.path.exists(args.t1)) | (not os.path.exists(args.aseg)):
+            Exception("dtifit_FA/dtifit_v1 do not exist in subject folder. "
+                      "Please run trac-all -prep to use subject input (--s). ")
+
+        # get lta file
+        args.lta = os.path.join(subject_dir,'dmri','xfms','anatorig2diff.bbr.lta')
+        if not os.path.exists(args.lta):
+            print('anatorig2diff.bbr.lta not found. Searching for alternative.')
+            lta_list = sorted(glob.glob(os.path.join(subject_dir,'dmri','xfms')
+                                        + '/anatorig2diff.*.lta'))
+            if len(lta_list)<1:
+                Exception('Transform between structural and DTI missing.'
+                          'Please check registration method in trac-all -prep.')
+            else:
+                args.lta = lta_list[0]
+                print('using %s' %os.path.basename(args.lta))
+
+
+        if args.o == None:
+            args.o = os.path.join(subject_dir,'dmri')
 
     # run prediction
     predict(


### PR DESCRIPTION
Merging in changes which will allow users to specify lta transform files to align structural and diffusion images. 

Also adds a --s flag to specify a freesurfer subject that has been run through recon-all and trac-all -prep. 

An updated model file thalseg_1.1.h5 will need to be uploaded to the git annex and properly linked. 