### PR TITLE
bf: fixed ThalamicNuclei segmentation naming

### DIFF
--- a/scripts/trac-preproc
+++ b/scripts/trac-preproc
@@ -1339,15 +1339,19 @@ if ($dointra && ! $dobase && -e $fsdir/mri/brain.mgz) then
   if ($usethalnuc) then
     set thalseg = ()
 
-    foreach thalver (v13 v12)
-      if (-e $fsdir/mri/ThalamicNuclei.$thalver.T1.FSvoxelSpace.mgz) then
-        set thalseg = ThalamicNuclei.$thalver.T1.FSvoxelSpace
+    foreach thalver (v13.T1. v12.T1. '' long.)
+      if (-e $fsdir/mri/ThalamicNuclei."$thalver"FSvoxelSpace.mgz) then
+        set thalseg = ThalamicNuclei."$thalver"FSvoxelSpace
         break
       endif
     end
 
     if ($#thalseg == 0) then
       echo "ERROR: Could not find thalamic nuclei segmentation in $fsdir/mri/" |& tee -a $LF
+      echo "ERROR: using any of the following patterns --->" |& tee -a $LF
+      echo "ERROR: ThalamicNuclei.v1[23].T1.FSvoxelSpace.mgz" |& tee -a $LF
+      echo "ERROR: ThalamicNuclei.FSvoxelSpace.mgz" |& tee -a $LF
+      echo "ERROR: ThalamicNuclei.long.FSvoxelSpace.mgz" |& tee -a $LF
       echo "ERROR: Thalamic nuclei segmentation is strongly recommended to use" |& tee -a $LF
       echo "ERROR: for tracts that terminate in or travel near the thalamus" |& tee -a $LF
       echo "ERROR: If there is good reason not to use it, set usethalnuc = 0" |& tee -a $LF


### PR DESCRIPTION
ThalamicNuclei segmentation naming conventions differ depending on the tool used:

**If segmented with segmentThalamicNuclei.sh**
-  ThalamicNuclei."$thalver"."$analysisID".mgz
default for "$thalver" is 'V13' (current version) and for "$analysisID" is 'T1'

**If segmented with segment_subregions --cross**
- ThalamicNuclei."$analysisID".FSvoxelSpace.mgz
default for "$analysisID" is an empty string

**If segmented with segment_subregions --long**
- ThalamicNuclei.long"$analysisID".FSvoxelSpace.mgz
default for "$analysisID" is an empty string

This fix incorporates these naming conventions. Since "$analysisID" is not taken into account, a change to the error message was made in order to instruct the user to adjust their ThalamicNuclei segmentation naming accordingly, if any  "$analysisID" suffix is present.

Testing was performed with segment ThalamicNuclei.sh, segment_subregions --cross and segment_subregions --long.
