### PR TITLE
update CNYBCH atlas seg files

### DIFF
--- a/distribution/average/CNYBCH.tar.gz
+++ b/distribution/average/CNYBCH.tar.gz
@@ -1,1 +1,1 @@
-../../.git/annex/objects/1v/kJ/SHA256E-s24618363--79df00bba55532f3b5e2349e15fb869df80d36f00b053cb1deacdb31ba82f8ff.tar.gz/SHA256E-s24618363--79df00bba55532f3b5e2349e15fb869df80d36f00b053cb1deacdb31ba82f8ff.tar.gz
+../../.git/annex/objects/j0/xm/SHA256E-s24617596--40783ba608dd5799ac47c77b546afcfb4a9a69abf8c3266070b5604d16fba4b5.tar.gz/SHA256E-s24617596--40783ba608dd5799ac47c77b546afcfb4a9a69abf8c3266070b5604d16fba4b5.tar.gz


### PR DESCRIPTION
Changed seg file names to match what infant_recon_all expects them to be named