### PR TITLE
Add configurable thalamic nuclei filename / Issue in creating aparc+aseg+thalnuc segmentation

### DIFF
--- a/scripts/trac-preproc
+++ b/scripts/trac-preproc
@@ -1350,7 +1350,8 @@ if ($dointra && ! $dobase && -e $fsdir/mri/brain.mgz) then
 
     set cmd = mri_binarize
     set cmd = ($cmd --i $fsdir/mri/$segname.mgz)
-    set cmd = ($cmd `printf "--replaceonly-nn %s 11 " $ids`)
+    set cmd = ($cmd --match $ids)
+    set cmd = ($cmd --replaceonly-nn 11)
     set cmd = ($cmd --o $labdir/anatorig/${segname}+thalnuc.nii.gz)
     echo $cmd
     $cmd

--- a/scripts/trac-preproc
+++ b/scripts/trac-preproc
@@ -1337,24 +1337,8 @@ if ($dointra && ! $dobase && -e $fsdir/mri/brain.mgz) then
   endif
 
   if ($usethalnuc) then
-    set thalseg = ()
-
-    foreach thalver (v13.T1. v12.T1. '' long.)
-      if (-e $fsdir/mri/ThalamicNuclei."$thalver"FSvoxelSpace.mgz) then
-        set thalseg = ThalamicNuclei."$thalver"FSvoxelSpace
-        break
-      endif
-    end
-
-    if ($#thalseg == 0) then
-      echo "ERROR: Could not find thalamic nuclei segmentation in $fsdir/mri/" |& tee -a $LF
-      echo "ERROR: using any of the following patterns --->" |& tee -a $LF
-      echo "ERROR: ThalamicNuclei.v1[23].T1.FSvoxelSpace.mgz" |& tee -a $LF
-      echo "ERROR: ThalamicNuclei.FSvoxelSpace.mgz" |& tee -a $LF
-      echo "ERROR: ThalamicNuclei.long.FSvoxelSpace.mgz" |& tee -a $LF
-      echo "ERROR: Thalamic nuclei segmentation is strongly recommended to use" |& tee -a $LF
-      echo "ERROR: for tracts that terminate in or travel near the thalamus" |& tee -a $LF
-      echo "ERROR: If there is good reason not to use it, set usethalnuc = 0" |& tee -a $LF
+    if (! -e $fsdir/mri/$thalsegname) then
+      echo "ERROR: Could not find thalamic nuclei segmentation: $fsdir/mri/$thalsegname" |& tee -a $LF
       goto error_exit
     endif
 
@@ -1374,7 +1358,7 @@ if ($dointra && ! $dobase && -e $fsdir/mri/brain.mgz) then
     # Merge main segmentation with thalamic nuclei segmentation
     set cmd = mri_concat
     set cmd = ($cmd --i $labdir/anatorig/${segname}+thalnuc.nii.gz)
-    set cmd = ($cmd --i $fsdir/mri/$thalseg.mgz)
+    set cmd = ($cmd --i $fsdir/mri/$thalsegname)
     set cmd = ($cmd --max)
     set cmd = ($cmd --o $labdir/anatorig/${segname}+thalnuc.nii.gz)
     echo $cmd


### PR DESCRIPTION
### **Add configurable thalamic nuclei filename**
Currently, the script attempts to auto-detect thalamic nuclei segmentation files using hardcoded patterns. This is problematic because filename patterns vary by FreeSurfer version (v12, v13) and analysis method (cross vs longitudinal), using additional scans (ANALYSIS_ID).

**Solution**
Add a configurable thalsegname parameter in dmrirc to specify the exact filename:

```#
# Name of thalamic nuclei segmentation file
# Must exist in each subject's FreeSurfer recon directory mri/
# Can vary based on FreeSurfer version and type of thalamic segmentation performed
# Default: ThalamicNuclei.v13.T1.FSvoxelSpace.mgz
#
set thalsegname = ThalamicNuclei.v13.T1.FSvoxelSpace.mgz
```

### **Add configurable thalamic nuclei filename](trac-preproc: Issue in creating aparc+aseg+thalnuc segmentation**
The trac-preproc script fails when creating the combined aparc+aseg+thalnuc segmentation due to missing parameters in the mri_binarize command:
```
ERROR: must specify minimum and/or maximum threshold or match values
error: niiRead(): error opening file [...]/aparc+aseg+thalnuc.nii.gz
```

**Solution**
Add --match to mri_binarize command.

Tested with FreeSurfer 7.4.1
