### PR TITLE
bf: fix erroneous activations in cortex and brainstem

### DIFF
--- a/mri_segment_thalamic_nuclei_dti_cnn/mri_segment_thalamic_nuclei_dti_cnn
+++ b/mri_segment_thalamic_nuclei_dti_cnn/mri_segment_thalamic_nuclei_dti_cnn
@@ -61,6 +61,7 @@ def main():
     parser.add_argument("--cpu", action="store_true", help="(optional) Enforce running with CPU rather than GPU.")
     parser.add_argument("--version1", action="store_true", help="(optional) Use version 1.0 of the model (defaults to 1.1 updated 1st Jun 2023).")
     parser.add_argument("--model", default=None, help="(optional) Use a different model file.")
+    parser.add_argument("--clean", action="store_true", help="(optional) Remove auto-generated realigned input images.")
 
     # check for no arguments
     if len(sys.argv) < 2:
@@ -175,7 +176,8 @@ def main():
         topology_classes=topology_classes,
         path_xfrm=args.lta,
         path_xfrm_inv=args.lta_inv,
-        suffix=suffix_vrsn
+        suffix=suffix_vrsn,
+        clean_switch=args.clean
     )
 
 
@@ -198,7 +200,8 @@ def predict(path_t1,
             topology_classes,
             path_xfrm=None,
             path_xfrm_inv=None,
-            suffix=None):
+            suffix=None,
+            clean_switch=False):
     '''
     Prediction pipeline.
     '''
@@ -280,7 +283,8 @@ def predict(path_t1,
                                                                          min_pad=min_pad,
                                                                          xfrm_aff=xfrm_i,
                                                                          path_output=path_segmentations[i],
-                                                                         invert_transform=invert_transform)
+                                                                         invert_transform=invert_transform,
+                                                                         clean_switch=clean_switch)
 
             # prediction
             shape_input = add_axis(np.array(image.shape[1:-1]))
@@ -327,6 +331,16 @@ def predict(path_t1,
             print('posteriors saved in:       ' + path_posteriors[0])
         if path_volumes[0] is not None:
             print('volumes saved in:          ' + path_volumes[0])
+
+        if path_xfrm is not None:
+            if not clean_switch:
+                print('\nTo check the result, run:')
+                print('  freeview ' + path_segmentations[0] + '.t1.dwispace.mgz ' + path_segmentations[0] +
+                      ':colormap=LUT -dti ' + path_v1[0] + ' ' + path_fa[0])
+        else:
+            print('\nTo check the result, run:')
+            print('  freeview ' + path_t1[0] + ' ' + path_segmentations[0] + ':colormap=LUT -dti ' + path_v1[0] + ' ' +
+                  path_fa[0])
     elif (len(path_segmentations) > 1) & (len(list_errors) < len(path_segmentations)):  # at least 1 image with no error
         # only print info if all segmentations are in the same folder, and we have unique vol/QC files
         if len(set([os.path.dirname(path_segmentations[i]) for i in range(len(path_segmentations))])) <= 1:
@@ -518,7 +532,7 @@ def prepare_output_files(path_t1, path_aseg, path_fa, path_v1, out_seg, out_post
 
 
 def preprocess(path_t1, path_aseg, path_fa, path_v1, n_levels=5, crop=None, min_pad=None, path_resample=None,
-               xfrm_aff=None,path_output=None,invert_transform=False):
+               xfrm_aff=None,path_output=None,invert_transform=False,clean_switch=False):
 
     # set transform application behaviour
     trans_flag = ' --lta '
@@ -555,7 +569,7 @@ def preprocess(path_t1, path_aseg, path_fa, path_v1, n_levels=5, crop=None, min_
 
     # Read and resample ASEG
     if xfrm_aff is not None:
-        temp_file = path_output +'.tmp.mgz'
+        temp_file = path_output +'.aseg.dwispace.mgz'
         temp_os = os.system('mri_vol2vol --mov ' +  path_aseg + ' --o ' + temp_file + trans_flag + xfrm_aff + ' --no-resample'
                   + ' --targ ' + path_fa + ' > /dev/null')
 
@@ -564,7 +578,8 @@ def preprocess(path_t1, path_aseg, path_fa, path_v1, n_levels=5, crop=None, min_
 
         aseg, aff, _ = load_volume(temp_file, im_only=False)
 
-        os.system('rm -rf ' + temp_file)
+        if clean_switch:
+            os.system('rm -rf ' + temp_file)
     else:
         aseg, aff, _ = load_volume(path_aseg, im_only=False)
 
@@ -572,7 +587,7 @@ def preprocess(path_t1, path_aseg, path_fa, path_v1, n_levels=5, crop=None, min_
 
     # Read and resample T1
     if xfrm_aff is not None:
-        temp_file = path_output +'.tmp.mgz'
+        temp_file = path_output +'.t1.dwispace.mgz'
         temp_os = os.system('mri_vol2vol --mov ' +  path_t1 + ' --o ' + temp_file + trans_flag + xfrm_aff + ' --no-resample'
                   + ' --targ ' + path_fa  + ' > /dev/null')
 
@@ -581,7 +596,8 @@ def preprocess(path_t1, path_aseg, path_fa, path_v1, n_levels=5, crop=None, min_
 
         im_t1, aff, _ = load_volume(temp_file, im_only=False)
 
-        os.system('rm -rf ' + temp_file)
+        if clean_switch:
+            os.system('rm -rf ' + temp_file)
     else:
         im_t1, aff, _ = load_volume(path_t1, im_only=False)
 

--- a/mri_segment_thalamic_nuclei_dti_cnn/mri_segment_thalamic_nuclei_dti_cnn
+++ b/mri_segment_thalamic_nuclei_dti_cnn/mri_segment_thalamic_nuclei_dti_cnn
@@ -14,7 +14,7 @@ from datetime import timedelta
 from itertools import combinations
 from scipy.ndimage import label as scipy_label
 from scipy.interpolate import RegularGridInterpolator
-from scipy.ndimage import binary_dilation, binary_erosion, gaussian_filter, distance_transform_edt, binary_fill_holes
+from scipy.ndimage import binary_dilation, binary_erosion, binary_closing, gaussian_filter, distance_transform_edt, binary_fill_holes
 
 # set tensorflow logging
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
@@ -689,11 +689,11 @@ def postprocess(post_patch_seg, shape, pad_idx, crop_idx,
     # get posteriors
     post_patch_seg = np.squeeze(post_patch_seg)
 
-    # fill holes
-    tmp_post_patch_seg = post_patch_seg[..., 1:]
-    post_patch_seg_mask = np.sum(tmp_post_patch_seg, axis=-1) > post_patch_seg[..., 0]
-    post_patch_seg_mask = binary_fill_holes(post_patch_seg_mask)
-    post_patch_seg[post_patch_seg_mask, 0] = 0
+    # # fill holes
+    # tmp_post_patch_seg = post_patch_seg[..., 1:]
+    # post_patch_seg_mask = np.sum(tmp_post_patch_seg, axis=-1) > post_patch_seg[..., 0]
+    # post_patch_seg_mask = binary_fill_holes(post_patch_seg_mask)
+    # post_patch_seg[post_patch_seg_mask, 0] = 0
 
     # reset posteriors to zero outside the largest connected component of each topological class
     thal_1_topology_indices = np.where(topology_classes == 1)[0]
@@ -702,10 +702,19 @@ def postprocess(post_patch_seg, shape, pad_idx, crop_idx,
     thal_2_post = np.sum(post_patch_seg[..., thal_2_topology_indices], axis=-1)
 
     thal_1_mask = (thal_1_post > post_patch_seg[..., 0]) & (thal_1_post > thal_2_post)
+    thal_1_mask = binary_closing(thal_1_mask)
+    thal_1_mask = binary_fill_holes(thal_1_mask)
+    thal_1_mask = get_largest_connected_component(thal_1_mask)
+
     thal_2_mask = (thal_2_post > post_patch_seg[..., 0]) & (thal_2_post > thal_1_post)
+    thal_2_mask = binary_closing(thal_2_mask)
+    thal_2_mask = binary_fill_holes(thal_2_mask)
+    thal_2_mask = get_largest_connected_component(thal_2_mask)
 
     post_patch_seg[..., thal_1_topology_indices] *= thal_1_mask[..., np.newaxis]
     post_patch_seg[..., thal_2_topology_indices] *= thal_2_mask[..., np.newaxis]
+
+    post_patch_seg[..., 0] *= (~thal_1_mask & ~thal_2_mask)
 
     post_patch_seg = crop_volume_with_idx(post_patch_seg, pad_idx, n_dims=3, return_copy=False)
 


### PR DESCRIPTION
Merging in changes which fix the binary operations used to cleanup the final activations. The operations include connected component analysis and smoothing of the external boundary. These were missed in the original port from the development environment used for the paper results. 

Some additional small changes are made to the save location of the realigned source data, to be consistent with the Bayesian tool, as well as the addition of an example freeview command for visualisation of the results. 