### PR TITLE
bf: mri_synthmorph: fix init transform variable name typo

### DIFF
--- a/mri_synthmorph/mri_synthmorph
+++ b/mri_synthmorph/mri_synthmorph
@@ -539,7 +539,7 @@ if arg.init:
         sf.system.fatal('initial transform geometry does not match images')
 
     net_to_mov = np.float32(ras_to_mov @ init.inv() @ fix_to_ras @ net_to_fix)
-    mov_to_new = np.float32(fix_to_net @ ras_to_fix @ init @ mov_to_ras)
+    mov_to_net = np.float32(fix_to_net @ ras_to_fix @ init @ mov_to_ras)
 
 
 # Take the input images to network space. When saving the moving image with the

--- a/mri_synthmorph/mri_synthmorph
+++ b/mri_synthmorph/mri_synthmorph
@@ -640,7 +640,7 @@ if arg.out_fixed:
 
 vmpeak = sf.system.vmpeak()
 if(vmpeak is not None):
-    print(f'#@# mri_synthmoph: {arg.model}, threads: {arg.threads}, VmPeak: {vmpeak}')
+    print(f'#@# mri_synthmorph: {arg.model}, threads: {arg.threads}, VmPeak: {vmpeak}')
 
 print('Thank you for choosing SynthMorph. Please cite us!')
 print(rewrap(ref))


### PR DESCRIPTION
In L542 of `mri_synthmorph/mri_synthmorph`, the variable `mov_to_new` is defined but never referenced again. In the full context of the code, I believe that this line is intended to redefine the `mov_to_net` variable to take the initial matrix transform into account and that this is simply a typo in the variable name. If I am correct, then this change should address bugs related to the application of initial transforms, but of course this should be verified.

In L643, I also corrected "mri_synthmoph" to be "mri_synthmorph", but this should not have any effect on code function.