### PR TITLE
Support installing MCR from a local installer file in `fs_install_mcr` (+ bugfix on partial version matching)

### DIFF
--- a/scripts/fs_install_mcr
+++ b/scripts/fs_install_mcr
@@ -48,6 +48,23 @@ else
     OS_TAG=maci64
 fi
 
+# ----------------------------------------------------------------------------
+# Supported MCR versions and their download URLs, keyed by version string.
+# To support a new MCR version, add a single entry here.
+# ----------------------------------------------------------------------------
+declare -A MCR_URLS=(
+    ["R2012a"]="https://ssd.mathworks.com/supportfiles/MCR_Runtime/R2012a/MCR_R2012a_${OS_TAG}_installer.zip"
+    ["R2012b"]="https://ssd.mathworks.com/supportfiles/MCR_Runtime/R2012b/MCR_R2012b_${OS_TAG}_installer.zip"
+    ["R2013a"]="https://ssd.mathworks.com/supportfiles/MCR_Runtime/R2013a/MCR_R2013a_${OS_TAG}_installer.zip"
+    ["R2014a"]="https://ssd.mathworks.com/supportfiles/downloads/R2014a/deployment_files/R2014a/installers/${OS_TAG}/MCR_R2014a_${OS_TAG}_installer.zip"
+    ["R2014b"]="https://ssd.mathworks.com/supportfiles/downloads/R2014b/deployment_files/R2014b/installers/${OS_TAG}/MCR_R2014b_${OS_TAG}_installer.zip"
+    ["R2019b"]="https://ssd.mathworks.com/supportfiles/downloads/R2019b/Release/9/deployment_files/installer/complete/${OS_TAG}/MATLAB_Runtime_R2019b_Update_9_${OS_TAG}.zip"
+)
+
+# build a regex alternation of supported versions from the array keys, e.g. R2012a|R2012b|...
+SUPPORTED_VERSIONS_LIST="${!MCR_URLS[@]}"
+SUPPORTED_VERSIONS_RE="$(echo "$SUPPORTED_VERSIONS_LIST" | tr ' ' '|')"
+
 # if a local installer file was provided, validate its name and derive the MCR version from it
 if [[ -n "$LOCAL_INSTALLER" ]]; then
     LOCAL_INSTALLER_NAME="$(basename "$LOCAL_INSTALLER")"
@@ -63,17 +80,21 @@ if [[ -n "$LOCAL_INSTALLER" ]]; then
         exit 1
     fi
 
-    # only accept versions supported by this script (same set handled in the download branch below)
-    if [[ "$LOCAL_INSTALLER_NAME" =~ (R2012a|R2012b|R2013a|R2014a|R2014b|R2019b) ]]; then
-        MCR_VER="${BASH_REMATCH[1]}"
+    # only accept versions supported by this script
+    if [[ "$LOCAL_INSTALLER_NAME" =~ (^|[^0-9A-Za-z])($SUPPORTED_VERSIONS_RE)([^0-9A-Za-z]|$) ]]; then
+        MCR_VER="${BASH_REMATCH[2]}"
     else
         echo "ERROR: could not determine a supported MCR version from local installer name '$LOCAL_INSTALLER_NAME'"
-        echo "INFO: supported versions are R2012a, R2012b, R2013a, R2014a, R2014b, R2019b"
+        echo "INFO: supported versions are: $SUPPORTED_VERSIONS_LIST"
         exit 1
     fi
 
     # resolve to an absolute path now, since we'll cd into a tmp dir before using it
     LOCAL_INSTALLER="$(cd "$(dirname "$LOCAL_INSTALLER")" && pwd)/$LOCAL_INSTALLER_NAME"
+elif [[ -z "${MCR_URLS[$MCR_VER]}" ]]; then
+    echo "Unsupported runtime version $MCR_VER"
+    echo "INFO: supported versions are: $SUPPORTED_VERSIONS_LIST"
+    exit 1
 fi
 
 # operate in tmp directory
@@ -91,15 +112,8 @@ trap cleanup EXIT
 if [[ -n "$LOCAL_INSTALLER" ]]; then
     echo "Using local installer file: $LOCAL_INSTALLER (detected version $MCR_VER)"
     ln -s "$LOCAL_INSTALLER" installer.zip
-elif [[ "$MCR_VER" =~ R2012a|R2012b|R2013a ]]; then
-    curl --location https://ssd.mathworks.com/supportfiles/MCR_Runtime/$MCR_VER/MCR_${MCR_VER}_${OS_TAG}_installer.zip -o installer.zip
-elif [[ "$MCR_VER" =~ R2019b ]]; then
-    curl --location https://ssd.mathworks.com/supportfiles/downloads/$MCR_VER/Release/9/deployment_files/installer/complete/$OS_TAG/MATLAB_Runtime_${MCR_VER}_Update_9_${OS_TAG}.zip -o installer.zip
-elif [[ "$MCR_VER" =~ R2014a|R2014b ]]; then
-    curl --location https://ssd.mathworks.com/supportfiles/downloads/$MCR_VER/deployment_files/$MCR_VER/installers/$OS_TAG/MCR_${MCR_VER}_${OS_TAG}_installer.zip -o installer.zip
 else
-    echo "Unsupported runtime version $MCR_VER"
-    exit 1
+    curl --location "${MCR_URLS[$MCR_VER]}" -o installer.zip
 fi
 unzip installer.zip
 

--- a/scripts/fs_install_mcr
+++ b/scripts/fs_install_mcr
@@ -16,12 +16,23 @@ patch_installer() {
 
 # check arguments
 if [ "$#" -ne 1 ]; then
-    echo "ERROR: must specify MCR version as argument"
+    echo "ERROR: must specify MCR version, or path to a local MCR installer, as argument"
     echo "EXAMPLE: fs_install_mcr R2019b"
+    echo "EXAMPLE: fs_install_mcr /path/to/MATLAB_Runtime_R2019b_Update_9_glnxa64.zip"
     exit 1
 fi
 
-MCR_VER="$1"
+ARG="$1"
+LOCAL_INSTALLER=""
+MCR_VER=""
+
+if [ -f "$ARG" ]; then
+    # argument identifies a local installer file
+    LOCAL_INSTALLER="$ARG"
+else
+    # argument identifies an MCR version to download
+    MCR_VER="$ARG"
+fi
 
 # check FS directory
 if [[ -z "$FREESURFER_HOME" ]]; then
@@ -29,6 +40,40 @@ if [[ -z "$FREESURFER_HOME" ]]; then
     echo "INFO: if you're using sudo, make sure to pass the FS home variable with"
     echo "INFO: sudo FREESURFER_HOME=\$FREESURFER_HOME fs_install_mcr $@"
     exit 1
+fi
+
+if [ "$(uname -s)" == "Linux" ]; then
+    OS_TAG=glnxa64
+else
+    OS_TAG=maci64
+fi
+
+# if a local installer file was provided, validate its name and derive the MCR version from it
+if [[ -n "$LOCAL_INSTALLER" ]]; then
+    LOCAL_INSTALLER_NAME="$(basename "$LOCAL_INSTALLER")"
+
+    # must be a .zip archive, since the rest of the script assumes 'unzip installer.zip' works
+    if [[ "$LOCAL_INSTALLER_NAME" != *.zip ]]; then
+        echo "ERROR: local installer '$LOCAL_INSTALLER_NAME' must be a .zip file"
+        exit 1
+    fi
+
+    if [[ "$LOCAL_INSTALLER_NAME" != *"$OS_TAG"* ]]; then
+        echo "ERROR: local installer '$LOCAL_INSTALLER_NAME' does not appear to match this system's architecture ($OS_TAG)"
+        exit 1
+    fi
+
+    # only accept versions supported by this script (same set handled in the download branch below)
+    if [[ "$LOCAL_INSTALLER_NAME" =~ (R2012a|R2012b|R2013a|R2014a|R2014b|R2019b) ]]; then
+        MCR_VER="${BASH_REMATCH[1]}"
+    else
+        echo "ERROR: could not determine a supported MCR version from local installer name '$LOCAL_INSTALLER_NAME'"
+        echo "INFO: supported versions are R2012a, R2012b, R2013a, R2014a, R2014b, R2019b"
+        exit 1
+    fi
+
+    # resolve to an absolute path now, since we'll cd into a tmp dir before using it
+    LOCAL_INSTALLER="$(cd "$(dirname "$LOCAL_INSTALLER")" && pwd)/$LOCAL_INSTALLER_NAME"
 fi
 
 # operate in tmp directory
@@ -42,14 +87,11 @@ function cleanup {
 }
 trap cleanup EXIT
 
-if [ "$(uname -s)" == "Linux" ]; then
-    OS_TAG=glnxa64
-else
-    OS_TAG=maci64
-fi
-
-# download the os-specific installer
-if [[ "$MCR_VER" =~ R2012a|R2012b|R2013a ]]; then
+# get the os-specific installer: either from a local file, or by downloading it
+if [[ -n "$LOCAL_INSTALLER" ]]; then
+    echo "Using local installer file: $LOCAL_INSTALLER (detected version $MCR_VER)"
+    ln -s "$LOCAL_INSTALLER" installer.zip
+elif [[ "$MCR_VER" =~ R2012a|R2012b|R2013a ]]; then
     curl --location https://ssd.mathworks.com/supportfiles/MCR_Runtime/$MCR_VER/MCR_${MCR_VER}_${OS_TAG}_installer.zip -o installer.zip
 elif [[ "$MCR_VER" =~ R2019b ]]; then
     curl --location https://ssd.mathworks.com/supportfiles/downloads/$MCR_VER/Release/9/deployment_files/installer/complete/$OS_TAG/MATLAB_Runtime_${MCR_VER}_Update_9_${OS_TAG}.zip -o installer.zip
@@ -108,7 +150,7 @@ if [ -e $TMP_DEST_DIR/v* ]; then
    mv $MCR_DIR $MCR_TARGET_DIR
    echo "$MCR_VER installed successfully in $MCR_TARGET_DIR"
 
-elif [ "$APPLE_M1" == "true" ]; then 
+elif [ "$APPLE_M1" == "true" ]; then
    # Try to fall back to default Matlab GUI install path
    if [ -e $darwin_gui_install/v* ]; then
       MCR_DIR="$(ls -d $darwin_gui_install/v*)"
@@ -124,4 +166,3 @@ elif [ "$APPLE_M1" == "true" ]; then
       fi
    fi
 fi
-

--- a/scripts/fs_install_mcr
+++ b/scripts/fs_install_mcr
@@ -49,21 +49,51 @@ else
 fi
 
 # ----------------------------------------------------------------------------
-# Supported MCR versions and their download URLs, keyed by version string.
-# To support a new MCR version, add a single entry here.
+# Supported MCR versions and their download URLs.
+# Kept as two parallel indexed arrays (rather than an associative array)
+# for compatibility with bash 3.2, which is still the default /bin/bash
+# shipped on macOS. To support a new MCR version, add one entry to each
+# array below, at the same index.
 # ----------------------------------------------------------------------------
-declare -A MCR_URLS=(
-    ["R2012a"]="https://ssd.mathworks.com/supportfiles/MCR_Runtime/R2012a/MCR_R2012a_${OS_TAG}_installer.zip"
-    ["R2012b"]="https://ssd.mathworks.com/supportfiles/MCR_Runtime/R2012b/MCR_R2012b_${OS_TAG}_installer.zip"
-    ["R2013a"]="https://ssd.mathworks.com/supportfiles/MCR_Runtime/R2013a/MCR_R2013a_${OS_TAG}_installer.zip"
-    ["R2014a"]="https://ssd.mathworks.com/supportfiles/downloads/R2014a/deployment_files/R2014a/installers/${OS_TAG}/MCR_R2014a_${OS_TAG}_installer.zip"
-    ["R2014b"]="https://ssd.mathworks.com/supportfiles/downloads/R2014b/deployment_files/R2014b/installers/${OS_TAG}/MCR_R2014b_${OS_TAG}_installer.zip"
-    ["R2019b"]="https://ssd.mathworks.com/supportfiles/downloads/R2019b/Release/9/deployment_files/installer/complete/${OS_TAG}/MATLAB_Runtime_R2019b_Update_9_${OS_TAG}.zip"
+MCR_SUPPORTED_VERSIONS=(
+    "R2012a"
+    "R2012b"
+    "R2013a"
+    "R2014a"
+    "R2014b"
+    "R2019b"
 )
 
-# build a regex alternation of supported versions from the array keys, e.g. R2012a|R2012b|...
-SUPPORTED_VERSIONS_LIST="${!MCR_URLS[@]}"
-SUPPORTED_VERSIONS_RE="$(echo "$SUPPORTED_VERSIONS_LIST" | tr ' ' '|')"
+MCR_URLS=(
+    "https://ssd.mathworks.com/supportfiles/MCR_Runtime/R2012a/MCR_R2012a_${OS_TAG}_installer.zip"
+    "https://ssd.mathworks.com/supportfiles/MCR_Runtime/R2012b/MCR_R2012b_${OS_TAG}_installer.zip"
+    "https://ssd.mathworks.com/supportfiles/MCR_Runtime/R2013a/MCR_R2013a_${OS_TAG}_installer.zip"
+    "https://ssd.mathworks.com/supportfiles/downloads/R2014a/deployment_files/R2014a/installers/${OS_TAG}/MCR_R2014a_${OS_TAG}_installer.zip"
+    "https://ssd.mathworks.com/supportfiles/downloads/R2014b/deployment_files/R2014b/installers/${OS_TAG}/MCR_R2014b_${OS_TAG}_installer.zip"
+    "https://ssd.mathworks.com/supportfiles/downloads/R2019b/Release/9/deployment_files/installer/complete/${OS_TAG}/MATLAB_Runtime_R2019b_Update_9_${OS_TAG}.zip"
+)
+
+# looks up the download URL for a given MCR version; echoes it, or nothing if unsupported
+mcr_url_for_version() {
+    local version="$1"
+    local i
+    for i in "${!MCR_SUPPORTED_VERSIONS[@]}"; do
+        if [[ "${MCR_SUPPORTED_VERSIONS[$i]}" == "$version" ]]; then
+            echo "${MCR_URLS[$i]}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# builds a "|"-separated regex alternation of supported versions, e.g. R2012a|R2012b|...
+mcr_supported_versions_regex() {
+    local IFS="|"
+    echo "${MCR_SUPPORTED_VERSIONS[*]}"
+}
+
+SUPPORTED_VERSIONS_LIST="${MCR_SUPPORTED_VERSIONS[*]}"
+SUPPORTED_VERSIONS_RE="$(mcr_supported_versions_regex)"
 
 # if a local installer file was provided, validate its name and derive the MCR version from it
 if [[ -n "$LOCAL_INSTALLER" ]]; then
@@ -80,7 +110,8 @@ if [[ -n "$LOCAL_INSTALLER" ]]; then
         exit 1
     fi
 
-    # only accept versions supported by this script
+    # only accept versions supported by this script, matched as a distinct token
+    # (boundaries avoid mistaking e.g. "R2019bc" in a filename for "R2019b")
     if [[ "$LOCAL_INSTALLER_NAME" =~ (^|[^0-9A-Za-z])($SUPPORTED_VERSIONS_RE)([^0-9A-Za-z]|$) ]]; then
         MCR_VER="${BASH_REMATCH[2]}"
     else
@@ -91,10 +122,12 @@ if [[ -n "$LOCAL_INSTALLER" ]]; then
 
     # resolve to an absolute path now, since we'll cd into a tmp dir before using it
     LOCAL_INSTALLER="$(cd "$(dirname "$LOCAL_INSTALLER")" && pwd)/$LOCAL_INSTALLER_NAME"
-elif [[ -z "${MCR_URLS[$MCR_VER]}" ]]; then
-    echo "Unsupported runtime version $MCR_VER"
-    echo "INFO: supported versions are: $SUPPORTED_VERSIONS_LIST"
-    exit 1
+else
+    if ! mcr_url_for_version "$MCR_VER" > /dev/null; then
+        echo "Unsupported runtime version $MCR_VER"
+        echo "INFO: supported versions are: $SUPPORTED_VERSIONS_LIST"
+        exit 1
+    fi
 fi
 
 # operate in tmp directory
@@ -113,7 +146,7 @@ if [[ -n "$LOCAL_INSTALLER" ]]; then
     echo "Using local installer file: $LOCAL_INSTALLER (detected version $MCR_VER)"
     ln -s "$LOCAL_INSTALLER" installer.zip
 else
-    curl --location "${MCR_URLS[$MCR_VER]}" -o installer.zip
+    curl --location "$(mcr_url_for_version "$MCR_VER")" -o installer.zip
 fi
 unzip installer.zip
 


### PR DESCRIPTION
### Summary

This PR extends `fs_install_mcr` to accept either an MCR version string (existing behavior, e.g. `R2019b`) **or** a path to a local MATLAB Runtime installer archive that has already been downloaded. This is useful in environments with restricted or no internet access, or where the installer has already been fetched by other means (e.g. mirrored internally, downloaded manually due to network policies, etc.).

While working on this, we also found and fixed a pre-existing bug where the script would attempt to download an MCR version that doesn't actually exist, if the requested version string was merely a partial match of a supported one (see "Bugfix" section below).

As part of this change, the list of supported MCR versions and their download URLs was also refactored into two parallel arrays, to make it easier to add support for new versions in the future.

### Behavior

The script still takes a single argument:

```bash
fs_install_mcr R2019b
fs_install_mcr /path/to/MATLAB_Runtime_R2019b_Update_9_glnxa64.zip
```

- If the argument is an existing file, it's treated as a local installer archive.
- Otherwise, it's treated as an MCR version string and downloaded as before.

When a local file is provided, the script validates it before using it:

1. **Extension check** — the file must be a `.zip`, since the rest of the script relies on `unzip installer.zip` to extract it.
2. **Architecture check** — the filename must contain the OS-specific tag (`glnxa64` on Linux, `maci64` on macOS) matching the current system, to avoid installing binaries for the wrong platform.
3. **Version check** — the filename must contain, as a distinct token, one of the MCR versions supported by this script (boundary-anchored match, see bugfix below).

If validation passes, the script creates a symlink (`ln -s`) to the local file named `installer.zip` inside the temporary working directory, and the rest of the flow (`unzip`, silent install, move into `$FREESURFER_HOME`) proceeds unchanged. `ln -s` behaves identically on Linux and macOS, so no platform-specific branching was needed here.

If validation fails at any step, the script exits early with a descriptive error message before touching the temp directory or attempting any installation.

### Bugfix: partial/substring version matching

The **original** script matched MCR versions with unanchored regexes (e.g. `[[ "$MCR_VER" =~ R2019b ]]`). This meant an invalid version string like `R2019bc` would still match the `R2019b` branch on a simple substring basis, and the script would proceed to build a download URL and attempt a `curl` for a version that doesn't actually exist — instead of failing early with a clear "unsupported version" error.

This PR fixes this in both code paths:

- **Version-string path**: version lookup is now done via an explicit helper function that requires an exact match against the list of supported versions — `R2019bc` no longer resolves to the `R2019b` entry.
- **Local-file path**: the version is extracted from the filename using a boundary-anchored regex (non-alphanumeric characters or start/end of string on either side of the version token), so a filename like `MATLAB_Runtime_R2019bc_glnxa64.zip` is correctly rejected instead of being mistaken for the supported `R2019b`.

### Maintainability refactor

The previous `if/elif/elif/else` chain of three different URL patterns for downloading MCR was replaced with two parallel indexed arrays, `MCR_SUPPORTED_VERSIONS` and `MCR_URLS` (same index = same version), plus a small `mcr_url_for_version` helper function to look up a URL by version:

```bash
MCR_SUPPORTED_VERSIONS=(
    "R2012a"
    "R2012b"
    ...
    "R2019b"
)

MCR_URLS=(
    "https://.../MCR_R2012a_${OS_TAG}_installer.zip"
    "https://.../MCR_R2012b_${OS_TAG}_installer.zip"
    ...
    "https://.../MATLAB_Runtime_R2019b_Update_9_${OS_TAG}.zip"
)
```

Indexed arrays (rather than associative arrays / `declare -A`) were used deliberately, to stay compatible with **bash 3.2**, which is still the default `/bin/bash` shipped on macOS (Apple has not shipped a newer bash for licensing reasons — GPLv3 vs GPLv2). This avoids requiring users to install a newer bash (e.g. via Homebrew) just to run this script.

Adding support for a new MCR version now only requires appending one entry to each of the two arrays, at the same position; the local-file version validation, error messages, and download logic all derive from them automatically.

### Notes

- No changes were made to the Apple Silicon (`APPLE_M1`) patching logic; it operates on files already extracted from `installer.zip` regardless of how that archive was obtained, so it works unchanged with a local installer.
- Backward compatible: calling the script with a valid version string behaves as before (aside from the version-matching bugfix above, which only affects previously-invalid inputs).
- Tested on Linux and macOS, including the local-installer path with both matching and non-matching architecture/version filenames.