### PR TITLE
Fix out-of-bounds read in GCAfindStableSamples (no change in output)

### DIFF
--- a/utils/gca.cpp
+++ b/utils/gca.cpp
@@ -4947,7 +4947,8 @@ GCA_SAMPLE *GCAfindStableSamples(GCA *gca,
         }
         if (nfound > 0) {
           double p = randomNumber(0, 1.0);
-          if (p < ((double)label_counts[best_label] / nfound)) {
+          /* best_label is -1 when no label qualified; don't index label_counts with it */
+          if (best_label >= 0 && p < ((double)label_counts[best_label] / nfound)) {
             continue;
           }
         }


### PR DESCRIPTION
label_counts[best_label] would read OOB when best_label=-1.
This is a no-op though, since the next block is conditional on best_label >= 0.
This would matter most for sanitized compilation (e.g., mri_em_register and mri_deface), where an OOB read would block.

This is the minimal change. Alternatively, we could also scope everything under a single conditional (best_label=>0), but then the randomNumber() stream would be shifted, failing to preserve behavior.