### PR TITLE
nf: Pass GPU setting to mri_synthstrip in recon-all

### DIFF
--- a/scripts/recon-all
+++ b/scripts/recon-all
@@ -1611,6 +1611,7 @@ if($SynthStrip) then
   if($ud || $ForceUpdate) then
     set xopts = `fsr-getxopts synthstrip $V8XoptsFile $GlobXOptsFile $XOptsFile`;
     set cmd = (mri_synthstrip --threads $OMP_NUM_THREADS -i $origvol -o $synthstrip $xopts)
+    if($UseGPU) set cmd = ($cmd -g)
     echo "\n $cmd \n" |& tee -a $LF |& tee -a $CF
     if($RunIt) then
       $fs_time $cmd |& tee -a $LF


### PR DESCRIPTION
Similar to the existing option for mri_synthseg, this activates the GPU option in mri_synthstrip when the -gpu flag is set in recon-all.