### PR TITLE
Fix expert option handling in v8.2.0 recon-all and rca-surfreg

### DIFF
--- a/scripts/rca-surfreg
+++ b/scripts/rca-surfreg
@@ -248,6 +248,7 @@ while( $#argv != 0 )
       set RunIt = 0;
       breaksw
 
+    case "--expert":
     case "-expert":
       if( $#argv < 1) goto arg1err;
       set XOptsFile = $argv[1]; shift;

--- a/scripts/recon-all
+++ b/scripts/recon-all
@@ -4217,7 +4217,7 @@ if($DoSurfReg) then
   if($UseNoNeg) set cmd = ($cmd --usenoneg)
   if($JosaReg) set cmd = ($cmd --josa)
   if($ForceUpdate) set cmd = ($cmd --force)
-  if($XOptsFile) set cmd = ($cmd --expert $XOptsFile)
+  if($#XOptsFile) set cmd = ($cmd --expert $XOptsFile)
   echo "#@# Surf Reg  `date`" |& tee -a $SF |& tee -a $LF |& tee -a $CF
   if($RunIt) then
     echo $cmd |& tee -a $LF


### PR DESCRIPTION
This PR fixes two expert-options issues:

1. recon-all evaluates` if($XOptsFile)`, which can expand to a path and trigger tcsh "`if: Expression Syntax.`"
2. rca-surfreg does not recognize` --expert`, although recon-all passes that flag.

Changes:
- replace `if($XOptsFile)` with `if($#XOptsFile)` in recon-all
- add support for `--expert` alongside `-expert` in rca-surfreg

Fixes Issue #1432