### PR TITLE
mri_aparc2aseg: reset winner-selection state for every voxel

### DIFF
--- a/mri_aparc2aseg/mri_aparc2aseg.cpp
+++ b/mri_aparc2aseg/mri_aparc2aseg.cpp
@@ -658,6 +658,22 @@ int main(int argc, char **argv)
         vtx.y = RAS->rptr[2][1];
         vtx.z = RAS->rptr[3][1];
 
+        // Reset the winner-selection state for THIS voxel. These variables
+        // are declared per-column, and the four winner blocks below all use
+        // strict/no-winner-possible comparisons: when every candidate is
+        // rejected (eg, all four distances forced to 1e15 by the dot checks,
+        // or a hemisphere is disabled), none of the blocks executes and the
+        // voxel would otherwise inherit annot/annotid/hemi/dmin from the
+        // previously processed voxel in the column - a stale ROI and
+        // possibly the wrong hemisphere - with annotid additionally read
+        // uninitialized at the first such voxel of each column. Resetting
+        // annotid to -1 routes a no-winner voxel into the existing
+        // "annotation is none -> unknown" handling below.
+        annot = 0;
+        annotid = -1;
+        hemi = 0;
+        dmin = 1e15;
+
         // Get the index of the closest vertex in the
         // lh.white, lh.pial, rh.white, rh.pial
         if(UseHash) {


### PR DESCRIPTION
Fixes #1471 

annot, annotid, hemi and dmin are declared once per column and the four closest-surface winner blocks use strict comparisons, so a voxel for which every candidate is rejected - all four distances forced to 1e15 by the sulcal-bank dot checks, or a hemisphere disabled - executed no block at all and silently inherited the previous voxel's annotation, hemisphere and distance. Such voxels could receive an unrelated ROI, or a ctx-lh label on a right-hemisphere voxel, depending only on scan order; at the first no-winner voxel of a column, annotid was read uninitialized. These are exactly the ambiguous sulcal-bank voxels the dot checks target, so the stale labels land in systematic locations.

Initialize the four variables at the top of each voxel iteration. A no-winner voxel now flows into the existing "annotation is none -> unknown" handling (annotid = -1), which keeps the aseg identity or assigns ctx-?h-unknown, instead of copying a neighbor's stale state. Voxels with a legitimate winner are unaffected, since the winning block overwrites all four variables.

Note this does not address a second, related problem: the boundary-check gating reads ASeg with MRIneighbors while the same parallel loop is rewriting ASeg in place, which makes the gate scan-order dependent and racy under OpenMP. That needs a snapshot of the pre-labeling segmentation and is left for a separate change.


Claude-Session: https://claude.ai/code/session_012d2sJAD5EUp4GqAStqoBX7