### PR TITLE
Fix recon-all '-autorecon1' flag

### DIFF
--- a/scripts/recon-all
+++ b/scripts/recon-all
@@ -7285,6 +7285,8 @@ while( $#argv != 0 )
       set DoTalairach      = 1;
       set DoTalCheck       = 1;
       set DoNormalization  = 1;
+      set DoCANormalize    = 1;
+      set DoGCAReg         = 1;
       set DoSkullStrip     = 1;
       set DoNuIntensityCor = 1;
       breaksw

--- a/scripts/recon-all
+++ b/scripts/recon-all
@@ -7285,8 +7285,8 @@ while( $#argv != 0 )
       set DoTalairach      = 1;
       set DoTalCheck       = 1;
       set DoNormalization  = 1;
-      set DoCANormalize    = 1;
       set DoGCAReg         = 1;
+      set DoCANormalize    = 1;
       set DoSkullStrip     = 1;
       set DoNuIntensityCor = 1;
       breaksw


### PR DESCRIPTION
Make the autorecon1 flag do gca_reg and ca_norm as they are needed for seg2cc which is a later step in the `autorecon1` pipeline. Alternatively the inputs to seg2cc may need to use a file other than `norm.mgz` for the `autorecon1`  pipeline to work.
Related #1335 