### PR TITLE
gcsa: compare island-relabeling log-likelihoods as doubles

### DIFF
--- a/utils/gcsa.cpp
+++ b/utils/gcsa.cpp
@@ -1554,7 +1554,14 @@ GCS *GCSAgetGC(GCSA_NODE *gcsan, int label, int *pn)
 
 int GCSAreclassifyLabel(GCSA *gcsa, MRI_SURFACE *mris, LABEL *area)
 {
-  int i, n, vno, annotation, best_label, max_ll, ll, nchanged, total;
+  int i, n, vno, annotation, best_label, nchanged, total;
+  // max_ll/ll must be double: gcsaNbhdGibbsLogLikelihood returns a double,
+  // and adjacent labels' log-likelihoods commonly differ by less than 1 at
+  // ambiguous boundaries. Storing them in ints truncated those fractional
+  // differences, so island vertices were absorbed into whichever neighbor
+  // label happened to come first in the adjacency list rather than the
+  // maximum-likelihood one. (GCSAreclassifyMarked already uses double.)
+  double max_ll, ll;
   double v_inputs[100];
 
   total = 0;


### PR DESCRIPTION
Fixes #1467 

GCSAreclassifyLabel (the island-absorption step run by every mris_ca_label postprocess) stored the return of gcsaNbhdGibbsLogLikelihood - a double - in an int before comparing candidates. Log-likelihoods of adjacent labels typically differ by well under 1.0 exactly where relabeling matters (at ambiguous boundaries), so the truncation destroyed the comparison and the island was absorbed into whichever neighboring label appeared first in the vertex adjacency list instead of the maximum-likelihood one. The effect is deterministic per mesh but arbitrary across subjects, and falls on small parcels (eg bankssts, transversetemporal) whose islands are most frequent.

Use double, as the sibling GCSAreclassifyMarked already does.


Claude-Session: https://claude.ai/code/session_012d2sJAD5EUp4GqAStqoBX7