### PR TITLE
bf: Fix tensorflow macos arm compatability

### DIFF
--- a/mri_easyreg/mri_easyreg
+++ b/mri_easyreg/mri_easyreg
@@ -412,7 +412,7 @@ def reformat_to_list(var, length=None, load_as_numpy=False, dtype=None):
     if var is None:
         return None
     var = load_array_if_path(var, load_as_numpy=load_as_numpy)
-    if isinstance(var, (int, float, np.int8, np.int16, np.int32, np.int64, np.float16, np.float32, np.float64, np.float128)):
+    if isinstance(var, (int, float, np.int8, np.int16, np.int32, np.int64, np.float16, np.float32, np.float64)):
         var = [var]
     elif isinstance(var, tuple):
         var = list(var)
@@ -931,7 +931,7 @@ def conv_enc(nb_features,
 
         if batch_norm is not None:
             name = '%s_bn_down_%d' % (prefix, level)
-            last_tensor = KL.BatchNormalization(axis=batch_norm, name=name)(last_tensor)
+            last_tensor = KL.BatchNormalization(axis=batch_norm, name=name, fused=False)(last_tensor)
 
         # max pool if we're not at the last level
         if level < (nb_levels - 1):
@@ -1057,7 +1057,7 @@ def conv_dec(nb_features,
 
         if batch_norm is not None:
             name = '%s_bn_up_%d' % (prefix, level)
-            last_tensor = KL.BatchNormalization(axis=batch_norm, name=name)(last_tensor)
+            last_tensor = KL.BatchNormalization(axis=batch_norm, name=name, fused=False)(last_tensor)
 
     # Compute likelyhood prediction (no activation yet)
     name = '%s_likelihood' % prefix

--- a/mri_segment_thalamic_nuclei_dti_cnn/mri_segment_thalamic_nuclei_dti_cnn
+++ b/mri_segment_thalamic_nuclei_dti_cnn/mri_segment_thalamic_nuclei_dti_cnn
@@ -1062,7 +1062,7 @@ def conv_enc(nb_features,
 
         if batch_norm is not None:
             name = '%s_bn_down_%d' % (prefix, level)
-            last_tensor = keras.layers.BatchNormalization(axis=batch_norm, name=name)(last_tensor)
+            last_tensor = keras.layers.BatchNormalization(axis=batch_norm, name=name, fused=False)(last_tensor)
 
         # max pool if we're not at the last level
         if level < (nb_levels - 1):
@@ -1197,7 +1197,7 @@ def conv_dec(nb_features,
 
         if batch_norm is not None:
             name = '%s_bn_up_%d' % (prefix, level)
-            last_tensor = keras.layers.BatchNormalization(axis=batch_norm, name=name)(last_tensor)
+            last_tensor = keras.layers.BatchNormalization(axis=batch_norm, name=name, fused=False)(last_tensor)
 
     # Compute likelyhood prediction (no activation yet)
     name = '%s_likelihood' % prefix
@@ -1464,7 +1464,7 @@ def reformat_to_list(var, length=None, load_as_numpy=False, dtype=None):
         return None
     var = load_array_if_path(var, load_as_numpy=load_as_numpy)
     if isinstance(var,
-                  (int, float, np.int8, np.int16, np.int32, np.int64, np.float16, np.float32, np.float64, np.float128)):
+                  (int, float, np.int8, np.int16, np.int32, np.int64, np.float16, np.float32, np.float64)):
         var = [var]
     elif isinstance(var, tuple):
         var = list(var)

--- a/mri_synthseg/mri_synthseg
+++ b/mri_synthseg/mri_synthseg
@@ -1201,7 +1201,7 @@ def conv_enc(nb_features,
 
         if batch_norm is not None:
             name = '%s_bn_down_%d' % (prefix, level)
-            last_tensor = keras.layers.BatchNormalization(axis=batch_norm, name=name)(last_tensor)
+            last_tensor = keras.layers.BatchNormalization(axis=batch_norm, name=name, fused=False)(last_tensor)
 
         # max pool if we're not at the last level
         if level < (nb_levels - 1):
@@ -1336,7 +1336,7 @@ def conv_dec(nb_features,
 
         if batch_norm is not None:
             name = '%s_bn_up_%d' % (prefix, level)
-            last_tensor = keras.layers.BatchNormalization(axis=batch_norm, name=name)(last_tensor)
+            last_tensor = keras.layers.BatchNormalization(axis=batch_norm, name=name, fused=False)(last_tensor)
 
     # Compute likelyhood prediction (no activation yet)
     name = '%s_likelihood' % prefix
@@ -1618,7 +1618,7 @@ def reformat_to_list(var, length=None, load_as_numpy=False, dtype=None):
     if var is None:
         return None
     var = load_array_if_path(var, load_as_numpy=load_as_numpy)
-    if isinstance(var, (int, float, np.int8, np.int16, np.int32, np.int64, np.float16, np.float32, np.float64, np.float128)):
+    if isinstance(var, (int, float, np.int8, np.int16, np.int32, np.int64, np.float16, np.float32, np.float64)):
         var = [var]
     elif isinstance(var, tuple):
         var = list(var)

--- a/mri_synthsr/mri_synthsr
+++ b/mri_synthsr/mri_synthsr
@@ -539,7 +539,7 @@ def conv_enc(nb_features,
 
         if batch_norm is not None:
             name = '%s_bn_down_%d' % (prefix, level)
-            last_tensor = keras.layers.BatchNormalization(axis=batch_norm, name=name)(last_tensor)
+            last_tensor = keras.layers.BatchNormalization(axis=batch_norm, name=name, fused=False)(last_tensor)
 
         # max pool if we're not at the last level
         if level < (nb_levels - 1):
@@ -674,7 +674,7 @@ def conv_dec(nb_features,
 
         if batch_norm is not None:
             name = '%s_bn_up_%d' % (prefix, level)
-            last_tensor = keras.layers.BatchNormalization(axis=batch_norm, name=name)(last_tensor)
+            last_tensor = keras.layers.BatchNormalization(axis=batch_norm, name=name, fused=False)(last_tensor)
 
     # Compute likelyhood prediction (no activation yet)
     name = '%s_likelihood' % prefix


### PR DESCRIPTION
Fixes issues with some of the tensorflow based tools when running on an arm based macos machine (M1, M2, M3 chipset). The two main issues are:

	1. a check for np.float128 which isn't a supported datatype on this chipset
	2. an error in the shape of tensors provided to batch- normalisation layers

Issue 1 can be fixed by removing the check as it's not likely to be necessary in most cases.

Issue 2 arrises as there are two implementations of batch norm in keras (fused/unfused). Tensors of rank 5 are not supported in the faster fused version, so a check is performed based on the input shape and the correct version should be selected. For some reason this check isn't working on the macOS arm chipsets (possibly a tensorflow-metal or keras version issue) and this causes the shape mismatch at inference.

Checking behaviour on an Ubuntu installation the batch norm does seem to default to the non-fused version so explicitly setting fused=False at network construction should avoid the issue altogether.

This commit applies the fix to mri_synthseg, mri_synthsr and mri_segment_thalamic_nuclei_dti_cnn but the issue is likely still present in other tensorflow based tools.