### PR TITLE
mri_vol2surf, mri_surf2vol: do not drop the final projection sample

### DIFF
--- a/mri_surf2vol/mri_surf2vol.cpp
+++ b/mri_surf2vol/mri_surf2vol.cpp
@@ -348,8 +348,15 @@ int main(int argc, char **argv) {
   if (fillribbon) {   /* fill entire ribbon */
     VtxVol = MRIconst(TempVol->width, TempVol->height, TempVol->depth, 1, -1, NULL);
     printf("VtxVol fixed\n");
-    nhits = 0; 
-    for (projfrac = ProjFracStart ; projfrac <= ProjFracStop ; projfrac += ProjFracDelta) {
+    nhits = 0;
+    // Step with an integer index rather than accumulating a float: repeated
+    // "projfrac += ProjFracDelta" builds up rounding error, so for many
+    // (start,stop,delta) triplets (eg, the 0 1 0.05 default) the final
+    // accumulated value exceeds ProjFracStop and the outermost (pial-most)
+    // fill pass is silently skipped.
+    int const nprojmax = (int)round((ProjFracStop-ProjFracStart)/ProjFracDelta) + 1;
+    for (int nthproj = 0; nthproj < nprojmax; nthproj++) {
+      projfrac = ProjFracStart + nthproj*ProjFracDelta;
       MRI *VtxVolp;
       VtxVolp = MRImapSurf2VolClosest(SrcSurf, OutVol, Qa2v, projfrac, mask);
       if (VtxVol == NULL) {

--- a/mri_vol2surf/mri_vol2surf.cpp
+++ b/mri_vol2surf/mri_vol2surf.cpp
@@ -592,10 +592,15 @@ int main(int argc, char **argv) {
   else
   {
     printf("Projecting %g %g %g\n",ProjFracMin,ProjFracMax,ProjFracDelta);
+    // Step with an integer index rather than accumulating a float:
+    // repeated "ProjFrac += ProjFracDelta" builds up rounding error, so for
+    // many (min,max,delta) triplets (eg, --projfrac-avg 0 1 0.1) the final
+    // accumulated value exceeds ProjFracMax by ~1e-7 and the deepest sample
+    // is silently dropped (0 1 0.1 sampled depths 0 to 0.9, mean 0.45).
+    int const nprojmax = (int)round((ProjFracMax-ProjFracMin)/ProjFracDelta) + 1;
     nproj = 0;
-    for (ProjFrac=ProjFracMin; 
-         ProjFrac <= ProjFracMax; 
-         ProjFrac += ProjFracDelta) {
+    for (int nthproj = 0; nthproj < nprojmax; nthproj++) {
+      ProjFrac = ProjFracMin + nthproj*ProjFracDelta;
       printf("%2d %g %g %g\n",nproj+1,ProjFrac,ProjFracMin,ProjFracMax);
       if(UseOld){
         printf("using old\n");


### PR DESCRIPTION
Fixes #1465 

The projection loops accumulated a float (ProjFrac += ProjFracDelta) and tested it against the range maximum. Accumulated rounding error makes the final value exceed the maximum by ~1e-7 for many (min,max,delta) triplets, so the deepest sample is silently dropped. With the documented invocation --projfrac-avg 0 1 0.1, mri_vol2surf samples depths 0 through 0.9 and the "average across cortex" is actually an average over mean depth 0.45, displaced toward the white surface by 0.05 x thickness at every vertex; --projfrac-avg 0.2 0.8 0.1 takes 6 of the 7 intended samples. Whether the endpoint is included depends on the delta chosen (0.2 and 0.25 happen to be exact in binary and are unaffected), so the flag's semantics silently vary with the step size. The same pattern in mri_surf2vol --fill-projfrac skips the outermost (pial-most) fill pass with the default 0 1 0.05 range.

Step with an integer index instead and derive each ProjFrac by multiplication, which keeps the sample count exact for any delta. The average divisor (nproj) continues to match the number of samples taken.

Verified by extracting both loops (before and after) into a standalone harness: previously 0 1 0.1 -> 10 samples, max depth 0.9; now 11 samples, max depth 1.0, mean depth exactly 0.5 for all tested ranges.


Claude-Session: https://claude.ai/code/session_012d2sJAD5EUp4GqAStqoBX7