### PR TITLE
Enhancements for mri_synthstrip Docker builds

### DIFF
--- a/mri_synthstrip/Dockerfile.cpu
+++ b/mri_synthstrip/Dockerfile.cpu
@@ -1,0 +1,33 @@
+# base image with Python and SynthStrip on path (eventually)
+FROM python:3.10-slim AS base
+ENV FREESURFER_HOME="/freesurfer"
+ENV PYTHONUSERBASE="$FREESURFER_HOME/env"
+ENV PATH="$FREESURFER_HOME:$PATH"
+
+# intermediate stage with build requirements not needed in final image
+FROM base AS build
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential
+
+RUN --mount=type=cache,target=/root/.cache pip3 install --user \
+    https://github.com/freesurfer/surfa/archive/ca4e26317d3556776268ede7de20752743bf49a2.zip
+
+RUN --mount=type=cache,target=/root/.cache pip3 install --user --index-url https://download.pytorch.org/whl/cpu \
+    torch==2.1.2
+
+# install synthstrip from local folder
+COPY --chmod=0775 mri_synthstrip $FREESURFER_HOME
+COPY --chmod=0664 synthstrip.*.pt $FREESURFER_HOME/models/
+
+# export build artifacts
+RUN python3 -V >python.txt
+RUN python3 -m pip freeze >requirements.txt
+
+FROM scratch AS export
+COPY --from=build *.txt /
+
+
+# only copy files needed and only once to avoid unnecessary layers
+FROM base
+COPY --from=build $FREESURFER_HOME $FREESURFER_HOME
+ENTRYPOINT ["mri_synthstrip"]

--- a/mri_synthstrip/Dockerfile.gpu
+++ b/mri_synthstrip/Dockerfile.gpu
@@ -1,27 +1,19 @@
 # base image with Python and SynthStrip on path (eventually)
-FROM ubuntu:22.04 AS base
+FROM python:3.10-slim AS base
 ENV FREESURFER_HOME="/freesurfer"
 ENV PYTHONUSERBASE="$FREESURFER_HOME/env"
 ENV PATH="$FREESURFER_HOME:$PATH"
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 && \
-    rm -rf /var/lib/apt/lists/*
-
-
 # intermediate stage with build requirements not needed in final image
 FROM base AS build
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    git \
-    python3-dev \
-    python3-pip
+    build-essential
 
-# install packages into user base simple easy COPY
-RUN python3 -m pip install -U pip
-RUN python3 -m pip install --user \
-    torch==2.1.2 \
-    git+https://github.com/freesurfer/surfa.git@0d83332351083b33c4da221e9d10a63a93ae7f52
+RUN --mount=type=cache,target=/root/.cache pip3 install --user \
+    https://github.com/freesurfer/surfa/archive/ca4e26317d3556776268ede7de20752743bf49a2.zip
+
+RUN --mount=type=cache,target=/root/.cache pip3 install --user --index-url https://download.pytorch.org/whl/cu118 \
+     torch==2.1.2
 
 # install synthstrip from local folder
 COPY --chmod=0775 mri_synthstrip $FREESURFER_HOME
@@ -30,7 +22,6 @@ COPY --chmod=0664 synthstrip.*.pt $FREESURFER_HOME/models/
 # export build artifacts
 RUN python3 -V >python.txt
 RUN python3 -m pip freeze >requirements.txt
-
 
 FROM scratch AS export
 COPY --from=build *.txt /


### PR DESCRIPTION
GPU Dockerfile
- switch to minimal python base image (~200MB savings)
- add support for docker build cache of pip files
- use github tarball of hash to avoid git install
- use official pytorch wheel

New CPU Dockerfile
- features as above
- 3.79GB (!!!) savings

I'd like to request the CPU tag variant be published alongside the regular one in Dockerhub.

Ref:
https://pytorch.org/get-started/previous-versions/