### PR TITLE
Updated distribution/CMakeLists.txt to install all luts under distribution/luts into FS_HOME/luts

### DIFF
--- a/distribution/CMakeLists.txt
+++ b/distribution/CMakeLists.txt
@@ -17,7 +17,10 @@ install(FILES
   FreeSurferColorLUT.txt
   luts/ReducedLabels24.txt
   luts/ReducedLabels35.txt
+  luts/ReducedLabels5.txt
   luts/ReducedLabels4.txt
+  luts/compressed_lut.txt
+  luts/nonlat.txt
   DESTINATION luts
 )
 


### PR DESCRIPTION
Some new cLUTs have been added under distribution/luts, but they are not currently getting installed along with the other cLUTs under FREESURFER_HOME/luts. Updated the CMakeLists.txt to install the following luts in to FREESURFER_HOME/luts:

- ReducedLabels5.txt
- nonlat.txt
- compressed_lut.txt