### PR TITLE
nf: synthseg/easyreg autocrop

### DIFF
--- a/mri_easyreg/mri_easyreg
+++ b/mri_easyreg/mri_easyreg
@@ -103,8 +103,8 @@ def main():
         print('   Reading reference image')
         ref_image, ref_aff, ref_h, ref_im_res, ref_shape, ref_pad_idx, ref_crop_idx = preprocess(path_image=args.ref,
                                                                                                  crop=None, min_pad=128,
-                                                                                                 autocrop=args.autocrop,
-                                                                                                 path_resample=None)
+                                                                                                 path_resample=None,
+                                                                                                 autocrop=args.autocrop)
         print('   Setting up segmentation net')
         segmentation_net = build_seg_model(model_file_segmentation=path_model_segmentation,
                                            model_file_parcellation=path_model_parcellation,
@@ -140,8 +140,8 @@ def main():
         print('   Reading floating image')
         flo_image, flo_aff, flo_h, flo_im_res, flo_shape, ref_pad_idx, ref_crop_idx = preprocess(path_image=args.flo,
                                                                                                  crop=None, min_pad=128,
-                                                                                                 autocrop=args.autocrop,
-                                                                                                 path_resample=None)
+                                                                                                 path_resample=None,
+                                                                                                 autocrop=args.autocrop)
         if segmentation_net is None:
             print('   Setting up segmentation net')
             segmentation_net = build_seg_model(model_file_segmentation=path_model_segmentation,
@@ -503,7 +503,7 @@ def load_volume(path_volume, im_only=True, squeeze=True, dtype=None, aff_ref=Non
 
 
 
-def preprocess(path_image, n_levels=5, crop=None, autocrop=False, min_pad=None, path_resample=None):
+def preprocess(path_image, n_levels=5, crop=None, min_pad=None, path_resample=None, autocrop=False):
     # read image and corresponding info
     im, _, aff, n_dims, n_channels, h, im_res = get_volume_info(path_image, True)
     if n_dims < 3:

--- a/mri_easyreg/mri_easyreg
+++ b/mri_easyreg/mri_easyreg
@@ -35,6 +35,7 @@ def main():
     parser.add_argument("--fwd_field", help="(optional) Forward field")
     parser.add_argument("--bak_field", help="(optional) Inverse field")
     parser.add_argument("--affine_only", action="store_true", help="(optional) Skips nonlinear part")
+    parser.add_argument("--autocrop", action="store_true", help="(optional) Ignore background voxels in FOV.")
     parser.add_argument("--threads", type=int, default=1, help="(optional) Number of cores to be used. Default is 1. You can use -1 to use all available cores")
 
     # parse commandline
@@ -102,6 +103,7 @@ def main():
         print('   Reading reference image')
         ref_image, ref_aff, ref_h, ref_im_res, ref_shape, ref_pad_idx, ref_crop_idx = preprocess(path_image=args.ref,
                                                                                                  crop=None, min_pad=128,
+                                                                                                 autocrop=args.autocrop,
                                                                                                  path_resample=None)
         print('   Setting up segmentation net')
         segmentation_net = build_seg_model(model_file_segmentation=path_model_segmentation,
@@ -138,6 +140,7 @@ def main():
         print('   Reading floating image')
         flo_image, flo_aff, flo_h, flo_im_res, flo_shape, ref_pad_idx, ref_crop_idx = preprocess(path_image=args.flo,
                                                                                                  crop=None, min_pad=128,
+                                                                                                 autocrop=args.autocrop,
                                                                                                  path_resample=None)
         if segmentation_net is None:
             print('   Setting up segmentation net')
@@ -500,7 +503,7 @@ def load_volume(path_volume, im_only=True, squeeze=True, dtype=None, aff_ref=Non
 
 
 
-def preprocess(path_image, n_levels=5, crop=None, min_pad=None, path_resample=None):
+def preprocess(path_image, n_levels=5, crop=None, autocrop=False, min_pad=None, path_resample=None):
     # read image and corresponding info
     im, _, aff, n_dims, n_channels, h, im_res = get_volume_info(path_image, True)
     if n_dims < 3:
@@ -535,6 +538,22 @@ def preprocess(path_image, n_levels=5, crop=None, min_pad=None, path_resample=No
 
     # normalise image
     im = rescale_volume(im, new_min=0, new_max=1, min_percentile=0.5, max_percentile=99.5)
+
+    # automatically crop out obvious background
+    if autocrop and crop_idx is None:
+        nz_locs = np.argwhere(im > 0)
+        min_indices = np.min(nz_locs, axis=0)
+        max_indices = np.max(nz_locs, axis=0)
+        nz_crop = max_indices - min_indices + 2
+        crop_shape = [find_closest_number_divisible_by_m(s, 2 ** n_levels, 'higher') for s in nz_crop]
+        half_dim_diff = np.floor_divide([crop_shape[i] - nz_crop[i] for i in range(n_dims)], 2)
+        min_crop_idx = np.maximum(min_indices - half_dim_diff, 0)
+        max_crop_idx = np.minimum(min_crop_idx + crop_shape, im.shape[:n_dims])
+        crop_idx = np.concatenate([np.array(min_crop_idx), np.array(max_crop_idx)])
+        if n_dims == 2:
+            im = im[crop_idx[0]: crop_idx[2], crop_idx[1]: crop_idx[3], ...]
+        elif n_dims == 3:
+            im = im[crop_idx[0]: crop_idx[3], crop_idx[1]: crop_idx[4], crop_idx[2]: crop_idx[5], ...]
 
     # pad image
     input_shape = im.shape[:n_dims]

--- a/mri_easyreg/mri_easyreg
+++ b/mri_easyreg/mri_easyreg
@@ -93,6 +93,10 @@ def main():
         if np.sum(ref_seg_buffer>1000)==0:
             sf.system.fatal('No cortical labels found; does the segmentation include cortical parcels?')
         segmentation_net = None
+        # even nearest neighbour interpolation can cause issues with matching labels,
+        # so we need to handle the segmentation values
+        if np.issubdtype( ref_seg_buffer.dtype, float ):
+            ref_seg_buffer = np.round(ref_seg_buffer).astype(int)
     else:
         print('Segmenting reference image')
         print('   Reading reference image')
@@ -125,6 +129,10 @@ def main():
         flo_seg_buffer, flo_seg_aff, flo_h = load_volume(args.flo_seg, im_only=False, squeeze=True, dtype=None, aff_ref=None)
         if np.sum(flo_seg_buffer>1000)==0:
             sf.system.fatal('No cortical labels found; does the segmentation include cortical parcels?')
+        # even nearest neighbour interpolation can cause issues with matching labels,
+        # so we need to handle the segmentation values
+        if np.issubdtype( flo_seg_buffer.dtype, float ):
+            flo_seg_buffer = np.round(flo_seg_buffer).astype(int)
     else:
         print('Segmenting floating image')
         print('   Reading floating image')

--- a/mri_easyreg/mri_easywarp
+++ b/mri_easyreg/mri_easywarp
@@ -139,9 +139,19 @@ def fast_3D_interp_torch(X, II, JJ, KK, mode):
         IIr = torch.round(II[ok]).long()
         JJr = torch.round(JJ[ok]).long()
         KKr = torch.round(KK[ok]).long()
-        c = X[IIr, JJr, KKr]
-        Y = torch.zeros(II.shape, device='cpu')
-        Y[ok] = c.float()
+
+        if len(X.shape) == 3:
+            c = X[IIr, JJr, KKr]
+            Y = torch.zeros(II.shape, device='cpu')
+            Y[ok] = c.float()
+        elif len(X.shape) == 4:
+            Y = torch.zeros([*II.shape, X.shape[3]], device='cpu')
+            for channel in range(X.shape[3]):
+                Xc = X[:, :, :, channel]
+                c = Xc[IIr, JJr, KKr]
+                Yc = torch.zeros(II.shape, device='cpu')
+                Yc[ok] = c.float()
+                Y[:, :, :, channel] = Yc
         
     elif mode=='linear':
         ok = (II>0) & (JJ>0) & (KK>0) & (II<=X.shape[0]-1) & (JJ<=X.shape[1]-1) & (KK<=X.shape[2]-1)
@@ -167,27 +177,38 @@ def fast_3D_interp_torch(X, II, JJ, KK, mode):
         wcz = KKv - fz
         wfz = 1 - wcz
 
-        c000 = X[fx, fy, fz]
-        c100 = X[cx, fy, fz]
-        c010 = X[fx, cy, fz]
-        c110 = X[cx, cy, fz]
-        c001 = X[fx, fy, cz]
-        c101 = X[cx, fy, cz]
-        c011 = X[fx, cy, cz]
-        c111 = X[cx, cy, cz]
+        if len(X.shape) == 3:
+            X = X[..., None]
 
-        c00 = c000 * wfx + c100 * wcx
-        c01 = c001 * wfx + c101 * wcx
-        c10 = c010 * wfx + c110 * wcx
-        c11 = c011 * wfx + c111 * wcx
+        Y = torch.zeros([*II.shape, X.shape[3]], device='cpu')
+        for channel in range(X.shape[3]):
+            Xc = X[:, :, :, channel]
 
-        c0 = c00 * wfy + c10 * wcy
-        c1 = c01 * wfy + c11 * wcy
+            c000 = Xc[fx, fy, fz]
+            c100 = Xc[cx, fy, fz]
+            c010 = Xc[fx, cy, fz]
+            c110 = Xc[cx, cy, fz]
+            c001 = Xc[fx, fy, cz]
+            c101 = Xc[cx, fy, cz]
+            c011 = Xc[fx, cy, cz]
+            c111 = Xc[cx, cy, cz]
 
-        c = c0 * wfz + c1 * wcz
+            c00 = c000 * wfx + c100 * wcx
+            c01 = c001 * wfx + c101 * wcx
+            c10 = c010 * wfx + c110 * wcx
+            c11 = c011 * wfx + c111 * wcx
 
-        Y = torch.zeros(II.shape, device='cpu')
-        Y[ok] = c.float()
+            c0 = c00 * wfy + c10 * wcy
+            c1 = c01 * wfy + c11 * wcy
+
+            c = c0 * wfz + c1 * wcz
+
+            Yc = torch.zeros(II.shape, device='cpu')
+            Yc[ok] = c.float()
+            Y[:, :, :, channel] = Yc
+
+        if Y.shape[3] == 1:
+            Y = Y[:, :, :, 0]
 
     else:
         sf.system.fatal('mode must be linear or nearest')

--- a/mri_synthseg/mri_synthseg
+++ b/mri_synthseg/mri_synthseg
@@ -49,6 +49,7 @@ def main():
     parser.add_argument("--post", help="(optional) Posteriors output(s). Must be a folder if --i designates a folder.")
     parser.add_argument("--resample", help="(optional) Resampled image(s). Must be a folder if --i is a folder.")
     parser.add_argument("--crop", nargs='+', type=int, help="(optional) Only analyse an image patch of the given size.")
+    parser.add_argument("--autocrop", action="store_true", help="(optional) Ignore background voxels in FOV.")
     parser.add_argument("--threads", type=int, default=1, help="(optional) Number of cores to be used. Default is 1.")
     parser.add_argument("--cpu", action="store_true", help="(optional) Enforce running with CPU rather than GPU.")
     parser.add_argument("--v1", action="store_true", help="(optional) Use SynthSeg 1.0 (updated 25/06/22).")
@@ -158,8 +159,11 @@ def main():
     tf.config.threading.set_intra_op_parallelism_threads(args.threads)
 
     lut_file = os.path.join(os.environ.get('FREESURFER_HOME'),'FreeSurferColorLUT.txt')
-    labels = None;
+    labels = None
     if(args.addctab): labels = sf.load_label_lookup(lut_file)
+
+    if args.crop is not None and args.autocrop:
+        sf.system.fatal('Argument --autocrop cannot be used with --crop.')
 
     # run prediction
     predict(
@@ -186,6 +190,7 @@ def main():
         labels_qc=labels_qc,
         names_qc=names_qc_labels,
         cropping=args.crop,
+        autocrop=args.autocrop,
         topology_classes=topology_classes,
         ct=args.ct,
         keepgeom=args.keepgeom,
@@ -221,6 +226,7 @@ def predict(path_images,
             labels_qc,
             names_qc,
             cropping,
+            autocrop,
             topology_classes,
             ct,
             keepgeom=False,
@@ -310,6 +316,7 @@ def predict(path_images,
             image, aff, h, im_res, shape, pad_idx, crop_idx = preprocess(path_image=path_images[i],
                                                                          ct=ct,
                                                                          crop=cropping,
+                                                                         autocrop=autocrop,
                                                                          min_pad=min_pad,
                                                                          path_resample=path_resampled[i])
 
@@ -558,7 +565,7 @@ def prepare_output_files(path_images, out_seg, out_posteriors, out_resampled, ou
            out_qc, unique_qc_file
 
 
-def preprocess(path_image, ct, n_levels=5, crop=None, min_pad=None, path_resample=None):
+def preprocess(path_image, ct, n_levels=5, crop=None, autocrop=False, min_pad=None, path_resample=None):
 
     # read image and corresponding info
     im, _, aff, n_dims, n_channels, h, im_res = get_volume_info(path_image, True)
@@ -596,6 +603,21 @@ def preprocess(path_image, ct, n_levels=5, crop=None, min_pad=None, path_resampl
     if ct:
         im = np.clip(im, 0, 80)
     im = rescale_volume(im, new_min=0, new_max=1, min_percentile=0.5, max_percentile=99.5)
+
+    if autocrop and crop_idx is None:
+        nz_locs = np.argwhere(im > 0)
+        min_indices = np.min(nz_locs, axis=0)
+        max_indices = np.max(nz_locs, axis=0)
+        nz_crop = max_indices - min_indices + 2
+        crop_shape = [find_closest_number_divisible_by_m(s, 2 ** n_levels, 'higher') for s in nz_crop]
+        half_dim_diff = np.floor_divide([crop_shape[i] - nz_crop[i] for i in range(n_dims)], 2)
+        min_crop_idx = np.maximum(min_indices - half_dim_diff, 0)
+        max_crop_idx = np.minimum(min_crop_idx + crop_shape, im.shape[:n_dims])
+        crop_idx = np.concatenate([np.array(min_crop_idx), np.array(max_crop_idx)])
+        if n_dims == 2:
+            im = im[crop_idx[0]: crop_idx[2], crop_idx[1]: crop_idx[3], ...]
+        elif n_dims == 3:
+            im = im[crop_idx[0]: crop_idx[3], crop_idx[1]: crop_idx[4], crop_idx[2]: crop_idx[5], ...]
 
     # pad image
     input_shape = im.shape[:n_dims]

--- a/mri_synthseg/mri_synthseg
+++ b/mri_synthseg/mri_synthseg
@@ -604,6 +604,7 @@ def preprocess(path_image, ct, n_levels=5, crop=None, autocrop=False, min_pad=No
         im = np.clip(im, 0, 80)
     im = rescale_volume(im, new_min=0, new_max=1, min_percentile=0.5, max_percentile=99.5)
 
+    # Automatically crop to bounding box of non-zero stuff in the re-normalised image
     if autocrop and crop_idx is None:
         nz_locs = np.argwhere(im > 0)
         min_indices = np.min(nz_locs, axis=0)

--- a/mri_synthseg/mri_synthseg
+++ b/mri_synthseg/mri_synthseg
@@ -190,11 +190,11 @@ def main():
         labels_qc=labels_qc,
         names_qc=names_qc_labels,
         cropping=args.crop,
-        autocrop=args.autocrop,
         topology_classes=topology_classes,
         ct=args.ct,
         keepgeom=args.keepgeom,
-        labels=labels
+        labels=labels,
+        autocrop=args.autocrop
     )
 
 
@@ -226,11 +226,11 @@ def predict(path_images,
             labels_qc,
             names_qc,
             cropping,
-            autocrop,
             topology_classes,
             ct,
             keepgeom=False,
-            labels=None):
+            labels=None,
+            autocrop=False):
     '''
     Prediction pipeline.
     '''
@@ -316,9 +316,9 @@ def predict(path_images,
             image, aff, h, im_res, shape, pad_idx, crop_idx = preprocess(path_image=path_images[i],
                                                                          ct=ct,
                                                                          crop=cropping,
-                                                                         autocrop=autocrop,
                                                                          min_pad=min_pad,
-                                                                         path_resample=path_resampled[i])
+                                                                         path_resample=path_resampled[i],
+                                                                         autocrop=autocrop)
 
             # prediction
             shape_input = add_axis(np.array(image.shape[1:-1]))
@@ -565,7 +565,7 @@ def prepare_output_files(path_images, out_seg, out_posteriors, out_resampled, ou
            out_qc, unique_qc_file
 
 
-def preprocess(path_image, ct, n_levels=5, crop=None, autocrop=False, min_pad=None, path_resample=None):
+def preprocess(path_image, ct, n_levels=5, crop=None, min_pad=None, path_resample=None, autocrop=False):
 
     # read image and corresponding info
     im, _, aff, n_dims, n_channels, h, im_res = get_volume_info(path_image, True)


### PR DESCRIPTION
In cases where the Field of View (FOV) is set too large on low resolution volumes, resampling to 1mm iso in synthseg gives  extremely large tensors (350+ to a side). In such cases the system can struggle to find large enough contiguous blocks of memory leading to 'bad alloc' errors. In such cases much of the FOV is unneeded and so can be cropped out to reduce memory pressure and compute time. 

Cropping manually with the --crop option requires knowledge of head placement and dimension and is limited to the centre of the FOV. However, synthseg already re-normalises input images and zero's out background noise. Here we've added the --autocrop flag to allow automatic cropping to the smallest bounding box containing everything that is not zeroed out by the normalisation step. 

Additional fixes include:
1. Multi-channel support for resampling using mri_easywarp
2. Handling of numerical roundoff when matching cortical parcellation labels in mri_easyreg
