### PR TITLE
Claustrum mac

### DIFF
--- a/mri_claustrum_seg/CMakeLists.txt
+++ b/mri_claustrum_seg/CMakeLists.txt
@@ -1,5 +1,8 @@
 project(mri_claustrum_seg)
 
+# Problems with python env on APPLE_ARM64
+if (NOT APPLE_ARM64)
+
 # handle FSPYTHON tree split install
 if (FSPYTHON_INSTALL_TREE)
     set(claustrum_python "${FSPYTHON_INSTALL_PREFIX}/python")
@@ -24,3 +27,5 @@ endif()
 
 ## isntall the atlas dir
 install_tarball(claustrum_seg.tar.gz DESTINATION average)
+
+endif()

--- a/mri_claustrum_seg/CMakeLists.txt
+++ b/mri_claustrum_seg/CMakeLists.txt
@@ -1,8 +1,5 @@
 project(mri_claustrum_seg)
 
-# currently only working on Linux platforms
-if(NOT APPLE)
-
 # handle FSPYTHON tree split install
 if (FSPYTHON_INSTALL_TREE)
     set(claustrum_python "${FSPYTHON_INSTALL_PREFIX}/python")
@@ -27,5 +24,3 @@ endif()
 
 ## isntall the atlas dir
 install_tarball(claustrum_seg.tar.gz DESTINATION average)
-
-endif()


### PR DESCRIPTION
Enabled mri_claustrum_seg install for Intel Macs.
Problem with installing all python dependencies still on the ARM platforms.