### PR TITLE
fsglm: divide FFx multi-row contrast statistic by J before the F CDF

### DIFF
--- a/utils/fsglm.cpp
+++ b/utils/fsglm.cpp
@@ -707,7 +707,14 @@ int GLMtestFFx(GLMMAT *glm)
     if (mtmp != NULL) {
       glm->gtigCVM[n] = MatrixMultiplyD(glm->gammat[n], glm->igCVM[n], glm->gtigCVM[n]);
       F = MatrixMultiplyD(glm->gtigCVM[n], glm->gamma[n], F);
-      glm->F[n] = F->rptr[1][1];
+      // gamma' * inv(gCVM) * gamma is a Wald statistic, distributed as
+      // J*F(J,dof) under the null for a J-row contrast; divide by J so the
+      // value handed to the F CDF is actually F-distributed. Without this,
+      // multi-row FFx contrasts inflate significance roughly J-fold (a J=2
+      // contrast with true p=0.05 was reported as p=0.0025). J=1 contrasts
+      // are unchanged. GLMtest() (random effects) already folds J into its
+      // denominator (dtmp = rvar * C->rows).
+      glm->F[n] = F->rptr[1][1] / glm->C[n]->rows;
       glm->p[n] = sc_cdf_fdist_Q(glm->F[n], glm->C[n]->rows, glm->ffxdof);
       glm->igCVM[n] = mtmp;
     }


### PR DESCRIPTION
Fixes #1463 

GLMtestFFx computed gamma' * inv(gCVM) * gamma and passed it directly to sc_cdf_fdist_Q(., J, ffxdof). That quantity is a Wald statistic, distributed as J*F(J,dof) under the null, so for multi-row (F) contrasts the reported p-values were inflated roughly J-fold: with J=2, a contrast at true p=0.05 was reported as p=0.0025. Single-row contrasts (J=1) are unchanged, and the random-effects path (GLMtest) already folds J into its denominator via dtmp = rvar * C->rows.

Verified by Monte Carlo (200k null draws, 3-group design, J=2 equality contrast, heteroscedastic known variances as in the FFx model): null rejection rate at alpha=0.05 is 0.224 with the previous code and 0.050 with this change.


Claude-Session: https://claude.ai/code/session_012d2sJAD5EUp4GqAStqoBX7