### PR TITLE
moved AANSegment volumes txt file to /stats/.stats

### DIFF
--- a/AANsegment/SegmentAAN.sh
+++ b/AANsegment/SegmentAAN.sh
@@ -231,6 +231,9 @@ else
 endif
 echo $returnVal
 
+# TEMPORARY: convert to .stats file under /stats
+mkdir -p ${SUBJECTS_DIR}/${SUBJECTNAME}/stats
+mv ${SUBJECTS_DIR}/${SUBJECTNAME}/mri/arousalNetworkVolumes.${SUFFIX}.txt ${SUBJECTS_DIR}/${SUBJECTNAME}/stats/arousalNetworkVolumes.${SUFFIX}.stats
 
 if ($returnVal) then
   uname -a | tee -a $AANNUCLOG


### PR DESCRIPTION
Added line to move the arousalNetworkVolumes.${SUFFIX}.txt outputted in /mri over to the /stats directory as arousalNetworkVolumes.${SUFFIX}.stats. 

mkdir -p .../stats/... is there just in-case one runs the script without recon-all. 

The name arousalNetworkVolumes is hard-coded since its name is created in downstream code. I will change this when we convert to python.

