### PR TITLE
feat: Add vector field rotation support in mri_convert and mri_vol2vol

### DIFF
--- a/mri_convert/mri_convert.cpp
+++ b/mri_convert/mri_convert.cpp
@@ -116,6 +116,7 @@ int main(int argc, char *argv[])
   float voxel_size[3];
   int in_i_direction_flag, in_j_direction_flag, in_k_direction_flag;
   int out_i_direction_flag, out_j_direction_flag, out_k_direction_flag;
+  int vector3d_flag = FALSE;
   int  in_orientation_flag = FALSE;
   char in_orientation_string[STRLEN];
   int  out_orientation_flag = FALSE;
@@ -162,6 +163,7 @@ int main(int argc, char *argv[])
   char in_name_only[STRLEN];
   char transform_fname[STRLEN];
   int transform_flag, invert_transform_flag;
+  int DoVectorRotation = FALSE; // flag to indicate vector field rotation should be applied
   LTA *lta_transform = NULL;
   MRI *mri_transformed = NULL;
   MRI *mritmp=NULL;
@@ -316,6 +318,7 @@ int main(int argc, char *argv[])
   out_i_size_flag = out_j_size_flag = out_k_size_flag = FALSE;
   in_i_direction_flag = in_j_direction_flag = in_k_direction_flag = FALSE;
   out_i_direction_flag = out_j_direction_flag = out_k_direction_flag = FALSE;
+  vector3d_flag = FALSE;
   in_center_flag = FALSE;
   delta_in_center_flag = FALSE;
   out_center_flag = FALSE;
@@ -690,6 +693,11 @@ int main(int argc, char *argv[])
       transform_flag = TRUE;
       invert_transform_flag = TRUE;
     }
+    else if (strcmp(argv[i], "--vector") == 0)
+    {
+      DoVectorRotation = TRUE;
+      printf("Vector field rotation enabled\n");
+    }
     ///////////////////////////////////////////////////////////
     else if (strcmp(argv[i], "--upsample") == 0 )
     {
@@ -833,6 +841,11 @@ int main(int argc, char *argv[])
                in_k_directions[2]);
       }
       in_k_direction_flag = TRUE;
+    }
+    else if(strcmp(argv[i], "--3d-vector") == 0 ||
+            strcmp(argv[i], "--3d_vector") == 0)
+    {
+      vector3d_flag = TRUE;
     }
     else if(strcmp(argv[i], "--ctab") == 0)
     {
@@ -3157,7 +3170,33 @@ int main(int argc, char *argv[])
              LTAtransformTypeName(lta_transform->type));
       MatrixPrint(stdout,lta_transform->xforms[0].m_L);
       printf("---------------------------------\n");
-
+    
+      MATRIX *m_rotation_3x3 = NULL;
+      if (DoVectorRotation) {
+        // Extract rotation matrix for vector field rotation
+        MATRIX *m_rotation_4x4 = MatrixAlloc(4, 4, MATRIX_REAL);
+        if (lta_transform->type == LINEAR_RAS_TO_RAS) {
+          Trns_ExtractRotationMatrix(lta_transform->xforms[0].m_L, m_rotation_4x4);
+        }
+        else {
+          //make a copy of lta 
+          LTA *lta_transform_copy = LTAcopy(lta_transform,NULL);
+          LTAchangeType(lta_transform_copy, LINEAR_RAS_TO_RAS);
+          if (Gdiag_no > 0) {
+            printf("lta_transform_copy->xforms[0].m_L:\n");
+            MatrixPrint(stdout, lta_transform_copy->xforms[0].m_L);
+          }
+          Trns_ExtractRotationMatrix(lta_transform_copy->xforms[0].m_L, m_rotation_4x4);
+          LTAfree(&lta_transform_copy);
+        }
+        if (Gdiag_no > 0) {
+          printf("R_rot_4x4:\n");
+          MatrixPrint(stdout, m_rotation_4x4);
+        }
+        // Extract 3x3 rotation matrix from top-left of 4x4 matrix
+        m_rotation_3x3 = MatrixCopyRegion(m_rotation_4x4, NULL, 1, 1, 3, 3, 1, 1);
+        MatrixFree(&m_rotation_4x4);
+      }
       /* LTAtransform() runs either MRIapplyRASlinearTransform()
          for RAS2RAS or MRIlinearTransform() for Vox2Vox. */
       /* MRIlinearTransform() calls MRIlinearTransformInterp() */
@@ -3219,6 +3258,15 @@ int main(int argc, char *argv[])
         mri_transformed->c_a = mri_template->c_a ;
         mri_transformed->c_s = mri_template->c_s ;
       }
+      
+      if (DoVectorRotation) {
+        printf("Applying rotation to vector field\n");
+        // Pass NULL for Vt2s since src == targ (in-place rotation)
+        // MRIvol2VolR will compute identity internally
+        MRIvol2VolR(mri_transformed, mri_transformed, NULL, 0, 0, m_rotation_3x3);
+        MatrixFree(&m_rotation_3x3);
+      }
+
       LTAfree(&lta_transform);
       MRIfree(&mri);
       mri = mri_transformed;

--- a/mri_vol2vol/mri_vol2vol.cpp
+++ b/mri_vol2vol/mri_vol2vol.cpp
@@ -97,6 +97,8 @@ mri_vol2vol
   --shear Sxy Sxz Syz : xz is in-plane
   --reg-final regfinal.dat : final reg after rot and trans (but not inv)
 
+  --vector        : treat input as vector field and apply rotation to vectors
+
   --synth : replace input with white gaussian noise
   --seed seed : seed for synth (def is to set from time of day)
 
@@ -472,6 +474,7 @@ ENDHELP --------------------------------------------------------------
 #include "registerio.h"
 #include "resample.h"
 #include "transform.h"
+#include "mriTransform.h"
 #include "gca.h"
 #include "gcamorph.h"
 #include "fio.h"
@@ -626,6 +629,7 @@ double MultiplyVal=0;
 int DownSample[3] = {0,0,0}; // downsample source
 int pedir = 2; // for VSM 1=x, 2=y, 3=z
 char *ctabfile = NULL;
+int DoVectorRotation = 0; // flag to indicate vector field rotation should be applied
 
 /*---------------------------------------------------------------*/
 int main(int argc, char **argv) {
@@ -903,6 +907,14 @@ int main(int argc, char **argv) {
   Stemp    = MRIxfmCRS2XYZ(mri_template,0);
   invStemp = MatrixInverse(Stemp,NULL);
 
+  // Compute ScannerRAS_input -> ScannerRAS_template transform
+  // Chain: ScannerRAS_input -> voxel_input -> tkRAS_input -> tkRAS_template -> voxel_template -> ScannerRAS_template
+  // = Stemp * invTtemp * invR * Tin * invSin
+  MATRIX *RAS_input_to_template = MatrixMultiply(Stemp, invTtemp, NULL);
+  MatrixMultiply(RAS_input_to_template, invR, RAS_input_to_template);
+  MatrixMultiply(RAS_input_to_template, Tin, RAS_input_to_template);
+  MatrixMultiply(RAS_input_to_template, invSin, RAS_input_to_template);
+
   if(noresample) {
     printf("Not resampling, only changing vox2ras matrix\n");
     // Compte new vox2ras instead of resampling
@@ -993,6 +1005,23 @@ int main(int argc, char **argv) {
 	if(vsmlta) printf("Using vsmlta\n");
 	MRIvol2VolVSM(in,out,vox2vox,interpcode,sinchw,vsm,vsmlta,pedir);
       }
+    }
+
+    if (DoVectorRotation) {
+      printf("Applying rotation to vector field\n");
+      MATRIX * R_rot_4x4 = MatrixAlloc(4, 4, MATRIX_REAL);
+      Trns_ExtractRotationMatrix(RAS_input_to_template, R_rot_4x4);
+      if (Gdiag_no > 0) {
+        printf("R_rot_4x4:\n");
+        MatrixPrint(stdout, R_rot_4x4);
+      }
+      // Extract 3x3 rotation matrix from top-left of 4x4 matrix
+      MATRIX * R_rot_3x3 = MatrixCopyRegion(R_rot_4x4, NULL, 1, 1, 3, 3, 1, 1);
+      MatrixFree(&R_rot_4x4);
+      // Pass NULL for Vt2s since src == targ (in-place rotation)
+      // MRIvol2VolR will compute identity internally
+      MRIvol2VolR(out, out, NULL, 0, 0, R_rot_3x3);
+      MatrixFree(&R_rot_3x3);
     }
   }
   else {
@@ -1303,6 +1332,10 @@ static int parse_commandline(int argc, char **argv) {
       sscanf(pargv[0],"%d",&pedir);
       nargsused = 1;
     } 
+    else if (!strcasecmp(option, "--vector")) {
+      DoVectorRotation = 1;
+      printf("Vector field rotation enabled\n");
+    }
     else if (istringnmatch(option, "--targ",0)) {
       if (nargc < 1) argnerr(option,1);
       targvolfile = pargv[0];
@@ -2399,6 +2432,7 @@ MATRIX *LoadRfsl(char *fname) {
   }
   return(FSLRegMat);
 }
+
 /*
   \fn MRI *MRIvol2volGCAM(MRI *src, LTA *srclta, GCA_MORPH *gcam, LTA *dstlta, MRI *vsm, int sample_type, MRI *dst)
   \brief Converts one volume into another using as many as four transforms: VSM, src linear, gcam/m3z, dst linear.


### PR DESCRIPTION
## Summary

Adds `--vector` flag support to `mri_convert` and `mri_vol2vol` to properly rotate 3D vector fields when applying spatial transformations. This ensures that vector components are correctly rotated along with the volume geometry.

## What Changed

### Files Modified
- `mri_convert/mri_convert.cpp` - Added `--vector` flag and vector rotation logic
- `mri_vol2vol/mri_vol2vol.cpp` - Added `--vector` flag and vector rotation logic

### Details

**mri_convert:**
- Added `DoVectorRotation` flag and `--vector` command-line option
- Extracts rotation matrix from the LTA transform using `Trns_ExtractRotationMatrix()`
- Converts transform to `LINEAR_RAS_TO_RAS` type if needed before extracting rotation
- Applies rotation to vector fields using `MRIvol2VolR()` after volume transformation
- Added `vector3d_flag` variable (initialized but reserved for future use)

**mri_vol2vol:**
- Added `DoVectorRotation` flag and `--vector` command-line option
- Computes `RAS_input_to_template` transform matrix to chain coordinate transformations
- Extracts 3x3 rotation matrix from the 4x4 transform matrix
- Applies rotation to vector fields using `MRIvol2VolR()` after resampling
- Added include for `mriTransform.h` header

**Implementation details:**
- Rotation matrix is extracted from the top-left 3x3 submatrix of the 4x4 transform
- `MRIvol2VolR()` handles both 3-frame vector fields and 9-frame tensor fields
- Vector rotation is applied in-place after the volume transformation is complete
- Works with both `LINEAR_RAS_TO_RAS` and `LINEAR_VOX_TO_VOX` transform types

## Why

When transforming volumes that contain 3D vectors (such as displacement fields, gradient fields, flow fields, etc.), the vectors themselves need to be rotated to match the transformed coordinate system. Without this feature, only the volume geometry would change while the vectors would remain in their original orientation, leading to incorrect results.

**Use cases:**
- Transforming displacement fields from image registration
- Rotating gradient or flow fields
- Transforming tensor fields (diffusion tensors)
- Any application where vector data needs to maintain correct orientation after spatial transformation
