### PR TITLE
fix #1294: check if output matrix is large enough to hold a copy

### DIFF
--- a/utils/matrix.cpp
+++ b/utils/matrix.cpp
@@ -161,6 +161,8 @@ MATRIX *MatrixCopy(const MATRIX *mIn, MATRIX *mOut)
   cols = mIn->cols;
 
   if (!mOut) mOut = MatrixAlloc(rows, cols, mIn->type);
+  if (mOut->rows < mIn->rows || mOut->cols < mIn->cols) return (NULL);
+  MatrixZero(mOut->rows, mOut->cols, mOut);
 
   if (!mOut) ErrorExit(ERROR_NO_MEMORY, "MatrixCopy: couldn't allocate mOut");
 

--- a/utils/matrix.cpp
+++ b/utils/matrix.cpp
@@ -160,9 +160,11 @@ MATRIX *MatrixCopy(const MATRIX *mIn, MATRIX *mOut)
   rows = mIn->rows;
   cols = mIn->cols;
 
-  if (!mOut) mOut = MatrixAlloc(rows, cols, mIn->type);
-  if (mOut->rows < mIn->rows || mOut->cols < mIn->cols) return (NULL);
-  MatrixZero(mOut->rows, mOut->cols, mOut);
+  if (!mOut) 
+	  mOut = MatrixAlloc(rows, cols, mIn->type);
+  else (mOut->rows < mIn->rows || mOut->cols < mIn->cols)
+	  return (NULL);
+  //MatrixZero(mOut->rows, mOut->cols, mOut); // Not really necessary, every element will be overwritten.
 
   if (!mOut) ErrorExit(ERROR_NO_MEMORY, "MatrixCopy: couldn't allocate mOut");
 


### PR DESCRIPTION
also initialize it to zero just in case it's larger than input matrix