### PR TITLE
Add environment variable FS_LICENSE to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ENV LOCAL_DIR /usr/local/freesurfer/local
 ENV FSFAST_HOME /usr/local/freesurfer/fsfast
 ENV FMRI_ANALYSIS_DIR /usr/local/freesurfer/fsfast
 ENV FUNCTIONALS_DIR /usr/local/freesurfer/sessions
+ENV FS_LICENSE /usr/local/freesurfer/.license/license.txt
 
 # set default fs options
 ENV FS_OVERRIDE 0


### PR DESCRIPTION
Add environment variables(`FS_LICENSE`) to prevent errors in missing licenses