### PR TITLE
ENH - matlab code; build in support for multiframe dicom files

### DIFF
--- a/matlab/load_dicom_fl.m
+++ b/matlab/load_dicom_fl.m
@@ -45,7 +45,7 @@ end
 nfiles = size(flist,1);
 
 tic
-fprintf('Loading dicom info foreach file \n');
+fprintf('Loading dicom info for each file \n');
 for n = 1:nfiles
   fname = deblank(flist(n,:));
   % fprintf('n = %d/%d, %s   %g\n',n,nfiles,fname,toc);
@@ -65,33 +65,61 @@ for n = 1:nfiles
   dcminfo0(n) = tmpinfo;
 end
 
-% Sort by slice location %
-dcminfo = sort_by_sliceloc(dcminfo0);
+ismultiframe = false;
+if numel(dcminfo0)==1
+  % check whether it is multiframe, or just a dicome sequence with a single slice
+  ismultiframe = isfield(dcminfo0, 'SharedFunctionalGroupsSequence') && isfield(dcminfo0, 'PerFrameFunctionalGroupsSequence');
+end
+
+if ~ismultiframe
+  % Sort by slice location %
+  dcminfo = sort_by_sliceloc(dcminfo0);
+  
+  ipp1 = dcminfo(1).ImagePositionPatient; % position of the first slice
+  ipp2 = dcminfo(2).ImagePositionPatient; % position of the second slice
+  ippn = dcminfo(nfiles).ImagePositionPatient; % position of the last slice
+  ipo1 = dcminfo(1).ImageOrientationPatient; % orientation information
+  ps   = dcminfo(1).PixelSpacing; % pixel spacing within the slice
+  nslice = nfiles;
+
+else
+  % the dicominfo function from matlab produces an ugly structure, with a
+  % lot of 'Item_x' fields, at least in MATLAB2022b, the next line cleans
+  % the structure a bit.
+  dcminfo = clean_dicominfo(dcminfo0); % there's just a single header
+  
+  ipp1 = dcminfo.PerFrameFunctionalGroupsSequence(1).PlanePositionSequence.ImagePositionPatient;
+  ipp2 = dcminfo.PerFrameFunctionalGroupsSequence(2).PlanePositionSequence.ImagePositionPatient;
+  ippn = dcminfo.PerFrameFunctionalGroupsSequence(end).PlanePositionSequence.ImagePositionPatient;
+  ipo1 = dcminfo.PerFrameFunctionalGroupsSequence(1).PlaneOrientationSequence.ImageOrientationPatient;
+  ps   = dcminfo.PerFrameFunctionalGroupsSequence(1).PixelMeasuresSequence.PixelSpacing;
+  nslice = dcminfo.NumberOfFrames;
+end
 
 % Slice direction cosine %
-sdc = dcminfo(nfiles).ImagePositionPatient-dcminfo(1).ImagePositionPatient;
+sdc = ippn - ipp1;
 sdc = sdc /sqrt(sum(sdc.^2));
 
 % Distance between slices %
-dslice = sqrt(sum((dcminfo(2).ImagePositionPatient-dcminfo(1).ImagePositionPatient).^2));
+dslice = sqrt(sum((ipp2 - ipp1).^2));
 
 % Matrix of direction cosines %
 Mdc = zeros(3,3);
-Mdc(:,1) = dcminfo(1).ImageOrientationPatient(1:3);
-Mdc(:,2) = dcminfo(1).ImageOrientationPatient(4:6);
+Mdc(:,1) = ipo1(1:3);
+Mdc(:,2) = ipo1(4:6);
 Mdc(:,3) = sdc;
 
 % Voxel resolution %
-delta = [dcminfo(1).PixelSpacing; dslice];
+delta = [ps; dslice];
 D = diag(delta);
 
 % XYZ of first voxel in first slice %
-P0 = dcminfo(1).ImagePositionPatient;
+P0 = ipp1;
 
 % Change Siemens to be RAS %
 % GE is also LPS - change it to be RAS, too - ebeth %
 Manufacturer = dcminfo(1).Manufacturer;
-if(strcmpi(Manufacturer,'Siemens') | strcmpi(Manufacturer,'ge medical systems'))
+if(strncmpi(Manufacturer,'Siemens',7) | strncmpi(Manufacturer,'ge medical systems',18))
   % Change to RAS
   Mdc(1,:) = -Mdc(1,:); 
   Mdc(2,:) = -Mdc(2,:); 
@@ -112,7 +140,7 @@ end
 % dimension. The "row" is the next fastest, etc.
 ndim1 = dcminfo(1).Columns;
 ndim2 = dcminfo(1).Rows;
-ndim3 = nfiles;
+ndim3 = nslice;
 vol = zeros(ndim1,ndim2,ndim3);
 
 fprintf('Loading data from each file.\n');
@@ -124,10 +152,16 @@ for n = 1:nfiles
     fprintf('ERROR: could not load pixel data from %s\n',fname);
     return;
   end
-  % Note: dicomread will transposed the image. This is supposed
-  % to help. Anyway, to make the vox2ras transform agree with
-  % the volume, the image is transposed back.
-  vol(:,:,n) = x'; %'
+  
+  if ismultiframe
+    vol = squeeze(x);
+    vol = permute(vol, [2 1 3]);
+  else
+    % Note: dicomread will transposed the image. This is supposed
+    % to help. Anyway, to make the vox2ras transform agree with
+    % the volume, the image is transposed back.
+    vol(:,:,n) = x'; %'
+  end
 end
 
 % Reorder dimensions so that ReadOut dim is first %
@@ -145,7 +179,7 @@ end
 % don't update c_ras - but now c_s should be zero.
 if(strcmpi(Manufacturer,'ge medical systems'))
   % Lines below correct for the Z-offset in GE machines
-  firstZ = dcminfo(1).ImagePositionPatient(3);
+  firstZ = ipp1(3);
   lastXYZ = M*[size(vol)';1]; %'
   % size(imvol) = number of slices in all 3 dirs
   lastZ = lastXYZ(3);
@@ -184,6 +218,48 @@ function dcminfo2 = sort_by_sliceloc(dcminfo)
   [tmp ind] = sort(sliceloc);
   dcminfo2 = dcminfo(ind);
 return;
+
+%----------------------------------------------------------%
+
+%----------------------------------------------------------%
+function dcminfo_out = clean_dicominfo(dcminfo_in)
+
+% subfunction to remove all instances from Item_x as fields from a
+% (sub-)structure
+
+fn = fieldnames(dcminfo_in);
+if all(strncmp(fn, 'Item_', 5))
+  for k = 1:numel(fn)
+    dcminfo_out(k) = dcminfo_in.(fn{k});
+  end
+else
+  for k = 1:numel(fn)
+    tmp = dcminfo_in.(fn{k});
+    if isstruct(tmp) && numel(fieldnames(tmp))>0 && all(strncmp(fieldnames(tmp), 'Item_', 5))
+      dcminfo_out.(fn{k}) = clean_dicominfo(tmp);
+      
+      % recurse
+      if isstruct(dcminfo_out.(fn{k}))
+        for kk = 1:numel(dcminfo_out.(fn{k}))
+          dcminfo_out.(fn{k})(kk) = clean_dicominfo(dcminfo_out.(fn{k})(kk));
+        end
+      end
+    elseif isstruct(tmp) && numel(fieldnames(tmp))>0
+      fn_tmp = fieldnames(tmp);
+      dcminfo_out.(fn{k}) = struct;
+      for kk = 1:numel(fn_tmp)
+        tmp2 = tmp.(fn_tmp{kk});
+        if isstruct(tmp2)
+          dcminfo_out.(fn{k}).(fn_tmp{kk}) = clean_dicominfo(tmp2); 
+        else
+          dcminfo_out.(fn{k}).(fn_tmp{kk}) = tmp2;
+        end
+      end
+    else
+      dcminfo_out.(fn{k}) = tmp;
+    end
+  end
+end
 
 %----------------------------------------------------------%
 


### PR DESCRIPTION
This is a long shot, and feel free to ignore, but this PR implements support for multiframe dicoms in the matlab reader.

Context: the Siemens Skyra scanner at the Donders Institute now natively creates multiframe dicoms since a recent software update. Our FieldTrip code (https://github.com/fieldtrip/fieldtrip) relies on load_dicom_fl.m for the reading of dicom anatomical volumes. Given the different formatting of the header (and data) this now fails for obvious reasons. 

I could easily implement a workaround that does not touch freesurfer functions, but on the off chance that you find this addition useful, I still submit it here, realizing that:
- the matlab code probably does not have the focus of attention of the developers
- core functionality (e.g. mri_convert) does not seem to support multiframe dicoms, so it could have been a conscious design choice not to support this particular file format (although I couldn't find anything about this when doing a shallow online search)
- I only tested the changed code on a few files that were collected at the Donders Institute, so I don't know how robust it is 