### PR TITLE
bf: Fix reading VTK Version 3.0 files

### DIFF
--- a/utils/mrisurf_io.cpp
+++ b/utils/mrisurf_io.cpp
@@ -2881,10 +2881,10 @@ MRI_SURFACE *MRISreadVTK(MRI_SURFACE *mris, const char *fname, MRI *curvmri)
     if (strncmp(cp, "vtk output", 10) == 0) {
       checks++;
     }
-    if (strncmp(cp, "surface file", 10) == 0) {
+    if (strncmp(cp, "surface file", 12) == 0) {
       checks++;
     }
-    if (strncmp(cp, "SURFACE FILE", 10) == 0) {
+    if (strncmp(cp, "SURFACE FILE", 12) == 0) {
       checks++;
     }
     if (strncmp(cp, "ASCII", 5) == 0) {

--- a/utils/mrisurf_io.cpp
+++ b/utils/mrisurf_io.cpp
@@ -2884,7 +2884,7 @@ MRI_SURFACE *MRISreadVTK(MRI_SURFACE *mris, const char *fname, MRI *curvmri)
     if (strncmp(cp, "surface file", 10) == 0) {
       checks++;
     }
-    if (strncmp(cp, "VTK OUTPUT", 10) == 0) {
+    if (strncmp(cp, "SURFACE FILE", 10) == 0) {
       checks++;
     }
     if (strncmp(cp, "ASCII", 5) == 0) {

--- a/utils/mrisurf_io.cpp
+++ b/utils/mrisurf_io.cpp
@@ -2881,6 +2881,12 @@ MRI_SURFACE *MRISreadVTK(MRI_SURFACE *mris, const char *fname, MRI *curvmri)
     if (strncmp(cp, "vtk output", 10) == 0) {
       checks++;
     }
+    if (strncmp(cp, "surface file", 10) == 0) {
+      checks++;
+    }
+    if (strncmp(cp, "VTK OUTPUT", 10) == 0) {
+      checks++;
+    }
     if (strncmp(cp, "ASCII", 5) == 0) {
       checks++;
     }


### PR DESCRIPTION
The VTK Version 3.0 surface files do not include "vtk output" in the file header. Instead, "surface file" is included. 

This very simple fix enables opening VTK Version 3.0 surface files without manually editing the file headers.